### PR TITLE
Use Task.Delay instead of Thread.Sleep

### DIFF
--- a/JIM.Scheduler/Program.cs
+++ b/JIM.Scheduler/Program.cs
@@ -14,6 +14,7 @@
 // **************************************************************************************
 
 using Serilog;
+using System.Threading.Tasks;
 InitialiseLogging();
 Log.Information("Starting JIM.Scheduler");
 
@@ -22,7 +23,7 @@ try
     while (true)
     {
         Log.Information("JIM.Scheduler - Doing some work!");
-        Thread.Sleep(4000);
+        await Task.Delay(4000);
     }
 }
 catch (Exception ex)

--- a/JIM.Web/Pages/Admin/Operations.razor
+++ b/JIM.Web/Pages/Admin/Operations.razor
@@ -151,7 +151,7 @@
                 if (stateHasChanged)
                     await InvokeAsync(StateHasChanged);
 
-                Thread.Sleep(TimeSpan.FromSeconds(2));
+                await Task.Delay(TimeSpan.FromSeconds(2), token);
                 if (token.IsCancellationRequested)
                     break;
             }

--- a/JIM.Web/Program.cs
+++ b/JIM.Web/Program.cs
@@ -9,6 +9,7 @@ using MudBlazor.Services;
 using Serilog;
 using Serilog.Events;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 // Required environment variables:
 // -------------------------------
@@ -210,7 +211,7 @@ static async Task InitialiseJimApplicationAsync()
         }
 
         Log.Information("JIM.Application is not ready yet. Sleeping...");
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace `Thread.Sleep` with `Task.Delay` across scheduler and web projects

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f6c77188326bad979c476fbd1ed