### PR TITLE
perf: Batch pending export reconciliation during import

### DIFF
--- a/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -111,6 +111,14 @@ public interface IConnectedSystemRepository
     public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId);
 
     /// <summary>
+    /// Retrieves Pending Exports for multiple Connected System Objects in a single query.
+    /// More efficient than calling GetPendingExportByConnectedSystemObjectIdAsync multiple times.
+    /// </summary>
+    /// <param name="connectedSystemObjectIds">The CSO IDs to retrieve pending exports for.</param>
+    /// <returns>A dictionary mapping CSO ID to its pending export (if any).</returns>
+    public Task<Dictionary<Guid, PendingExport>> GetPendingExportsByConnectedSystemObjectIdsAsync(IEnumerable<Guid> connectedSystemObjectIds);
+
+    /// <summary>
     /// Gets all Connected System Objects that are joined to a specific Metaverse Object.
     /// Used for evaluating MVO deletion exports.
     /// </summary>

--- a/test/JIM.Worker.Tests/Synchronisation/ImportCreateObjectTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportCreateObjectTests.cs
@@ -4,6 +4,7 @@ using JIM.Models.Activities;
 using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Models.Staging;
+using JIM.Models.Transactional;
 using JIM.PostgresData;
 using JIM.Worker.Processors;
 using JIM.Worker.Tests.Models;
@@ -27,6 +28,10 @@ public class ImportCreateObjectTests
     private Mock<DbSet<ConnectedSystemPartition>> MockDbSetConnectedSystemPartitions { get; set; }
     private List<Activity> ActivitiesData { get; set; }
     private Mock<DbSet<Activity>> MockDbSetActivities { get; set; }
+    private List<ServiceSetting> ServiceSettingsData { get; set; }
+    private Mock<DbSet<ServiceSetting>> MockDbSetServiceSettings { get; set; }
+    private List<PendingExport> PendingExportsData { get; set; }
+    private Mock<DbSet<PendingExport>> MockDbSetPendingExports { get; set; }
     private Mock<JimDbContext> MockJimDbContext { get; set; }
     private JimApplication Jim { get; set; }
     #endregion
@@ -63,7 +68,15 @@ public class ImportCreateObjectTests
         var fullImportRunProfile = ConnectedSystemRunProfilesData[0];
         ActivitiesData = TestUtilities.GetActivityData(fullImportRunProfile.RunType, fullImportRunProfile.Id);
         MockDbSetActivities = ActivitiesData.BuildMockDbSet();
-        
+
+        // set up the service settings mock
+        ServiceSettingsData = TestUtilities.GetServiceSettingsData();
+        MockDbSetServiceSettings = ServiceSettingsData.BuildMockDbSet();
+
+        // set up the pending exports mock (empty - import tests don't have pending exports to reconcile)
+        PendingExportsData = new List<PendingExport>();
+        MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
+
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
@@ -71,7 +84,9 @@ public class ImportCreateObjectTests
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(MockDbSetConnectedSystemRunProfiles.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemPartitions).Returns(MockDbSetConnectedSystemPartitions.Object);
-        
+        MockJimDbContext.Setup(m => m.ServiceSettingItems).Returns(MockDbSetServiceSettings.Object);
+        MockJimDbContext.Setup(m => m.PendingExports).Returns(MockDbSetPendingExports.Object);
+
         // instantiate Jim using the mocked db context
         Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object));
     }

--- a/test/JIM.Worker.Tests/Synchronisation/ImportDeleteObjectTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportDeleteObjectTests.cs
@@ -4,6 +4,7 @@ using JIM.Models.Activities;
 using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Models.Staging;
+using JIM.Models.Transactional;
 using JIM.PostgresData;
 using JIM.Worker.Processors;
 using JIM.Worker.Tests.Models;
@@ -27,6 +28,10 @@ public class ImportDeleteObjectTests
     private Mock<DbSet<ConnectedSystemPartition>> MockDbSetConnectedSystemPartitions { get; set; }
     private List<Activity> ActivitiesData { get; set; }
     private Mock<DbSet<Activity>> MockDbSetActivities { get; set; }
