### PR TITLE
Fix random usage and clean up comments

### DIFF
--- a/JIM.Application/Extensions.cs
+++ b/JIM.Application/Extensions.cs
@@ -13,7 +13,7 @@ public static class Extensions
         var enumerable = sequence as T[] ?? sequence.ToArray();
         var totalWeight = enumerable.Sum(weightSelector);
         // The weight we are after...
-        var itemWeightIndex = (float)new Random().NextDouble() * totalWeight;
+        var itemWeightIndex = (float)Random.Shared.NextDouble() * totalWeight;
         float currentWeightIndex = 0;
 
         foreach (var item in from weightedItem in enumerable select new { Value = weightedItem, Weight = weightSelector(weightedItem) })


### PR DESCRIPTION
## Summary
- use `Random.Shared` for weighted selection
- correct random item selection in metaverse reference assignment
- adjust manager and subordinate selection percentages
- calculate removed attribute values correctly
- clean up boolean generation comments

## Testing
- `dotnet test JIM.sln --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684fc1d776cc83269b108beb20550047