### PR TITLE
Track MVO attribute changes during disconnection/recall and fix deletion UX

### DIFF
--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -516,18 +516,7 @@
                             <strong>The metaverse object was deleted.</strong>
                             @if (!string.IsNullOrEmpty(mvoDeletedOutcome.TargetEntityDescription))
                             {
-                                <text> The identity </text>
-                                @if (mvoDeletedOutcome.TargetEntityId.HasValue)
-                                {
-                                    <MudLink Href="@GetMvoHref(mvoDeletedOutcome.TargetEntityId.Value)">
-                                        @mvoDeletedOutcome.TargetEntityDescription
-                                    </MudLink>
-                                }
-                                else
-                                {
-                                    <strong>@mvoDeletedOutcome.TargetEntityDescription</strong>
-                                }
-                                <text> was removed from the metaverse immediately (no grace period).</text>
+                                <text> The identity <strong>@mvoDeletedOutcome.TargetEntityDescription</strong> was removed from the metaverse immediately (no grace period).</text>
                             }
                         </MudText>
                     </MudStack>

--- a/src/JIM.Web/Shared/OutcomeTreeNode.razor
+++ b/src/JIM.Web/Shared/OutcomeTreeNode.razor
@@ -182,6 +182,8 @@
             or ActivityRunProfileExecutionItemSyncOutcomeType.PendingExportCreated
             or ActivityRunProfileExecutionItemSyncOutcomeType.Disconnected
             or ActivityRunProfileExecutionItemSyncOutcomeType.DisconnectedOutOfScope
+            or ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted
+            or ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeletionScheduled
         && !IsPendingExportChildOfProvisioned;
 
     /// <summary>
@@ -204,9 +206,13 @@
 
     /// <summary>
     /// Whether this outcome has an MVO link (Guid target entity ID that isn't empty).
+    /// Excluded when the MVO no longer exists: MvoDeleted outcomes themselves, or parent
+    /// outcomes (e.g. Disconnected) that have an MvoDeleted child in their causality tree.
     /// </summary>
     private bool HasMvoLink =>
-        Outcome.TargetEntityId.HasValue && Outcome.TargetEntityId.Value != Guid.Empty;
+        Outcome.TargetEntityId.HasValue && Outcome.TargetEntityId.Value != Guid.Empty
+        && Outcome.OutcomeType != ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted
+        && !Outcome.Children.Any(c => c.OutcomeType == ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted);
 
     private string GetInlineSeparator() =>
         Outcome.OutcomeType switch
@@ -235,38 +241,22 @@
 
         return Outcome.OutcomeType switch
         {
-            // Projected, Joined, Provisioned, PendingExportCreated, and Disconnected types show their target inline on the title row
+            // Projected, Joined, Provisioned, PendingExportCreated, Disconnected, and MVO deletion types
+            // show their target inline on the title row
             ActivityRunProfileExecutionItemSyncOutcomeType.Projected => null,
             ActivityRunProfileExecutionItemSyncOutcomeType.Joined => null,
             ActivityRunProfileExecutionItemSyncOutcomeType.Provisioned => null,
             ActivityRunProfileExecutionItemSyncOutcomeType.PendingExportCreated => null,
             ActivityRunProfileExecutionItemSyncOutcomeType.Disconnected => null,
             ActivityRunProfileExecutionItemSyncOutcomeType.DisconnectedOutOfScope => null,
+            ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted => null,
+            ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeletionScheduled => null,
             // AttributeFlow child nodes don't need a separate MVO description line
             ActivityRunProfileExecutionItemSyncOutcomeType.AttributeFlow => null,
-            ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted
-                => RenderMvoDescription("MVO deleted: "),
-            ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeletionScheduled
-                => RenderMvoDescription("MVO scheduled for deletion: "),
             // For connected system targets (pending exports, exports), just show the name
             _ => RenderPlainDescription()
         };
     }
