### PR TITLE
feat: claims diagnostic viewer and sign-out/Keycloak docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,11 +134,13 @@ JIM_SSO_API_SCOPE=jim-api
 # Only set this if your provider's issuer URL differs from its authority URL,
 # or you need to trust multiple issuers (e.g., during a provider migration).
 #
-# The bundled Keycloak defaults below cover both access paths:
-#   - localhost:8181 (browser, local F5 debugging)
-#   - jim.keycloak:8080 (Docker DNS, back-channel from jim.web container)
+# The bundled Keycloak is configured with KC_HOSTNAME=http://localhost:8181,
+# so its 'iss' claim is always http://localhost:8181/realms/jim regardless
+# of whether JIM.Web reaches Keycloak via localhost (native debugging) or
+# Docker DNS (full stack). Only the back-channel endpoint URLs in the
+# discovery document vary by access path; the token 'iss' claim is constant.
 #
-JIM_SSO_VALID_ISSUERS=http://localhost:8181/realms/jim,http://jim.keycloak:8080/realms/jim
+JIM_SSO_VALID_ISSUERS=http://localhost:8181/realms/jim
 
 # =============================================================================
 # User Identity Mapping

--- a/docs/administration/configuration.md
+++ b/docs/administration/configuration.md
@@ -82,6 +82,25 @@ These variables control how JIM maps authenticated users to metaverse objects, e
 
 ---
 
+## Service Settings
+
+Service settings are stored in the database and managed through the admin UI at **Admin > Service Settings** (`/admin/settings`). They can be changed at runtime by users with the Administrator role; most take effect immediately, without restarting the JIM containers.
+
+This differs from environment variables, which are applied at process startup and tend to be infrastructure-level concerns (database connection, OIDC authority, log paths). Service settings are the day-to-day operational knobs.
+
+The settings listed below are the ones most commonly adjusted; the full list is discoverable in the admin UI.
+
+| Key                          | Display name              | Category        | Description                                                                                                                                                                                                                                                      | Default       |
+|------------------------------|---------------------------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `SSO.EnableLogOut`           | SSO enable log-out        | SSO             | Controls whether the sign-out button is shown in the JIM user menu. Set to `false` for deployments where users cannot realistically sign out of their enterprise-managed SSO session, for example on domain-joined devices with seamless SSO. | `true`        |
+| `Sync.PartitionValidationMode` | Run profile partition validation | Synchronisation | Controls how JIM behaves when a run profile is executed for a Connected System that supports partitions but has none selected. `Error` blocks execution; `Warning` allows execution but logs a warning.                                                         | `Error`       |
+| `History.RetentionPeriod`    | History retention period  | History         | The duration for which activity and audit history is retained. Format: `d.hh:mm:ss`. Longer periods increase database size and may affect performance.                                                                                                          | `90.00:00:00` (90 days) |
+
+!!! tip "Editing service settings"
+    Navigate to **Admin > Service Settings**, use the filter and search box to locate the setting by key or display name, and click the edit icon. Changes are audited: the settings page shows who last modified each value and when.
+
+---
+
 ## Logging
 
 | Variable           | Description                                                                        | Default         | Example          |

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -39,6 +39,7 @@ JIM requires an OIDC-compliant identity provider for authentication. This guide 
         - Platform: **Web**
         - URI: `https://your-jim-url/signin-oidc`
 5. Click **Register**
+6. After registration, go to **Authentication** and add a second Web redirect URI for the sign-out callback: `https://your-jim-url/signout-callback-oidc`, then click **Save**. Entra ID validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
 
 ### Step 2: Note the Application Details
 
@@ -93,7 +94,9 @@ To enable OAuth authentication in the Swagger UI:
 4. Add redirect URI: `https://your-jim-url/api/swagger/oauth2-redirect.html`
 5. Click **Configure**
 
-### Step 5b: Configure PowerShell Module Authentication (Optional)
+### Step 5b: Configure PowerShell Module Authentication (Optional but recommended)
+
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
 
 To enable interactive browser-based authentication for the JIM PowerShell module:
 
@@ -161,7 +164,8 @@ JIM_SSO_API_SCOPE=api://12345678-1234-1234-1234-123456789abc/access_as_user
 
 1. Note the **Client Identifier** (auto-generated GUID)
 2. Add the **Redirect URI**: `https://your-jim-url/signin-oidc`
