### PR TITLE
feat: LDAP connector pipelining with configurable concurrency (Phase 2)

### DIFF
--- a/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/JIM.Application/Servers/ExportExecutionServer.cs
@@ -326,7 +326,7 @@ public class ExportExecutionServer
                         List<ExportResult> exportResults;
                         using (Diagnostics.Diagnostics.Connector.StartSpan("ExportBatch").SetTag("batchSize", batch.Count))
                         {
-                            exportResults = connector.Export(batch);
+                            exportResults = await connector.ExportAsync(batch, cancellationToken);
                         }
 
                         // Process results with ExportResult data
@@ -409,7 +409,7 @@ public class ExportExecutionServer
                             using (Diagnostics.Diagnostics.Connector.StartSpan("ExportDeferredBatch")
                                 .SetTag("batchSize", batch.Count))
                             {
-                                exportResults = connector.Export(batch);
+                                exportResults = await connector.ExportAsync(batch, cancellationToken);
                             }
 
                             using (Diagnostics.Diagnostics.Database.StartSpan("ProcessDeferredBatchSuccess")
@@ -842,7 +842,7 @@ public class ExportExecutionServer
             });
 
             // File-based export - execute all at once (file connectors typically batch internally)
-            var exportResults = connector.Export(connectedSystem.SettingValues, pendingExports);
+            var exportResults = await connector.ExportAsync(connectedSystem.SettingValues, pendingExports, cancellationToken);
 
             // Check if the connector supports auto-confirm and the setting is enabled
             var autoConfirm = false;

--- a/JIM.Connectors/File/FileConnector.cs
+++ b/JIM.Connectors/File/FileConnector.cs
@@ -483,13 +483,13 @@ public class FileConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     #endregion
 
     #region IConnectorExportUsingFiles members
-    public List<ExportResult> Export(IList<ConnectedSystemSettingValue> settings, IList<PendingExport> pendingExports)
+    public Task<List<ExportResult>> ExportAsync(IList<ConnectedSystemSettingValue> settings, IList<PendingExport> pendingExports, CancellationToken cancellationToken)
     {
         var logger = Log.ForContext<FileConnector>();
-        logger.Verbose("Export() called with {Count} pending exports", pendingExports.Count);
+        logger.Verbose("ExportAsync() called with {Count} pending exports", pendingExports.Count);
 
         var export = new FileConnectorExport(settings, pendingExports, logger);
-        return export.Execute();
+        return Task.FromResult(export.Execute());
     }
     #endregion
 

--- a/JIM.Connectors/JIM.Connectors.csproj
+++ b/JIM.Connectors/JIM.Connectors.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="JIM.Worker.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JIM.Connectors/LDAP/ILdapOperationExecutor.cs
+++ b/JIM.Connectors/LDAP/ILdapOperationExecutor.cs
@@ -1,0 +1,22 @@
+using System.DirectoryServices.Protocols;
+
+namespace JIM.Connectors.LDAP;
+
+/// <summary>
+/// Abstraction over LDAP connection operations to enable unit testing.
+/// LdapConnection is a sealed class and cannot be mocked directly with Moq.
+/// Production code uses <see cref="LdapOperationExecutor"/> which delegates to a real LdapConnection.
+/// </summary>
+internal interface ILdapOperationExecutor
+{
+    /// <summary>
+    /// Sends an LDAP request synchronously.
+    /// </summary>
+    DirectoryResponse SendRequest(DirectoryRequest request);
+
+    /// <summary>
+    /// Sends an LDAP request asynchronously using the APM pattern wrapper.
+    /// Enables concurrent LDAP operations on the same connection via message-ID multiplexing.
+    /// </summary>
+    Task<DirectoryResponse> SendRequestAsync(DirectoryRequest request);
+}

--- a/JIM.Connectors/LDAP/LdapConnectionExtensions.cs
+++ b/JIM.Connectors/LDAP/LdapConnectionExtensions.cs
@@ -1,0 +1,31 @@
+using System.DirectoryServices.Protocols;
+
+namespace JIM.Connectors.LDAP;
+
+/// <summary>
+/// Extension methods for LdapConnection to provide Task-based async operations.
+/// Wraps the legacy APM pattern (BeginSendRequest/EndSendRequest) using Task.Factory.FromAsync.
+/// The underlying native LDAP library uses polling rather than true async callbacks,
+/// but this still enables multiple concurrent in-flight requests on the same connection
+/// via LDAP message-ID multiplexing.
+/// </summary>
+internal static class LdapConnectionExtensions
+{
+    /// <summary>
+    /// Sends an LDAP request asynchronously using the APM pattern wrapper.
+    /// Enables multiple concurrent requests on the same LdapConnection via message-ID multiplexing.
+    /// </summary>
+    internal static Task<DirectoryResponse> SendRequestAsync(
+        this LdapConnection connection,
+        DirectoryRequest request)
+    {
+        return Task.Factory.FromAsync(
+            (callback, state) => connection.BeginSendRequest(
+                request,
+                PartialResultProcessing.NoPartialResultSupport,
+                callback,
+                state),
+            connection.EndSendRequest,
+            null);
+    }
+}

--- a/JIM.Connectors/LDAP/LdapConnectorConstants.cs
+++ b/JIM.Connectors/LDAP/LdapConnectorConstants.cs
@@ -47,6 +47,10 @@ internal static class LdapConnectorConstants
     internal const int DEFAULT_MAX_RETRIES = 3;
     internal const int DEFAULT_RETRY_DELAY_MS = 1000;
 