-
-    private RenderFragment RenderMvoDescription(string prefix) => __builder =>
-    {
-        <MudText Typo="Typo.body1" Class="mud-text-secondary">
-            @prefix
-            @if (Outcome.TargetEntityId.HasValue && Outcome.TargetEntityId.Value != Guid.Empty)
-            {
-                <MudLink Href="@GetMvoHref(Outcome.TargetEntityId.Value)">@Outcome.TargetEntityDescription</MudLink>
-            }
-            else
-            {
-                @Outcome.TargetEntityDescription
-            }
-        </MudText>
-    };
 
     private RenderFragment RenderPlainDescription() => __builder =>
     {

--- a/src/JIM.Worker/Models/MetaverseObjectChangeResult.cs
+++ b/src/JIM.Worker/Models/MetaverseObjectChangeResult.cs
@@ -46,6 +46,22 @@ public readonly struct MetaverseObjectChangeResult
     public MvoDeletionFate MvoDeletionFate { get; init; }
 
     /// <summary>
+    /// MVO attribute values that were recalled (removed) during disconnection.
+    /// Captured before applying pending changes so the caller can add them to _pendingMvoChanges
+    /// for MVO change tracking. This enables the RPEI detail page to show recalled attribute
+    /// values in the causality tree's expandable attribute change table.
+    /// Only populated for DisconnectedOutOfScope when attribute recall occurred.
+    /// </summary>
+    public List<MetaverseObjectAttributeValue>? RecalledAttributeValues { get; init; }
+
+    /// <summary>
+    /// The MVO that was disconnected. Needed by the caller to create MVO change tracking records,
+    /// because the CSO→MVO join has already been broken by the time the result is returned.
+    /// Only populated for DisconnectedOutOfScope when attribute recall occurred.
+    /// </summary>
+    public MetaverseObject? DisconnectedMvo { get; init; }
+
+    /// <summary>
     /// Creates a result indicating no changes occurred.
     /// </summary>
     public static MetaverseObjectChangeResult NoChanges() => new() { HasChanges = false };
@@ -97,14 +113,19 @@ public readonly struct MetaverseObjectChangeResult
     /// </summary>
     /// <param name="attributeFlowCount">Optional count of attribute removals that occurred during disconnection.</param>
     /// <param name="mvoDeletionFate">The fate of the MVO after the disconnection.</param>
+    /// <param name="recalledAttributeValues">MVO attribute values that were recalled, for change tracking.</param>
     public static MetaverseObjectChangeResult DisconnectedOutOfScope(
         int? attributeFlowCount = null,
-        MvoDeletionFate mvoDeletionFate = MvoDeletionFate.NotDeleted) => new()
+        MvoDeletionFate mvoDeletionFate = MvoDeletionFate.NotDeleted,
+        List<MetaverseObjectAttributeValue>? recalledAttributeValues = null,
+        MetaverseObject? disconnectedMvo = null) => new()
     {
         HasChanges = true,
         ChangeType = ObjectChangeType.DisconnectedOutOfScope,
         AttributeFlowCount = attributeFlowCount,
-        MvoDeletionFate = mvoDeletionFate
+        MvoDeletionFate = mvoDeletionFate,
+        RecalledAttributeValues = recalledAttributeValues,
+        DisconnectedMvo = disconnectedMvo
     };
 
     /// <summary>

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -378,6 +378,13 @@ public abstract class SyncTaskProcessorBase
                     {
                         existingRpei.AttributeFlowCount = changeResult.AttributeFlowCount;
                     }
