### PR TITLE
Fix CSV import edge cases

### DIFF
--- a/JIM.Connectors/File/FileConnector.cs
+++ b/JIM.Connectors/File/FileConnector.cs
@@ -100,6 +100,8 @@ public class FileConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         await reader.CsvReader.ReadAsync();
         reader.CsvReader.ReadHeader();
         var columnNames = reader.CsvReader.HeaderRecord;
+        if (columnNames == null || columnNames.Length == 0)
+            throw new InvalidOperationException("CSV file is missing column headers.");
 
         // start building the schema by inspecting the file!
         var schema = new ConnectorSchema();

--- a/JIM.Connectors/File/FileConnectorImport.cs
+++ b/JIM.Connectors/File/FileConnectorImport.cs
@@ -98,7 +98,9 @@ internal class FileConnectorImport
 
                 if (attribute.Type == AttributeDataType.Text)
                 {
-                    importObjectAttribute.StringValues.Add(_reader.CsvReader.GetField(attribute.Name));
+                    var stringValue = _reader.CsvReader.GetField(attribute.Name);
+                    if (!string.IsNullOrEmpty(stringValue))
+                        importObjectAttribute.StringValues.Add(stringValue);
                 }
                 else if (attribute.Type == AttributeDataType.Number)
                 {
@@ -118,7 +120,9 @@ internal class FileConnectorImport
                 }
                 else if (attribute.Type == AttributeDataType.Reference)
                 {
-                    importObjectAttribute.ReferenceValues.Add(_reader.CsvReader.GetField(attribute.Name));
+                    var referenceValue = _reader.CsvReader.GetField(attribute.Name);
+                    if (!string.IsNullOrEmpty(referenceValue))
+                        importObjectAttribute.ReferenceValues.Add(referenceValue);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- validate header presence when building file connector schema
- skip empty string and reference values during CSV import

## Testing
- `dotnet build JIM.sln --no-restore`
- `dotnet test JIM.sln --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684ff1af2da88326864dbd8a3621bf20