### PR TITLE
Add comprehensive tests for full sync capability (Issue #90)

### DIFF
--- a/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
+++ b/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
@@ -632,7 +632,7 @@ public class FullSyncTests
         ConnectedSystemObjectsData[0].Status = ConnectedSystemObjectStatus.Obsolete;
 
         // verify that attempting to process this throws NotImplementedException
-        Assert.ThrowsAsync<NotImplementedException>(async () =>
+        await Assert.ThrowsAsync<NotImplementedException>(async () =>
         {
             var connectedSystem = await Jim.ConnectedSystems.GetConnectedSystemAsync(1);
             var activity = ActivitiesData.First();


### PR DESCRIPTION
Added missing tests to increase coverage of CSO/Metaverse synchronization:

- CSO projection to MVO: Tests that CSOs successfully create new MVOs when
  ProjectToMetaverse is enabled
- Pending attribute value additions: Tests all data types (Text, DateTime,
  Number, Guid, Reference) are correctly added to MVO pending additions
- Pending attribute value removals: Tests that removed CSO attributes trigger
  pending removals on MVO
- CSO obsolete deletion for non-joined CSOs: Tests that obsolete CSOs without
  joins are successfully deleted
- CSO obsolete deletion for joined CSOs: Documents current NotImplementedException
  limitation for joined CSO deletion (pending MVO deletion rules implementation)
- CSO join transitions: Tests CSO successfully transitions from non-joined to
  joined state
- Duplicate join prevention: Tests that multiple CSOs from same system cannot
  join to same MVO (1:1 relationship enforced)

These tests follow TDD approach and document both implemented and pending
functionality per issue #90 requirements.