+
+                    // Capture recalled attribute values for MVO change tracking (enables attribute change table in RPEI detail)
+                    if (changeResult.RecalledAttributeValues != null && changeResult.DisconnectedMvo != null)
+                    {
+                        _pendingMvoChanges.Add((changeResult.DisconnectedMvo, new List<MetaverseObjectAttributeValue>(),
+                            changeResult.RecalledAttributeValues, ObjectChangeType.DisconnectedOutOfScope, existingRpei));
+                    }
                 }
                 else
                 {
@@ -391,6 +398,13 @@ public abstract class SyncTaskProcessorBase
                     if (changeResult.AttributeFlowCount.HasValue)
                     {
                         runProfileExecutionItem.AttributeFlowCount = changeResult.AttributeFlowCount;
+                    }
+
+                    // Capture recalled attribute values for MVO change tracking (enables attribute change table in RPEI detail)
+                    if (changeResult.RecalledAttributeValues != null && changeResult.DisconnectedMvo != null)
+                    {
+                        _pendingMvoChanges.Add((changeResult.DisconnectedMvo, new List<MetaverseObjectAttributeValue>(),
+                            changeResult.RecalledAttributeValues, ObjectChangeType.DisconnectedOutOfScope, runProfileExecutionItem));
                     }
 
                     // Build sync outcome for RPEIs not already covered by ProcessMetaverseObjectChangesAsync
@@ -753,6 +767,11 @@ public abstract class SyncTaskProcessorBase
 
                 // Track attribute removals on the RPEI (these are part of the disconnection)
                 deletionExecutionItem.AttributeFlowCount = mvo.PendingAttributeValueRemovals.Count;
+
+                // Capture MVO changes for change tracking BEFORE applying (which clears the pending lists).
+                // This enables the RPEI detail page to show the recalled attribute values in the causality tree.
+                var removals = mvo.PendingAttributeValueRemovals.ToList();
+                _pendingMvoChanges.Add((mvo, new List<MetaverseObjectAttributeValue>(), removals, ObjectChangeType.Disconnected, deletionExecutionItem));
 
                 Log.Information("ProcessObsoleteConnectedSystemObjectAsync: Applying {Count} attribute removals to MVO {MvoId} and queueing for export evaluation",
                     changedAttributes.Count, mvo.Id);
@@ -2685,6 +2704,7 @@ public abstract class SyncTaskProcessorBase
                 // Check if we should remove contributed attributes based on the object type setting.
                 // Skip recall when a grace period is configured (see ProcessObsoleteConnectedSystemObjectAsync).
                 int attributeRemovalCount = 0;
+                List<MetaverseObjectAttributeValue>? recalledAttributeValues = null;
                 var hasGracePeriod = mvo.Type?.DeletionGracePeriod is { } gracePeriod && gracePeriod > TimeSpan.Zero;
                 if (connectedSystemObject.Type.RemoveContributedAttributesOnObsoletion && !hasGracePeriod)
                 {
@@ -2700,6 +2720,14 @@ public abstract class SyncTaskProcessorBase
                     }
 
                     attributeRemovalCount = contributedAttributes.Count;
+
+                    // Capture recalled attribute values BEFORE applying (which clears the pending lists).
+                    // These are passed back in the result so the caller can add them to _pendingMvoChanges
+                    // for MVO change tracking, enabling the RPEI detail page to show recalled attribute values.
+                    if (mvo.PendingAttributeValueRemovals.Count > 0)
+                    {
+                        recalledAttributeValues = mvo.PendingAttributeValueRemovals.ToList();
+                    }
                 }
 
                 // Break the CSO-MVO join
@@ -2719,7 +2747,9 @@ public abstract class SyncTaskProcessorBase
 
                 return MetaverseObjectChangeResult.DisconnectedOutOfScope(
                     attributeFlowCount: attributeRemovalCount > 0 ? attributeRemovalCount : null,
-                    mvoDeletionFate: mvoDeletionFate);
+                    mvoDeletionFate: mvoDeletionFate,
+                    recalledAttributeValues: recalledAttributeValues,
+                    disconnectedMvo: recalledAttributeValues != null ? mvo : null);
         }
     }
 

--- a/test/JIM.Worker.Tests/Models/MetaverseObjectChangeResultTests.cs
+++ b/test/JIM.Worker.Tests/Models/MetaverseObjectChangeResultTests.cs
@@ -1,3 +1,4 @@
+using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Worker.Models;
 using JIM.Worker.Processors;
@@ -515,6 +516,69 @@ public class MetaverseObjectChangeResultTests
         var result = new MetaverseObjectChangeResult();
 
         Assert.That(result.MvoDeletionFate, Is.EqualTo(MvoDeletionFate.NotDeleted));
