### PR TITLE
Standardise on 'connector space' terminology

### DIFF
--- a/src/JIM.Models/Activities/Activity.cs
+++ b/src/JIM.Models/Activities/Activity.cs
@@ -135,7 +135,7 @@ public class Activity
     // -----------------------------------------------------------------------------------------------------------------
 
     #region Import Stats
-    /// <summary>Count of new CSOs added to staging during import.</summary>
+    /// <summary>Count of new CSOs added to the connector space during import.</summary>
     public int TotalAdded { get; set; }
 
     /// <summary>Count of existing CSOs updated during import.</summary>

--- a/src/JIM.Models/Activities/ActivityRunProfileExecutionStats.cs
+++ b/src/JIM.Models/Activities/ActivityRunProfileExecutionStats.cs
@@ -13,7 +13,7 @@ public class ActivityRunProfileExecutionStats
 
     #region Import Stats (CSO operations)
     /// <summary>
-    /// Count of new CSOs added to staging during import.
+    /// Count of new CSOs added to the connector space during import.
     /// </summary>
     public int TotalCsoAdds { get; set; }
 

--- a/src/JIM.Models/Enums/ObjectChangeType.cs
+++ b/src/JIM.Models/Enums/ObjectChangeType.cs
@@ -10,7 +10,7 @@ public enum ObjectChangeType
 
     // Import operations (CSO changes)
     /// <summary>
-    /// CSO added to staging.
+    /// CSO added to the connector space.
     /// </summary>
     Added,
 

--- a/src/JIM.Models/Staging/ConnectedSystemEnums.cs
+++ b/src/JIM.Models/Staging/ConnectedSystemEnums.cs
@@ -131,7 +131,7 @@ public enum ConnectedSystemRunType
     /// </summary>
     NotSet = 0,
     /// <summary>