+    // Export concurrency settings
+    internal const int DEFAULT_EXPORT_CONCURRENCY = 1;
+    internal const int MAX_EXPORT_CONCURRENCY = 16;
+
     /// <summary>
     /// LDAP_SERVER_SHOW_DELETED_OID - Server control that allows searching for deleted (tombstone) objects.
     /// When included in a search request, the directory returns objects from the Deleted Objects container.

--- a/JIM.Connectors/LDAP/LdapOperationExecutor.cs
+++ b/JIM.Connectors/LDAP/LdapOperationExecutor.cs
@@ -1,0 +1,23 @@
+using System.DirectoryServices.Protocols;
+
+namespace JIM.Connectors.LDAP;
+
+/// <summary>
+/// Production implementation of <see cref="ILdapOperationExecutor"/> that delegates to a real LdapConnection.
+/// Supports both synchronous and asynchronous LDAP operations.
+/// </summary>
+internal class LdapOperationExecutor : ILdapOperationExecutor
+{
+    private readonly LdapConnection _connection;
+
+    internal LdapOperationExecutor(LdapConnection connection)
+    {
+        _connection = connection;
+    }
+
+    public DirectoryResponse SendRequest(DirectoryRequest request)
+        => _connection.SendRequest(request);
+
+    public Task<DirectoryResponse> SendRequestAsync(DirectoryRequest request)
+        => _connection.SendRequestAsync(request);
+}

--- a/JIM.Connectors/Mock/MockCallConnector.cs
+++ b/JIM.Connectors/Mock/MockCallConnector.cs
@@ -243,7 +243,7 @@ public class MockCallConnector : IConnector, IConnectorCapabilities, IConnectorI
         // No-op for mock
     }
 
-    public List<ExportResult> Export(IList<PendingExport> pendingExports)
+    public Task<List<ExportResult>> ExportAsync(IList<PendingExport> pendingExports, CancellationToken cancellationToken)
     {
         if (ExportExceptionToThrow != null)
             throw ExportExceptionToThrow;
@@ -252,6 +252,8 @@ public class MockCallConnector : IConnector, IConnectorCapabilities, IConnectorI
 
         foreach (var pendingExport in pendingExports)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             _exportedItems.Add(pendingExport);
 
             ExportResult result;
@@ -277,7 +279,7 @@ public class MockCallConnector : IConnector, IConnectorCapabilities, IConnectorI
             results.Add(result);
         }
 
-        return results;
+        return Task.FromResult(results);
     }
 
     public void CloseExportConnection()

--- a/JIM.Models/Interfaces/IConnectorExportUsingCalls.cs
+++ b/JIM.Models/Interfaces/IConnectorExportUsingCalls.cs
@@ -1,4 +1,4 @@
-﻿using JIM.Models.Staging;
+using JIM.Models.Staging;
 using JIM.Models.Transactional;
 namespace JIM.Models.Interfaces;
 
@@ -12,8 +12,9 @@ public interface IConnectorExportUsingCalls
     /// For Create operations, the ExportResult should include the system-assigned ExternalId (e.g., objectGUID).
     /// </summary>
     /// <param name="pendingExports">The list of pending exports to process.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the export operation.</param>
     /// <returns>A list of ExportResult objects corresponding to each pending export.</returns>
-    public List<ExportResult> Export(IList<PendingExport> pendingExports);
+    public Task<List<ExportResult>> ExportAsync(IList<PendingExport> pendingExports, CancellationToken cancellationToken);
 
     public void CloseExportConnection();
 }

--- a/JIM.Models/Interfaces/IConnectorExportUsingFiles.cs
+++ b/JIM.Models/Interfaces/IConnectorExportUsingFiles.cs
@@ -1,4 +1,4 @@
-﻿using JIM.Models.Staging;
+using JIM.Models.Staging;
 using JIM.Models.Transactional;
 namespace JIM.Models.Interfaces;
 
@@ -12,6 +12,7 @@ public interface IConnectorExportUsingFiles
     /// </summary>
     /// <param name="settings">The connected system settings the user has specified. Recommend this is where you pass in the output file path.</param>
     /// <param name="pendingExports">The connected system object pending exports that need to write to the output file for the connected system to consume.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the export operation.</param>
     /// <returns>A list of ExportResult objects corresponding to each pending export. For file-based exports, ExternalId is typically not available.</returns>
-    public List<ExportResult> Export(IList<ConnectedSystemSettingValue> settings, IList<PendingExport> pendingExports);
+    public Task<List<ExportResult>> ExportAsync(IList<ConnectedSystemSettingValue> settings, IList<PendingExport> pendingExports, CancellationToken cancellationToken);
 }

--- a/test/JIM.Worker.Tests/Connectors/FileConnectorExportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/FileConnectorExportTests.cs
@@ -40,14 +40,14 @@ public class FileConnectorExportTests
     #region No-op and Error Tests
 
     [Test]
-    public void Export_WithNoPendingExports_CreatesNoFile()
+    public async Task Export_WithNoPendingExports_CreatesNoFileAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
         var pendingExports = new List<PendingExport>();
 
         // Act
