### PR TITLE
fix: prevent entity tracking conflicts during cross-page reference resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Fixed entity tracking conflict during cross-page reference resolution at scale — Full Sync no longer fails with "ConnectedSystemObject cannot be tracked" when groups share members across resolution batches (10,000+ users)
+
 ## [0.8.0] - 2026-04-01
 
 ### Added

--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -282,6 +282,13 @@ public interface ISyncRepository
     /// </summary>
     Task DeleteMetaverseObjectAsync(MetaverseObject metaverseObject);
 
+    /// <summary>
+    /// Deletes MVO attribute values by their IDs using raw SQL.
+    /// Used during cross-page reference resolution where the change tracker is cleared between
+    /// batches — EF cannot infer collection removals after clearing, so deletions must be explicit.
+    /// </summary>
+    Task DeleteMetaverseObjectAttributeValuesByIdsAsync(IReadOnlyList<Guid> attributeValueIds);
+
     #endregion
 
     #region Pending Exports

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -820,6 +820,16 @@ public class SyncRepository : ISyncRepository
         return Task.CompletedTask;
     }
 
+    public Task DeleteMetaverseObjectAttributeValuesByIdsAsync(IReadOnlyList<Guid> attributeValueIds)
+    {
+        var idsToDelete = attributeValueIds.ToHashSet();
+        foreach (var mvo in _mvos.Values)
+        {
+            mvo.AttributeValues.RemoveAll(av => idsToDelete.Contains(av.Id));
+        }
+        return Task.CompletedTask;
+    }
+
     #endregion
 
     #region Pending Exports

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -847,14 +847,22 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     /// Batch loads Connected System Objects by their IDs with the full Include chain needed for
     /// sync reference attribute processing. Used for cross-page reference resolution after all
     /// pages have been processed and all MVOs exist in the database.
+    ///
+    /// CSOs are loaded with AsNoTracking to prevent entity tracking conflicts during batched
+    /// cross-page resolution. Between batches, CSOs from export reconciliation or EF relationship
+    /// fixup can accumulate in the change tracker — loading new batch CSOs as tracked entities
+    /// would conflict with those already-tracked instances. Since CSOs are read-only during
+    /// cross-page resolution (only MVOs are modified and persisted), tracking is not needed.
+    ///
+    /// Because CSOs are untracked, EF Core relationship fixup cannot automatically populate
+    /// cso.MetaverseObject. Instead, LoadMetaverseObjectsForCsosAsync manually stitches the
+    /// MetaverseObject navigation after loading MVOs (which remain tracked for persistence).
     /// </summary>
     public async Task<List<ConnectedSystemObject>> GetConnectedSystemObjectsForReferenceResolutionAsync(IList<Guid> csoIds)
     {
         if (csoIds.Count == 0)
             return [];
 
-        // Shallow Include chain — same approach as GetConnectedSystemObjectsAsync.
-        // ReferenceValue navigations populated via direct SQL (PopulateReferenceValuesAsync).
         var csoQuery = Repository.Database.ConnectedSystemObjects
             .Include(cso => cso.Type)
             .Include(cso => cso.AttributeValues)
@@ -928,18 +936,26 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     }
 
     /// <summary>
-    /// Loads Metaverse Objects and their attribute values for a set of CSOs in a separate query.
-    /// EF Core relationship fixup automatically populates cso.MetaverseObject navigations for
-    /// entities tracked in the same DbContext, so no manual stitching is required.
+    /// Loads Metaverse Objects and their attribute values for a set of CSOs in a separate query,
+    /// then manually stitches cso.MetaverseObject navigations.
     ///
-    /// This replaces the previous approach of loading MVOs as part of the CSO query's Include
-    /// chain with AsSplitQuery(), which suffered from a materialisation bug (dotnet/efcore#33826).
-    /// By loading MVOs in a dedicated query, we avoid the deep Include nesting that triggered the bug.
+    /// MVOs are loaded as tracked entities (required for UpdateMetaverseObjectsAsync persistence).
+    /// CSOs may be tracked or untracked depending on the caller:
+    /// - Per-page sync: CSOs are tracked → EF relationship fixup auto-populates cso.MetaverseObject
+    /// - Cross-page resolution: CSOs are untracked (AsNoTracking) → manual stitching required
+    ///
+    /// Manual stitching handles both cases correctly — for tracked CSOs it's redundant but harmless.
     ///
     /// The MVO query includes:
     /// - Type: Required for deletion rule evaluation and export rule filtering
     /// - AttributeValues.Attribute: Required for attribute name/type lookup during sync and expression evaluation
