### PR TITLE
Pending export confirmation and partial failure handling

### DIFF
--- a/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -981,6 +981,16 @@ public class ConnectedSystemServer
     {
         await Application.Repository.ConnectedSystems.DeletePendingExportAsync(pendingExport);
     }
+
+    /// <summary>
+    /// Updates a Pending Export object.
+    /// Used when removing successfully applied attribute changes and updating error tracking.
+    /// </summary>
+    /// <param name="pendingExport">The Pending Export to update.</param>
+    public async Task UpdatePendingExportAsync(PendingExport pendingExport)
+    {
+        await Application.Repository.ConnectedSystems.UpdatePendingExportAsync(pendingExport);
+    }
     #endregion
 
     #region Sync Rules

--- a/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -40,6 +40,13 @@ public interface IConnectedSystemRepository
     public Task DeletePendingExportAsync(PendingExport pendingExport);
 
     /// <summary>
+    /// Updates a Pending Export object.
+    /// Used when removing successfully applied attribute changes and updating error tracking.
+    /// </summary>
+    /// <param name="pendingExport">The Pending Export to update.</param>
+    public Task UpdatePendingExportAsync(PendingExport pendingExport);
+
+    /// <summary>
     /// Retrieves all the Connected System Object Types for a given Connected System.
     /// Includes Attributes.
     /// </summary>

--- a/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -721,6 +721,12 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         Repository.Database.PendingExports.Remove(pendingExport);
         await Repository.Database.SaveChangesAsync();
     }
+
+    public async Task UpdatePendingExportAsync(PendingExport pendingExport)
+    {
+        Repository.Database.PendingExports.Update(pendingExport);
+        await Repository.Database.SaveChangesAsync();
+    }
     #endregion
 
     #region Sync Rules

--- a/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
+++ b/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
@@ -191,11 +191,14 @@ public class FullSyncTests
     }
 
     /// <summary>
-    /// Tests that a PendingExport is NOT deleted when only some attributes match.
-    /// This occurs when an export is only partially successful, requiring retry on the next sync run.
+    /// Tests that when a PendingExport is only partially successful:
+    /// 1. Successfully applied attribute changes are removed from the PendingExport
+    /// 2. Failed attribute changes remain in the PendingExport
+    /// 3. ErrorCount is incremented
+    /// 4. Status is updated to ExportNotImported
     /// </summary>
     [Test]
