### PR TITLE
fix: sanitise user-controlled strings in new log calls (CWE-117)

### DIFF
--- a/src/JIM.Web/Controllers/Api/UserInfoController.cs
+++ b/src/JIM.Web/Controllers/Api/UserInfoController.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Asp.Versioning;
 using JIM.Application;
 using JIM.Models.Core;
+using JIM.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -55,7 +56,7 @@ public class UserInfoController(ILogger<UserInfoController> logger, JimApplicati
 
         if (!hasMvoId)
         {
-            _logger.LogDebug("UserInfo: Authenticated user '{Name}' has no JIM identity (no MetaverseObject)", name);
+            _logger.LogDebug("UserInfo: Authenticated user '{Name}' has no JIM identity (no MetaverseObject)", LogSanitiser.Sanitise(name));
 
             return Task.FromResult<IActionResult>(Ok(new
             {
@@ -70,7 +71,7 @@ public class UserInfoController(ILogger<UserInfoController> logger, JimApplicati
         }
 
         _logger.LogDebug("UserInfo: User '{Name}' (MVO {MetaverseObjectId}) has roles: {Roles}",
-            name, mvoId, string.Join(", ", roles));
+            LogSanitiser.Sanitise(name), mvoId, LogSanitiser.Sanitise(string.Join(", ", roles)));
 
         return Task.FromResult<IActionResult>(Ok(new
         {

--- a/src/JIM.Web/Middleware/Api/GlobalExceptionHandler.cs
+++ b/src/JIM.Web/Middleware/Api/GlobalExceptionHandler.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using JIM.Utilities;
 using JIM.Web.Models.Api;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -38,11 +39,11 @@ public class GlobalExceptionHandler(RequestDelegate next, ILogger<GlobalExceptio
         if (isTransient)
         {
             _logger.LogWarning(exception, "Transient database error on {Method} {Path}: {Message}",
-                context.Request.Method, context.Request.Path, exception.Message);
+                context.Request.Method, LogSanitiser.Sanitise(context.Request.Path), LogSanitiser.Sanitise(exception.Message));
         }
         else
         {
-            _logger.LogError(exception, "An unhandled exception occurred: {Message}", exception.Message);
+            _logger.LogError(exception, "An unhandled exception occurred: {Message}", LogSanitiser.Sanitise(exception.Message));
         }
 
         var response = context.Response;


### PR DESCRIPTION
## Summary
- 🔒 Wraps user-controlled values with `LogSanitiser.Sanitise()` in `UserInfoController` (JWT claim name and roles) and `GlobalExceptionHandler` (request path and exception message)
- These log calls were introduced after the log sanitisation work in #401 and missed the pattern, triggering new CodeQL CWE-117 alerts

## Test plan
- [x] `dotnet build src/JIM.Web/` passes with zero warnings/errors
- [ ] Verify CodeQL alerts #100 and companion alert are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)