-    /// - AttributeValues.ReferenceValue: Required for detecting existing MVO reference values
+    ///
+    /// IMPORTANT: AttributeValues.ReferenceValue is intentionally NOT included.
+    /// The sync engine uses the scalar FK (ReferenceValueId) to detect existing MVO reference
+    /// values — the navigation property is only a fallback for newly-created, unflushed MVOs.
+    /// Including ReferenceValue would load ConnectedSystemObject entities into the change tracker
+    /// via the MVO→AttributeValue→ReferenceValue path, causing entity tracking conflicts when
+    /// the same CSO is referenced by multiple batches during cross-page reference resolution.
     /// </summary>
     private async Task LoadMetaverseObjectsForCsosAsync(List<ConnectedSystemObject> csos)
     {
@@ -952,19 +968,26 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         if (mvoIds.Count == 0)
             return;
 
-        // Loading MVOs into the same DbContext triggers EF Core relationship fixup,
-        // which automatically populates cso.MetaverseObject for all tracked CSOs
-        // whose MetaverseObjectId matches a loaded MVO's primary key.
+        // MVOs remain tracked for persistence by UpdateMetaverseObjectsAsync.
         // Note: ContributedBySystem navigation is NOT included — the sync path uses the
         // scalar FK (ContributedBySystemId) directly, avoiding the need to load the full entity.
-        await Repository.Database.MetaverseObjects
+        var mvos = await Repository.Database.MetaverseObjects
             .Include(mvo => mvo.Type)
             .Include(mvo => mvo.AttributeValues)
                 .ThenInclude(av => av.Attribute)
-            .Include(mvo => mvo.AttributeValues)
-                .ThenInclude(av => av.ReferenceValue)
             .Where(mvo => mvoIds.Contains(mvo.Id))
             .ToListAsync();
+
+        // Manually stitch cso.MetaverseObject navigations. This is required when CSOs are loaded
+        // with AsNoTracking (cross-page resolution) since EF relationship fixup only works for
+        // tracked entities. For tracked CSOs (per-page sync), fixup already populated the navigation
+        // but this explicit assignment is harmless and ensures correctness in both cases.
+        var mvosById = mvos.ToDictionary(mvo => mvo.Id);
+        foreach (var cso in csos)
+        {
+            if (cso.MetaverseObjectId.HasValue && mvosById.TryGetValue(cso.MetaverseObjectId.Value, out var mvo))
+                cso.MetaverseObject = mvo;
+        }
     }
 
 
@@ -2790,7 +2813,11 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         if (mvoIds.Count == 0)
             return new Dictionary<Guid, ConnectedSystemObject>();
 
+        // AsNoTracking: these CSOs are used for reference resolution display (snapshot/causality
+        // tree). Tracking them would cause identity conflicts during cross-page reference
+        // resolution when the same CSO is loaded by multiple flush operations.
         var csos = await Repository.Database.ConnectedSystemObjects
+            .AsNoTracking()
             .Include(cso => cso.Type)
             .Include(cso => cso.AttributeValues)
                 .ThenInclude(av => av.Attribute)

--- a/src/JIM.PostgresData/Repositories/SyncRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.cs
@@ -5,6 +5,7 @@ using JIM.Models.Logic;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
 using JIM.Models.Utility;
+using Microsoft.EntityFrameworkCore;
 using Serilog;
 
 namespace JIM.PostgresData.Repositories;
@@ -183,6 +184,16 @@ public partial class SyncRepository : ISyncRepository
 
     public Task DeleteMetaverseObjectAsync(MetaverseObject metaverseObject)
         => _repo.Metaverse.DeleteMetaverseObjectAsync(metaverseObject);
+
+    public async Task DeleteMetaverseObjectAttributeValuesByIdsAsync(IReadOnlyList<Guid> attributeValueIds)
+    {
+        if (attributeValueIds.Count == 0)
+            return;
+
+        await _context.Database.ExecuteSqlRawAsync(
+            @"DELETE FROM ""MetaverseObjectAttributeValues"" WHERE ""Id"" = ANY({0})",
+            attributeValueIds.ToArray());
+    }
 
     #endregion
 

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -1457,12 +1457,15 @@ public abstract class SyncTaskProcessorBase
                                         (r.ConnectedSystemObject != null && r.ConnectedSystemObject.Id == cso.Id));
 
                 // Capture additions and removals BEFORE applying changes (they get cleared by ApplyPendingMetaverseObjectAttributeChanges)
