### PR TITLE
fix: Handle null values and ambiguous matches in matching rules

### DIFF
--- a/JIM.Models/Activities/ActivityRunProfileExecutionItemErrorType.cs
+++ b/JIM.Models/Activities/ActivityRunProfileExecutionItemErrorType.cs
@@ -3,6 +3,7 @@
 public enum ActivityRunProfileExecutionItemErrorType
 {
     NotSet,
+    AmbiguousMatch,
     CouldNotMatchObjectType,
     CouldNotJoinDueToExistingJoin,
     DuplicateImportedAttributes,

--- a/JIM.Worker/Processors/SyncFullSyncTaskProcessor.cs
+++ b/JIM.Worker/Processors/SyncFullSyncTaskProcessor.cs
@@ -565,9 +565,10 @@ public class SyncFullSyncTaskProcessor
             }
             catch (JIM.Models.Exceptions.MultipleMatchesException ex)
             {
-                runProfileExecutionItem.ErrorType = ActivityRunProfileExecutionItemErrorType.UnhandledError;
-                runProfileExecutionItem.ErrorMessage = $"Multiple Metaverse Objects match this Connected System Object. " +
-                    $"Check your Object Matching Rules to ensure unique matches. Details: {ex.Message}";
+                runProfileExecutionItem.ErrorType = ActivityRunProfileExecutionItemErrorType.AmbiguousMatch;
+                runProfileExecutionItem.ErrorMessage = $"Multiple Metaverse Objects ({ex.Matches.Count}) match this Connected System Object. " +
+                    $"An MVO can only be joined to a single CSO per Connected System. " +
+                    $"Check your Object Matching Rules to ensure unique matches. Matching MVO IDs: {string.Join(", ", ex.Matches)}";
                 _activity.RunProfileExecutionItems.Add(runProfileExecutionItem);
                 return;
             }


### PR DESCRIPTION
## Summary

Completes Phase 8 tasks 8.11 and 8.12 from Issue #203.

### 8.11 - Null Value Handling

- **Decision**: Null values are always a non-match (skip, don't match)
- Skip null/empty attribute values during matching evaluation
- Added null checks to both `MetaverseRepository.FindMetaverseObjectUsingMatchingRuleAsync` and `ConnectedSystemRepository.FindConnectedSystemObjectUsingMatchingRuleAsync`
- Prevents `null == null` from incorrectly matching objects together

### 8.12 - Ambiguous Match Scenarios

- **Decision**: Leave all CSOs in ambiguous match disconnected (clean state for admin to resolve)
- Added `AmbiguousMatch` error type to `ActivityRunProfileExecutionItemErrorType`
- Updated error message to include count and IDs of matching MVOs for easier debugging
- Existing behaviour for "MVO already joined to another CSO" unchanged (`CouldNotJoinDueToExistingJoin`)

## Test Plan

- [x] Build succeeds
- [x] All 622 tests pass
- [ ] Integration test with null attribute values
- [ ] Integration test with duplicate matching values

## Closes

Completes Phase 8 of #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)