-    public async Task PendingExportKeptWhenCsoStatePartiallyMatchesTestAsync()
+    public async Task PendingExportPartialMatchRemovesSuccessfulAttributesAndIncrementsErrorCountTestAsync()
     {
         // get the first CSO that we'll have a pending export for
         var cso = ConnectedSystemObjectsData[0];
@@ -216,6 +219,7 @@ public class FullSyncTests
             ConnectedSystemObject = cso,
             Status = PendingExportStatus.Pending,
             ChangeType = PendingExportChangeType.Update,
+            ErrorCount = 0,
             AttributeValueChanges = new List<PendingExportAttributeValueChange>
             {
                 new()
@@ -249,6 +253,7 @@ public class FullSyncTests
         PendingExportsData.Add(pendingExport);
 
         // update the CSO with only 2 of the 3 pending changes (simulating partial export success)
+        // DisplayName and EmployeeNumber succeeded, Role failed
         var csoDisplayNameValue = cso.AttributeValues.FirstOrDefault(av => av.AttributeId == (int)MockSourceSystemAttributeNames.DISPLAY_NAME);
         if (csoDisplayNameValue != null)
             csoDisplayNameValue.StringValue = "Updated Name";
@@ -260,18 +265,15 @@ public class FullSyncTests
         // Role is NOT updated - this simulates an export failure for this attribute
         var csoRoleValue = cso.AttributeValues.FirstOrDefault(av => av.AttributeId == (int)MockSourceSystemAttributeNames.ROLE);
         if (csoRoleValue != null)
-            csoRoleValue.StringValue = "Manager"; // Different from pending export value
+            csoRoleValue.StringValue = "Manager"; // Different from pending export value "Senior Manager"
 
         // verify setup
         Assert.That(PendingExportsData.Count, Is.EqualTo(1), "Expected one pending export before sync.");
-        Assert.That(cso.AttributeValues.Single(av => av.AttributeId == (int)MockSourceSystemAttributeNames.DISPLAY_NAME).StringValue,
-            Is.EqualTo("Updated Name"), "Expected CSO to have the updated display name.");
-        Assert.That(cso.AttributeValues.Single(av => av.AttributeId == (int)MockSourceSystemAttributeNames.EMPLOYEE_NUMBER).IntValue,
-            Is.EqualTo(999), "Expected CSO to have the updated employee number.");
-        Assert.That(cso.AttributeValues.Single(av => av.AttributeId == (int)MockSourceSystemAttributeNames.ROLE).StringValue,
-            Is.Not.EqualTo("Senior Manager"), "Expected CSO Role to NOT match the pending export value.");
+        Assert.That(pendingExport.AttributeValueChanges.Count, Is.EqualTo(3), "Expected 3 attribute changes before sync.");
+        Assert.That(pendingExport.ErrorCount, Is.EqualTo(0), "Expected ErrorCount to be 0 before sync.");
+        Assert.That(pendingExport.Status, Is.EqualTo(PendingExportStatus.Pending), "Expected Status to be Pending before sync.");
 
-        // setup mock to handle pending export deletion (shouldn't be called)
+        // setup mock to handle pending export deletion (shouldn't be called for partial match)
         var deleteCallCount = 0;
         MockDbSetPendingExports.Setup(set => set.Remove(It.IsAny<PendingExport>())).Callback(
             (PendingExport entity) => {
@@ -285,11 +287,95 @@ public class FullSyncTests
         var syncFullSyncTaskProcessor = new SyncFullSyncTaskProcessor(Jim, connectedSystem, runProfile, activity, new CancellationTokenSource());
         await syncFullSyncTaskProcessor.PerformFullSyncAsync();
 
-        // verify the pending export was NOT deleted because not all attributes matched
+        // verify the pending export was NOT deleted
         Assert.That(PendingExportsData.Count, Is.EqualTo(1),
-            "Expected pending export to be kept when CSO state only partially matches the pending changes.");
+            "Expected pending export to be kept when CSO state only partially matches.");
         Assert.That(deleteCallCount, Is.EqualTo(0),
             "Expected Delete to not be called when pending export doesn't fully match.");
+
+        // verify successful attribute changes were removed (DisplayName and EmployeeNumber)
+        Assert.That(pendingExport.AttributeValueChanges.Count, Is.EqualTo(1),
+            "Expected only 1 failed attribute change to remain in the pending export.");
+        Assert.That(pendingExport.AttributeValueChanges.Single().AttributeId,
+            Is.EqualTo((int)MockSourceSystemAttributeNames.ROLE),
+            "Expected only the failed Role attribute change to remain.");
+
+        // verify ErrorCount was incremented
+        Assert.That(pendingExport.ErrorCount, Is.EqualTo(1),
+            "Expected ErrorCount to be incremented to 1 after partial failure.");
+
+        // verify Status was updated to ExportNotImported
+        Assert.That(pendingExport.Status, Is.EqualTo(PendingExportStatus.ExportNotImported),
+            "Expected Status to be updated to ExportNotImported after partial failure.");
+    }
+
+    /// <summary>
+    /// Tests that ErrorCount continues to increment on repeated partial failures.
+    /// </summary>
+    [Test]
+    public async Task PendingExportErrorCountIncrementsOnRepeatedPartialFailuresTestAsync()
+    {
+        // get the first CSO that we'll have a pending export for
+        var cso = ConnectedSystemObjectsData[0];
+        var connectedSystem = ConnectedSystemsData[0];
+
+        // get the connected system object type attributes we'll use
+        var csUserType = ConnectedSystemObjectTypesData.Single(q => q.Name == "SOURCE_USER");
+        var roleAttr = csUserType.Attributes.Single(a => a.Id == (int)MockSourceSystemAttributeNames.ROLE);
+
+        // create a pending export that has already failed twice (ErrorCount = 2)
+        var pendingExport = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = connectedSystem.Id,
+            ConnectedSystem = connectedSystem,
+            ConnectedSystemObject = cso,
+            Status = PendingExportStatus.ExportNotImported,
+            ChangeType = PendingExportChangeType.Update,
+            ErrorCount = 2, // Already failed twice
+            AttributeValueChanges = new List<PendingExportAttributeValueChange>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    ChangeType = PendingExportAttributeChangeType.Update,
+                    AttributeId = (int)MockSourceSystemAttributeNames.ROLE,
+                    Attribute = roleAttr,
+                    StringValue = "Senior Manager"
+                }
+            }
+        };
+
+        // add the pending export to our mock data
+        PendingExportsData.Add(pendingExport);
+
+        // Role is still NOT matching - the export continues to fail
+        var csoRoleValue = cso.AttributeValues.FirstOrDefault(av => av.AttributeId == (int)MockSourceSystemAttributeNames.ROLE);
+        if (csoRoleValue != null)
+            csoRoleValue.StringValue = "Manager"; // Still different from pending export value
+
+        // verify setup
+        Assert.That(pendingExport.ErrorCount, Is.EqualTo(2), "Expected ErrorCount to be 2 before sync.");
+
+        // setup mock
+        MockDbSetPendingExports.Setup(set => set.Remove(It.IsAny<PendingExport>())).Callback(
+            (PendingExport entity) => PendingExportsData.Remove(entity));
+
+        // run full sync
+        var activity = ActivitiesData.First();
+        var runProfile = ConnectedSystemRunProfilesData.Single(q => q.ConnectedSystemId == connectedSystem.Id && q.RunType == ConnectedSystemRunType.FullSynchronisation);
+        var syncFullSyncTaskProcessor = new SyncFullSyncTaskProcessor(Jim, connectedSystem, runProfile, activity, new CancellationTokenSource());
+        await syncFullSyncTaskProcessor.PerformFullSyncAsync();
+
+        // verify ErrorCount was incremented to 3
+        Assert.That(pendingExport.ErrorCount, Is.EqualTo(3),
+            "Expected ErrorCount to be incremented to 3 after another failure.");
+
+        // verify the pending export still exists with the failed attribute
+        Assert.That(PendingExportsData.Count, Is.EqualTo(1),
+            "Expected pending export to be kept.");
+        Assert.That(pendingExport.AttributeValueChanges.Count, Is.EqualTo(1),
+            "Expected failed attribute change to still be present.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Implements pending export deletion when CSO state matches all expected attribute values
- Adds partial failure handling: removes successfully applied attribute changes while keeping failed ones for retry
- Tracks failures via ErrorCount incrementing and Status update to ExportNotImported

## Test plan
- [x] All 75 tests pass (27 model tests + 48 worker tests)
- [x] `PendingExportDeletedWhenCsoStateMatchesTestAsync` - verifies complete match deletes pending export
- [x] `PendingExportPartialMatchRemovesSuccessfulAttributesAndIncrementsErrorCountTestAsync` - verifies partial match handling
- [x] `PendingExportErrorCountIncrementsOnRepeatedPartialFailuresTestAsync` - verifies repeated failure tracking

Relates to #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)