### PR TITLE
Fix reference generation when no source objects

### DIFF
--- a/JIM.Application/Servers/DataGenerationServer.cs
+++ b/JIM.Application/Servers/DataGenerationServer.cs
@@ -490,7 +490,13 @@ public class DataGenerationServer
         }
 
         // is this going to be slow?
-        var metaverseObjectsOfTypes = metaverseObjects.Where(q => q != null && templateAttribute.ReferenceMetaverseObjectTypes != null && templateAttribute.ReferenceMetaverseObjectTypes.Contains(q.Type)).ToList();
+        var metaverseObjectsOfTypes = metaverseObjects.Where(q => q != null &&
+                                                                  templateAttribute.ReferenceMetaverseObjectTypes != null &&
+                                                                  templateAttribute.ReferenceMetaverseObjectTypes.Contains(q.Type)).ToList();
+
+        if (metaverseObjectsOfTypes.Count == 0)
+            return;
+
         if (templateAttribute.MetaverseAttribute.AttributePlurality == AttributePlurality.SingleValued)
         {
             // pick a random metaverse object and assign


### PR DESCRIPTION
## Summary
- avoid crashes when choosing a reference value during data generation
- fix `.ToList()` placement per review comment

## Testing
- `dotnet build JIM.sln -v minimal`
- `dotnet test JIM.sln --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_684ff52bfe4083268c2dac11a6217508