-    /// Imports all objects from the Connected System, replacing the existing connector space staging data.
+    /// Imports all objects from the Connected System, replacing the existing connector space data.
     /// </summary>
     FullImport = 1,
     /// <summary>

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
@@ -93,14 +93,14 @@ function Get-JIMConnectedSystemObject {
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting Connected System Object $Id from Connected System $ConnectedSystemId"
-                $result = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/staging/$Id"
+                $result = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space/$Id"
                 $result
             }
 
             'AttributeValues' {
                 Write-Verbose "Getting attribute values for '$AttributeName' on CSO $Id (Page: $Page, PageSize: $PageSize)"
                 $encodedAttrName = [System.Uri]::EscapeDataString($AttributeName)
-                $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/staging/$Id/attributes/$encodedAttrName/values?page=$Page&pageSize=$PageSize"
+                $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space/$Id/attributes/$encodedAttrName/values?page=$Page&pageSize=$PageSize"
                 if ($Search) {
                     $endpoint += "&search=$([System.Uri]::EscapeDataString($Search))"
                 }
@@ -118,7 +118,7 @@ function Get-JIMConnectedSystemObject {
                 $encodedAttrName = [System.Uri]::EscapeDataString($AttributeName)
 
                 while ($hasMore) {
-                    $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/staging/$Id/attributes/$encodedAttrName/values?page=$currentPage&pageSize=$PageSize"
+                    $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space/$Id/attributes/$encodedAttrName/values?page=$currentPage&pageSize=$PageSize"
                     if ($Search) {
                         $endpoint += "&search=$([System.Uri]::EscapeDataString($Search))"
                     }

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemUnresolvedReferenceCount.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemUnresolvedReferenceCount.ps1
@@ -58,7 +58,7 @@ function Get-JIMConnectedSystemUnresolvedReferenceCount {
         Write-Verbose "Getting unresolved reference count for Connected System: $ConnectedSystemId"
 
         try {
-            $result = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/staging/unresolved-references/count"
+            $result = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space/unresolved-references/count"
             [int]$result
         }
         catch {

--- a/src/JIM.Utilities/GeneralUtilities.cs
+++ b/src/JIM.Utilities/GeneralUtilities.cs
@@ -101,7 +101,7 @@ public static class Utilities
 
     public static string GetConnectedSystemObjectsHref(int connectedSystemId)
     {
-        return $"/admin/connected-systems/{connectedSystemId}/staging";
+        return $"/admin/connected-systems/{connectedSystemId}/connector-space";
     }
 
     public static string GetConnectedSystemObjectHref(ConnectedSystemObject connectedSystemObject)
@@ -116,7 +116,7 @@ public static class Utilities
 
     public static string GetConnectedSystemObjectHref(int connectedSystemId, Guid connectedSystemObjectId)
     {
-        return $"/admin/connected-systems/{connectedSystemId}/staging/{connectedSystemObjectId}";
+        return $"/admin/connected-systems/{connectedSystemId}/connector-space/{connectedSystemObjectId}";
     }
 
     /// <summary>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -373,7 +373,7 @@ public class SynchronisationController(
     /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
     /// <param name="id">The unique identifier (GUID) of the connected system object.</param>
     /// <returns>The connected system object details with capped MVA values and per-attribute summaries.</returns>
-    [HttpGet("connected-systems/{connectedSystemId:int}/staging/{id:guid}", Name = "GetConnectedSystemObject")]
+    [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/{id:guid}", Name = "GetConnectedSystemObject")]
     [ProducesResponseType(typeof(ConnectedSystemObjectDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -403,7 +403,7 @@ public class SynchronisationController(
     /// <param name="pageSize">Number of values per page (1-100). Default: 50.</param>
     /// <param name="search">Optional search text to filter values.</param>
     /// <returns>A paginated set of attribute values with total count.</returns>
-    [HttpGet("connected-systems/{connectedSystemId:int}/staging/{csoId:guid}/attributes/{attributeName}/values", Name = "GetAttributeValuesPaged")]
+    [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/{csoId:guid}/attributes/{attributeName}/values", Name = "GetAttributeValuesPaged")]
     [ProducesResponseType(typeof(PaginatedResponse<ConnectedSystemObjectAttributeValueDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetAttributeValuesPagedAsync(
@@ -470,7 +470,7 @@ public class SynchronisationController(
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
     /// <returns>The count of unresolved reference attribute values.</returns>
-    [HttpGet("connected-systems/{connectedSystemId:int}/staging/unresolved-references/count", Name = "GetUnresolvedReferenceCount")]
+    [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/unresolved-references/count", Name = "GetUnresolvedReferenceCount")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetUnresolvedReferenceCountAsync(int connectedSystemId)

--- a/src/JIM.Web/Helpers.cs
+++ b/src/JIM.Web/Helpers.cs
@@ -242,7 +242,7 @@ public static class Helpers
         {
             // Import operations
             ObjectChangeType.Added =>
-                "A new connected system object (CSO) was discovered in the source system and added to the staging area.",
+                "A new connected system object (CSO) was discovered in the source system and added to the connector space.",
             ObjectChangeType.Updated =>
                 "An existing connected system object (CSO) was updated with changed attribute values from the source system.",
             ObjectChangeType.Deleted when !isSyncContext =>

--- a/src/JIM.Web/Models/Api/ActivityDtos.cs
+++ b/src/JIM.Web/Models/Api/ActivityDtos.cs
@@ -96,7 +96,7 @@ public class ActivityHeader
 
     #region Import Stats
     /// <summary>
-    /// Count of new CSOs added to staging during import.
+    /// Count of new CSOs added to the connector space during import.
     /// </summary>
     public int TotalAdded { get; set; }
 
@@ -472,7 +472,7 @@ public class ActivityRunProfileExecutionStatsDto
 
     #region Import Stats (CSO operations)
     /// <summary>
-    /// Number of CSOs added to staging during import.
+    /// Number of CSOs added to the connector space during import.
     /// </summary>
     public int TotalCsoAdds { get; set; }
 

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -1326,7 +1326,7 @@ else if (_activityRunProfileExecutionItem.ObjectChangeType == ObjectChangeType.N
         return _activityRunProfileExecutionItem?.ObjectChangeType switch
         {
             // Import operations
-            ObjectChangeType.Added => $"{typeName} Added to Staging",
+            ObjectChangeType.Added => $"{typeName} Added to Connector Space",
             ObjectChangeType.Updated => $"{typeName} Updated",
             ObjectChangeType.Deleted => IsSyncContext() ? "Source Deletion Processed" : $"{typeName} Deletion Detected",
             // Sync operations
@@ -1437,15 +1437,15 @@ else if (_activityRunProfileExecutionItem.ObjectChangeType == ObjectChangeType.N
         {
             // Import operations
             ObjectChangeType.Added => hasExternalId
-            ? $"A new connected system object ({externalId}) was imported and added to the staging area."
-            : "A new connected system object was imported and added to the staging area.",
+            ? $"A new connected system object ({externalId}) was imported and added to the connector space."
+            : "A new connected system object was imported and added to the connector space.",
             ObjectChangeType.Updated => hasExternalId
             ? $"The connected system object ({externalId}) was updated with new attribute values."
             : "The connected system object was updated with new attribute values.",
             ObjectChangeType.Deleted => IsSyncContext()
             ? (hasExternalId
-            ? $"The connected system object ({externalId}) was removed from staging after the source system deletion was confirmed."
-            : "The connected system object was removed from staging after the source system deletion was confirmed.")
+            ? $"The connected system object ({externalId}) was removed from the connector space after the source system deletion was confirmed."
+            : "The connected system object was removed from the connector space after the source system deletion was confirmed.")
             : (hasExternalId
             ? $"The connected system object ({externalId}) was detected as deleted from the source system and marked for removal."
             : "The connected system object was detected as deleted from the source system and marked for removal."),

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
@@ -8,8 +8,8 @@
                    Color="Color.Default"
                    Size="Size.Small"
                    StartIcon="@Icons.Material.Filled.Storage"
-                   Href="@($"/admin/connected-systems/{ConnectedSystem.Id}/staging")">
-            View Staging
+                   Href="@($"/admin/connected-systems/{ConnectedSystem.Id}/connector-space")">
+            View Connector Space
         </MudButton>
         <MudButton Variant="Variant.Filled"
                    Color="@(PendingExportCount > 0 ? Color.Warning : Color.Default)"

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
@@ -1,4 +1,4 @@
-﻿@page "/admin/connected-systems/{CsId:int}/staging/{CsoId}"
+﻿@page "/admin/connected-systems/{CsId:int}/connector-space/{CsoId}"
 @attribute [Authorize(Roles = "Administrator")]
 @using JIM.Models.Staging
 @using JIM.Models.Staging.DTOs
@@ -336,7 +336,7 @@
             new("Home", href: "/", icon: Icons.Material.Filled.Home),
             new("Connected Systems", href: "/admin/connected-systems/"),
             new(ConnectedSystemHeader.Name, href: Utilities.GetConnectedSystemHref(ConnectedSystemHeader)),
-            new("Staging", href: Utilities.GetConnectedSystemObjectsHref(ConnectedSystemHeader)),
+            new("Connector Space", href: Utilities.GetConnectedSystemObjectsHref(ConnectedSystemHeader)),
             new(GetDisplayIdentifier(), href: null, disabled: true)
         };
 

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectList.razor
@@ -1,4 +1,4 @@
-@page "/admin/connected-systems/{Id:int}/staging"
+@page "/admin/connected-systems/{Id:int}/connector-space"
 @attribute [Authorize(Roles = "Administrator")]
 @implements IFullWidthPage
 @implements IDisposable
@@ -20,7 +20,7 @@
 @if (_showIntro)
 {
     <MudAlert Severity="Severity.Normal" Class="mt-3 mb-3" ShowCloseIcon="true" CloseIconClicked="() => _showIntro = false">
-        This is the staging area for this Connected System. Inbound changes from the system are held here before being committed to the Metaverse. Outbound changes are staged here ahead of synchronisation to the connected system.
+        This is the connector space for this Connected System. Inbound changes from the system are held here before being committed to the Metaverse. Outbound changes are held here ahead of synchronisation to the connected system.
     </MudAlert>
 }
 
@@ -346,7 +346,7 @@ else
             new("Home", href: "/", icon: Icons.Material.Filled.Home),
             new("Connected Systems", href: "/admin/connected-systems/"),
             new(_connectedSystemHeader.Name, href: Utilities.GetConnectedSystemHref(_connectedSystemHeader)),
-            new("Staging", href: null, disabled: true)
+            new("Connector Space", href: null, disabled: true)
         };
 
         _objectTypes = (await jim.ConnectedSystems.GetObjectTypesAsync(Id))

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -104,7 +104,7 @@
                                     {
                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                             <MudChip T="string" Color="Color.Default">@_pendingExport.ConnectedSystemObject.Type.Name</MudChip>
-                                            <MudLink Href="@($"/admin/connected-systems/{ConnectedSystemId}/staging/{_pendingExport.ConnectedSystemObject.Id}")">
+                                            <MudLink Href="@($"/admin/connected-systems/{ConnectedSystemId}/connector-space/{_pendingExport.ConnectedSystemObject.Id}")">
                                                 @GetCsoDisplayName()
                                             </MudLink>
                                         </MudStack>

--- a/src/JIM.Web/Pages/Admin/PendingExportList.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportList.razor
@@ -128,7 +128,7 @@
             <MudTd DataLabel="Target Object">
                 @if (context.ConnectedSystemObjectId.HasValue)
                 {
-                    <MudLink Href="@($"/admin/connected-systems/{Id}/staging/{context.ConnectedSystemObjectId}")">
+                    <MudLink Href="@($"/admin/connected-systems/{Id}/connector-space/{context.ConnectedSystemObjectId}")">
                         @(context.TargetObjectIdentifier ?? context.ConnectedSystemObjectId.ToString())
                     </MudLink>
                 }

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -556,7 +556,7 @@ public abstract class SyncTaskProcessorBase
     /// CSO deletions are batched for performance - call FlushObsoleteCsoOperationsAsync() at page boundaries.
     /// When a joined CSO is obsoleted with Disconnect action, two RPEIs are produced:
     /// 1. Disconnected - records the CSO-MVO join being broken (with any attribute removals)
-    /// 2. Deleted - records the CSO being removed from staging
+    /// 2. Deleted - records the CSO being removed from the connector space
     /// </summary>
     /// <returns>The execution items if CSO was obsoleted (for the caller to add to the activity), empty list otherwise.</returns>
     protected async Task<List<ActivityRunProfileExecutionItem>> ProcessObsoleteConnectedSystemObjectAsync(


### PR DESCRIPTION
## Summary

- Replace all user-facing instances of "staging" with "connector space" to align with the glossary and architectural documentation
- Changes span UI routes, breadcrumbs, button labels, activity messages, API endpoints, PowerShell cmdlets, and code comments
- The `JIM.Models.Staging` namespace is unchanged as it is internal code organisation with no user-facing impact

## Changes

- **UI routes**: `/staging` → `/connector-space` (2 pages + utility method)
- **UI labels**: breadcrumbs, button text, alert text updated (4 files)
- **UI links**: hardcoded `/staging/` URLs in pending export pages updated (3 files)
- **Activity messages**: "Added to Staging" → "Added to Connector Space" etc.
- **API routes**: `/staging/` → `/connector-space/` (3 endpoints)
- **PowerShell cmdlets**: API endpoint paths updated (2 cmdlets)
- **Code comments**: XML docs updated across models and processors (6 files)

## Test plan

- [x] Full solution builds with zero errors and warnings
- [x] All 2,516 tests pass
- [x] Zero remaining `/staging` references in src, test, or docs
- [ ] Verify UI routes resolve correctly after deployment
- [ ] Verify PowerShell cmdlets work against updated API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)