-3. Click **Next**
+3. Add a second **Redirect URI** for the sign-out callback: `https://your-jim-url/signout-callback-oidc`. AD FS validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
+4. Click **Next**
 
 ### Step 3: Configure Access Control
 
@@ -173,7 +177,9 @@ JIM_SSO_API_SCOPE=api://12345678-1234-1234-1234-123456789abc/access_as_user
 1. Select **openid** and **profile** scopes
 2. Click **Next** and then **Close**
 
-### Step 4a: Configure PowerShell Module Authentication (Optional)
+### Step 4a: Configure PowerShell Module Authentication (Optional but recommended)
+
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
 
 The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. AD FS supports this through native applications.
 
@@ -336,7 +342,9 @@ If you need separate API clients for service-to-service communication:
 3. Click **Add client scope**
 4. Select `jim-api` and add as **Optional**
 
-### Step 6a: Configure PowerShell Module Authentication (Optional)
+### Step 6a: Configure PowerShell Module Authentication (Optional but recommended)
+
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
 
 The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. This requires creating a public client in Keycloak.
 
@@ -430,14 +438,27 @@ You should see a JSON response with endpoints for `authorization_endpoint`, `tok
     - `name` -- Your display name
     - `email` -- Your email address
 
-### 4. Test the API (Swagger)
+### 4. Test Sign-Out
+
+1. With an active JIM session, open the user menu in the navigation drawer (bottom-left)
+2. Click **Sign out** and confirm the dialog
+3. You should be redirected briefly to your identity provider's end-session endpoint, then returned to JIM
+4. You should end up signed out of JIM; reopening a protected page should redirect you to your identity provider to sign in again
+
+!!! info "Scope of sign-out"
+    Sign-out clears the JIM session cookie and notifies the identity provider via RP-initiated logout (OIDC [end_session_endpoint](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)). Whether the user is also signed out of other applications that share the same identity provider session depends entirely on the identity provider's single sign-out configuration, not JIM.
+
+!!! tip "Hiding the sign-out button"
+    For deployments where users cannot realistically sign out of their enterprise-managed SSO session (for example, on domain-joined devices with seamless SSO), administrators can hide the sign-out button entirely by setting the `SSO.EnableLogOut` service setting to `false`. See [Service Settings](configuration.md#service-settings) in the configuration reference.
+
+### 5. Test the API (Swagger)
 
 1. Navigate to `https://your-jim-url/api/swagger`
 2. Click **Authorise**
 3. Log in with your identity provider
 4. Try an API endpoint (e.g. `GET /api/v1/health`)
 
-### 5. Test the PowerShell Module
+### 6. Test the PowerShell Module
 
 If you configured PowerShell module authentication:
 