+    }
+
+    #endregion
+
+    #region RecalledAttributeValues Tests
+
+    [Test]
+    public void DisconnectedOutOfScope_WithNoRecalledAttributes_ReturnsNull()
+    {
+        var result = MetaverseObjectChangeResult.DisconnectedOutOfScope();
+
+        Assert.That(result.RecalledAttributeValues, Is.Null);
+    }
+
+    [Test]
+    public void DisconnectedOutOfScope_WithRecalledAttributes_ReturnsValues()
+    {
+        var attr = new MetaverseAttribute { Id = 1, Name = "DisplayName", Type = AttributeDataType.Text };
+        var attrValue = new MetaverseObjectAttributeValue { Attribute = attr, StringValue = "Test" };
+        var recalledValues = new List<MetaverseObjectAttributeValue> { attrValue };
+
+        var result = MetaverseObjectChangeResult.DisconnectedOutOfScope(
+            attributeFlowCount: 1,
+            recalledAttributeValues: recalledValues);
+
+        Assert.That(result.RecalledAttributeValues, Is.Not.Null);
+        Assert.That(result.RecalledAttributeValues, Has.Count.EqualTo(1));
+        Assert.That(result.RecalledAttributeValues![0].StringValue, Is.EqualTo("Test"));
+    }
+
+    [Test]
+    public void DisconnectedOutOfScope_WithDisconnectedMvo_ReturnsMvo()
+    {
+        var mvo = new MetaverseObject { Id = Guid.NewGuid() };
+        var attr = new MetaverseAttribute { Id = 1, Name = "DisplayName", Type = AttributeDataType.Text };
+        var attrValue = new MetaverseObjectAttributeValue { Attribute = attr, StringValue = "Test" };
+        var recalledValues = new List<MetaverseObjectAttributeValue> { attrValue };
+
+        var result = MetaverseObjectChangeResult.DisconnectedOutOfScope(
+            attributeFlowCount: 1,
+            recalledAttributeValues: recalledValues,
+            disconnectedMvo: mvo);
+
+        Assert.That(result.DisconnectedMvo, Is.Not.Null);
+        Assert.That(result.DisconnectedMvo!.Id, Is.EqualTo(mvo.Id));
+    }
+
+    [Test]
+    public void DisconnectedOutOfScope_WithNoRecalledAttributes_HasNullDisconnectedMvo()
+    {
+        var result = MetaverseObjectChangeResult.DisconnectedOutOfScope(attributeFlowCount: 0);
+
+        Assert.That(result.RecalledAttributeValues, Is.Null);
+        Assert.That(result.DisconnectedMvo, Is.Null);
+    }
+
+    [Test]
+    public void DefaultStruct_HasNullRecalledAttributeValues()
+    {
+        var result = new MetaverseObjectChangeResult();
+
+        Assert.That(result.RecalledAttributeValues, Is.Null);
+        Assert.That(result.DisconnectedMvo, Is.Null);
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Workflows/AttributeRecallExpressionWorkflowTests.cs
+++ b/test/JIM.Worker.Tests/Workflows/AttributeRecallExpressionWorkflowTests.cs
@@ -439,6 +439,27 @@ public class AttributeRecallExpressionWorkflowTests : WorkflowTestBase
         Assert.That(disconnectedRpei, Is.Not.Null,
             "Delta Sync should produce a Disconnected RPEI when a joined CSO is obsoleted");
 
+        // Verify MVO change tracking records were created for the recalled attributes.
+        // This enables the RPEI detail page to show the attribute change table for recall scenarios.
+        var mvoChanges = await DbContext.Set<MetaverseObjectChange>()
+            .Include(c => c.AttributeChanges)
+            .ThenInclude(ac => ac.ValueChanges)
+            .Where(c => c.MetaverseObject!.Id == mvoId)
+            .OrderByDescending(c => c.ChangeTime)
+            .ToListAsync();
+
+        var recallChange = mvoChanges.FirstOrDefault(c => c.ChangeType == ObjectChangeType.Disconnected);
+        Assert.That(recallChange, Is.Not.Null,
+            "MVO change tracking should record a Disconnected change when attributes are recalled");
+        Assert.That(recallChange!.AttributeChanges, Has.Count.EqualTo(1),
+            "MVO change should record the recalled Description attribute");
+        var recalledAttrChange = recallChange.AttributeChanges.First();
+        Assert.That(recalledAttrChange.Attribute.Name, Is.EqualTo("Description"),
+            "Recalled attribute should be the Training-contributed Description");
+        Assert.That(recalledAttrChange.ValueChanges, Has.Count.EqualTo(1));
+        Assert.That(recalledAttrChange.ValueChanges.First().ValueChangeType, Is.EqualTo(ValueChangeType.Remove),
+            "Recalled attribute value change should be a Remove");
+
         // Verify aggregate stats for Training Delta Sync (guards against double-counting bugs)
         Assert.That(trainingDeltaSyncActivity.TotalDisconnected, Is.EqualTo(1), "Training Delta Sync: expected 1 disconnection.");
         Assert.That(trainingDeltaSyncActivity.TotalAttributeFlows, Is.EqualTo(1), "Training Delta Sync: expected 1 attribute flow (recalled Description).");


### PR DESCRIPTION
## Summary
- Enable MVO change tracking for disconnection and attribute recall scenarios so the RPEI detail page shows recalled attribute values in the expandable attribute change table
- Fix causality tree UI for MVO deletion scenarios: suppress links to deleted MVOs, render MvoDeleted/MvoDeletionScheduled inline, remove link from MVO Deleted alert box

## Test plan
- [x] Unit tests for `MetaverseObjectChangeResult` recalled attribute properties
- [x] Workflow test assertions verifying `MetaverseObjectChange` records created during recall
- [x] Full solution build and 1806 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)