-        var results = _connector.Export(settingValues, pendingExports);
+        var results = await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         Assert.That(File.Exists(_testExportPath), Is.False);
@@ -55,7 +55,7 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_WithMissingFilePath_ThrowsException()
+    public Task Export_WithMissingFilePath_ThrowsExceptionAsync()
     {
         // Arrange
         var settingValues = new List<ConnectedSystemSettingValue>
@@ -79,11 +79,12 @@ public class FileConnectorExportTests
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act & Assert
-        Assert.Throws<JIM.Models.Exceptions.InvalidSettingValuesException>(() => _connector.Export(settingValues, pendingExports));
+        Assert.ThrowsAsync<JIM.Models.Exceptions.InvalidSettingValuesException>(async () => await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None));
+        return Task.CompletedTask;
     }
 
     [Test]
-    public void Export_WithNoExternalIdAttribute_ReturnsFailedResults()
+    public async Task Export_WithNoExternalIdAttribute_ReturnsFailedResultsAsync()
     {
         // Arrange - create exports with no IsExternalId attribute
         var settingValues = CreateExportSettingValues(_testExportPath);
@@ -117,7 +118,7 @@ public class FileConnectorExportTests
         };
 
         // Act
-        var results = _connector.Export(settingValues, pendingExports);
+        var results = await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(1));
@@ -130,14 +131,14 @@ public class FileConnectorExportTests
     #region Create Export Tests
 
     [Test]
-    public void Export_Create_WritesFileWithCorrectHeaders()
+    public async Task Export_Create_WritesFileWithCorrectHeadersAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var lines = File.ReadAllLines(_testExportPath);
@@ -156,14 +157,14 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Create_WritesCorrectData()
+    public async Task Export_Create_WritesCorrectDataAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var content = File.ReadAllText(_testExportPath);
@@ -173,14 +174,14 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Create_ReturnsSuccessWithExternalId()
+    public async Task Export_Create_ReturnsSuccessWithExternalIdAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act
-        var results = _connector.Export(settingValues, pendingExports);
+        var results = await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(1));
@@ -190,7 +191,7 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Create_WithNoExternalIdValue_ReturnsFailed()
+    public async Task Export_Create_WithNoExternalIdValue_ReturnsFailedAsync()
     {
         // Arrange - create export where external ID attribute has no value
         var settingValues = CreateExportSettingValues(_testExportPath);
@@ -233,7 +234,7 @@ public class FileConnectorExportTests
         };
 
         // Act
-        var results = _connector.Export(settingValues, pendingExports);
+        var results = await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(1));
@@ -242,7 +243,7 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_MultipleCreates_WritesAllRows()
+    public async Task Export_MultipleCreates_WritesAllRowsAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
@@ -252,7 +253,7 @@ public class FileConnectorExportTests
         pendingExports.AddRange(CreateSingleCreatePendingExport("emp003", "Bob Wilson", "bwilson@example.com"));
 
         // Act
-        var results = _connector.Export(settingValues, pendingExports);
+        var results = await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(3));
@@ -272,16 +273,16 @@ public class FileConnectorExportTests
     #region Update Export Tests
 
     [Test]