@@ -459,6 +480,29 @@ Test-JIMConnection
 # Message        : Connection successful
 # TokenExpiresAt : <date/time>
 ```
+
+---
+
+## Sign-Out Troubleshooting
+
+Sign-out uses OIDC [RP-initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html): JIM clears its local session cookie, then redirects the browser to the identity provider's `end_session_endpoint` with an `id_token_hint` and a `post_logout_redirect_uri`. The identity provider ends its session and redirects the browser back to JIM.
+
+The most common failure modes and how to fix them:
+
+**"AADSTS50011: The reply URL specified in the request does not match..."** (Entra ID)
+: The post-logout URI (`https://your-jim-url/signout-callback-oidc`) is not registered against the app. Add it to **Authentication** > **Platform configurations** > **Web** > **Redirect URIs** and save. See [Entra ID Step 1](#step-1-register-the-application).
+
+**"Invalid post_logout_redirect_uri"** or similar (AD FS, Keycloak)
+: Same root cause as above: the URI is not in the application's registered redirect URI list. For AD FS, add `https://your-jim-url/signout-callback-oidc` to the Web Application's Redirect URIs (see [AD FS Step 2](#step-2-configure-the-native-application)). For Keycloak, add it to **Valid post logout redirect URIs** on the client (see [Keycloak Step 2](#step-2-create-a-client-for-jim)).
+
+**"Missing parameters: id_token_hint"** (Keycloak and other strict providers)
+: Keycloak and other strict OIDC providers require `id_token_hint` on the end-session request per the OIDC specification. JIM persists the ID token during sign-in automatically so the middleware can include it on sign-out. If you see this error, verify your identity provider is actually issuing an ID token (the `openid` scope must be requested, which JIM does by default) and that your client configuration is not stripping it.
+
+**Sign-out appears to succeed, but refreshing the page keeps you signed in**
+: This usually means the identity provider still has an active single sign-on session and is silently re-authenticating JIM via the `prompt=none` flow (or cached browser credentials). This is working as designed for SSO. To test a full sign-out flow, use a private/incognito browser window, or sign out of the identity provider session directly.
+
+**The sign-out button is missing from the user menu**
+: The sign-out button is gated by the `SSO.EnableLogOut` service setting, which is enabled by default. See [Service Settings](configuration.md#service-settings) in the configuration reference.
 
 ---
 

--- a/docs/developer/dev-environment.md
+++ b/docs/developer/dev-environment.md
@@ -50,12 +50,28 @@ JIM ships a bundled Keycloak instance for development SSO, removing the need for
 | Admin console URL | `http://localhost:8181` |
 | Admin credentials | `admin` / `admin` |
 | Pre-configured realm | `jim` |
+| Pre-configured test users | `admin` / `admin`, `user` / `user` |
 
 Keycloak management aliases:
 
 - `jim-keycloak`: Start Keycloak only (for local debugging workflow)
 - `jim-keycloak-stop`: Stop Keycloak
 - `jim-keycloak-logs`: View Keycloak logs
+
+### Front-channel and back-channel URLs
+
+The bundled Keycloak is configured so that the browser and JIM.Web each see the right endpoint URLs for their network path, without JIM.Web having to rewrite URLs itself. This makes sign-in and sign-out work identically whether you run JIM.Web natively (`jim-build-light`) or inside the full Docker stack (`jim-build`).
+
+Three environment variables in [docker-compose.override.yml](https://github.com/TetronIO/JIM/blob/main/docker-compose.override.yml) make this work:
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `KC_HOSTNAME` | `http://localhost:8181` | The public, browser-facing URL. Advertised in the discovery document, `iss` claim, redirects, and the `end_session_endpoint`. |
+| `KC_HOSTNAME_STRICT` | `false` | Accept requests whose `Host` header doesn't match `KC_HOSTNAME`, so back-channel calls from inside the Docker network are not rejected. |
+| `KC_HOSTNAME_BACKCHANNEL_DYNAMIC` | `true` | Derive back-channel endpoint URLs (token, userinfo, JWKS) from each request's `Host` header, so JIM.Web in the Docker network receives `jim.keycloak:8080` endpoints while the browser receives `localhost:8181` endpoints. |
+
+!!! warning "Do not change these without reading the comment block"
+    The three `KC_HOSTNAME*` variables work as a set. Removing or changing any of them in isolation will break sign-in or sign-out (or both) in at least one of the three supported dev scenarios: Codespaces, devcontainer native debugging (`jim-build-light`), and devcontainer Docker stack (`jim-build`). See the inline comment in [docker-compose.override.yml](https://github.com/TetronIO/JIM/blob/main/docker-compose.override.yml) for the full rationale.
 
 ## Shell Aliases
 

--- a/src/JIM.Web/Pages/Claims.razor
+++ b/src/JIM.Web/Pages/Claims.razor
@@ -1,15 +1,22 @@
 ﻿@page "/claims"
 @using System.Security.Claims
+@inject IJimApplicationFactory JimFactory
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
 
 <PageTitle>Your Claims</PageTitle>
 <MudText Typo="Typo.h4">Your Claims</MudText>
+<MudText Typo="Typo.body1" Class="mt-2">
+    Claims are pieces of information about you that your identity provider has asserted during sign-in. JIM uses these
+    values to establish your identity, display your name, and determine what you are authorised to do. The table below
+    lists every claim present on your current session, which is useful for diagnosing sign-in, authorisation, or
+    identity mapping issues.
+</MudText>
 
 @if (User != null)
 {
-    <MudTable Items="@User.Claims.OrderBy(q=> q.Type)" Hover="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5">
+    <MudTable Items="@User.Claims.OrderBy(q=> q.Type)" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5">
         <HeaderContent>
             <MudTh><MudText Typo="Typo.button">Claim Type</MudText></MudTh>
             <MudTh><MudText Typo="Typo.button">Claim Value</MudText></MudTh>
@@ -19,12 +26,39 @@
             <MudTd DataLabel="Claim Value">@context.Value</MudTd>
         </RowTemplate>
     </MudTable>
+
+    <MudText Typo="Typo.h4" Class="mt-8">Identity Provider</MudText>
+    <MudText Typo="Typo.body1" Class="mt-2">
+        Non-sensitive details about the identity provider JIM is configured to trust, together with runtime information
+        about how your current session was authenticated. Secrets (client secret, tokens) are deliberately excluded.
+    </MudText>
+
+    <MudTable Items="@_idpInfo" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5">
+        <HeaderContent>
+            <MudTh><MudText Typo="Typo.button">Setting</MudText></MudTh>
+            <MudTh><MudText Typo="Typo.button">Value</MudText></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Setting">@context.Label</MudTd>
+            <MudTd DataLabel="Value">
+                @if (string.IsNullOrEmpty(context.Value))
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary"><em>(not set)</em></MudText>
+                }
+                else
+                {
+                    @context.Value
+                }
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 }
 
 @code {
     [CascadingParameter]
     private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
     private ClaimsPrincipal? User { get; set; }
+    private List<IdpInfoRow> _idpInfo = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -32,5 +66,27 @@
             return;
 
         User = (await AuthenticationStateTask).User;
+
+        using var jim = JimFactory.Create();
+        var settings = await jim.ServiceSettings.GetServiceSettingsAsync();
+
+        var identity = User.Identity as ClaimsIdentity;
+        var issuer = User.FindFirstValue("iss");
+
+        _idpInfo =
+        [
+            new IdpInfoRow("Authority", settings?.SSOAuthority),
+            new IdpInfoRow("Client ID", settings?.SSOClientId),
+            new IdpInfoRow("Unique identifier claim", settings?.SSOUniqueIdentifierClaimType),
+            new IdpInfoRow("Mapped metaverse attribute", settings?.SSOUniqueIdentifierMetaverseAttribute?.Name),
+            new IdpInfoRow("Sign-out enabled", settings is null ? null : settings.SSOEnableLogOut ? "Yes" : "No"),
+            new IdpInfoRow("Token issuer (iss)", issuer),
+            new IdpInfoRow("Authentication type", identity?.AuthenticationType),
+            new IdpInfoRow("Is authenticated", identity?.IsAuthenticated == true ? "Yes" : "No"),
+            new IdpInfoRow("Name claim type", identity?.NameClaimType),
+            new IdpInfoRow("Role claim type", identity?.RoleClaimType),
+        ];
     }
+
+    private sealed record IdpInfoRow(string Label, string? Value);
 }

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -206,6 +206,17 @@ try
             // .NET looks for the legacy XML URI by default. Point it at the standard OIDC claim.
             options.TokenValidationParameters.NameClaimType = "name";
 
+            // By default, the ASP.NET Core OpenIdConnect handler drops a number of "protocol" claims
+            // (iss, aud, azp, acr, auth_time, ...) after it has validated them, so they never reach
+            // the cookie identity. Explicitly map them back in so administrators can diagnose sign-in
+            // issues from the /claims page without enabling trace logging. These values are not used
+            // for authorisation decisions; they are informational only.
+            options.ClaimActions.MapJsonKey("iss", "iss");
+            options.ClaimActions.MapJsonKey("aud", "aud");
+            options.ClaimActions.MapJsonKey("azp", "azp");
+            options.ClaimActions.MapJsonKey("acr", "acr");
+            options.ClaimActions.MapJsonKey("auth_time", "auth_time");
+
             // Accept tokens from any configured valid issuer (supports Docker DNS + localhost dual-path)
             if (validIssuers.Length > 0)
             {

--- a/src/JIM.Web/Shared/DrawerUserMenu.razor
+++ b/src/JIM.Web/Shared/DrawerUserMenu.razor
@@ -1,8 +1,10 @@
 @using System.Security.Claims
+@using Microsoft.Extensions.Hosting
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IJimApplicationFactory JimFactory
 @inject IDialogService DialogService
 @inject NavigationManager NavigationManager
+@inject IWebHostEnvironment Environment
 
 @if (_loaded)
 {
@@ -52,6 +54,16 @@
                                    Color="Color.Primary" Size="Size.Small" Class="ma-0 jim-user-menu-switch" />
                     </div>
                 </MudListItem>
+                @if (_isDevelopment)
+                {
+                    <MudDivider Class="my-1" />
+                    <MudListItem OnClick="HandleViewClaims">
+                        <div class="d-flex align-center gap-2">
+                            <MudIcon Icon="@Icons.Material.Filled.Badge" Size="Size.Small" />
+                            <MudText Typo="Typo.body2">View claims</MudText>
+                        </div>
+                    </MudListItem>
+                }
                 @if (_showSignOut)
                 {
                     <MudDivider Class="my-1" />
@@ -96,6 +108,7 @@
     private string? _preferredUsername;
     private string _initials = "?";
     private bool _showSignOut;
+    private bool _isDevelopment;
     private bool _loaded;
 
     protected override async Task OnInitializedAsync()
@@ -110,6 +123,8 @@
         using var jim = JimFactory.Create();
         var settings = await jim.ServiceSettings.GetServiceSettingsAsync();
         _showSignOut = settings?.SSOEnableLogOut ?? true;
+
+        _isDevelopment = Environment.IsDevelopment();
 
         _loaded = true;
     }
@@ -132,6 +147,12 @@
     private async Task HandleToggleDarkMode()
     {
         await IsDarkModeChanged.InvokeAsync(!IsDarkMode);
+    }
+
+    private void HandleViewClaims()
+    {
+        ClosePopover();
+        NavigationManager.NavigateTo("/claims");
     }
 
     private async Task HandleSignOutAsync()


### PR DESCRIPTION
## Summary

- **Dev-only claims viewer in the user menu** — adds a "View claims" item to the navigation drawer user menu, gated on `IWebHostEnvironment.IsDevelopment()` so it only renders in the Development environment. Links to the existing `/claims` page. The page now has an introductory paragraph, a dense claims table, and a second "Identity Provider" table showing non-sensitive configuration (authority, client ID, unique identifier claim, mapped metaverse attribute, issuer, authentication type, name/role claim types). Secrets and tokens are deliberately excluded.
- **Expose OIDC protocol claims for diagnostics** — `iss`, `aud`, `azp`, `acr`, and `auth_time` are no longer dropped by the ASP.NET Core OpenIdConnect handler before reaching the cookie identity. They are now mapped back in via `ClaimActions.MapJsonKey(...)` so administrators can see them on the `/claims` page when debugging sign-in. Validation still happens via `TokenValidationParameters` as before; this change is strictly informational.
- **Documentation updates** — documents sign-out callback URIs for Entra ID and AD FS, adds a "Test sign-out" step to the verification walkthrough, explains the `SSO.EnableLogOut` service setting, documents the bundled Keycloak `KC_HOSTNAME` configuration and the resulting single-issuer simplification of `JIM_SSO_VALID_ISSUERS`, and flags the PowerShell module as recommended in the SSO setup flow.

## Why

The `/claims` page existed as an unlinked dev diagnostic but had no discoverability. Putting it behind a dev-only menu item makes it available in the devcontainer and native local dev without risking exposure in production. While adding it, the page grew a second table that answers the common follow-up question ("what IdP config is JIM actually using?") without needing to enable trace logging or shell into the container, and the protocol-claim mappings fix a gap where `iss`/`aud`/etc. were invisible despite being validated.

The docs commit captures the sign-out and Keycloak hostname work that completed the recent sign-out stabilisation effort.

## Test plan

- [x] `dotnet build JIM.sln` — 0 warnings, 0 errors
- [x] `dotnet test JIM.sln` — 2535 passed, 0 failed across 6 test projects
- [ ] Manual: start devcontainer stack, sign in, open user menu, confirm "View claims" item appears, navigate to `/claims`, confirm both tables render with `iss`/`aud`/`auth_time` populated
- [ ] Manual: set `ASPNETCORE_ENVIRONMENT=Production` (or unset it) and confirm the menu item is hidden

## Related

- Part of the sign-out work (#49)
- Groundwork context for Centralised Entitlement Management (#515)

🤖 Generated with [Claude Code](https://claude.com/claude-code)