### PR TITLE
fix: Preserve original watermark during paginated delta imports

### DIFF
--- a/JIM.Connectors/Mock/MockCallConnector.cs
+++ b/JIM.Connectors/Mock/MockCallConnector.cs
@@ -128,6 +128,12 @@ public class MockCallConnector : IConnector, IConnectorCapabilities, IConnectorI
     #region State Accessors
 
     /// <summary>
+    /// Gets the persisted connector data values passed to each ImportAsync call.
+    /// Useful for verifying that the correct watermark is passed during paginated imports.
+    /// </summary>
+    public List<string?> ImportPersistedDataHistory { get; } = new();
+
+    /// <summary>
     /// Gets all pending exports that were processed during Export calls.
     /// Useful for verifying what was sent to the "target system".
     /// </summary>
@@ -151,6 +157,7 @@ public class MockCallConnector : IConnector, IConnectorCapabilities, IConnectorI
         _confirmingImportFactory = null;
         TestExceptionToThrow = null;
         ExportExceptionToThrow = null;
+        ImportPersistedDataHistory.Clear();
     }
 
     /// <summary>
@@ -203,6 +210,9 @@ public class MockCallConnector : IConnector, IConnectorCapabilities, IConnectorI
         ILogger logger,
         CancellationToken cancellationToken)
     {
+        // Record the persisted data passed on each call for test verification
+        ImportPersistedDataHistory.Add(persistedConnectorData);
+
         if (TestExceptionToThrow != null)
             throw TestExceptionToThrow;
 


### PR DESCRIPTION
## Summary
- Fixed paging bug in delta imports that caused objects to be missed when results span multiple pages

## Problem
When a delta import has more objects than the page size (default 100), the worker was updating the persisted connector data (USN watermark) DURING the paging loop. This caused subsequent pages to use the NEW watermark instead of the ORIGINAL one, missing objects.

Example scenario:
1. Page 1: Load previous USN (4261), query for `uSNChanged >= 4262`, get 100 results + capture new USN (4400)
2. **Bug**: Immediately update connected system's persisted data to USN=4400
3. Page 2: Called with `persistedConnectorData=4400` (the NEW value!)
4. Connector loads USN=4400 as watermark, queries for `uSNChanged >= 4401`
5. **All objects with USN 4262-4400 that weren't in page 1 are MISSED**

## Solution
- Capture the original persisted data at the START of the import
- Pass this original value to ALL pages of the import  
- Only update the connected system's persisted data AFTER all pages are processed

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [ ] Run `./test/integration/Run-IntegrationTests.ps1 -Template Small` to verify fix

## Additional Changes
- Added `ImportPersistedDataHistory` to `MockCallConnector` for future tests verifying paginated import behaviour

Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)