+    private List<ServiceSetting> ServiceSettingsData { get; set; }
+    private Mock<DbSet<ServiceSetting>> MockDbSetServiceSettings { get; set; }
+    private List<PendingExport> PendingExportsData { get; set; }
+    private Mock<DbSet<PendingExport>> MockDbSetPendingExports { get; set; }
     private Mock<JimDbContext> MockJimDbContext { get; set; }
     private JimApplication Jim { get; set; }
     #endregion
@@ -42,28 +47,36 @@ public class ImportDeleteObjectTests
     {
         TestUtilities.SetEnvironmentVariables();
         InitiatedBy = TestUtilities.GetInitiatedBy();
-        
+
         // set up the connected systems mock
         ConnectedSystemsData = TestUtilities.GetConnectedSystemData();
         MockDbSetConnectedSystems = ConnectedSystemsData.BuildMockDbSet();
-        
+
         // setup up the connected system run profiles mock
         ConnectedSystemRunProfilesData = TestUtilities.GetConnectedSystemRunProfileData();
         MockDbSetConnectedSystemRunProfiles = ConnectedSystemRunProfilesData.BuildMockDbSet();
-        
+
         // set up the connected system object types mock. this acts as the persisted schema in JIM
         ConnectedSystemObjectTypesData = TestUtilities.GetConnectedSystemObjectTypeData();
         MockDbSetConnectedSystemObjectTypes = ConnectedSystemObjectTypesData.BuildMockDbSet();
-        
+
         // setup up the Connected System Partitions mock
         ConnectedSystemPartitionsData = TestUtilities.GetConnectedSystemPartitionData();
         MockDbSetConnectedSystemPartitions = ConnectedSystemPartitionsData.BuildMockDbSet();
-        
+
         // set up the activity mock
         var fullImportRunProfile = ConnectedSystemRunProfilesData[0];
         ActivitiesData = TestUtilities.GetActivityData(fullImportRunProfile.RunType, fullImportRunProfile.Id);
         MockDbSetActivities = ActivitiesData.BuildMockDbSet();
-        
+
+        // set up the service settings mock
+        ServiceSettingsData = TestUtilities.GetServiceSettingsData();
+        MockDbSetServiceSettings = ServiceSettingsData.BuildMockDbSet();
+
+        // set up the pending exports mock (empty - import tests don't have pending exports to reconcile)
+        PendingExportsData = new List<PendingExport>();
+        MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
+
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
@@ -71,7 +84,9 @@ public class ImportDeleteObjectTests
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(MockDbSetConnectedSystemRunProfiles.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemPartitions).Returns(MockDbSetConnectedSystemPartitions.Object);
-        
+        MockJimDbContext.Setup(m => m.ServiceSettingItems).Returns(MockDbSetServiceSettings.Object);
+        MockJimDbContext.Setup(m => m.PendingExports).Returns(MockDbSetPendingExports.Object);
+
         // instantiate Jim using the mocked db context
         Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object));
     }

--- a/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectMvaTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectMvaTests.cs
@@ -4,6 +4,7 @@ using JIM.Models.Activities;
 using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Models.Staging;
+using JIM.Models.Transactional;
 using JIM.PostgresData;
 using JIM.Worker.Processors;
 using JIM.Worker.Tests.Models;
@@ -28,6 +29,10 @@ public class ImportUpdateObjectMvaTests
     private Mock<DbSet<ConnectedSystemPartition>> MockDbSetConnectedSystemPartitions { get; set; }
     private List<Activity> ActivitiesData { get; set; }
     private Mock<DbSet<Activity>> MockDbSetActivities { get; set; }
+    private List<ServiceSetting> ServiceSettingsData { get; set; }
+    private Mock<DbSet<ServiceSetting>> MockDbSetServiceSettings { get; set; }
+    private List<PendingExport> PendingExportsData { get; set; }
+    private Mock<DbSet<PendingExport>> MockDbSetPendingExports { get; set; }
     private Mock<JimDbContext> MockJimDbContext { get; set; }
     private JimApplication Jim { get; set; }
     #endregion
