### PR TITLE
fix: sanitise Request.Method in GlobalExceptionHandler (CWE-117)

### DIFF
--- a/src/JIM.Web/Middleware/Api/GlobalExceptionHandler.cs
+++ b/src/JIM.Web/Middleware/Api/GlobalExceptionHandler.cs
@@ -39,7 +39,7 @@ public class GlobalExceptionHandler(RequestDelegate next, ILogger<GlobalExceptio
         if (isTransient)
         {
             _logger.LogWarning(exception, "Transient database error on {Method} {Path}: {Message}",
-                context.Request.Method, LogSanitiser.Sanitise(context.Request.Path), LogSanitiser.Sanitise(exception.Message));
+                LogSanitiser.Sanitise(context.Request.Method), LogSanitiser.Sanitise(context.Request.Path), LogSanitiser.Sanitise(exception.Message));
         }
         else
         {


### PR DESCRIPTION
## Summary
- 🔒 Wraps `context.Request.Method` with `LogSanitiser.Sanitise()` in the transient database error log entry in `GlobalExceptionHandler`
- Resolves code scanning alert #101 (cs/log-forging, CWE-117)
- `Path` and `Message` were already sanitised on the same line — `Method` was missed when this branch was added

## Test plan
- [x] `dotnet build` passes with 0 errors
- [ ] CodeQL re-scan confirms alert is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)