-    public void Export_Update_MergesWithExistingFile()
+    public async Task Export_Update_MergesWithExistingFileAsync()
     {
         // Arrange - create initial file with one row
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com");
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - update the display name
         var updateExports = CreateSingleUpdatePendingExport("emp001", "displayName", "John Updated");
-        var results = _connector.Export(settingValues, updateExports);
+        var results = await _connector.ExportAsync(settingValues, updateExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(1));
@@ -294,16 +295,16 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Update_PreservesUnchangedAttributes()
+    public async Task Export_Update_PreservesUnchangedAttributesAsync()
     {
         // Arrange - create initial file with one row
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com");
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - update only display name, email should be preserved
         var updateExports = CreateSingleUpdatePendingExport("emp001", "displayName", "John Updated");
-        _connector.Export(settingValues, updateExports);
+        await _connector.ExportAsync(settingValues, updateExports, CancellationToken.None);
 
         // Assert
         var content = File.ReadAllText(_testExportPath);
@@ -312,18 +313,18 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Update_PreservesOtherRows()
+    public async Task Export_Update_PreservesOtherRowsAsync()
     {
         // Arrange - create initial file with two rows
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = new List<PendingExport>();
         createExports.AddRange(CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com"));
         createExports.AddRange(CreateSingleCreatePendingExport("emp002", "Jane Doe", "jdoe@example.com"));
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - update only emp001
         var updateExports = CreateSingleUpdatePendingExport("emp001", "displayName", "John Updated");
-        _connector.Export(settingValues, updateExports);
+        await _connector.ExportAsync(settingValues, updateExports, CancellationToken.None);
 
         // Assert - emp002 should still be there
         var content = File.ReadAllText(_testExportPath);
@@ -337,18 +338,18 @@ public class FileConnectorExportTests
     #region Delete Export Tests
 
     [Test]
-    public void Export_Delete_RemovesRowFromFile()
+    public async Task Export_Delete_RemovesRowFromFileAsync()
     {
         // Arrange - create initial file with two rows
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = new List<PendingExport>();
         createExports.AddRange(CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com"));
         createExports.AddRange(CreateSingleCreatePendingExport("emp002", "Jane Doe", "jdoe@example.com"));
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - delete emp001
         var deleteExports = CreateSingleDeletePendingExport("emp001");
-        var results = _connector.Export(settingValues, deleteExports);
+        var results = await _connector.ExportAsync(settingValues, deleteExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(1));
@@ -362,16 +363,16 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Delete_ForNonExistentRow_StillSucceeds()
+    public async Task Export_Delete_ForNonExistentRow_StillSucceedsAsync()
     {
         // Arrange - create file with one row
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com");
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - delete a row that doesn't exist
         var deleteExports = CreateSingleDeletePendingExport("emp999");
-        var results = _connector.Export(settingValues, deleteExports);
+        var results = await _connector.ExportAsync(settingValues, deleteExports, CancellationToken.None);
 
         // Assert - should still succeed (idempotent)
         Assert.That(results, Has.Count.EqualTo(1));
@@ -383,21 +384,21 @@ public class FileConnectorExportTests
     #region Mixed Operations Tests
 
     [Test]
-    public void Export_MixedOperations_HandlesCreateUpdateDelete()
+    public async Task Export_MixedOperations_HandlesCreateUpdateDeleteAsync()
     {
         // Arrange - create initial file with two rows
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = new List<PendingExport>();
         createExports.AddRange(CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com"));
         createExports.AddRange(CreateSingleCreatePendingExport("emp002", "Jane Doe", "jdoe@example.com"));
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - create emp003, update emp001, delete emp002
         var mixedExports = new List<PendingExport>();
         mixedExports.AddRange(CreateSingleCreatePendingExport("emp003", "Bob Wilson", "bwilson@example.com"));
         mixedExports.AddRange(CreateSingleUpdatePendingExport("emp001", "displayName", "John Updated"));
         mixedExports.AddRange(CreateSingleDeletePendingExport("emp002"));
-        var results = _connector.Export(settingValues, mixedExports);
+        var results = await _connector.ExportAsync(settingValues, mixedExports, CancellationToken.None);
 
         // Assert
         Assert.That(results, Has.Count.EqualTo(3));
@@ -417,14 +418,14 @@ public class FileConnectorExportTests
     #region Delimiter Tests
 
     [Test]
-    public void Export_WithCustomDelimiter_UsesCorrectDelimiter()
+    public async Task Export_WithCustomDelimiter_UsesCorrectDelimiterAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath, delimiter: ";");
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var header = File.ReadLines(_testExportPath).First();
@@ -437,14 +438,14 @@ public class FileConnectorExportTests
     #region Full-State File Tests
 
     [Test]
-    public void Export_WithNoExistingFile_CreatesNewFile()
+    public async Task Export_WithNoExistingFile_CreatesNewFileAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         Assert.That(File.Exists(_testExportPath), Is.True);
@@ -453,16 +454,16 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_CreateForExistingExternalId_TreatsAsUpdate()
+    public async Task Export_CreateForExistingExternalId_TreatsAsUpdateAsync()
     {
         // Arrange - create initial file
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com");
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - create again with same External ID (should overwrite)
         var duplicateCreate = CreateSingleCreatePendingExport("emp001", "John Updated", "jupdated@example.com");
-        var results = _connector.Export(settingValues, duplicateCreate);
+        var results = await _connector.ExportAsync(settingValues, duplicateCreate, CancellationToken.None);
 
         // Assert
         Assert.That(results[0].Success, Is.True);
@@ -475,14 +476,14 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_HeadersOrderedAlphabetically()
+    public async Task Export_HeadersOrderedAlphabeticallyAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
         var pendingExports = CreateSingleCreatePendingExport("emp001");
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var header = File.ReadLines(_testExportPath).First();
@@ -498,7 +499,7 @@ public class FileConnectorExportTests
     #region Attribute Type Tests
 
     [Test]
-    public void Export_Create_HandlesIntegerValues()
+    public async Task Export_Create_HandlesIntegerValuesAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
@@ -525,7 +526,7 @@ public class FileConnectorExportTests
         };
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var content = File.ReadAllText(_testExportPath);
@@ -533,7 +534,7 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Create_HandlesBooleanValues()
+    public async Task Export_Create_HandlesBooleanValuesAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
@@ -560,7 +561,7 @@ public class FileConnectorExportTests
         };
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var content = File.ReadAllText(_testExportPath);
@@ -568,7 +569,7 @@ public class FileConnectorExportTests
     }
 
     [Test]
-    public void Export_Create_HandlesDateTimeValues()
+    public async Task Export_Create_HandlesDateTimeValuesAsync()
     {
         // Arrange
         var settingValues = CreateExportSettingValues(_testExportPath);
@@ -596,7 +597,7 @@ public class FileConnectorExportTests
         };
 
         // Act
-        _connector.Export(settingValues, pendingExports);
+        await _connector.ExportAsync(settingValues, pendingExports, CancellationToken.None);
 
         // Assert
         var content = File.ReadAllText(_testExportPath);
@@ -608,12 +609,12 @@ public class FileConnectorExportTests
     #region Remove Attribute Tests
 
     [Test]
-    public void Export_Update_RemoveAttribute_SetsEmptyValue()
+    public async Task Export_Update_RemoveAttribute_SetsEmptyValueAsync()
     {
         // Arrange - create initial file
         var settingValues = CreateExportSettingValues(_testExportPath);
         var createExports = CreateSingleCreatePendingExport("emp001", "John Smith", "jsmith@example.com");
-        _connector.Export(settingValues, createExports);
+        await _connector.ExportAsync(settingValues, createExports, CancellationToken.None);
 
         // Act - remove email attribute
         var objectType = new ConnectedSystemObjectType { Id = 1, Name = "User" };
@@ -646,7 +647,7 @@ public class FileConnectorExportTests
             }
         };
 
-        _connector.Export(settingValues, updateExports);
+        await _connector.ExportAsync(settingValues, updateExports, CancellationToken.None);
 
         // Assert - the row should still exist but email should be empty
         var lines = File.ReadAllLines(_testExportPath);

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorExportAsyncTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorExportAsyncTests.cs
@@ -1,0 +1,537 @@
+using JIM.Connectors.LDAP;
+using JIM.Models.Core;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+using Moq;
+using NUnit.Framework;
+using Serilog;
+using System.DirectoryServices.Protocols;
+using System.Reflection;
+
+namespace JIM.Worker.Tests.Connectors;
+
+[TestFixture]
+public class LdapConnectorExportAsyncTests
+{
+    private Mock<ILdapOperationExecutor> _mockExecutor = null!;
+    private IList<ConnectedSystemSettingValue> _defaultSettings = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockExecutor = new Mock<ILdapOperationExecutor>();
+        _defaultSettings = new List<ConnectedSystemSettingValue>
+        {
+            new()
+            {
+                Setting = new ConnectorDefinitionSetting { Name = "Delete Behaviour" },
+                StringValue = "Delete"
+            }
+        };
+    }
+
+    #region ExecuteAsync basic tests
+
+    [Test]
+    public async Task ExecuteAsync_EmptyList_ReturnsEmptyResultsAsync()
+    {
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(new List<PendingExport>(), CancellationToken.None);
+
+        Assert.That(results, Is.Empty);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ConcurrencyOne_DelegatesToSyncExecuteAsync()
+    {
+        // With concurrency=1, ExecuteAsync delegates to Execute (sync path)
+        var pendingExport = CreateUpdatePendingExport("CN=Test,DC=test,DC=local");
+
+        SetupModifyResponse(ResultCode.Success);
+
+        var export = CreateExport(concurrency: 1);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+        // Verify sync SendRequest was called (not async)
+        _mockExecutor.Verify(e => e.SendRequest(It.IsAny<ModifyRequest>()), Times.Once);
+        _mockExecutor.Verify(e => e.SendRequestAsync(It.IsAny<DirectoryRequest>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ConcurrencyGreaterThanOne_UsesAsyncPathAsync()
+    {
+        var pendingExport = CreateUpdatePendingExport("CN=Test,DC=test,DC=local");
+
+        SetupAsyncModifyResponse(ResultCode.Success);
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+        // Verify async SendRequestAsync was called
+        _mockExecutor.Verify(e => e.SendRequestAsync(It.IsAny<ModifyRequest>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Positional ordering tests
+
+    [Test]
+    public async Task ExecuteAsync_MaintainsPositionalOrdering_WhenConcurrentAsync()
+    {
+        // Create 5 update exports with different DNs
+        var exports = new List<PendingExport>();
+        for (var i = 0; i < 5; i++)
+        {
+            exports.Add(CreateUpdatePendingExport($"CN=User{i},DC=test,DC=local"));
+        }
+
+        SetupAsyncModifyResponse(ResultCode.Success);
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(exports, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(5));
+        // All should succeed and maintain 1:1 positional correspondence
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.That(results[i].Success, Is.True,
+                $"Result at index {i} should be successful");
+        }
+    }
+
+    #endregion
+
+    #region Individual failure isolation tests
+
+    [Test]
+    public async Task ExecuteAsync_IndividualFailure_DoesNotAbortOtherExportsAsync()
+    {
+        var exports = new List<PendingExport>
+        {
+            CreateUpdatePendingExport("CN=Good1,DC=test,DC=local"),
+            CreateUpdatePendingExport("CN=Bad,DC=test,DC=local"),
+            CreateUpdatePendingExport("CN=Good2,DC=test,DC=local")
+        };
+
+        var callCount = 0;
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<ModifyRequest>()))
+            .ReturnsAsync(() =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                // Second call fails
+                if (count == 2)
+                    return CreateDirectoryResponse<ModifyResponse>(ResultCode.InsufficientAccessRights);
+
+                return CreateDirectoryResponse<ModifyResponse>(ResultCode.Success);
+            });
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(exports, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(3));
+        // At least 2 should succeed (the failure doesn't abort others)
+        var successCount = results.Count(r => r.Success);
+        Assert.That(successCount, Is.GreaterThanOrEqualTo(2));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ExceptionInOneExport_OthersStillCompleteAsync()
+    {
+        var exports = new List<PendingExport>
+        {
+            CreateUpdatePendingExport("CN=Good,DC=test,DC=local"),
+            CreateUpdatePendingExport(null!) // Will cause exception (no DN)
+        };
+
+        SetupAsyncModifyResponse(ResultCode.Success);
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(exports, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(2));
+        Assert.That(results[0].Success, Is.True);
+        Assert.That(results[1].Success, Is.False);
+        Assert.That(results[1].ErrorMessage, Is.Not.Null);
+    }
+
+    #endregion
+
+    #region CancellationToken tests
+
+    [Test]
+    public void ExecuteAsync_CancellationRequested_ThrowsOperationCancelledExceptionAsync()
+    {
+        var exports = new List<PendingExport>
+        {
+            CreateUpdatePendingExport("CN=Test,DC=test,DC=local")
+        };
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var export = CreateExport(concurrency: 4);
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await export.ExecuteAsync(exports, cts.Token));
+    }
+
+    #endregion
+
+    #region Create operation tests
+
+    [Test]
+    public async Task ExecuteAsync_CreateOperation_SendsAddRequestAsync()
+    {
+        var pendingExport = CreateCreatePendingExport("CN=NewUser,OU=Users,DC=test,DC=local", "user");
+
+        // Setup Add response
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<AddRequest>()))
+            .ReturnsAsync(CreateDirectoryResponse<AddResponse>(ResultCode.Success));
+
+        // Setup objectGUID search response (returns empty - non-fatal)
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<SearchRequest>()))
+            .ReturnsAsync(CreateDirectoryResponse<SearchResponse>(ResultCode.Success));
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+        Assert.That(results[0].SecondaryExternalId, Is.EqualTo("CN=NewUser,OU=Users,DC=test,DC=local"));
+
+        // Verify Add was called, then Search for GUID
+        _mockExecutor.Verify(e => e.SendRequestAsync(It.IsAny<AddRequest>()), Times.Once);
+        _mockExecutor.Verify(e => e.SendRequestAsync(It.IsAny<SearchRequest>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Update with rename tests
+
+    [Test]
+    public async Task ExecuteAsync_UpdateWithRename_RenameCompletesBeforeModifyAsync()
+    {
+        var pendingExport = CreateUpdateWithRenamePendingExport(
+            "CN=OldName,DC=test,DC=local",
+            "CN=NewName,DC=test,DC=local");
+
+        var callOrder = new List<string>();
+
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<ModifyDNRequest>()))
+            .ReturnsAsync(() =>
+            {
+                callOrder.Add("Rename");
+                return CreateDirectoryResponse<ModifyDNResponse>(ResultCode.Success);
+            });
+
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<ModifyRequest>()))
+            .ReturnsAsync(() =>
+            {
+                callOrder.Add("Modify");
+                return CreateDirectoryResponse<ModifyResponse>(ResultCode.Success);
+            });
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+        Assert.That(results[0].SecondaryExternalId, Is.EqualTo("CN=NewName,DC=test,DC=local"));
+
+        // Verify rename happened before modify
+        Assert.That(callOrder, Has.Count.EqualTo(2));
+        Assert.That(callOrder[0], Is.EqualTo("Rename"));
+        Assert.That(callOrder[1], Is.EqualTo("Modify"));
+    }
+
+    #endregion
+
+    #region Delete operation tests
+
+    [Test]
+    public async Task ExecuteAsync_HardDelete_SendsDeleteRequestAsync()
+    {
+        var pendingExport = CreateDeletePendingExport("CN=ToDelete,DC=test,DC=local");
+
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<DeleteRequest>()))
+            .ReturnsAsync(CreateDirectoryResponse<DeleteResponse>(ResultCode.Success));
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+        _mockExecutor.Verify(e => e.SendRequestAsync(It.IsAny<DeleteRequest>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Mixed operation tests
+
+    [Test]
+    public async Task ExecuteAsync_MixedOperations_MaintainsCorrectResultsAsync()
+    {
+        var exports = new List<PendingExport>
+        {
+            CreateUpdatePendingExport("CN=Update1,DC=test,DC=local"),
+            CreateDeletePendingExport("CN=Delete1,DC=test,DC=local"),
+            CreateUpdatePendingExport("CN=Update2,DC=test,DC=local")
+        };
+
+        SetupAsyncModifyResponse(ResultCode.Success);
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<DeleteRequest>()))
+            .ReturnsAsync(CreateDirectoryResponse<DeleteResponse>(ResultCode.Success));
+
+        var export = CreateExport(concurrency: 4);
+        var results = await export.ExecuteAsync(exports, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results.All(r => r.Success), Is.True);
+    }
+
+    #endregion
+
+    #region Concurrency clamping tests
+
+    [Test]
+    public async Task ExecuteAsync_ConcurrencyExceedsMax_ClampedToMaxAsync()
+    {
+        // Concurrency of 100 should be clamped to MAX_EXPORT_CONCURRENCY (16)
+        var pendingExport = CreateUpdatePendingExport("CN=Test,DC=test,DC=local");
+
+        SetupAsyncModifyResponse(ResultCode.Success);
+
+        var export = CreateExport(concurrency: 100);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ConcurrencyZero_ClampedToOneAsync()
+    {
+        // Concurrency of 0 should be clamped to 1 (sync path)
+        var pendingExport = CreateUpdatePendingExport("CN=Test,DC=test,DC=local");
+
+        SetupModifyResponse(ResultCode.Success);
+
+        var export = CreateExport(concurrency: 0);
+        var results = await export.ExecuteAsync(new List<PendingExport> { pendingExport }, CancellationToken.None);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Success, Is.True);
+        // Concurrency 0 clamped to 1 -> sync path
+        _mockExecutor.Verify(e => e.SendRequest(It.IsAny<ModifyRequest>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Helper methods
+
+    private LdapConnectorExport CreateExport(int concurrency)
+    {
+        return new LdapConnectorExport(
+            _mockExecutor.Object,
+            _defaultSettings,
+            Log.Logger,
+            concurrency);
+    }
+
+    private static PendingExport CreateUpdatePendingExport(string dn)
+    {
+        var csoType = new ConnectedSystemObjectType { Name = "user" };
+        var dnAttribute = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 1,
+            Name = "distinguishedName",
+            ConnectedSystemObjectType = csoType
+        };
+
+        var testAttribute = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 2,
+            Name = "displayName",
+            ConnectedSystemObjectType = csoType
+        };
+
+        return new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ChangeType = PendingExportChangeType.Update,
+            ConnectedSystemObject = new ConnectedSystemObject
+            {
+                Id = Guid.NewGuid(),
+                Type = csoType,
+                SecondaryExternalIdAttributeId = dnAttribute.Id,
+                AttributeValues = new List<ConnectedSystemObjectAttributeValue>
+                {
+                    new()
+                    {
+                        AttributeId = dnAttribute.Id,
+                        StringValue = dn
+                    }
+                }
+            },
+            AttributeValueChanges = new List<PendingExportAttributeValueChange>
+            {
+                new()
+                {
+                    Attribute = testAttribute,
+                    ChangeType = PendingExportAttributeChangeType.Update,
+                    StringValue = "Test User"
+                }
+            }
+        };
+    }
+
+    private static PendingExport CreateCreatePendingExport(string dn, string objectClass)
+    {
+        var csoType = new ConnectedSystemObjectType { Name = objectClass };
+        var dnAttribute = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 1,
+            Name = "distinguishedName",
+            ConnectedSystemObjectType = csoType
+        };
+
+        return new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ChangeType = PendingExportChangeType.Create,
+            ConnectedSystemObject = new ConnectedSystemObject
+            {
+                Id = Guid.NewGuid(),
+                Type = csoType
+            },
+            AttributeValueChanges = new List<PendingExportAttributeValueChange>
+            {
+                new()
+                {
+                    Attribute = dnAttribute,
+                    ChangeType = PendingExportAttributeChangeType.Add,
+                    StringValue = dn
+                }
+            }
+        };
+    }
+
+    private static PendingExport CreateUpdateWithRenamePendingExport(string currentDn, string newDn)
+    {
+        var csoType = new ConnectedSystemObjectType { Name = "user" };
+        var dnAttribute = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 1,
+            Name = "distinguishedName",
+            ConnectedSystemObjectType = csoType
+        };
+
+        var testAttribute = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 2,
+            Name = "displayName",
+            ConnectedSystemObjectType = csoType
+        };
+
+        return new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ChangeType = PendingExportChangeType.Update,
+            ConnectedSystemObject = new ConnectedSystemObject
+            {
+                Id = Guid.NewGuid(),
+                Type = csoType,
+                SecondaryExternalIdAttributeId = dnAttribute.Id,
+                AttributeValues = new List<ConnectedSystemObjectAttributeValue>
+                {
+                    new()
+                    {
+                        AttributeId = dnAttribute.Id,
+                        StringValue = currentDn
+                    }
+                }
+            },
+            AttributeValueChanges = new List<PendingExportAttributeValueChange>
+            {
+                new()
+                {
+                    Attribute = dnAttribute,
+                    ChangeType = PendingExportAttributeChangeType.Update,
+                    StringValue = newDn
+                },
+                new()
+                {
+                    Attribute = testAttribute,
+                    ChangeType = PendingExportAttributeChangeType.Update,
+                    StringValue = "Renamed User"
+                }
+            }
+        };
+    }
+
+    private static PendingExport CreateDeletePendingExport(string dn)
+    {
+        var csoType = new ConnectedSystemObjectType { Name = "user" };
+        var dnAttribute = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 1,
+            Name = "distinguishedName",
+            ConnectedSystemObjectType = csoType
+        };
+
+        return new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ChangeType = PendingExportChangeType.Delete,
+            ConnectedSystemObject = new ConnectedSystemObject
+            {
+                Id = Guid.NewGuid(),
+                Type = csoType,
+                SecondaryExternalIdAttributeId = dnAttribute.Id,
+                AttributeValues = new List<ConnectedSystemObjectAttributeValue>
+                {
+                    new()
+                    {
+                        AttributeId = dnAttribute.Id,
+                        StringValue = dn
+                    }
+                }
+            },
+            AttributeValueChanges = new List<PendingExportAttributeValueChange>()
+        };
+    }
+
+    private void SetupModifyResponse(ResultCode resultCode)
+    {
+        _mockExecutor.Setup(e => e.SendRequest(It.IsAny<ModifyRequest>()))
+            .Returns(CreateDirectoryResponse<ModifyResponse>(resultCode));
+    }
+
+    private void SetupAsyncModifyResponse(ResultCode resultCode)
+    {
+        _mockExecutor.Setup(e => e.SendRequestAsync(It.IsAny<ModifyRequest>()))
+            .ReturnsAsync(CreateDirectoryResponse<ModifyResponse>(resultCode));
+    }
+
+    /// <summary>
+    /// Creates a DirectoryResponse subclass instance with the specified ResultCode.
+    /// DirectoryResponse subclasses have an internal 5-parameter constructor:
+    /// (string dn, DirectoryControl[] controls, ResultCode result, string message, Uri[] referral)
+    /// </summary>
+    private static T CreateDirectoryResponse<T>(ResultCode resultCode) where T : DirectoryResponse
+    {
+        var response = (T)Activator.CreateInstance(
+            typeof(T),
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            args: new object?[] { "", Array.Empty<DirectoryControl>(), resultCode, "", Array.Empty<Uri>() },
+            culture: null)!;
+
+        return response;
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorTests.cs
@@ -335,12 +335,13 @@ public class LdapConnectorTests
     #region IConnectorExportUsingCalls tests
 
     [Test]
-    public void Export_WithoutOpenExportConnection_ThrowsInvalidOperationException()
+    public void ExportAsync_WithoutOpenExportConnection_ThrowsInvalidOperationExceptionAsync()
     {
         var pendingExports = new List<JIM.Models.Transactional.PendingExport>();
 
-        var exception = Assert.Throws<InvalidOperationException>(() => _connector.Export(pendingExports));
-        Assert.That(exception.Message, Does.Contain("OpenExportConnection"));
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await _connector.ExportAsync(pendingExports, CancellationToken.None));
+        Assert.That(exception!.Message, Does.Contain("OpenExportConnection"));
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/OutboundSync/ExportAttributeChangeStatusTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportAttributeChangeStatusTests.cs
@@ -355,8 +355,8 @@ public class ExportAttributeChangeStatusTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult> { ExportResult.Succeeded() });
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult> { ExportResult.Succeeded() });
 
         // Mock update
         MockDbSetPendingExports.Setup(set => set.Update(It.IsAny<PendingExport>()));