@@ -43,28 +48,36 @@ public class ImportUpdateObjectMvaTests
     {
         TestUtilities.SetEnvironmentVariables();
         InitiatedBy = TestUtilities.GetInitiatedBy();
-        
+
         // set up the connected systems mock
         ConnectedSystemsData = TestUtilities.GetConnectedSystemData();
         MockDbSetConnectedSystems = ConnectedSystemsData.BuildMockDbSet();
-        
+
         // setup up the connected system run profiles mock
         ConnectedSystemRunProfilesData = TestUtilities.GetConnectedSystemRunProfileData();
         MockDbSetConnectedSystemRunProfiles = ConnectedSystemRunProfilesData.BuildMockDbSet();
-        
+
         // set up the connected system object types mock. this acts as the persisted schema in JIM
         ConnectedSystemObjectTypesData = TestUtilities.GetConnectedSystemObjectTypeData();
         MockDbSetConnectedSystemObjectTypes = ConnectedSystemObjectTypesData.BuildMockDbSet();
-        
+
         // setup up the Connected System Partitions mock
         ConnectedSystemPartitionsData = TestUtilities.GetConnectedSystemPartitionData();
         MockDbSetConnectedSystemPartitions = ConnectedSystemPartitionsData.BuildMockDbSet();
-        
+
         // set up the activity mock
         var fullImportRunProfile = ConnectedSystemRunProfilesData[0];
         ActivitiesData = TestUtilities.GetActivityData(fullImportRunProfile.RunType, fullImportRunProfile.Id);
         MockDbSetActivities = ActivitiesData.BuildMockDbSet();
-        
+
+        // set up the service settings mock
+        ServiceSettingsData = TestUtilities.GetServiceSettingsData();
+        MockDbSetServiceSettings = ServiceSettingsData.BuildMockDbSet();
+
+        // set up the pending exports mock (empty - import tests don't have pending exports to reconcile)
+        PendingExportsData = new List<PendingExport>();
+        MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
+
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
@@ -72,7 +85,9 @@ public class ImportUpdateObjectMvaTests
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(MockDbSetConnectedSystemRunProfiles.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemPartitions).Returns(MockDbSetConnectedSystemPartitions.Object);
-        
+        MockJimDbContext.Setup(m => m.ServiceSettingItems).Returns(MockDbSetServiceSettings.Object);
+        MockJimDbContext.Setup(m => m.PendingExports).Returns(MockDbSetPendingExports.Object);
+
         // instantiate Jim using the mocked db context
         Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object));
         

--- a/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectSvaTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectSvaTests.cs
@@ -4,6 +4,7 @@ using JIM.Models.Activities;
 using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Models.Staging;
+using JIM.Models.Transactional;
 using JIM.PostgresData;
 using JIM.Worker.Processors;
 using JIM.Worker.Tests.Models;
@@ -28,6 +29,10 @@ public class ImportUpdateObjectSvaTests
     private Mock<DbSet<ConnectedSystemPartition>> MockDbSetConnectedSystemPartitions { get; set; }
     private List<Activity> ActivitiesData { get; set; }
     private Mock<DbSet<Activity>> MockDbSetActivities { get; set; }
+    private List<ServiceSetting> ServiceSettingsData { get; set; }
+    private Mock<DbSet<ServiceSetting>> MockDbSetServiceSettings { get; set; }
+    private List<PendingExport> PendingExportsData { get; set; }
+    private Mock<DbSet<PendingExport>> MockDbSetPendingExports { get; set; }
     private Mock<JimDbContext> MockJimDbContext { get; set; }
     private JimApplication Jim { get; set; }
     #endregion
