### PR TITLE
fix: Prevent duplicate imports when auto-selecting child containers

### DIFF
--- a/test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs
+++ b/test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs
@@ -486,6 +486,103 @@ public class ConnectedSystemExtensionsTests
 
     #endregion
 
+    #region ConnectedSystemContainer Parent-Child Relationship Tests
+
+    [Test]
+    public void AddChildContainer_SetsParentContainerReference()
+    {
+        // Arrange
+        var parent = new ConnectedSystemContainer { Name = "Parent", Selected = true };
+        var child = new ConnectedSystemContainer { Name = "Child", Selected = false };
+
+        // Act
+        parent.AddChildContainer(child);
+
+        // Assert
+        Assert.That(child.ParentContainer, Is.SameAs(parent));
+        Assert.That(parent.ChildContainers, Contains.Item(child));
+    }
+
+    [Test]
+    public void ParentContainer_CanTraverseUpHierarchy()
+    {
+        // Arrange - Build a 3-level hierarchy
+        var grandparent = new ConnectedSystemContainer { Name = "Grandparent", Selected = true };
+        var parent = new ConnectedSystemContainer { Name = "Parent", Selected = false };
+        var child = new ConnectedSystemContainer { Name = "Child", Selected = false };
+
+        grandparent.AddChildContainer(parent);
+        parent.AddChildContainer(child);
+
+        // Act & Assert - Traverse from child to grandparent
+        Assert.That(child.ParentContainer, Is.SameAs(parent));
+        Assert.That(child.ParentContainer?.ParentContainer, Is.SameAs(grandparent));
+        Assert.That(child.ParentContainer?.ParentContainer?.ParentContainer, Is.Null);
+    }
+
+    [Test]
+    public void AreAnyChildContainersSelected_WhenChildSelected_ReturnsTrue()
+    {
+        // Arrange
+        var parent = new ConnectedSystemContainer { Name = "Parent", Selected = false };
+        var child = new ConnectedSystemContainer { Name = "Child", Selected = true };
+        parent.AddChildContainer(child);
+
+        // Act
+        var result = parent.AreAnyChildContainersSelected();
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void AreAnyChildContainersSelected_WhenNoChildrenSelected_ReturnsFalse()
+    {
+        // Arrange
+        var parent = new ConnectedSystemContainer { Name = "Parent", Selected = true };
+        var child = new ConnectedSystemContainer { Name = "Child", Selected = false };
+        parent.AddChildContainer(child);
+
+        // Act
+        var result = parent.AreAnyChildContainersSelected();
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void AreAnyChildContainersSelected_WhenGrandchildSelected_ReturnsTrue()
+    {
+        // Arrange - Parent is selected, child is not, grandchild is selected
+        var parent = new ConnectedSystemContainer { Name = "Parent", Selected = true };
+        var child = new ConnectedSystemContainer { Name = "Child", Selected = false };
+        var grandchild = new ConnectedSystemContainer { Name = "Grandchild", Selected = true };
+
+        parent.AddChildContainer(child);
+        child.AddChildContainer(grandchild);
+
+        // Act
+        var result = parent.AreAnyChildContainersSelected();
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void AreAnyChildContainersSelected_WhenNoChildren_ReturnsFalse()
+    {
+        // Arrange
+        var container = new ConnectedSystemContainer { Name = "Container", Selected = true };
+
+        // Act
+        var result = container.AreAnyChildContainersSelected();
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static ConnectedSystem CreateConnectedSystemWithMode(string mode)


### PR DESCRIPTION
## Summary

Fixes the issue where auto-selected child containers caused duplicate LDAP imports. When export creates a new container (e.g., `OU=IT`) under an already-selected parent (`OU=Borton Corp`), the container was incorrectly being selected separately, causing the same objects to be imported multiple times.

## Problem

Since the LDAP connector always uses `SearchScope.Subtree`, when both a parent and child container are selected:
- The parent's search finds objects in all descendants
- The child's search finds the same objects again
- Objects appear multiple times in import results
- CSOs get matched multiple times, causing duplicate attribute value additions

**Observed behaviour:**
- Warning: "CSO was already matched by a previous import object"
- Attribute values tripled: `'Test, Test, Test'` instead of `'Test'`

## Solution

Added `IsAnyAncestorSelected()` helper method that checks if any ancestor container is already selected. If so, the new child container is added to the hierarchy but with `Selected=false`, since it's implicitly included via the ancestor's subtree search.

**New log message:**
```
Added container OU=IT,OU=Borton Corp,DC=testdomain,DC=local, Selected: False (ancestor already selected, implicitly included via subtree)
```

## Changes

- Modified `RefreshAndAutoSelectContainersAsync` in [ConnectedSystemServer.cs](JIM.Application/Servers/ConnectedSystemServer.cs) to prevent selecting child containers when a parent is already selected
- Added `IsAnyAncestorSelected()` private helper method to walk the container hierarchy
- Added 6 unit tests in [ConnectedSystemExtensionsTests.cs](test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs) to verify parent-child container relationships
- Updated logging to clarify when containers are implicitly included

## Validation

Integration tests confirm:
- No more "already matched" warnings
- Attribute values are now single values, not tripled
- Containers are correctly added to hierarchy but not double-selected

## Related

- #266 - Support OneLevel container scope (Post-MVP enhancement for future granular control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)