@@ -402,8 +402,8 @@ public class ExportAttributeChangeStatusTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult> { ExportResult.Succeeded() });
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult> { ExportResult.Succeeded() });
 
         MockDbSetPendingExports.Setup(set => set.Update(It.IsAny<PendingExport>()));
 
@@ -466,8 +466,8 @@ public class ExportAttributeChangeStatusTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult> { ExportResult.Succeeded() });
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult> { ExportResult.Succeeded() });
 
         MockDbSetPendingExports.Setup(set => set.Update(It.IsAny<PendingExport>()));
 

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
@@ -736,8 +736,8 @@ public class ExportExecutionTests
         var mockContainerCreation = mockConnector.As<IConnectorContainerCreation>();
 
         mockConnector.Setup(c => c.Name).Returns("Test Container Creation Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult> { ExportResult.Succeeded() });
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult> { ExportResult.Succeeded() });
 
         // Simulate that the connector created two OUs during export
         var createdContainers = new List<string>
@@ -810,8 +810,8 @@ public class ExportExecutionTests
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
 
         mockConnector.Setup(c => c.Name).Returns("Test Regular Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult> { ExportResult.Succeeded() });
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult> { ExportResult.Succeeded() });
 
         // Act
         var result = await Jim.ExportExecution.ExecuteExportsAsync(
@@ -888,8 +888,8 @@ public class ExportExecutionTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Failing Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult>
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult>
             {
                 ExportResult.Failed("Connection to target system failed")
             });