-                // This is needed for both export (Remove changes for MVAs) and MVO change tracking
+                // This is needed for both export (Remove changes for MVAs) and MVO change tracking.
+                // Check both ReferenceValue (navigation, set for in-memory resolved refs) and
+                // ReferenceValueId (scalar FK, always set for persisted refs). The navigation may
+                // be null when the ReferenceValue ThenInclude is omitted from MVO loading queries.
                 var refAddedAttributes = mvo.PendingAttributeValueAdditions
-                    .Where(av => av.ReferenceValue != null)
+                    .Where(av => av.ReferenceValue != null || av.ReferenceValueId.HasValue)
                     .ToList();
                 var refRemovedAttributesList = mvo.PendingAttributeValueRemovals
-                    .Where(av => av.ReferenceValue != null)
+                    .Where(av => av.ReferenceValue != null || av.ReferenceValueId.HasValue)
                     .ToList();
                 // Also keep as HashSet for export evaluation (existing code expects HashSet)
                 var refRemovedAttributes = refRemovedAttributesList.Count > 0
@@ -1653,6 +1656,12 @@ public abstract class SyncTaskProcessorBase
         var resolvedCount = 0;
         var updatedExistingRpeis = new List<ActivityRunProfileExecutionItem>();
 
+        // Collect IDs of removed MVO attribute values across all batches for explicit raw SQL deletion.
+        // When ClearChangeTracker() runs between batches, EF loses knowledge of attribute values
+        // removed from MVO.AttributeValues collections (ApplyPendingAttributeChanges). Without this,
+        // the removed rows persist in the database and member removals are never exported.
+        var removedMvoAttributeValueIds = new List<Guid>();
+
         for (var batchIndex = 0; batchIndex < totalBatches; batchIndex++)
         {
             var batch = _unresolvedCrossPageReferences
@@ -1715,6 +1724,14 @@ public abstract class SyncTaskProcessorBase
                     var refRemovedAttributes = refRemovedAttributesList.Count > 0
                         ? refRemovedAttributesList.ToHashSet()
                         : (HashSet<MetaverseObjectAttributeValue>?)null;
+
+                    // Collect IDs of removed attribute values for explicit deletion after
+                    // ClearChangeTracker (which loses EF's collection-removal knowledge).
+                    foreach (var removed in refRemovedAttributesList)
+                    {
+                        if (removed.Id != Guid.Empty)
+                            removedMvoAttributeValueIds.Add(removed.Id);
+                    }
 
                     // Merge into existing RPEI if one was created during initial page processing
                     // (e.g., Projected or Joined). This prevents duplicate RPEIs for the same CSO
@@ -1928,6 +1945,27 @@ public abstract class SyncTaskProcessorBase
             {
                 _syncRepo.SetAutoDetectChangesEnabled(true);
             }
+
+            // Clear the change tracker between batches to prevent entity tracking conflicts.
+            // Each batch loads CSOs, MVOs, MetaverseObjectType, MetaverseAttribute, and other
+            // entities into the tracker. Without clearing, subsequent batches encounter identity
+            // conflicts when the same shared entities (e.g., MetaverseObjectType) are loaded again.
+            // All batch data has been fully persisted above, so clearing is safe.
+            // The Activity entity will be re-attached by UpdateActivityAsync's detached handling.
+            if (batchIndex < totalBatches - 1)
+                _syncRepo.ClearChangeTracker();
+        }
+
+        // Explicitly delete removed MVO attribute values via raw SQL.
+        // ClearChangeTracker between batches erases EF's knowledge of attribute values removed
+        // from MVO.AttributeValues collections (by ApplyPendingAttributeChanges). Without this
+        // explicit deletion, the removed rows persist in the database — member removals would
+        // never be exported to target systems.
+        if (removedMvoAttributeValueIds.Count > 0)
+        {
+            await _syncRepo.DeleteMetaverseObjectAttributeValuesByIdsAsync(removedMvoAttributeValueIds);
+            Log.Information("ResolveCrossPageReferences: Explicitly deleted {Count} removed MVO attribute values via raw SQL",
+                removedMvoAttributeValueIds.Count);
         }
 
         Log.Information("ResolveCrossPageReferences: Completed cross-page reference resolution for {Count} CSOs",
@@ -2096,8 +2134,11 @@ public abstract class SyncTaskProcessorBase
         if (csoIds.Count == 0)
             return;
 
-        // Batch lookup: find DELETE PEs already in the DB for these CSO IDs
-        var persistedPesByCsoId = await _syncRepo.GetPendingExportsByConnectedSystemObjectIdsAsync(csoIds);
+        // Batch lookup: find DELETE PEs already in the DB for these CSO IDs.
+        // Use the lightweight (AsNoTracking, no CSO Include) variant to avoid loading
+        // ConnectedSystemObject entities into the change tracker — tracked CSOs from this
+        // query would conflict with CSOs loaded during cross-page reference resolution batches.
+        var persistedPesByCsoId = await _syncRepo.GetPendingExportsLightweightByConnectedSystemObjectIdsAsync(csoIds);
 
         if (persistedPesByCsoId.Count == 0)
             return;

--- a/test/integration/Setup-Scenario8.ps1
+++ b/test/integration/Setup-Scenario8.ps1
@@ -146,6 +146,7 @@ if ($isOpenLDAP) {
     $groupImportMappings = @(
         @{ LdapAttr = "cn"; MvAttr = "Account Name" }
         @{ LdapAttr = "cn"; MvAttr = "Common Name" }
+        @{ LdapAttr = "cn"; MvAttr = "Display Name" }
         @{ LdapAttr = "description"; MvAttr = "Description" }
         @{ LdapAttr = "member"; MvAttr = "Static Members" }
     )


### PR DESCRIPTION
## Summary

- 🐛 Fixed EF Core entity tracking conflicts during cross-page reference resolution at scale (10,000+ users / 500 groups)
- 🐛 Fixed member removal not being exported during delta sync when `ReferenceValue` navigation is null
- 🧪 Added `cn → Display Name` IAF mapping for OpenLDAP groups in Scenario 8 integration test setup

## Root Cause

Cross-page reference resolution processes CSOs in batches. Between batches, shared entities (ConnectedSystemObject, MetaverseObject, MetaverseObjectType, MetaverseAttribute) accumulated in the EF Core change tracker, causing identity conflicts when subsequent batches loaded overlapping entities.

Separately, `ProcessDeferredReferenceAttributes` filtered removed attribute values by `av.ReferenceValue != null` only, missing values where the navigation was null but the scalar FK (`ReferenceValueId`) was set — causing member removals to be silently dropped during export evaluation.

## Changes

**`src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs`**
- Remove `ThenInclude(av => av.ReferenceValue)` from `LoadMetaverseObjectsForCsosAsync` (sync engine uses scalar FK)
- Add `AsNoTracking` to `GetConnectedSystemObjectsByMetaverseObjectIdsAsync` (snapshot/display only)

**`src/JIM.Worker/Processors/SyncTaskProcessorBase.cs`**
- Add `ClearChangeTracker()` between batches in `ResolveCrossPageReferencesAsync`
- Collect removed MVO attribute value IDs during processing, delete via raw SQL after batch loop (compensates for tracker clear erasing EF's collection-removal knowledge)
- Switch `ReconcileDeferredExportsAgainstPersistedDeletesAsync` to lightweight `AsNoTracking` PE query
- Fix `ProcessDeferredReferenceAttributes` to check both `ReferenceValue` and `ReferenceValueId` when capturing removals

**`src/JIM.Data/Repositories/ISyncRepository.cs`** + implementations
- Add `DeleteMetaverseObjectAttributeValuesByIdsAsync` for explicit raw SQL deletion

**`test/integration/Setup-Scenario8.ps1`**
- Add `cn → Display Name` IAF mapping for OpenLDAP groups

## Test plan

- [x] Full solution build — 0 errors
- [x] Full solution test — 2,164 tests pass (0 failures)
- [x] Integration test: Scenario 8 Large (10,000 users / 500 groups) — all 6 steps pass (InitialSync, ForwardSync, DetectDrift, ReassertState, NewGroup, DeleteGroup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)