### PR TITLE
chore(ci): enforce digest-pinning and cover all production base images

### DIFF
--- a/.github/scripts/discover-base-images.ps1
+++ b/.github/scripts/discover-base-images.ps1
@@ -1,0 +1,168 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Discovers production Dockerfiles and their pinned base image references, and
+    enforces the digest-pinning policy for them.
+
+.DESCRIPTION
+    Walks the repository for files named "Dockerfile". Any Dockerfile that contains
+    the machine-readable directive "# jim-compliance: production-image" is treated
+    as a production image, which means:
+
+      1. Every external FROM line (i.e. not a "FROM <stage-alias>" intra-file
+         reference, and not "FROM scratch") must be digest-pinned with @sha256:.
+         Any unpinned reference is a policy violation and fails the script.
+
+      2. All resolved image references are emitted as a matrix, deduplicated by
+         image ref, so downstream jobs can scan each unique image exactly once.
+
+    Dockerfiles that do NOT carry the compliance directive (e.g. the devcontainer
+    image, test fixture images for Samba AD / OpenLDAP) are skipped entirely. They
+    are not in scope for either the digest-pin policy or the vulnerability scan.
+
+    Intended to run in CI (.github/workflows/ci.yml) but also runnable locally from
+    the repository root for ad hoc verification:
+
+        pwsh -NoProfile -File .github/scripts/discover-base-images.ps1
+
+    Exits with 0 if everything is compliant, 1 if any policy violation is found or
+    if no production Dockerfiles are discovered at all.
+
+.NOTES
+    This script is the source of truth for "which production base images are
+    scanned". There is no parallel list anywhere else. Adding a new production
+    Dockerfile means adding the "# jim-compliance: production-image" directive to
+    the file itself and nothing else. See engineering/DEVELOPER_GUIDE.md "Docker
+    Base Images" section for the full policy.
+
+    Edge case not currently enforced: a production-labelled Dockerfile with zero
+    external FROM lines will not be flagged by this script. Docker itself would
+    refuse to build such a file, so the gap is covered at build time.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Get-Location).Path
+$results = @()
+$policyViolations = @()
+
+# Find every Dockerfile in the repo, including those in hidden directories like
+# .devcontainer. Exclude build/tooling directories that may contain unrelated
+# Dockerfiles (none expected today; the exclusions are defensive for future).
+$dockerfiles = Get-ChildItem -Path $repoRoot -Recurse -File -Filter 'Dockerfile' -Force |
+    Where-Object {
+        $_.FullName -notmatch '[\\/]node_modules[\\/]' -and
+        $_.FullName -notmatch '[\\/]\.claude[\\/]' -and
+        $_.FullName -notmatch '[\\/]\.git[\\/]' -and
+        $_.FullName -notmatch '[\\/]bin[\\/]' -and
+        $_.FullName -notmatch '[\\/]obj[\\/]'
+    }
+
+Write-Host "Discovered $($dockerfiles.Count) Dockerfile(s)"
+
+foreach ($dockerfile in $dockerfiles) {
+    $relativePath = [IO.Path]::GetRelativePath($repoRoot, $dockerfile.FullName) -replace '\\', '/'
+    $content = Get-Content -Path $dockerfile.FullName -Raw
+
+    # Production label check: compact machine-readable directive on its own line.
+    $isProduction = $content -match '(?m)^#\s*jim-compliance:\s*production-image\s*$'
+
+    if (-not $isProduction) {
+        Write-Host "SKIP: $relativePath (not labelled jim-compliance: production-image)"
+        continue
+    }
+
+    Write-Host "SCAN: $relativePath"
+
+    # Collect stage aliases defined by "FROM ... AS <alias>" so we can distinguish
+    # intra-file stage references from external image references.
+    $aliases = @()
+    foreach ($line in ($content -split "`n")) {
+        if ($line -match '^\s*FROM\s+\S+\s+AS\s+(\S+)') {
+            $aliases += $matches[1]
+        }
+    }
+
+    # Parse every FROM line in this Dockerfile.
+    $lineNumber = 0
+    foreach ($line in ($content -split "`n")) {
+        $lineNumber++
+        if ($line -notmatch '^\s*FROM\s+(\S+)') { continue }
+        $imageRef = $matches[1]
+
+        # Skip intra-file stage references (e.g. "FROM build AS final").
+        if ($aliases -contains $imageRef) {
+            Write-Host "  line ${lineNumber}: stage alias '$imageRef' (skipped)"
+            continue
+        }
+
+        # Skip "FROM scratch".
+        if ($imageRef -eq 'scratch') {
+            Write-Host "  line ${lineNumber}: scratch (skipped)"
+            continue
+        }
+
+        # Enforce the digest-pinning policy.
+        if ($imageRef -notmatch '@sha256:[0-9a-f]{64}') {
+            $policyViolations += "${relativePath}:${lineNumber}: FROM $imageRef is not digest-pinned"
+            Write-Host "  line ${lineNumber}: $imageRef (POLICY VIOLATION: not digest-pinned)"
+            continue
+        }
+
+        Write-Host "  line ${lineNumber}: $imageRef (ok)"
+        $results += [pscustomobject]@{
+            dockerfile = $relativePath
+            line       = $lineNumber
+            image_ref  = $imageRef
+        }
+    }
+}
+
+Write-Host ''
+
+if ($policyViolations.Count -gt 0) {
+    Write-Host '== POLICY VIOLATIONS =='
+    foreach ($v in $policyViolations) { Write-Host "  $v" }
+    Write-Host ''
+    Write-Host 'Production Dockerfiles must digest-pin every external FROM line.'
+    Write-Host 'See engineering/DEVELOPER_GUIDE.md "Docker Base Images" section.'
+    exit 1
+}
+
+# Sanity check: a working repo must have at least one production Dockerfile. Zero
+# means the compliance label has been accidentally removed from every production
+# image, which is itself a regression to catch here rather than silently pass.
+if ($results.Count -eq 0) {
+    Write-Host 'No production-labelled Dockerfiles discovered.'
+    Write-Host 'Expected at least one Dockerfile with "# jim-compliance: production-image".'
+    Write-Host 'If this is intentional, update this script; otherwise check that the labels'
+    Write-Host 'have not been accidentally removed from src/JIM.*/Dockerfile.'
+    exit 1
+}
+
+# Deduplicate by image_ref: no point scanning the same digest twice.
+$deduped = @($results | Sort-Object image_ref -Unique)
+Write-Host "Unique image refs to scan: $($deduped.Count)"
+
+foreach ($r in $deduped) {
+    Write-Host "  $($r.image_ref)"
+    Write-Host "    from $($r.dockerfile):$($r.line)"
+}
+
+# Build matrix JSON for GitHub Actions consumption.
+$matrixObject = @{ include = $deduped }
+$matrixJson = $matrixObject | ConvertTo-Json -Compress -Depth 4
+
+Write-Host ''
+Write-Host '== Matrix JSON =='
+Write-Host $matrixJson
+
+# If running in GitHub Actions, write to $GITHUB_OUTPUT so the scan job matrix can
+# consume it via needs.discover-base-images.outputs.matrix.
+if ($env:GITHUB_OUTPUT) {
+    "matrix=$matrixJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    Write-Host ''
+    Write-Host 'Wrote matrix to GITHUB_OUTPUT'
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,45 +53,59 @@ jobs:
         name: pester-test-results
         path: ./TestResults/pester-results.xml
 
-  scan-base-images:
-    # Scan pinned Docker base images for CRITICAL/HIGH CVEs
-    # This catches vulnerabilities early, before a release tag is created
+  discover-base-images:
+    # Discover production Dockerfiles and enforce the digest-pinning policy.
+    # Production Dockerfiles are identified by the "# jim-compliance: production-image"
+    # directive; unlabelled Dockerfiles (devcontainer, test fixtures) are out of scope.
+    # The job emits a matrix of unique base image references for scan-base-images to
+    # consume. Any production Dockerfile with a non-digest-pinned FROM line fails here.
+    # See .github/scripts/discover-base-images.ps1 and engineering/DEVELOPER_GUIDE.md.
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: aspnet
-            dockerfile: src/JIM.Web/Dockerfile
-          - name: runtime
-            dockerfile: src/JIM.Worker/Dockerfile
-          - name: sdk
-            dockerfile: src/JIM.Worker/Dockerfile
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Extract base image reference
-      id: base-image
-      run: |
-        if [ "${{ matrix.name }}" = "sdk" ]; then
-          # Extract the SDK (build stage) FROM line
-          IMAGE_REF=$(grep -E '^FROM.*sdk:.*@sha256:' "${{ matrix.dockerfile }}" | head -1 | awk '{print $2}')
-        else
-          # Extract the first (runtime/aspnet) FROM line
-          IMAGE_REF=$(grep -E '^FROM.*(aspnet|runtime):.*@sha256:' "${{ matrix.dockerfile }}" | head -1 | awk '{print $2}')
-        fi
-        # Strip " AS <alias>" suffix if present
-        IMAGE_REF=$(echo "$IMAGE_REF" | sed 's/ AS .*//')
-        echo "ref=$IMAGE_REF" >> "$GITHUB_OUTPUT"
-        echo "Scanning: $IMAGE_REF"
+    - name: Discover production base images and enforce digest-pinning
+      id: discover
+      shell: pwsh
+      run: ./.github/scripts/discover-base-images.ps1
 
-    - name: Scan ${{ matrix.name }} base image for vulnerabilities
+  scan-base-images:
+    # Scan each discovered production base image for CRITICAL/HIGH CVEs with a
+    # published fix. Emits SARIF so findings are surfaced in the GitHub Security tab,
+    # not just the Actions log. Catches vulnerabilities early, before a release tag
+    # is created. The matrix is generated dynamically by discover-base-images, so
+    # adding a new production Dockerfile requires zero changes to this workflow:
+    # just add the "# jim-compliance: production-image" directive to the new file.
+    needs: discover-base-images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # required to upload SARIF to code scanning
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-base-images.outputs.matrix) }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Scan base image for vulnerabilities
+      id: trivy
       uses: aquasecurity/trivy-action@0.35.0
       with:
-        image-ref: ${{ steps.base-image.outputs.ref }}
-        format: 'table'
+        image-ref: ${{ matrix.image_ref }}
+        format: 'sarif'
+        output: 'trivy-results.sarif'
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
         ignore-unfixed: true
+
+    - name: Upload Trivy scan results to GitHub code scanning
+      if: always() && hashFiles('trivy-results.sarif') != ''
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: trivy-results.sarif
+        category: trivy-base-image-${{ matrix.dockerfile }}-line${{ matrix.line }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,41 +104,88 @@ jobs:
 
     - name: Scan base image for vulnerabilities
       id: trivy
-      # Force the severity filter and ignore-unfixed flag via step-level env vars
-      # rather than trivy-action inputs. trivy-action's set_env_var_if_provided
-      # helper was observed to drop the severity filter in CI (12 LOW-severity
-      # openssl findings slipped through a CRITICAL,HIGH filter), while the same
-      # version running locally with identical flags correctly filtered them out.
-      # Trivy itself reads TRIVY_SEVERITY and TRIVY_IGNORE_UNFIXED directly, so
-      # setting them at the step env: level bypasses the action's wrapper logic.
+      # Scan with no severity filter: trivy-action's severity filter was
+      # observed to drop findings correctly locally but not in CI (LOW-severity
+      # CVEs leaked through despite severity=CRITICAL,HIGH). We instead let
+      # Trivy emit every finding into the SARIF and apply our own CVSS-based
+      # filter in the next step, which is both more reliable and more honest
+      # (uses the same CVSS score GitHub Code Scanning uses to classify alerts).
+      # We DO keep ignore-unfixed: there's no value in blocking on CVEs that
+      # have no upstream fix available.
       env:
-        TRIVY_SEVERITY: CRITICAL,HIGH
         TRIVY_IGNORE_UNFIXED: 'true'
       uses: aquasecurity/trivy-action@0.35.0
       with:
         image-ref: ${{ matrix.image_ref }}
         format: 'sarif'
         output: 'trivy-results.sarif'
-        # Do not rely on trivy-action's exit-code mechanism: observed to exit 1
-        # without producing findings in the SARIF file (see docker pull step
-        # comment above). We evaluate SARIF findings explicitly in the next step.
+        # Do not rely on trivy-action's exit-code mechanism: it was observed to
+        # exit 1 without producing findings in the SARIF file. We evaluate
+        # findings explicitly in the next step.
         exit-code: '0'
         cache: 'false'
 
-    - name: Fail build on Trivy findings
+    - name: Fail build on fixable HIGH/CRITICAL Trivy findings
       shell: pwsh
       run: |
         if (-not (Test-Path 'trivy-results.sarif')) {
           Write-Error "Trivy did not produce a SARIF file."
           exit 1
         }
+
         $sarif = Get-Content 'trivy-results.sarif' -Raw | ConvertFrom-Json
-        $findings = 0
-        foreach ($run in $sarif.runs) {
-          if ($run.results) { $findings += @($run.results).Count }
+
+        # Build a ruleId -> CVSS score map from the SARIF rules catalogue.
+        # Trivy writes the CVSS base score to rule.properties.'security-severity'
+        # as a decimal string (e.g. "7.5"). This is the same field GitHub Code
+        # Scanning reads to classify alerts as low/medium/high/critical.
+        $severityByRule = @{}
+        foreach ($r in $sarif.runs) {
+          foreach ($rule in $r.tool.driver.rules) {
+            $score = 0.0
+            $raw = $rule.properties.'security-severity'
+            if ($raw) { [void][double]::TryParse($raw, [ref]$score) }
+            $severityByRule[$rule.id] = $score
+          }
         }
-        Write-Host "Trivy reported $findings finding(s) for ${{ matrix.image_ref }}"
-        if ($findings -gt 0) {
+
+        # Walk results, classify by CVSS, and count only HIGH (>= 7.0) and
+        # CRITICAL (>= 9.0). Also collect a sample for the log.
+        $critical = 0
+        $high     = 0
+        $medium   = 0
+        $low      = 0
+        $blocking = @()
+        foreach ($r in $sarif.runs) {
+          foreach ($result in @($r.results)) {
+            if (-not $result) { continue }
+            $ruleId = $result.ruleId
+            $score  = [double]$severityByRule[$ruleId]
+            if ($score -ge 9.0) {
+              $critical++
+              $blocking += "$ruleId (CVSS $score)"
+            } elseif ($score -ge 7.0) {
+              $high++
+              $blocking += "$ruleId (CVSS $score)"
+            } elseif ($score -ge 4.0) {
+              $medium++
+            } else {
+              $low++
+            }
+          }
+        }
+
+        Write-Host "Trivy findings for ${{ matrix.image_ref }}:"
+        Write-Host "  CRITICAL: $critical"
+        Write-Host "  HIGH:     $high"
+        Write-Host "  MEDIUM:   $medium  (not blocking)"
+        Write-Host "  LOW:      $low  (not blocking)"
+        Write-Host ''
+
+        $blockingCount = $critical + $high
+        if ($blockingCount -gt 0) {
+          Write-Host "Blocking CVEs (CVSS >= 7.0):"
+          $blocking | Sort-Object -Unique | ForEach-Object { Write-Host "  $_" }
           Write-Host ''
           Write-Host 'Fixable CRITICAL/HIGH vulnerabilities found. Failing build.'
           Write-Host 'See the GitHub Security tab for details:'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
         ignore-unfixed: true
+        # Disable Trivy's DB cache: cached vuln DBs have been observed to cause
+        # the scanner to exit 1 within ~12ms of "Detecting vulnerabilities" with
+        # no findings written to the SARIF file (phantom failure). A fresh DB
+        # download per run adds ~5-10s per matrix leg, which is acceptable for
+        # a security-critical scan. See PR #520 discussion.
+        cache: 'false'
 
     - name: Upload Trivy scan results to GitHub code scanning
       if: always() && hashFiles('trivy-results.sarif') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,16 @@ jobs:
 
     - name: Scan base image for vulnerabilities
       id: trivy
+      # Force the severity filter and ignore-unfixed flag via step-level env vars
+      # rather than trivy-action inputs. trivy-action's set_env_var_if_provided
+      # helper was observed to drop the severity filter in CI (12 LOW-severity
+      # openssl findings slipped through a CRITICAL,HIGH filter), while the same
+      # version running locally with identical flags correctly filtered them out.
+      # Trivy itself reads TRIVY_SEVERITY and TRIVY_IGNORE_UNFIXED directly, so
+      # setting them at the step env: level bypasses the action's wrapper logic.
+      env:
+        TRIVY_SEVERITY: CRITICAL,HIGH
+        TRIVY_IGNORE_UNFIXED: 'true'
       uses: aquasecurity/trivy-action@0.35.0
       with:
         image-ref: ${{ matrix.image_ref }}
@@ -113,8 +123,6 @@ jobs:
         # without producing findings in the SARIF file (see docker pull step
         # comment above). We evaluate SARIF findings explicitly in the next step.
         exit-code: '0'
-        severity: 'CRITICAL,HIGH'
-        ignore-unfixed: true
         cache: 'false'
 
     - name: Fail build on Trivy findings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # Pull the base image into the local Docker daemon so Trivy can read it via
+    # source="docker". Without this step, Trivy on GitHub-hosted runners was
+    # exiting 1 after the "Detecting vulnerabilities" log line with no findings
+    # written to the SARIF file (phantom failure). Running the same Trivy version
+    # with the same env vars locally against a digest-pinned image always returned
+    # exit 0 with zero findings, confirming the root cause was image acquisition,
+    # not vulnerability detection. See PR #520 discussion.
+    - name: Pull base image
+      run: docker pull ${{ matrix.image_ref }}
+
     - name: Scan base image for vulnerabilities
       id: trivy
       uses: aquasecurity/trivy-action@0.35.0
@@ -99,15 +109,35 @@ jobs:
         image-ref: ${{ matrix.image_ref }}
         format: 'sarif'
         output: 'trivy-results.sarif'
-        exit-code: '1'
+        # Do not rely on trivy-action's exit-code mechanism: observed to exit 1
+        # without producing findings in the SARIF file (see docker pull step
+        # comment above). We evaluate SARIF findings explicitly in the next step.
+        exit-code: '0'
         severity: 'CRITICAL,HIGH'
         ignore-unfixed: true
-        # Disable Trivy's DB cache: cached vuln DBs have been observed to cause
-        # the scanner to exit 1 within ~12ms of "Detecting vulnerabilities" with
-        # no findings written to the SARIF file (phantom failure). A fresh DB
-        # download per run adds ~5-10s per matrix leg, which is acceptable for
-        # a security-critical scan. See PR #520 discussion.
         cache: 'false'
+
+    - name: Fail build on Trivy findings
+      shell: pwsh
+      run: |
+        if (-not (Test-Path 'trivy-results.sarif')) {
+          Write-Error "Trivy did not produce a SARIF file."
+          exit 1
+        }
+        $sarif = Get-Content 'trivy-results.sarif' -Raw | ConvertFrom-Json
+        $findings = 0
+        foreach ($run in $sarif.runs) {
+          if ($run.results) { $findings += @($run.results).Count }
+        }
+        Write-Host "Trivy reported $findings finding(s) for ${{ matrix.image_ref }}"
+        if ($findings -gt 0) {
+          Write-Host ''
+          Write-Host 'Fixable CRITICAL/HIGH vulnerabilities found. Failing build.'
+          Write-Host 'See the GitHub Security tab for details:'
+          Write-Host '  https://github.com/TetronIO/JIM/security/code-scanning'
+          exit 1
+        }
+        Write-Host 'No fixable CRITICAL/HIGH vulnerabilities found.'
 
     - name: Upload Trivy scan results to GitHub code scanning
       if: always() && hashFiles('trivy-results.sarif') != ''

--- a/.github/workflows/metrics-sync.yml
+++ b/.github/workflows/metrics-sync.yml
@@ -14,6 +14,12 @@ on:
       - 'test/integration/Get-HostFingerprint.ps1'
       - 'test/integration/Stream-WorkerLogs.ps1'
 
+# Principle of least privilege: this workflow only reads the repo (to checkout
+# and git diff) and dispatches to jim-metrics via a separate PAT stored in
+# secrets.METRICS_REPO_DISPATCH_TOKEN. The default GITHUB_TOKEN needs no writes.
+permissions:
+  contents: read
+
 jobs:
   notify-metrics-repo:
     runs-on: ubuntu-latest

--- a/engineering/COMPLIANCE_MAPPING.md
+++ b/engineering/COMPLIANCE_MAPPING.md
@@ -43,6 +43,18 @@ The frameworks and standards covered include those commonly required by:
 
 ---
 
+## Operational Considerations
+
+### Upstream-only base image CVEs
+
+JIM's container base images derive from Microsoft's `mcr.microsoft.com/dotnet/<runtime|aspnet|sdk>:10.0-noble` images. Vulnerability scanning (Trivy via the `scan-base-images` CI job) can correctly flag CVEs as "fixable upstream" during the gap between an Ubuntu security release and a Microsoft refresh of the `10.0-noble` digest. JIM cannot apply the fix directly in those cases; the fix lives in a layer JIM does not own.
+
+The response procedure for this situation is documented in [`engineering/DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) under "When the scan-base-images gate blocks on an upstream-only CVE". The available options range from waiting for Microsoft's next rebuild (default), through targeted in-Dockerfile mitigations, to documented temporary gate downgrades. The choice is case-by-case based on CVE severity and timing rather than a pre-baked policy, because the right answer genuinely depends on the specific CVE.
+
+This is a known and intentional limitation of digest-pinned base images. It is not a compliance gap: digest pinning, vulnerability scanning, and SBOM generation all operate correctly. The constraint is purely on remediation latency for one class of finding.
+
+---
+
 ## NIST Cybersecurity Framework (CSF) 2.0 Mapping
 
 ### GOVERN (GV) - Establish and maintain cybersecurity governance

--- a/engineering/COMPLIANCE_MAPPING.md
+++ b/engineering/COMPLIANCE_MAPPING.md
@@ -2,8 +2,8 @@
 
 | | |
 |---|---|
-| **Version** | 1.0 |
-| **Last Updated** | 2026-02-16 |
+| **Version** | 1.1 |
+| **Last Updated** | 2026-04-10 |
 | **Status** | Active |
 
 ---
@@ -51,7 +51,7 @@ The frameworks and standards covered include those commonly required by:
 |-------------|------------------------|--------|
 | GV.OC - Organisational Context | JIM designed for regulated environments; air-gapped deployment supported | Implemented |
 | GV.RM - Risk Management Strategy | Threat modelling required for new features (CLAUDE.md) | Implemented |
-| GV.SC - Supply Chain Risk Management | Dependency review, SBOM generation, pinned versions (CLAUDE.md) | Implemented |
+| GV.SC - Supply Chain Risk Management | Dependency review, SBOM generation, pinned versions (CLAUDE.md). Production Docker base images are digest-pinned and the policy is enforced by CI (`.github/workflows/ci.yml` `discover-base-images` job), not just documented. | Implemented |
 
 ### IDENTIFY (ID) - Understand cybersecurity risks
 
@@ -112,13 +112,13 @@ The UK Government's Software Security Code of Practice defines 14 principles acr
 |-----------|-------------|---------------|--------|
 | 5 | Protect the build environment | GitHub Actions CI/CD, pinned action versions | Aligned |
 | 6 | Secure the development tools and processes | Devcontainer with controlled toolchain, dependency pinning | Aligned |
-| 7 | Manage and secure third-party components | Dependency review policy, SBOM generation, vulnerability scanning | Aligned |
+| 7 | Manage and secure third-party components | Dependency review policy, SBOM generation. Container base image vulnerability scanning runs on every push and PR with results surfaced to GitHub code scanning (SARIF). Digest-pinning of production base images is enforced by CI rather than by convention. | Aligned |
 
 ### Theme 3: Deployment and Maintenance
 
 | Principle | Requirement | JIM Alignment | Status |
 |-----------|-------------|---------------|--------|
-| 8 | Deploy securely | Docker containerisation, deployment best practices in SECURITY.md | Aligned |
+| 8 | Deploy securely | Docker containerisation, deployment best practices in SECURITY.md. **Planned**: pre-release integration test gate so no release can be cut unless the full integration test suite has passed (tracked in #518). | Aligned |
 | 9 | Provide timely security updates | SECURITY.md defines 30-day critical vulnerability resolution SLA | Aligned |
 | 10 | Manage end of life securely | Only latest version supported, clear update guidance | Aligned |
 
@@ -194,7 +194,7 @@ This maps JIM's features to the NIST SP 800-53 control families most relevant to
 | Control | Description | JIM Implementation |
 |---------|-------------|-------------------|
 | SI-2 | Flaw Remediation | Vulnerability disclosure policy, dependency scanning |
-| SI-3 | Malicious Code Protection | Container scanning, dependency vulnerability checks |
+| SI-3 | Malicious Code Protection | Container base image scanning (Trivy) on every push/PR with results in GitHub code scanning; dependency vulnerability checks via Dependabot |
 | SI-7 | Software Integrity | SHA256 checksums on releases, signed commits |
 | SI-10 | Information Input Validation | Input validation at all API boundaries, DTO annotations |
 
@@ -202,7 +202,7 @@ This maps JIM's features to the NIST SP 800-53 control families most relevant to
 
 | Control | Description | JIM Implementation |
 |---------|-------------|-------------------|
-| SA-11 | Developer Testing and Evaluation | Mandatory build/test before commit, security test requirements |
+| SA-11 | Developer Testing and Evaluation | Mandatory build/test before commit, security test requirements. **Planned**: pre-release integration test gate enforcing that no release can be cut unless the full integration test suite has passed (tracked in #518). |
 | SA-15 | Development Process | Secure SDLC documented in CLAUDE.md |
 | SA-22 | Unsupported System Components | Dependency management, outdated package monitoring |
 

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -849,6 +849,18 @@ All production Dockerfiles pin their dependencies for reproducible, auditable bu
 - **Functional apt packages**: Libraries that JIM calls at runtime (libldap, cifs-utils) are pinned to exact versions (e.g., `libldap-2.5-0=2.5.13+dfsg-5`).
 - **Diagnostic utilities**: Tools like `curl` and `iputils-ping` are not pinned, as they are only used for health checks and debugging, not functional code paths.
 
+**The digest-pinning policy is machine-enforced.** Every production Dockerfile carries the directive `# jim-compliance: production-image` near the top of the file. The CI workflow (`.github/workflows/ci.yml`, `discover-base-images` job) scans the repository for Dockerfiles with this directive, parses every external `FROM` line, and fails the build if any of them is missing a `@sha256:` digest. The underlying script is [`.github/scripts/discover-base-images.ps1`](../.github/scripts/discover-base-images.ps1).
+
+Dockerfiles without the compliance directive (`.devcontainer/Dockerfile`, the integration test fixture images under `test/integration/docker/`) are deliberately out of scope. They are dev or test infrastructure, not customer-shipped artefacts, and are expected to track upstream tags rather than pinned digests. **Do not add the directive to a non-production Dockerfile, and do not remove it from a production one.**
+
+When adding a new production Dockerfile:
+
+1. Add `# jim-compliance: production-image` to the file (see `src/JIM.Web/Dockerfile` for the canonical format)
+2. Ensure every external `FROM` line uses `@sha256:` digest pinning
+3. That's it. The discovery script finds the new file automatically; no workflow or config update is required.
+
+Vulnerability scanning runs against every discovered production base image on every push and PR. Findings are surfaced in the GitHub Security tab via SARIF upload in addition to the Actions log, so they are visible to reviewers and auditable after the fact.
+
 **Why this matters**: `System.DirectoryServices.Protocols` (the .NET LDAP client) P/Invokes into the native `libldap` shared library at runtime. An incompatible libldap version could cause silent behavioural differences or crashes during LDAP/AD operations.
 
 Before merging a Docker digest update PR:

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -875,6 +875,28 @@ docker run --rm <image>@<new-digest> bash -c \
   "apt-get update -qq && apt-cache policy libldap-common libldap-2.5-0 cifs-utils"
 ```
 
+##### When the scan-base-images gate blocks on an upstream-only CVE
+
+The `scan-base-images` CI job fails the build whenever Trivy reports a fixable HIGH or CRITICAL CVE (CVSS >= 7.0) in any production base image. "Fixable" means an upstream-patched version of the affected package exists.
+
+For most JIM-installed packages (the apt versions we pin in our Dockerfiles), "fixable" means we can bump the pinned version ourselves and the gate clears on the next build. But the bulk of packages in a base image come from the **Microsoft `dotnet/<runtime|aspnet|sdk>:10.0-noble` image layer**, not from JIM. We do not control when Microsoft rebuilds those images. Microsoft typically rebuilds on its own cadence (often monthly, sometimes longer); during the gap between an Ubuntu security release and a Microsoft refresh, Trivy can correctly flag a CVE as "fixable upstream" even though we have no way to apply the fix ourselves.
+
+When this happens, every PR and every push to `main` will fail the `scan-base-images` job until either Microsoft publishes a refreshed digest (which Dependabot will then propose) or we apply a manual workaround.
+
+**Response options, in order of preference:**
+
+1. **Wait for the Microsoft rebuild.** This is the default and best response when the CVE risk is acceptable to wait out. Check https://mcr.microsoft.com/en-us/product/dotnet/runtime/tags for the current published digest of `10.0-noble`. If it differs from what is pinned in the Dockerfiles, bump the digest manually (or wait for Dependabot to propose it). This typically takes a few days to a few weeks depending on Microsoft's release cadence.
+
+2. **Apply `apt-get upgrade` in the Dockerfile** as a temporary measure if the CVE is severe enough that waiting is not acceptable. This pulls current Ubuntu security patches at *build* time rather than at *base image publish* time. Trade-off: it weakens the reproducibility guarantee of pinning by digest. Only do this for genuinely urgent issues, and revert as soon as Microsoft publishes a refreshed image.
+
+3. **Temporarily lower the gate threshold from HIGH to CRITICAL** in `.github/workflows/ci.yml` (the `Fail build on fixable HIGH/CRITICAL Trivy findings` step) if the blocking CVE is HIGH but not CRITICAL and the work jam is unacceptable. Two-line change. **Revert as soon as the underlying CVE is resolved.**
+
+4. **Dismiss the specific alert** in the GitHub Security tab with a "won't fix - upstream dependency" reason and a comment explaining why. This requires the alert to first reach the Security tab via SARIF upload, which it will on every CI run. Dismissal only suppresses the specific alert; if the same CVE is detected against a different package or a new base image, it reappears.
+
+**Do not** add `continue-on-error: true` to the scan step. That permanently weakens the gate and is not the same as a documented temporary downgrade.
+
+The choice between options 1-4 depends on the specific CVE, its CVSS score, the nature of the affected component, and how long Microsoft is likely to take. There is no pre-baked policy because the right answer is genuinely case-dependent. When in doubt, escalate to a maintainer.
+
 #### GitHub Actions
 
 - Actions are pinned by major version tag (e.g., `actions/checkout@v4`)

--- a/src/JIM.Scheduler/Dockerfile
+++ b/src/JIM.Scheduler/Dockerfile
@@ -1,4 +1,8 @@
 # syntax=docker/dockerfile:1
+# jim-compliance: production-image
+# This image ships to customers. Base image digest pinning is enforced by CI
+# (see .github/workflows/ci.yml scan-base-images job). Do not remove the
+# @sha256: digest from any FROM line or this Dockerfile will fail CI.
 # See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 ARG VERSION=dev

--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -1,4 +1,8 @@
 # syntax=docker/dockerfile:1
+# jim-compliance: production-image
+# This image ships to customers. Base image digest pinning is enforced by CI
+# (see .github/workflows/ci.yml scan-base-images job). Do not remove the
+# @sha256: digest from any FROM line or this Dockerfile will fail CI.
 # See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 ARG VERSION=dev

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -1,4 +1,8 @@
 # syntax=docker/dockerfile:1
+# jim-compliance: production-image
+# This image ships to customers. Base image digest pinning is enforced by CI
+# (see .github/workflows/ci.yml scan-base-images job). Do not remove the
+# @sha256: digest from any FROM line or this Dockerfile will fail CI.
 # See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 ARG VERSION=dev


### PR DESCRIPTION
## Summary

Refactors `scan-base-images` in CI from a hand-maintained static matrix into a discover-then-scan pattern that (1) covers every production Dockerfile automatically, (2) enforces the digest-pinning policy as a CI gate rather than an aspirational convention, and (3) surfaces vulnerability findings to GitHub code scanning via SARIF rather than only to Actions logs.

## Why

The previous job had three compounding gaps that together weakened JIM's supply chain compliance posture:

1. **`src/JIM.Scheduler/Dockerfile` was never scanned.** The static matrix had three legs but only referenced two Dockerfiles (Web once, Worker twice for runtime+sdk). Worker and Scheduler happen to use the same base image digest today, but "they're identical" is a dangerous assumption for security-critical scanning: nothing prevents a future commit from drifting them apart with zero scan coverage on the Scheduler leg.

2. **Digest-pinning was documented policy, not enforced policy.** [engineering/DEVELOPER_GUIDE.md](engineering/DEVELOPER_GUIDE.md#L848) states that production Dockerfiles must pin base images by `@sha256:` digest, but no CI check enforced it. A future commit could silently remove a digest and the change would pass all existing CI.

3. **The matrix was hand-maintained.** Adding a new production Dockerfile required a manual `ci.yml` edit. A forgotten edit would silently leave the new Dockerfile unscanned. This is exactly the class of drift that caused the Dependabot path breakage fixed in #504 (eight weeks of silent Dependabot failure after Dockerfiles moved under `src/`).

## What changes

### New: `.github/scripts/discover-base-images.ps1`

PowerShell discovery script that walks the repository for `Dockerfile`s, identifies production images by the machine-readable directive `# jim-compliance: production-image`, parses every external `FROM` line, enforces digest-pinning, and emits a deduplicated matrix of unique image references for downstream scanning.

- Handles multi-stage Dockerfiles by collecting `FROM ... AS <alias>` entries and skipping intra-file stage references
- Skips `FROM scratch`
- Traverses hidden directories (so `.devcontainer/Dockerfile` is found and correctly reported as unlabelled)
- Fails with a clear error if any production Dockerfile contains a non-digest-pinned `FROM`
- Fails if zero production Dockerfiles are discovered (regression guard against accidental label removal)
- Runs locally for ad-hoc verification: `pwsh -NoProfile -File .github/scripts/discover-base-images.ps1`

### Changed: `.github/workflows/ci.yml`

Replaces the single static `scan-base-images` job with a two-job pattern:

- **`discover-base-images`**: runs the discovery script, emits the matrix as job output
- **`scan-base-images`**: consumes `needs.discover-base-images.outputs.matrix` via `fromJSON`, scans each unique image with Trivy, emits SARIF (not table), and uploads to GitHub code scanning. `security-events: write` permission is scoped to this job only

Trivy settings preserved from the existing job: `severity: CRITICAL,HIGH`, `exit-code: 1`, `ignore-unfixed: true`. The only scan behaviour that changes is the output format (table -> SARIF) and the addition of the code scanning upload.

### Changed: Three production Dockerfiles

`src/JIM.Web/Dockerfile`, `src/JIM.Worker/Dockerfile`, `src/JIM.Scheduler/Dockerfile` each carry a new directive block:

```dockerfile
# syntax=docker/dockerfile:1
# jim-compliance: production-image
# This image ships to customers. Base image digest pinning is enforced by CI
# (see .github/workflows/ci.yml scan-base-images job). Do not remove the
# @sha256: digest from any FROM line or this Dockerfile will fail CI.
```

The directive is both machine-readable (discovery script greps for it) and self-documenting (a human reading the file immediately understands the policy scope without cross-referencing external docs). The approach is locality-of-reference correct: the policy lives with the artefact it governs.

`.devcontainer/Dockerfile` and `test/integration/docker/**/Dockerfile` are deliberately left unlabelled. They are developer and test infrastructure, not customer-shipped artefacts, and tracking upstream tags is the correct behaviour for them.

### Changed: `engineering/COMPLIANCE_MAPPING.md`

Version bumped 1.0 -> 1.1. Three "Implemented" entries strengthened to reflect that digest-pinning is now machine-enforced:

- **NIST CSF GV.SC** (Supply Chain Risk Management)
- **UK Software Security Code of Practice Principle 7** (Manage and secure third-party components)
- **NIST SP 800-53 SI-3** (Malicious Code Protection)

Two "Planned" entries added referencing #518 for the future pre-release integration test gate:

- **UK Software Security Code of Practice Principle 8** (Deploy securely)
- **NIST SP 800-53 SA-11** (Developer Testing and Evaluation)

### Changed: `engineering/DEVELOPER_GUIDE.md`

The "Docker Base Images" subsection under "Dependency Pinning and Updates" is extended to document the compliance directive convention, how CI enforces it, and a "how to add a new production Dockerfile" recipe for future contributors.

## Related tracking issues

Created alongside this change to capture follow-up compliance work:

- #517: Pin all GitHub Actions by commit SHA (v0.9-STABILISATION)
- #518: Pre-release integration test gate (v1.0-ILM-COMPLETE)
- #519: Continuous SBOM generation on main (v1.0-ILM-COMPLETE)

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Positive test: discovery script runs against the real repo and correctly identifies 6 Dockerfiles (3 scanned, 3 skipped)
- [x] Negative test: discovery script against a synthetic Dockerfile with unpinned FROM fails with exit 1 and clear violation message
- [x] Deduplication verified: Worker and Scheduler both reference the same `runtime` digest; discovery emits only one matrix entry for it
- [x] Stage alias handling verified: `FROM build AS publish` and `FROM base AS final` correctly skipped
- [x] CRLF compatibility verified: script with CRLF line endings runs identically on Linux `pwsh` (the repo `.gitattributes` forces `*.ps1 text eol=crlf`)
- [x] First CI run on this PR validates the dynamic `fromJSON` matrix works as expected — post-merge verification: every `ci.yml` run on `main` since the merge has a successful `discover-base-images` -> `scan-base-images` dependency chain with the matrix legs dynamically expanded (confirmed on runs 24259797536, 24260333867, 24260337415, 24264679695, 24265336670).
- [x] First CI run validates SARIF upload to code scanning works and findings appear in Security tab — confirmed via `gh api repos/TetronIO/JIM/code-scanning/analyses`: 15 Trivy analyses have been uploaded post-merge, each tagged with a category matching the `trivy-base-image-<dockerfile>-line<N>` template from `ci.yml`, proving the SARIF upload path is working end-to-end.
- [x] Post-merge: verify no workflow is broken (`release.yml` audited to confirm it does not reference the old job structure) — confirmed: `release.yml` contains zero references to `scan-base-images` or the old static matrix structure, and all `ci.yml` runs on `main` continue to pass.

## What to expect after merge

1. **New check names on PRs**. The matrix leg names change from e.g. `scan-base-images (aspnet, src/JIM.Web/Dockerfile)` to the GitHub-derived leg name based on the dynamic matrix content. If `main`'s branch protection requires any of the old names by string match, those requirements will need to be updated to the new names.

2. **GitHub Security tab populates for the first time**. Any unfixed CRITICAL/HIGH CVEs in the current base images (there are several; see SBOM Observer screenshot from the conversation that spawned this work) will appear as informational findings in the Security tab. They will NOT fail the build (`ignore-unfixed: true` is preserved) but they will be visible and auditable.

3. **Adding a new production Dockerfile becomes zero-config.** Drop a `Dockerfile` with `# jim-compliance: production-image` and digest-pinned `FROM` lines into any directory. Discovery picks it up automatically on the next CI run. No workflow edit required.