@@ -1004,8 +1004,8 @@ public class ExportExecutionTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Successful Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult>
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult>
             {
                 ExportResult.Succeeded(generatedObjectGuid.ToString())
             });
@@ -1128,8 +1128,8 @@ public class ExportExecutionTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Failing Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult>
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult>
             {
                 ExportResult.Failed("LDAP error: The object exists. Attribute member already exists")
             });
@@ -1234,8 +1234,8 @@ public class ExportExecutionTests
         var mockConnector = new Mock<IConnector>();
         var mockExportConnector = mockConnector.As<IConnectorExportUsingCalls>();
         mockConnector.Setup(c => c.Name).Returns("Test Failing Connector");
-        mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-            .Returns(new List<ExportResult>
+        mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExportResult>
             {
                 ExportResult.Failed("Connection timeout")
             });

--- a/test/JIM.Worker.Tests/Workflows/ExportConfirmationWorkflowTests.cs
+++ b/test/JIM.Worker.Tests/Workflows/ExportConfirmationWorkflowTests.cs
@@ -142,13 +142,13 @@ public class ExportConfirmationWorkflowTests
 
         if (success)
         {
-            mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-                .Returns(new List<ExportResult> { ExportResult.Succeeded() });
+            mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ExportResult> { ExportResult.Succeeded() });
         }
         else
         {
-            mockExportConnector.Setup(c => c.Export(It.IsAny<IList<PendingExport>>()))
-                .Returns(new List<ExportResult> { ExportResult.Failed("Export failed") });
+            mockExportConnector.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ExportResult> { ExportResult.Failed("Export failed") });
         }
 
         MockDbSetPendingExports.Setup(set => set.Update(It.IsAny<PendingExport>()));


