### PR TITLE
feat: metaverse attribute data integrity validation (#465)

### DIFF
--- a/src/JIM.Application/Exceptions/MetaverseAttributeInUseException.cs
+++ b/src/JIM.Application/Exceptions/MetaverseAttributeInUseException.cs
@@ -1,0 +1,36 @@
+using JIM.Models.Core.DTOs;
+
+namespace JIM.Application.Exceptions;
+
+/// <summary>
+/// Thrown when an operation on a metaverse attribute is blocked because the attribute
+/// is still in use (has stored values or is referenced by sync rule configurations).
+/// </summary>
+public class MetaverseAttributeInUseException : InvalidOperationException
+{
+    /// <summary>
+    /// Sync rules that reference the attribute (via mappings, matching rules, or scoping criteria).
+    /// Empty if the exception is about stored values rather than sync rule references.
+    /// </summary>
+    public List<SyncRuleReference> ReferencingSyncRules { get; }
+
+    /// <summary>
+    /// The number of metaverse objects affected, if the exception relates to stored attribute values.
+    /// Null if the exception is about sync rule references.
+    /// </summary>
+    public int? AffectedObjectCount { get; }
+
+    public MetaverseAttributeInUseException(string message, List<SyncRuleReference> referencingSyncRules)
+        : base(message)
+    {
+        ReferencingSyncRules = referencingSyncRules;
+        AffectedObjectCount = null;
+    }
+
+    public MetaverseAttributeInUseException(string message, int affectedObjectCount)
+        : base(message)
+    {
+        ReferencingSyncRules = [];
+        AffectedObjectCount = affectedObjectCount;
+    }
+}

--- a/src/JIM.Application/Servers/MetaverseServer.cs
+++ b/src/JIM.Application/Servers/MetaverseServer.cs
@@ -8,6 +8,7 @@ using JIM.Models.Search;
 using JIM.Models.Security;
 using JIM.Models.Staging;
 using JIM.Models.Utility;
+using JIM.Application.Exceptions;
 using JIM.Application.Utilities;
 using Serilog;
 namespace JIM.Application.Servers;
@@ -159,12 +160,17 @@ public class MetaverseServer
     /// </summary>
     /// <param name="attribute">The attribute to delete.</param>
     /// <param name="initiatedBy">The user who initiated the deletion.</param>
+    /// <exception cref="MetaverseAttributeInUseException">
+    /// Thrown if the attribute is referenced by sync rules or has stored values on metaverse objects.
+    /// </exception>
     public async Task DeleteMetaverseAttributeAsync(MetaverseAttribute attribute, MetaverseObject? initiatedBy)
     {
         if (attribute == null)
             throw new ArgumentNullException(nameof(attribute));
 
         Log.Debug("DeleteMetaverseAttributeAsync() called for {Attribute}", attribute.Name);
+
+        await ValidateAttributeDeletionAsync(attribute);
 
         var activity = new Activity
         {
@@ -236,12 +242,17 @@ public class MetaverseServer
     /// </summary>
     /// <param name="attribute">The attribute to delete.</param>
     /// <param name="initiatedByApiKey">The API key that initiated the deletion.</param>
+    /// <exception cref="MetaverseAttributeInUseException">
+    /// Thrown if the attribute is referenced by sync rules or has stored values on metaverse objects.
+    /// </exception>
     public async Task DeleteMetaverseAttributeAsync(MetaverseAttribute attribute, ApiKey initiatedByApiKey)
     {
         if (attribute == null)
             throw new ArgumentNullException(nameof(attribute));
 
         Log.Debug("DeleteMetaverseAttributeAsync() called for {Attribute} (API key initiated)", attribute.Name);
+
+        await ValidateAttributeDeletionAsync(attribute);
 
         var activity = new Activity
         {
@@ -254,6 +265,59 @@ public class MetaverseServer
         await Application.Repository.Metaverse.DeleteMetaverseAttributeAsync(attribute);
 
         await Application.Activities.CompleteActivityAsync(activity);
+    }
+
+    /// <summary>
+    /// Validates that removing object types from an attribute's mappings will not orphan stored values.
+    /// Call this before modifying the attribute's MetaverseObjectTypes collection.
+    /// </summary>
+    /// <param name="attribute">The attribute with its current object type associations loaded.</param>
+    /// <param name="newObjectTypeIds">The new set of object type IDs to be associated with the attribute.</param>
+    /// <exception cref="MetaverseAttributeInUseException">
+    /// Thrown if any object type being removed has metaverse objects with stored values for this attribute.
+    /// </exception>
+    public async Task ValidateObjectTypeRemovalAsync(MetaverseAttribute attribute, List<int> newObjectTypeIds)
+    {
+        if (attribute == null)
+            throw new ArgumentNullException(nameof(attribute));
+
+        var currentTypeIds = attribute.MetaverseObjectTypes.Select(t => t.Id).ToHashSet();
+        var removedTypeIds = currentTypeIds.Except(newObjectTypeIds).ToList();
+
+        foreach (var removedTypeId in removedTypeIds)
+        {
+            var count = await Application.Repository.Metaverse.GetAttributeValueObjectCountByTypeAsync(attribute.Id, removedTypeId);
+            if (count > 0)
+            {
+                var objectType = await Application.Repository.Metaverse.GetMetaverseObjectTypeAsync(removedTypeId, false);
+                var typeName = objectType?.Name ?? removedTypeId.ToString();
+                throw new MetaverseAttributeInUseException(
+                    $"Cannot remove object type '{typeName}' from attribute '{attribute.Name}': {count:N0} '{typeName}' object(s) have values for this attribute. Remove the values first.",
+                    count);
+            }
+        }
+    }
+
+    private async Task ValidateAttributeDeletionAsync(MetaverseAttribute attribute)
+    {
+        // Check sync rule references first (higher priority: removing references is prerequisite)
+        var syncRuleRefs = await Application.Repository.Metaverse.GetSyncRulesReferencingAttributeAsync(attribute.Id);
+        if (syncRuleRefs.Count > 0)
+        {
+            var ruleNames = string.Join(", ", syncRuleRefs.Select(r => r.Name));
+            throw new MetaverseAttributeInUseException(
+                $"Cannot delete attribute '{attribute.Name}': it is referenced by {syncRuleRefs.Count} sync rule(s) ({ruleNames}). Remove the references first.",
+                syncRuleRefs);
+        }
+
+        // Check stored values
+        var objectCount = await Application.Repository.Metaverse.GetAttributeValueObjectCountAsync(attribute.Id);
+        if (objectCount > 0)
+        {
+            throw new MetaverseAttributeInUseException(
+                $"Cannot delete attribute '{attribute.Name}': {objectCount:N0} metaverse object(s) have values stored for this attribute. Remove the values first.",
+                objectCount);
+        }
     }
     #endregion
 

--- a/src/JIM.Data/Repositories/IMetaverseRepository.cs
+++ b/src/JIM.Data/Repositories/IMetaverseRepository.cs
@@ -279,5 +279,30 @@ public interface IMetaverseRepository
     /// </summary>
     /// <param name="attribute">The attribute to delete.</param>
     public Task DeleteMetaverseAttributeAsync(MetaverseAttribute attribute);
+
+    /// <summary>
+    /// Counts the number of distinct metaverse objects that have at least one value
+    /// stored for the specified attribute.
+    /// </summary>
+    /// <param name="attributeId">The unique identifier of the attribute.</param>
+    /// <returns>The count of distinct metaverse objects with values for this attribute.</returns>
+    public Task<int> GetAttributeValueObjectCountAsync(int attributeId);
+
+    /// <summary>
+    /// Counts the number of distinct metaverse objects of a specific type that have
+    /// at least one value stored for the specified attribute.
+    /// </summary>
+    /// <param name="attributeId">The unique identifier of the attribute.</param>
+    /// <param name="metaverseObjectTypeId">The unique identifier of the object type to filter by.</param>
+    /// <returns>The count of distinct metaverse objects of the given type with values for this attribute.</returns>
+    public Task<int> GetAttributeValueObjectCountByTypeAsync(int attributeId, int metaverseObjectTypeId);
+
+    /// <summary>
+    /// Gets the sync rules that reference the specified metaverse attribute via
+    /// sync rule mappings, mapping sources, object matching rules, or scoping criteria.
+    /// </summary>
+    /// <param name="attributeId">The unique identifier of the attribute.</param>
+    /// <returns>A list of sync rule references (ID and Name) that use this attribute.</returns>
+    public Task<List<SyncRuleReference>> GetSyncRulesReferencingAttributeAsync(int attributeId);
     #endregion
 }

--- a/src/JIM.Models/Core/DTOs/SyncRuleReference.cs
+++ b/src/JIM.Models/Core/DTOs/SyncRuleReference.cs
@@ -1,0 +1,11 @@
+namespace JIM.Models.Core.DTOs;
+
+/// <summary>
+/// Lightweight reference to a sync rule, used in validation error responses
+/// to identify which sync rules reference a given metaverse attribute.
+/// </summary>
+public class SyncRuleReference
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
+++ b/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
@@ -225,6 +225,61 @@ public class MetaverseRepository : IMetaverseRepository
         Repository.Database.MetaverseAttributes.Remove(attribute);
         await Repository.Database.SaveChangesAsync();
     }
+
+    public async Task<int> GetAttributeValueObjectCountAsync(int attributeId)
+    {
+        return await Repository.Database.MetaverseObjectAttributeValues
+            .Where(v => v.AttributeId == attributeId)
+            .Select(v => v.MetaverseObject)
+            .Distinct()
+            .CountAsync();
+    }
+
+    public async Task<int> GetAttributeValueObjectCountByTypeAsync(int attributeId, int metaverseObjectTypeId)
+    {
+        return await Repository.Database.MetaverseObjectAttributeValues
+            .Where(v => v.AttributeId == attributeId && v.MetaverseObject.Type.Id == metaverseObjectTypeId)
+            .Select(v => v.MetaverseObject)
+            .Distinct()
+            .CountAsync();
+    }
+
+    public async Task<List<SyncRuleReference>> GetSyncRulesReferencingAttributeAsync(int attributeId)
+    {
+        // Sync rule mappings where this attribute is the target (import rules)
+        var fromMappings = Repository.Database.SyncRuleMappings
+            .Where(m => m.TargetMetaverseAttributeId == attributeId && m.SyncRule != null)
+            .Select(m => new SyncRuleReference { Id = m.SyncRule!.Id, Name = m.SyncRule.Name });
+
+        // Sync rule mapping sources where this attribute is the source (export rules)
+        // SyncRuleMappingSource has no navigation to SyncRuleMapping, so join through the parent
+        var fromMappingSources = Repository.Database.SyncRuleMappings
+            .Where(m => m.Sources.Any(s => s.MetaverseAttributeId == attributeId) && m.SyncRule != null)
+            .Select(m => new SyncRuleReference { Id = m.SyncRule!.Id, Name = m.SyncRule.Name });
+
+        // Object matching rules where this attribute is the target
+        var fromMatchingRules = Repository.Database.ObjectMatchingRules
+            .Where(r => r.TargetMetaverseAttributeId == attributeId && r.SyncRule != null)
+            .Select(r => new SyncRuleReference { Id = r.SyncRule!.Id, Name = r.SyncRule.Name });
+
+        // Scoping criteria where this attribute is referenced (navigate from SyncRule down)
+        var fromScopingCriteria = Repository.Database.SyncRules
+            .Where(sr => sr.ObjectScopingCriteriaGroups
+                .Any(g => g.Criteria.Any(c => c.MetaverseAttribute != null && c.MetaverseAttribute.Id == attributeId)
+                       || g.ChildGroups.Any(cg => cg.Criteria.Any(c => c.MetaverseAttribute != null && c.MetaverseAttribute.Id == attributeId))))
+            .Select(sr => new SyncRuleReference { Id = sr.Id, Name = sr.Name });
+
+        // Union all sources and deduplicate by sync rule ID
+        var allReferences = await fromMappings
+            .Union(fromMappingSources)
+            .Union(fromMatchingRules)
+            .Union(fromScopingCriteria)
+            .GroupBy(r => r.Id)
+            .Select(g => g.First())
+            .ToListAsync();
+
+        return allReferences;
+    }
     #endregion
 
     #region metaverse objects

--- a/src/JIM.Web/Controllers/Api/MetaverseController.cs
+++ b/src/JIM.Web/Controllers/Api/MetaverseController.cs
@@ -3,6 +3,7 @@ using Asp.Versioning;
 using JIM.Web.Extensions.Api;
 using JIM.Web.Models.Api;
 using JIM.Application;
+using JIM.Application.Exceptions;
 using JIM.Models.Core;
 using JIM.Models.Core.DTOs;
 using JIM.Models.Security;
@@ -281,6 +282,17 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
         // Update object type associations if specified
         if (request.ObjectTypeIds != null)
         {
+            // Validate that removing object types won't orphan stored attribute values
+            try
+            {
+                await _application.Metaverse.ValidateObjectTypeRemovalAsync(attribute, request.ObjectTypeIds);
+            }
+            catch (MetaverseAttributeInUseException ex)
+            {
+                _logger.LogWarning("Cannot update attribute {Id} object types: {Message}", id, ex.Message);
+                return BadRequest(ApiErrorResponse.ValidationError(ex.Message));
+            }
+
             // Collection is loaded from the query when ObjectTypeIds is specified
             attribute.MetaverseObjectTypes.Clear();
             foreach (var objectTypeId in request.ObjectTypeIds)
@@ -331,12 +343,23 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
         if (attribute.BuiltIn)
             return BadRequest(ApiErrorResponse.BadRequest("Cannot delete built-in attributes."));
 
-        // Get the current API key for Activity attribution
-        var apiKey = await GetCurrentApiKeyAsync();
-        if (apiKey != null)
-            await _application.Metaverse.DeleteMetaverseAttributeAsync(attribute, apiKey);
-        else
-            await _application.Metaverse.DeleteMetaverseAttributeAsync(attribute, (MetaverseObject?)null);
+        try
+        {
+            // Get the current API key for Activity attribution
+            var apiKey = await GetCurrentApiKeyAsync();
+            if (apiKey != null)
+                await _application.Metaverse.DeleteMetaverseAttributeAsync(attribute, apiKey);
+            else
+                await _application.Metaverse.DeleteMetaverseAttributeAsync(attribute, (MetaverseObject?)null);
+        }
+        catch (MetaverseAttributeInUseException ex)
+        {
+            _logger.LogWarning("Cannot delete attribute {Id}: {Message}", id, ex.Message);
+            var error = ApiErrorResponse.ValidationError(ex.Message);
+            if (ex.ReferencingSyncRules.Count > 0)
+                error.Details = System.Text.Json.JsonSerializer.Serialize(ex.ReferencingSyncRules);
+            return BadRequest(error);
+        }
 
         _logger.LogInformation("Deleted metaverse attribute: {Id}", id);
 

--- a/test/JIM.Web.Api.Tests/MetaverseControllerAttributeTests.cs
+++ b/test/JIM.Web.Api.Tests/MetaverseControllerAttributeTests.cs
@@ -6,9 +6,11 @@ using System.Threading.Tasks;
 using JIM.Web.Controllers.Api;
 using JIM.Web.Models.Api;
 using JIM.Application;
+using JIM.Application.Exceptions;
 using JIM.Data;
 using JIM.Data.Repositories;
 using JIM.Models.Core;
+using JIM.Models.Core.DTOs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -76,6 +78,14 @@ public class MetaverseControllerAttributeTests
         {
             HttpContext = new DefaultHttpContext { User = principal }
         };
+
+        // Default: no sync rule references and no stored values (so existing delete tests pass)
+        _mockMetaverseRepo.Setup(r => r.GetSyncRulesReferencingAttributeAsync(It.IsAny<int>()))
+            .ReturnsAsync(new List<SyncRuleReference>());
+        _mockMetaverseRepo.Setup(r => r.GetAttributeValueObjectCountAsync(It.IsAny<int>()))
+            .ReturnsAsync(0);
+        _mockMetaverseRepo.Setup(r => r.GetAttributeValueObjectCountByTypeAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(0);
     }
 
     #region CreateAttributeAsync tests
@@ -464,6 +474,114 @@ public class MetaverseControllerAttributeTests
         await _controller.DeleteAttributeAsync(1);
 
         _mockMetaverseRepo.Verify(r => r.DeleteMetaverseAttributeAsync(attribute), Times.Once);
+    }
+
+    #endregion
+
+    #region DeleteAttributeAsync validation error tests
+
+    [Test]
+    public async Task DeleteAttributeAsync_WithSyncRuleReferences_ReturnsValidationError()
+    {
+        var attribute = new MetaverseAttribute
+        {
+            Id = 1,
+            Name = "costCentre",
+            BuiltIn = false
+        };
+
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseAttributeAsync(1))
+            .ReturnsAsync(attribute);
+
+        var syncRuleRefs = new List<SyncRuleReference>
+        {
+            new() { Id = 10, Name = "Import Users from LDAP" },
+            new() { Id = 20, Name = "Export Users to LDAP" }
+        };
+        _mockMetaverseRepo.Setup(r => r.GetSyncRulesReferencingAttributeAsync(1))
+            .ReturnsAsync(syncRuleRefs);
+
+        var result = await _controller.DeleteAttributeAsync(1);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        var badRequest = (BadRequestObjectResult)result;
+        var error = badRequest.Value as ApiErrorResponse;
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error!.Code, Is.EqualTo(ApiErrorCodes.ValidationError));
+        Assert.That(error.Message, Does.Contain("costCentre"));
+        Assert.That(error.Message, Does.Contain("sync rule(s)"));
+    }
+
+    [Test]
+    public async Task DeleteAttributeAsync_WithStoredValues_ReturnsValidationError()
+    {
+        var attribute = new MetaverseAttribute
+        {
+            Id = 1,
+            Name = "costCentre",
+            BuiltIn = false
+        };
+
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseAttributeAsync(1))
+            .ReturnsAsync(attribute);
+
+        _mockMetaverseRepo.Setup(r => r.GetSyncRulesReferencingAttributeAsync(1))
+            .ReturnsAsync(new List<SyncRuleReference>());
+
+        _mockMetaverseRepo.Setup(r => r.GetAttributeValueObjectCountAsync(1))
+            .ReturnsAsync(1523);
+
+        var result = await _controller.DeleteAttributeAsync(1);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        var badRequest = (BadRequestObjectResult)result;
+        var error = badRequest.Value as ApiErrorResponse;
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error!.Code, Is.EqualTo(ApiErrorCodes.ValidationError));
+        Assert.That(error.Message, Does.Contain("costCentre"));
+        Assert.That(error.Message, Does.Contain("1,523"));
+    }
+
+    #endregion
+
+    #region UpdateAttributeAsync validation error tests
+
+    [Test]
+    public async Task UpdateAttributeAsync_RemovingObjectTypeWithValues_ReturnsValidationError()
+    {
+        var personType = new MetaverseObjectType { Id = 1, Name = "person" };
+        var groupType = new MetaverseObjectType { Id = 2, Name = "group" };
+        var attribute = new MetaverseAttribute
+        {
+            Id = 1,
+            Name = "costCentre",
+            BuiltIn = false,
+            MetaverseObjectTypes = new List<MetaverseObjectType> { personType, groupType }
+        };
+
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseAttributeWithObjectTypesAsync(1))
+            .ReturnsAsync(attribute);
+
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectTypeAsync(1, false))
+            .ReturnsAsync(personType);
+
+        _mockMetaverseRepo.Setup(r => r.GetAttributeValueObjectCountByTypeAsync(1, 1))
+            .ReturnsAsync(450);
+
+        var request = new UpdateMetaverseAttributeRequest
+        {
+            ObjectTypeIds = new List<int> { 2 } // Removing personType (1)
+        };
+
+        var result = await _controller.UpdateAttributeAsync(1, request);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        var badRequest = (BadRequestObjectResult)result;
+        var error = badRequest.Value as ApiErrorResponse;
+        Assert.That(error, Is.Not.Null);
+        Assert.That(error!.Code, Is.EqualTo(ApiErrorCodes.ValidationError));
+        Assert.That(error.Message, Does.Contain("person"));
+        Assert.That(error.Message, Does.Contain("costCentre"));
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Servers/MetaverseServerAttributeValidationTests.cs
+++ b/test/JIM.Worker.Tests/Servers/MetaverseServerAttributeValidationTests.cs
@@ -1,0 +1,282 @@
+using JIM.Application;
+using JIM.Application.Exceptions;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using JIM.Models.Core.DTOs;
+using JIM.Models.Activities;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+[TestFixture]
+public class MetaverseServerAttributeValidationTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IMetaverseRepository> _mockMetaverseRepo = null!;
+    private Mock<IActivityRepository> _mockActivityRepo = null!;
+    private JimApplication _jim = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockMetaverseRepo = new Mock<IMetaverseRepository>();
+        _mockActivityRepo = new Mock<IActivityRepository>();
+
+        _mockRepository.Setup(r => r.Metaverse).Returns(_mockMetaverseRepo.Object);
+        _mockRepository.Setup(r => r.Activity).Returns(_mockActivityRepo.Object);
+
+        _mockActivityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<Activity>()))
+            .Returns(Task.CompletedTask);
+        _mockActivityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<Activity>()))
+            .Returns(Task.CompletedTask);
+
+        _jim = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _jim.Dispose();
+    }
+
+    #region DeleteMetaverseAttributeAsync validation
+
+    [Test]
+    public async Task DeleteMetaverseAttributeAsync_WithSyncRuleReferences_ThrowsMetaverseAttributeInUseExceptionAsync()
+    {
+        // Arrange
+        var attribute = new MetaverseAttribute { Id = 42, Name = "costCentre" };
+        var syncRuleRefs = new List<SyncRuleReference>
+        {
+            new() { Id = 1, Name = "Import Users from LDAP" },
+            new() { Id = 2, Name = "Export Users to LDAP" }
+        };
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetSyncRulesReferencingAttributeAsync(attribute.Id))
+            .ReturnsAsync(syncRuleRefs);
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<MetaverseAttributeInUseException>(
+            () => _jim.Metaverse.DeleteMetaverseAttributeAsync(attribute, (MetaverseObject?)null));
+
+        Assert.That(ex!.Message, Does.Contain("costCentre"));
+        Assert.That(ex.Message, Does.Contain("2 sync rule(s)"));
+        Assert.That(ex.Message, Does.Contain("Import Users from LDAP"));
+        Assert.That(ex.Message, Does.Contain("Export Users to LDAP"));
+        Assert.That(ex.ReferencingSyncRules, Has.Count.EqualTo(2));
+
+        // Verify delete was NOT called
+        _mockMetaverseRepo.Verify(
+            r => r.DeleteMetaverseAttributeAsync(It.IsAny<MetaverseAttribute>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DeleteMetaverseAttributeAsync_WithStoredValues_ThrowsMetaverseAttributeInUseExceptionAsync()
+    {
+        // Arrange
+        var attribute = new MetaverseAttribute { Id = 42, Name = "costCentre" };
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetSyncRulesReferencingAttributeAsync(attribute.Id))
+            .ReturnsAsync(new List<SyncRuleReference>());
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetAttributeValueObjectCountAsync(attribute.Id))
+            .ReturnsAsync(1523);
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<MetaverseAttributeInUseException>(
+            () => _jim.Metaverse.DeleteMetaverseAttributeAsync(attribute, (MetaverseObject?)null));
+
+        Assert.That(ex!.Message, Does.Contain("costCentre"));
+        Assert.That(ex.Message, Does.Contain("1,523 metaverse object(s)"));
+        Assert.That(ex.AffectedObjectCount, Is.EqualTo(1523));
+
+        // Verify delete was NOT called
+        _mockMetaverseRepo.Verify(
+            r => r.DeleteMetaverseAttributeAsync(It.IsAny<MetaverseAttribute>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DeleteMetaverseAttributeAsync_WithSyncRulesAndStoredValues_ChecksSyncRulesFirstAsync()
+    {
+        // Arrange: attribute has both sync rule references AND stored values
+        var attribute = new MetaverseAttribute { Id = 42, Name = "costCentre" };
+        var syncRuleRefs = new List<SyncRuleReference>
+        {
+            new() { Id = 1, Name = "Import Users from LDAP" }
+        };
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetSyncRulesReferencingAttributeAsync(attribute.Id))
+            .ReturnsAsync(syncRuleRefs);
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetAttributeValueObjectCountAsync(attribute.Id))
+            .ReturnsAsync(500);
+
+        // Act & Assert: sync rule check takes priority
+        var ex = Assert.ThrowsAsync<MetaverseAttributeInUseException>(
+            () => _jim.Metaverse.DeleteMetaverseAttributeAsync(attribute, (MetaverseObject?)null));
+
+        Assert.That(ex!.Message, Does.Contain("sync rule(s)"));
+        Assert.That(ex.ReferencingSyncRules, Has.Count.EqualTo(1));
+
+        // Value count should NOT have been checked since sync rule check failed first
+        _mockMetaverseRepo.Verify(
+            r => r.GetAttributeValueObjectCountAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DeleteMetaverseAttributeAsync_WithNoReferencesOrValues_SucceedsAsync()
+    {
+        // Arrange
+        var attribute = new MetaverseAttribute { Id = 42, Name = "costCentre" };
+        var initiatedBy = TestUtilities.GetInitiatedBy();
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetSyncRulesReferencingAttributeAsync(attribute.Id))
+            .ReturnsAsync(new List<SyncRuleReference>());
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetAttributeValueObjectCountAsync(attribute.Id))
+            .ReturnsAsync(0);
+
+        _mockMetaverseRepo
+            .Setup(r => r.DeleteMetaverseAttributeAsync(attribute))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _jim.Metaverse.DeleteMetaverseAttributeAsync(attribute, initiatedBy);
+
+        // Assert: delete was called
+        _mockMetaverseRepo.Verify(
+            r => r.DeleteMetaverseAttributeAsync(attribute), Times.Once);
+    }
+
+    [Test]
+    public async Task DeleteMetaverseAttributeAsync_ApiKeyOverload_WithSyncRuleReferences_ThrowsAsync()
+    {
+        // Arrange
+        var attribute = new MetaverseAttribute { Id = 42, Name = "costCentre" };
+        var apiKey = new JIM.Models.Security.ApiKey
+        {
+            Id = Guid.NewGuid(),
+            Name = "TestKey",
+            KeyHash = "hash",
+            KeyPrefix = "pfx",
+            IsEnabled = true,
+            Created = DateTime.UtcNow
+        };
+        var syncRuleRefs = new List<SyncRuleReference>
+        {
+            new() { Id = 1, Name = "Import Users" }
+        };
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetSyncRulesReferencingAttributeAsync(attribute.Id))
+            .ReturnsAsync(syncRuleRefs);
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<MetaverseAttributeInUseException>(
+            () => _jim.Metaverse.DeleteMetaverseAttributeAsync(attribute, apiKey));
+
+        Assert.That(ex!.ReferencingSyncRules, Has.Count.EqualTo(1));
+    }
+
+    #endregion
+
+    #region ValidateObjectTypeRemovalAsync
+
+    [Test]
+    public async Task ValidateObjectTypeRemovalAsync_WithValuesForRemovedType_ThrowsMetaverseAttributeInUseExceptionAsync()
+    {
+        // Arrange
+        var personType = new MetaverseObjectType { Id = 1, Name = "person" };
+        var groupType = new MetaverseObjectType { Id = 2, Name = "group" };
+        var attribute = new MetaverseAttribute
+        {
+            Id = 42,
+            Name = "costCentre",
+            MetaverseObjectTypes = new List<MetaverseObjectType> { personType, groupType }
+        };
+
+        // Removing "person" (keeping only "group")
+        var newObjectTypeIds = new List<int> { 2 };
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetAttributeValueObjectCountByTypeAsync(attribute.Id, personType.Id))
+            .ReturnsAsync(450);
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetMetaverseObjectTypeAsync(personType.Id, false))
+            .ReturnsAsync(personType);
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<MetaverseAttributeInUseException>(
+            () => _jim.Metaverse.ValidateObjectTypeRemovalAsync(attribute, newObjectTypeIds));
+
+        Assert.That(ex!.Message, Does.Contain("person"));
+        Assert.That(ex.Message, Does.Contain("costCentre"));
+        Assert.That(ex.Message, Does.Contain("450"));
+        Assert.That(ex.AffectedObjectCount, Is.EqualTo(450));
+    }
+
+    [Test]
+    public async Task ValidateObjectTypeRemovalAsync_WithNoValuesForRemovedType_SucceedsAsync()
+    {
+        // Arrange
+        var personType = new MetaverseObjectType { Id = 1, Name = "person" };
+        var groupType = new MetaverseObjectType { Id = 2, Name = "group" };
+        var attribute = new MetaverseAttribute
+        {
+            Id = 42,
+            Name = "costCentre",
+            MetaverseObjectTypes = new List<MetaverseObjectType> { personType, groupType }
+        };
+
+        // Removing "person" (keeping only "group")
+        var newObjectTypeIds = new List<int> { 2 };
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetAttributeValueObjectCountByTypeAsync(attribute.Id, personType.Id))
+            .ReturnsAsync(0);
+
+        _mockMetaverseRepo
+            .Setup(r => r.GetMetaverseObjectTypeAsync(personType.Id, false))
+            .ReturnsAsync(personType);
+
+        // Act & Assert: should not throw
+        Assert.DoesNotThrowAsync(
+            () => _jim.Metaverse.ValidateObjectTypeRemovalAsync(attribute, newObjectTypeIds));
+    }
+
+    [Test]
+    public async Task ValidateObjectTypeRemovalAsync_AddingObjectTypes_SucceedsAsync()
+    {
+        // Arrange: attribute currently has "person", adding "group"
+        var personType = new MetaverseObjectType { Id = 1, Name = "person" };
+        var attribute = new MetaverseAttribute
+        {
+            Id = 42,
+            Name = "costCentre",
+            MetaverseObjectTypes = new List<MetaverseObjectType> { personType }
+        };
+
+        // Adding "group" (keeping "person")
+        var newObjectTypeIds = new List<int> { 1, 2 };
+
+        // Act & Assert: no removals, should not throw or query for values
+        Assert.DoesNotThrowAsync(
+            () => _jim.Metaverse.ValidateObjectTypeRemovalAsync(attribute, newObjectTypeIds));
+
+        _mockMetaverseRepo.Verify(
+            r => r.GetAttributeValueObjectCountByTypeAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Block deletion of metaverse attributes referenced by sync rule configurations (mappings, matching rules, scoping criteria), returning the referencing sync rule IDs and names
- Block deletion of attributes that have stored values on metaverse objects, returning the affected object count
- Block removal of object type mappings from an attribute when objects of that type have stored values

Validation enforced in the application layer (`MetaverseServer`) so all JIM clients get the same protection. API returns `400 VALIDATION_ERROR` with structured error details.

Closes #465

## Test plan
- [x] 8 application-layer tests (MetaverseServerAttributeValidationTests): delete with sync refs, delete with values, sync refs checked first, success path, API key overload, object type removal with/without values, adding types
- [x] 3 controller-layer tests: delete returns VALIDATION_ERROR for sync refs and stored values, update returns VALIDATION_ERROR for object type removal
- [x] All 21 existing MetaverseControllerAttributeTests continue to pass
- [x] Full solution build: 0 warnings, 0 errors
- [x] Full solution test: all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)