@@ -43,28 +48,36 @@ public class ImportUpdateObjectSvaTests
     {
         TestUtilities.SetEnvironmentVariables();
         InitiatedBy = TestUtilities.GetInitiatedBy();
-        
+
         // set up the connected systems mock
         ConnectedSystemsData = TestUtilities.GetConnectedSystemData();
         MockDbSetConnectedSystems = ConnectedSystemsData.BuildMockDbSet();
-        
+
         // setup up the connected system run profiles mock
         ConnectedSystemRunProfilesData = TestUtilities.GetConnectedSystemRunProfileData();
         MockDbSetConnectedSystemRunProfiles = ConnectedSystemRunProfilesData.BuildMockDbSet();
-        
+
         // set up the connected system object types mock. this acts as the persisted schema in JIM
         ConnectedSystemObjectTypesData = TestUtilities.GetConnectedSystemObjectTypeData();
         MockDbSetConnectedSystemObjectTypes = ConnectedSystemObjectTypesData.BuildMockDbSet();
-        
+
         // setup up the Connected System Partitions mock
         ConnectedSystemPartitionsData = TestUtilities.GetConnectedSystemPartitionData();
         MockDbSetConnectedSystemPartitions = ConnectedSystemPartitionsData.BuildMockDbSet();
-        
+
         // set up the activity mock
         var fullImportRunProfile = ConnectedSystemRunProfilesData[0];
         ActivitiesData = TestUtilities.GetActivityData(fullImportRunProfile.RunType, fullImportRunProfile.Id);
         MockDbSetActivities = ActivitiesData.BuildMockDbSet();
-        
+
+        // set up the service settings mock
+        ServiceSettingsData = TestUtilities.GetServiceSettingsData();
+        MockDbSetServiceSettings = ServiceSettingsData.BuildMockDbSet();
+
+        // set up the pending exports mock (empty - import tests don't have pending exports to reconcile)
+        PendingExportsData = new List<PendingExport>();
+        MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
+
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
@@ -72,7 +85,9 @@ public class ImportUpdateObjectSvaTests
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(MockDbSetConnectedSystemRunProfiles.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemPartitions).Returns(MockDbSetConnectedSystemPartitions.Object);
-        
+        MockJimDbContext.Setup(m => m.ServiceSettingItems).Returns(MockDbSetServiceSettings.Object);
+        MockJimDbContext.Setup(m => m.PendingExports).Returns(MockDbSetPendingExports.Object);
+
         // instantiate Jim using the mocked db context
         Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object));
         

--- a/test/JIM.Worker.Tests/TestUtilities.cs
+++ b/test/JIM.Worker.Tests/TestUtilities.cs
@@ -1063,6 +1063,25 @@ public static class TestUtilities
     }
 
     /// <summary>
+    /// Returns the service settings required for sync processors.
+    /// </summary>
+    public static List<ServiceSetting> GetServiceSettingsData()
+    {
+        return new List<ServiceSetting>
+        {
+            new()
+            {
+                Key = "Sync.PageSize",
+                DisplayName = "Sync Page Size",
+                Category = ServiceSettingCategory.Synchronisation,
+                ValueType = ServiceSettingValueType.Integer,
+                DefaultValue = "1000",
+                Value = null
+            }
+        };
+    }
+
+    /// <summary>
     /// Creates a test WorkerTask with the specified activity and initiator for use with SyncImportTaskProcessor.
     /// </summary>
     public static SynchronisationWorkerTask CreateTestWorkerTask(Activity activity, MetaverseObject? initiatedBy)


### PR DESCRIPTION
## Summary

- Implements batched database operations for pending export reconciliation during import
- Reduces `ReconcilePendingExports` phase from ~89 seconds to ~3.6 seconds (96% improvement)
- Reduces overall `FullImport` time from ~144 seconds to ~57 seconds (60% improvement)

## Changes

- **Repository layer**: Added `GetPendingExportsByConnectedSystemObjectIdsAsync` method to bulk fetch pending exports by CSO IDs using `AsSplitQuery()` for efficient loading
- **Service layer**: Added `ReconcileCsoAgainstPendingExport` method for in-memory reconciliation without database operations
- **Worker layer**: Refactored `ReconcilePendingExportsAsync` to use page-based batched operations with configurable sync page size

## Technical Details

The previous implementation performed N reads + N writes per CSO (where N is the number of updated CSOs). The new implementation:
1. Bulk fetches all pending exports for a page of CSOs in a single query
2. Performs reconciliation in-memory using a dictionary lookup
3. Batch persists deletions and updates at the end of each page

Uses the "Sync page size" service setting for batch size to ensure consistency across sync operations.

## Performance Metrics (Medium test - 8,010 objects)

| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| ReconcilePendingExports | 89,690ms | 3,626ms | **96%** |
| ReconcileCso (per-object) | 89,483ms | 0ms | **Eliminated** |
| FullImport | 144,059ms | 57,299ms | **60%** |

## Test Plan

- [x] All existing unit tests pass
- [x] Added mock setup for `ServiceSettingItems` and `PendingExports` in import tests
- [x] Medium integration test validates performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)