### PR DESCRIPTION
## Summary

- **Async export interfaces**: `Export()` → `ExportAsync()` with `CancellationToken` on both `IConnectorExportUsingCalls` and `IConnectorExportUsingFiles`, all implementors updated
- **LDAP async operations**: New `SendRequestAsync()` APM wrapper via `BeginSendRequest`/`EndSendRequest`, behind `ILdapOperationExecutor` abstraction (LdapConnection is sealed)
- **Configurable concurrency**: New "Export Concurrency" per-connector setting (default: 1, max: 16). At concurrency=1, delegates to existing sync path. At concurrency>1, uses `SemaphoreSlim`-based parallel execution across exports within each batch
- **Worker stability fix**: Replaced heartbeat update with `ExecuteUpdateAsync` to bypass EF Core change tracker race condition (`DbUpdateConcurrencyException`), added try/catch to log errors via Serilog

## Key design decisions

- Multi-step operations (create+GUID, rename+modify, UAC read+write) remain sequential **within** each export — concurrency is **across** exports
- Container creation serialised via dedicated `SemaphoreSlim(1,1)` to prevent race conditions
- Concurrency=1 is a safe default that preserves identical behaviour to pre-Phase 2

## Test plan

- [x] 13 new unit tests for async LDAP export (`LdapConnectorExportAsyncTests`)
- [x] All existing tests updated and passing (1,545 total)
- [x] Integration test: Scenario 8 Medium at concurrency=1 — 6/6 tests pass, 0 crashes, 0 errors
- [x] Worker heartbeat race condition eliminated (was 15 crashes, now 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)