### PR TITLE
fix: set unlimited size limit on Glitterband OpenLDAP database

### DIFF
--- a/test/integration/docker/openldap/scripts/01-add-second-suffix.sh
+++ b/test/integration/docker/openldap/scripts/01-add-second-suffix.sh
@@ -68,6 +68,7 @@ olcDbIndex: objectClass eq
 olcDbIndex: uid eq
 olcDbIndex: cn eq
 olcDbIndex: entryUUID eq
+olcSizeLimit: unlimited
 olcAccess: {0}to * by dn.exact="cn=admin,dc=glitterband,dc=local" manage by * read
 LDIF
 


### PR DESCRIPTION
## Summary

- The Glitterband (second partition) database had no `olcSizeLimit` configured, inheriting OpenLDAP's default of 500
- At XLarge scale (50K objects per partition), Scenario 9 scoped imports failed with "The size limit was exceeded"
- Adds `olcSizeLimit: unlimited` to the Glitterband database creation in the init script

## Test plan

- [x] Full regression XLarge OpenLDAP: 7/8 passed, only S9 failed with this error
- [ ] Re-run S9 XLarge to confirm fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)