### PR TITLE
chore(ci): fix Dependabot Docker paths after src/ refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,48 +55,14 @@ updates:
   # IMPORTANT: When a digest update is merged, you must also update the pinned
   # apt package versions in the corresponding Dockerfile to match the new base image.
   # Run: docker run --rm <image>@<new-digest> bash -c "apt-get update -qq && apt-cache policy <pkg>"
+  #
+  # Add new Dockerfile directories to the list below; Dependabot does not recurse.
   - package-ecosystem: "docker"
-    directory: "/JIM.Web"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Europe/London"
-    reviewers:
-      - "TetronIO/jim-maintainers"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      dotnet-base-images:
-        patterns:
-          - "mcr.microsoft.com/dotnet/*"
-
-  - package-ecosystem: "docker"
-    directory: "/JIM.Worker"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Europe/London"
-    reviewers:
-      - "TetronIO/jim-maintainers"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      dotnet-base-images:
-        patterns:
-          - "mcr.microsoft.com/dotnet/*"
-
-  - package-ecosystem: "docker"
-    directory: "/JIM.Scheduler"
+    directories:
+      - "/src/JIM.Web"
+      - "/src/JIM.Worker"
+      - "/src/JIM.Scheduler"
+      - "/.devcontainer"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot's three Docker blocks for JIM.Web, JIM.Worker, and JIM.Scheduler have been silently failing for ~8 weeks. The paths reference the pre-\`src/\` layout and no longer match where the Dockerfiles live.

## Root cause

- **16 Feb 2026:** Dependabot successfully opened and merged PRs #321-#326 updating base image digests against \`/JIM.Web/Dockerfile\`, \`/JIM.Worker/Dockerfile\`, \`/JIM.Scheduler/Dockerfile\`.
- **Same day:** Commit \`70b35553\` (*refactor: Move source projects into src/ directory to declutter repo root*) relocated all three Dockerfiles to \`src/JIM.Web/\`, \`src/JIM.Worker/\`, \`src/JIM.Scheduler/\`.
- \`.github/dependabot.yml\` was not updated to match, so every subsequent scheduled Dependabot run has been unable to find any Dockerfiles to scan.
- OS-level CVEs in the pinned base images have accumulated in release SBOMs (discovered via SBOM Observer showing 9 vulnerabilities in \`sbom-jim-worker.spdx.json\`, all traceable to \`openssl\`, \`tar\`, \`bsdutils\`, and \`cvs-utils\` in the Ubuntu Noble base layer).

## Fix

Consolidate the three near-identical Docker blocks into a single entry using the multi-directory \`directories\` key ([GitHub, June 2024](https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/)), pointing at the correct \`src/\` paths. Also include \`.devcontainer/\`, which ships a Dockerfile but was never tracked by Dependabot.

\`\`\`yaml
- package-ecosystem: \"docker\"
  directories:
    - \"/src/JIM.Web\"
    - \"/src/JIM.Worker\"
    - \"/src/JIM.Scheduler\"
    - \"/.devcontainer\"
\`\`\`

All other settings (schedule, reviewers, groups, ignore rules) are preserved unchanged.

## What to expect after merge

1. On the next scheduled run (Monday 09:00 Europe/London), Dependabot will scan all four Dockerfiles.
2. At present, the live digests on MCR for \`dotnet/aspnet:10.0-noble\`, \`dotnet/runtime:10.0-noble\`, and \`dotnet/sdk:10.0-noble\` exactly match what's already pinned in the repo (Microsoft last rebuilt these on 2026-04-03), so no bump PR will open immediately.
3. When Microsoft next publishes a rebuilt \`10.0-noble\` image incorporating Ubuntu security patches, Dependabot will open a grouped PR within 24 hours. Merging it will clear the CVEs currently showing in SBOM Observer.

## Test plan

- [x] YAML parses cleanly (\`python3 -c 'import yaml; yaml.safe_load(...)'\`)
- [x] All four update blocks preserved (nuget, docker-images, docker-compose, github-actions)
- [x] Docker block contains all three production Dockerfile paths plus devcontainer
- [x] No .NET build/test required; \`.github/\` config is in the CLAUDE.md build/test exception list
- [ ] Post-merge: verify next Dependabot scheduled run (Monday 09:00 BST) shows no errors in repo Insights -> Dependency graph -> Dependabot