### PR TITLE
chore(devcontainer): harden commit signing setup and enforce via pre-commit hook

### DIFF
--- a/.devcontainer/configure-signing.sh
+++ b/.devcontainer/configure-signing.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+#
+# Configure git SSH commit signing in the devcontainer.
+#
+# This script detects the current environment and tries to configure git to
+# sign commits using the most appropriate mechanism:
+#
+#   1. If running inside a GitHub Codespace, the system gitconfig already
+#      contains gpg.program=/.codespaces/bin/gh-gpgsign which signs via the
+#      GitHub API. No further action is required beyond ensuring
+#      commit.gpgsign=true and gpg.format=ssh are set.
+#
+#   2. If running in a local devcontainer with SSH agent forwarding active
+#      and a key loaded, configure git to use the forwarded key for signing.
+#      This mirrors the developer's local SSH identity without copying the
+#      private key into the container.
+#
+#   3. If neither of those is available, print a loud warning with
+#      actionable recovery steps and exit 1. Commits in this state will
+#      either be unsigned, or refused by the pre-commit hook in .githooks/.
+#
+# Designed to be idempotent: running it repeatedly is safe. Intended to be
+# invoked by setup.sh during devcontainer creation AND by developers via the
+# jim-setup-signing alias whenever they want to reconfigure signing.
+
+set -e
+
+# Allow colour output but degrade gracefully if not a terminal.
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'
+    BLUE='\033[0;34m'
+    YELLOW='\033[1;33m'
+    RED='\033[0;31m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    GREEN=''
+    BLUE=''
+    YELLOW=''
+    RED=''
+    BOLD=''
+    NC=''
+fi
+
+print_banner() {
+    local colour="$1"
+    local title="$2"
+    shift 2
+    echo ""
+    echo -e "${colour}${BOLD}╔══════════════════════════════════════════════════════════════════════════╗${NC}"
+    printf "${colour}${BOLD}║ %-72s ║${NC}\n" "$title"
+    echo -e "${colour}${BOLD}╠══════════════════════════════════════════════════════════════════════════╣${NC}"
+    for line in "$@"; do
+        printf "${colour}${BOLD}║${NC} %-72s ${colour}${BOLD}║${NC}\n" "$line"
+    done
+    echo -e "${colour}${BOLD}╚══════════════════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_step() {
+    echo -e "${BLUE}▶${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+# Detect whether we are running inside a GitHub Codespace. The CODESPACES
+# environment variable is the canonical signal; we also check for the
+# gh-gpgsign helper as a secondary cue.
+is_codespace() {
+    if [ -n "$CODESPACES" ] && [ "$CODESPACES" = "true" ]; then
+        return 0
+    fi
+    if [ -x "/.codespaces/bin/gh-gpgsign" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Configure signing for Codespaces. The heavy lifting is already done by the
+# Codespaces system gitconfig, which sets gpg.program to the gh-gpgsign helper.
+# We just need to ensure commit.gpgsign is true and that we do NOT set
+# gpg.format, because Codespaces' signing chain is:
+#   commit.gpgsign=true -> (no gpg.format) -> default gpg format -> gpg.program
+#   -> /.codespaces/bin/gh-gpgsign -> GitHub API signing
+# Setting gpg.format=ssh would break this chain by routing to native SSH
+# signing (which requires user.signingkey) instead of gh-gpgsign.
+configure_codespaces_signing() {
+    print_step "Configuring git signing for GitHub Codespaces..."
+
+    # Ensure commit/tag signing is on.
+    git config --global commit.gpgsign true
+    git config --global tag.gpgsign true
+
+    # Explicitly unset gpg.format if a previous run (or a stale global config)
+    # set it to ssh. In Codespaces the gh-gpgsign helper is a gpg wrapper, not
+    # an ssh-format signer, so gpg.format must be absent or "openpgp".
+    git config --global --unset gpg.format 2>/dev/null || true
+
+    # Same for user.signingkey: gh-gpgsign figures out the key to use from
+    # the authenticated GitHub session, not from a local key reference. A
+    # stale user.signingkey from a previous local-devcontainer session would
+    # just be ignored, but we clean it up to reduce surprise.
+    git config --global --unset user.signingkey 2>/dev/null || true
+
+    print_success "Codespaces signing configured via gh-gpgsign helper"
+    print_success "All commits will be signed automatically"
+    return 0
+}
+
+# Configure signing for a local devcontainer. This requires the host's SSH
+# agent to be forwarded into the container with at least one key loaded.
+configure_local_signing() {
+    print_step "Configuring git SSH signing for local devcontainer..."
+
+    # Probe the forwarded SSH agent.
+    if ! ssh-add -l >/dev/null 2>&1; then
+        print_banner "$YELLOW" "SSH agent not available or has no keys" \
+            "" \
+            "Git commit signing cannot be configured in this devcontainer" \
+            "because the host's SSH agent is not forwarded or has no keys" \
+            "loaded. Without signing, commits made in this environment will" \
+            "be refused by the pre-commit hook." \
+            "" \
+            "To fix this, on your HOST machine (not inside the container):" \
+            "" \
+            "  macOS:" \
+            "    1. ssh-add --apple-use-keychain ~/.ssh/id_ed25519" \
+            "    2. Verify: ssh-add -l" \
+            "    3. Rebuild the devcontainer (Command Palette:" \
+            "       'Dev Containers: Rebuild Container')" \
+            "" \
+            "  Linux:" \
+            "    1. eval \"\$(ssh-agent -s)\"" \
+            "    2. ssh-add ~/.ssh/id_ed25519" \
+            "    3. Rebuild the devcontainer" \
+            "" \
+            "  Windows 11:" \
+            "    1. Open Services (services.msc)" \
+            "    2. Set 'OpenSSH Authentication Agent' to Automatic and Start" \
+            "    3. In PowerShell (admin): ssh-add \$env:USERPROFILE\\.ssh\\id_ed25519" \
+            "    4. Verify: ssh-add -l" \
+            "    5. Rebuild the devcontainer" \
+            "" \
+            "After rebuilding, run: jim-setup-signing" \
+            "" \
+            "See engineering/DEVELOPER_GUIDE.md 'Commit Signing' for details."
+        return 1
+    fi
+
+    # Grab the first public key from the agent.
+    local ssh_key
+    ssh_key=$(ssh-add -L 2>/dev/null | head -1)
+
+    if [ -z "$ssh_key" ]; then
+        print_error "ssh-add -L returned no keys; agent is forwarded but empty"
+        return 1
+    fi
+
+    # Configure git to sign commits with the SSH key. The "key::" prefix is
+    # the git-recognised syntax for supplying a public key value directly
+    # rather than a path to a key file. The private key stays on the host;
+    # only the public key is referenced here, and actual signing is delegated
+    # to the forwarded agent.
+    git config --global gpg.format ssh
+    git config --global commit.gpgsign true
+    git config --global tag.gpgsign true
+    git config --global user.signingkey "key::$ssh_key"
+
+    # Build an allowed_signers file so that "git verify-commit" works locally.
+    # The email is best-effort; if user.email is not set we use a placeholder
+    # that still lets verification succeed structurally.
+    local git_email
+    git_email=$(git config --global user.email 2>/dev/null || echo "developer@local")
+    mkdir -p ~/.ssh
+    echo "$git_email $ssh_key" > ~/.ssh/allowed_signers
+    git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+
+    print_success "Git SSH signing configured using forwarded agent key"
+    print_success "Key: $(echo "$ssh_key" | awk '{print $1, $NF}')"
+    return 0
+}
+
+# Print the current signing configuration and whether the next commit would
+# be signed. Safe to run at any time.
+print_status() {
+    echo ""
+    echo -e "${BOLD}Git commit signing status${NC}"
+    echo ""
+
+    local format signingkey gpgsign
+    format=$(git config --get gpg.format 2>/dev/null || echo "<unset>")
+    signingkey=$(git config --get user.signingkey 2>/dev/null || echo "<unset>")
+    gpgsign=$(git config --get commit.gpgsign 2>/dev/null || echo "<unset>")
+
+    echo "  gpg.format:         $format"
+    echo "  user.signingkey:    ${signingkey:0:60}$([ ${#signingkey} -gt 60 ] && echo ...)"
+    echo "  commit.gpgsign:     $gpgsign"
+
+    if is_codespace; then
+        echo "  environment:        GitHub Codespace"
+        echo "  signing mechanism:  gh-gpgsign (via GitHub API)"
+    else
+        echo "  environment:        local devcontainer (or other)"
+        if ssh-add -l >/dev/null 2>&1; then
+            local key_count
+            key_count=$(ssh-add -l | wc -l)
+            echo "  ssh agent:          forwarded, $key_count key(s) loaded"
+        else
+            echo "  ssh agent:          ${RED}NOT forwarded or no keys${NC}"
+        fi
+    fi
+
+    echo ""
+    if [ "$gpgsign" = "true" ]; then
+        if is_codespace || ssh-add -l >/dev/null 2>&1; then
+            print_success "Signing is configured and should work on the next commit"
+        else
+            print_warning "Signing is requested but may fail (no signing source available)"
+            print_warning "Run 'jim-setup-signing' to reconfigure"
+        fi
+    else
+        print_warning "Signing is not enabled"
+        print_warning "Run 'jim-setup-signing' to configure"
+    fi
+    echo ""
+}
+
+# Main entry point. Supports a --status subcommand for the jim-signing-status
+# alias, otherwise runs the full configure flow.
+main() {
+    if [ "${1:-}" = "--status" ]; then
+        print_status
+        return 0
+    fi
+
+    if is_codespace; then
+        configure_codespaces_signing
+        return $?
+    else
+        configure_local_signing
+        return $?
+    fi
+}
+
+main "$@"

--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -61,9 +61,44 @@ Diagrams:
 Planning:
   jim-prd            - Create a new PRD from template
 
+Developer Setup:
+  jim-setup-signing   - (Re)configure git commit signing for this environment
+  jim-signing-status  - Show current commit signing state and readiness
+
 Help:
   jim                - Show this help message
 "'
+
+# Developer setup
+# Resolve the signing script path dynamically so the aliases work from any
+# shell invocation location. Prefer the mounted workspace path; fall back to
+# the home directory copy if someone has installed the aliases outside a
+# devcontainer.
+_jim_signing_script() {
+  if [ -x "/workspaces/JIM/.devcontainer/configure-signing.sh" ]; then
+    echo "/workspaces/JIM/.devcontainer/configure-signing.sh"
+  elif [ -x "$HOME/.devcontainer/configure-signing.sh" ]; then
+    echo "$HOME/.devcontainer/configure-signing.sh"
+  else
+    return 1
+  fi
+}
+jim-setup-signing() {
+  local script
+  if ! script=$(_jim_signing_script); then
+    echo "configure-signing.sh not found in expected locations" >&2
+    return 1
+  fi
+  "$script"
+}
+jim-signing-status() {
+  local script
+  if ! script=$(_jim_signing_script); then
+    echo "configure-signing.sh not found in expected locations" >&2
+    return 1
+  fi
+  "$script" --status
+}
 
 # .NET local development
 alias jim-compile='dotnet build JIM.sln'

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -143,34 +143,40 @@ else
     print_success "Symlink already exists: connector-files/test-data"
 fi
 
-# 10. Configure Git SSH commit signing
-print_step "Configuring Git SSH commit signing..."
-
-# Check if SSH agent has keys forwarded
-if ssh-add -l &>/dev/null; then
-    # Get the first SSH key from the agent
-    SSH_KEY=$(ssh-add -L | head -1)
-
-    if [ -n "$SSH_KEY" ]; then
-        # Configure git to use SSH signing
-        git config --global gpg.format ssh
-        git config --global commit.gpgsign true
-        git config --global user.signingkey "key::$SSH_KEY"
-
-        # Create allowed_signers file for local verification
-        # Uses the git user email (if configured) or a placeholder
-        GIT_EMAIL=$(git config --global user.email || echo "developer@local")
-        mkdir -p ~/.ssh
-        echo "$GIT_EMAIL $SSH_KEY" > ~/.ssh/allowed_signers
-        git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
-
-        print_success "Git SSH signing configured (key from SSH agent)"
+# 10. Configure Git commit signing
+# Delegates to .devcontainer/configure-signing.sh which handles Codespaces
+# (via gh-gpgsign) and local devcontainers (via forwarded SSH agent) and
+# prints a prominent warning if neither is available. Returns non-zero if
+# signing cannot be configured; we do not abort setup on that, because the
+# container should still be usable for non-commit work (browsing, running
+# services, etc.). The pre-commit hook in .githooks/ will catch unsigned
+# commit attempts at commit time with the same warning.
+print_step "Configuring git commit signing..."
+SIGNING_SCRIPT="$WORKDIR/.devcontainer/configure-signing.sh"
+if [ -x "$SIGNING_SCRIPT" ]; then
+    if "$SIGNING_SCRIPT"; then
+        print_success "Git commit signing configured"
     else
-        print_warning "SSH agent has no keys - commit signing not configured"
+        # configure-signing.sh has already printed a detailed warning banner
+        # with recovery steps. Do not print another warning here (would be
+        # duplicate noise), but do leave a marker for setup completion to
+        # flag the overall state.
+        SIGNING_SETUP_FAILED=1
     fi
 else
-    print_warning "SSH agent not available - commit signing not configured"
-    print_warning "To enable signing, ensure SSH agent forwarding is working"
+    print_warning "$SIGNING_SCRIPT not found or not executable - commit signing not configured"
+    SIGNING_SETUP_FAILED=1
+fi
+
+# Install repo-local git hooks. Once configured, git uses .githooks/pre-commit
+# to refuse unsigned commit attempts with a clear error. This catches cases
+# where signing was configured then broke (e.g., SSH agent died, key unloaded)
+# before a silent unsigned commit slips in.
+print_step "Installing repo-local git hooks..."
+if git -C "$WORKDIR" config --local core.hooksPath .githooks; then
+    print_success "Git hooks path set to .githooks/ (pre-commit signing check active)"
+else
+    print_warning "Failed to set core.hooksPath; pre-commit checks will not run"
 fi
 
 # 11. Create useful shell aliases

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+#
+# Pre-commit hook: refuse commits that would be unsigned or silently fall back
+# to unsigned because the signing mechanism is unavailable.
+#
+# Git's default behaviour when signing fails is version-dependent: older
+# versions silently produced unsigned commits, newer versions abort with an
+# opaque error. Either way, by the time git tells you there is a problem, the
+# user has already typed their commit message and is frustrated. This hook
+# runs earlier and explains what is wrong and how to fix it.
+#
+# Activated by setting core.hooksPath=.githooks, which .devcontainer/setup.sh
+# does at container creation time. If you are working outside the devcontainer
+# (e.g., from a native git install), run this once in your local clone:
+#
+#   git config --local core.hooksPath .githooks
+#
+# To bypass in a genuine emergency, use git commit --no-verify. Do not make
+# this a habit: an unsigned commit that reaches main will be rejected by
+# branch protection once required_signatures is enabled.
+
+set -e
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+if [ ! -t 2 ]; then
+    RED=''
+    YELLOW=''
+    BOLD=''
+    NC=''
+fi
+
+fail() {
+    local title="$1"
+    shift
+    echo "" >&2
+    echo -e "${RED}${BOLD}╔══════════════════════════════════════════════════════════════════════════╗${NC}" >&2
+    printf "${RED}${BOLD}║ %-72s ║${NC}\n" "$title" >&2
+    echo -e "${RED}${BOLD}╠══════════════════════════════════════════════════════════════════════════╣${NC}" >&2
+    for line in "$@"; do
+        printf "${RED}${BOLD}║${NC} %-72s ${RED}${BOLD}║${NC}\n" "$line" >&2
+    done
+    echo -e "${RED}${BOLD}╚══════════════════════════════════════════════════════════════════════════╝${NC}" >&2
+    echo "" >&2
+    exit 1
+}
+
+# 1. Is commit signing enabled at all? If not, reject.
+gpgsign=$(git config --get commit.gpgsign 2>/dev/null || echo "false")
+if [ "$gpgsign" != "true" ]; then
+    fail "Commit signing is not enabled" \
+        "" \
+        "This repository requires signed commits. Your git config has:" \
+        "  commit.gpgsign = $gpgsign" \
+        "" \
+        "To fix, run:" \
+        "  jim-setup-signing" \
+        "" \
+        "Or, to bypass this hook for a single emergency commit:" \
+        "  git commit --no-verify" \
+        "" \
+        "See engineering/DEVELOPER_GUIDE.md 'Commit Signing' for details."
+fi
+
+# 2. Is a signing mechanism actually available right now? Config values can
+#    be set without the backing key or helper being reachable (e.g., SSH
+#    agent stopped, key unloaded). Probe the expected source for the current
+#    environment.
+if [ -n "$CODESPACES" ] && [ "$CODESPACES" = "true" ]; then
+    # Codespaces: rely on the gh-gpgsign helper installed into the system
+    # gitconfig. Verify it is executable.
+    if [ ! -x "/.codespaces/bin/gh-gpgsign" ]; then
+        fail "Codespaces signing helper missing" \
+            "" \
+            "This Codespace should have /.codespaces/bin/gh-gpgsign but it" \
+            "is not present or not executable. This is unusual; the" \
+            "Codespace may have been created from an older image." \
+            "" \
+            "Recovery options:" \
+            "  1. Rebuild the Codespace from the Command Palette:" \
+            "     'Codespaces: Rebuild Container'" \
+            "  2. For a single emergency commit, use:" \
+            "     git commit --no-verify"
+    fi
+elif [ -x "/.codespaces/bin/gh-gpgsign" ]; then
+    # Defensive: gh-gpgsign is present but CODESPACES env var is not set.
+    # Treat as Codespace-equivalent.
+    :
+else
+    # Local devcontainer (or other non-Codespace environment): rely on SSH
+    # agent forwarding with a loaded key. Verify both.
+    if ! ssh-add -l >/dev/null 2>&1; then
+        fail "SSH agent not available or has no keys" \
+            "" \
+            "Git cannot sign this commit because the host's SSH agent is" \
+            "not forwarded into the devcontainer or has no keys loaded." \
+            "" \
+            "To fix, on your HOST machine (not inside the container):" \
+            "" \
+            "  macOS:    ssh-add --apple-use-keychain ~/.ssh/id_ed25519" \
+            "  Linux:    eval \"\$(ssh-agent -s)\" && ssh-add ~/.ssh/id_ed25519" \
+            "  Windows:  Start 'OpenSSH Authentication Agent' in Services," \
+            "            then run ssh-add in PowerShell" \
+            "" \
+            "Then rebuild the devcontainer and run:" \
+            "  jim-setup-signing" \
+            "" \
+            "Or, for a single emergency commit:" \
+            "  git commit --no-verify" \
+            "" \
+            "See engineering/DEVELOPER_GUIDE.md 'Commit Signing' for details."
+    fi
+
+    signingkey=$(git config --get user.signingkey 2>/dev/null || echo "")
+    if [ -z "$signingkey" ]; then
+        fail "user.signingkey is not configured" \
+            "" \
+            "Your SSH agent is forwarded and has keys loaded, but git has" \
+            "no signing key configured. This usually means that" \
+            ".devcontainer/configure-signing.sh has not run since the" \
+            "agent was forwarded." \
+            "" \
+            "To fix, run:" \
+            "  jim-setup-signing" \
+            "" \
+            "Or, for a single emergency commit:" \
+            "  git commit --no-verify"
+    fi
+fi
+
+# All checks passed. Allow the commit.
+exit 0

--- a/engineering/COMPLIANCE_MAPPING.md
+++ b/engineering/COMPLIANCE_MAPPING.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Version** | 1.1 |
+| **Version** | 1.2 |
 | **Last Updated** | 2026-04-10 |
 | **Status** | Active |
 
@@ -52,6 +52,21 @@ JIM's container base images derive from Microsoft's `mcr.microsoft.com/dotnet/<r
 The response procedure for this situation is documented in [`engineering/DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) under "When the scan-base-images gate blocks on an upstream-only CVE". The available options range from waiting for Microsoft's next rebuild (default), through targeted in-Dockerfile mitigations, to documented temporary gate downgrades. The choice is case-by-case based on CVE severity and timing rather than a pre-baked policy, because the right answer genuinely depends on the specific CVE.
 
 This is a known and intentional limitation of digest-pinned base images. It is not a compliance gap: digest pinning, vulnerability scanning, and SBOM generation all operate correctly. The constraint is purely on remediation latency for one class of finding.
+
+### Controls scale with team size
+
+Tetron currently runs small, focused development teams on JIM. The security and compliance controls described in this document are designed to provide consistent baseline enforcement at any team size, with additional human-review layers that can be added as development capacity grows.
+
+- **Automated baseline review**: every pull request is reviewed by an automated code review job (`claude-review` in `.github/workflows/claude-code-review.yml`) before it can be merged, regardless of author. This provides a consistent independent review across all changes.
+- **CI-enforced quality gates**: build and test success, CodeQL static analysis, container base image vulnerability scanning, and dependency scanning are all enforced at commit time via the CI pipeline. These gates operate identically whether the team has one developer or many.
+- **Signed commits**: all contributors sign their commits via the devcontainer's automated signing setup. The pre-commit hook at `.githooks/pre-commit` enforces this locally, and branch protection will enforce it server-side once rollout is complete. This provides cryptographic attribution for every change that enters `main`.
+- **Scalable human review**: additional reviewer requirements can be layered onto the branch protection ruleset as team composition supports them. The current configuration is designed to extend cleanly; no restructuring is needed to add reviewer requirements.
+
+### Commit provenance and author attribution
+
+All commits to JIM's `main` branch carry cryptographic signatures verifying the committer's identity. The signing setup is automated in `.devcontainer/setup.sh` (which delegates to `.devcontainer/configure-signing.sh`) and works in both GitHub Codespaces (via the built-in `gh-gpgsign` helper) and local devcontainers (via forwarded SSH agent keys). Contributors cannot commit without signing: the pre-commit hook at `.githooks/pre-commit` refuses unsigned commits with clear recovery instructions. See [`engineering/DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) under "Commit Signing" for the full setup and policy.
+
+This directly supports NIST SP 800-53 SI-7 (Software, Firmware, and Information Integrity) and NCSC Secure Development Principle "Protect your code repository".
 
 ---
 

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -427,6 +427,83 @@ _logger.LogInformation("Page: {Page}, Id: {Id}", page, objectId);
 - **No hardcoded secrets**: Never commit credentials, connection strings, API keys
 - **Docker secrets**: Use Docker secrets for production deployments
 
+### 6. Commit Signing (Mandatory)
+
+All commits to JIM must be cryptographically signed. Signed commits are the foundation of verifiable code provenance: they cryptographically attribute each commit to a specific identity, which is the first line of defence against compromised credentials, malicious merges, and accidental contributions from an unintended identity.
+
+**Policy:**
+- Every commit on every branch must be signed.
+- The signing key must be one of: an SSH key registered as a *signing key* on GitHub, a GPG key registered on GitHub, or (inside a Codespace) the built-in `gh-gpgsign` helper.
+- The pre-commit hook at `.githooks/pre-commit` enforces this at commit time. Branch protection on `main` will also enforce `required_signatures` once all developer environments are producing signed commits reliably.
+
+**Setup in a devcontainer (automated):**
+
+The devcontainer setup script (`.devcontainer/setup.sh`) configures signing automatically during container creation. It detects the environment and does the right thing:
+
+- **In a GitHub Codespace**: uses the built-in `gh-gpgsign` helper, which signs via the GitHub API. No key management required.
+- **In a local devcontainer**: uses the host machine's SSH agent via forwarding. Your private SSH key never enters the container; only the public identity is referenced.
+
+If signing is not successfully configured at container creation, the setup script prints a prominent warning with recovery steps. At any time, you can re-run the signing configuration via `jim-setup-signing` or inspect the current state via `jim-signing-status`.
+
+**Host-side prerequisites (for local devcontainers):**
+
+SSH agent forwarding only works if the host machine has an SSH agent running with your key loaded. This is per-OS:
+
+- **macOS**: the Keychain-integrated SSH agent is usually running at login. Add your key once with `ssh-add --apple-use-keychain ~/.ssh/id_ed25519`; it persists across reboots. Verify with `ssh-add -l`.
+- **Linux**: start an agent in your login shell and add your key. A common pattern in `~/.bashrc` or `~/.zshrc`:
+  ```bash
+  if ! pgrep -u "$USER" ssh-agent >/dev/null; then
+      eval "$(ssh-agent -s)"
+  fi
+  ssh-add -l >/dev/null 2>&1 || ssh-add ~/.ssh/id_ed25519
+  ```
+- **Windows 11**: the built-in "OpenSSH Authentication Agent" service is present but **disabled by default**. Open `services.msc`, set the service to "Automatic", and start it. Then in PowerShell: `ssh-add $env:USERPROFILE\.ssh\id_ed25519`. Verify with `ssh-add -l`. This persists across reboots.
+
+After loading the key on the host, **rebuild the devcontainer** (Command Palette: *Dev Containers: Rebuild Container*). This is essential; the devcontainer connects to the agent at startup and will not pick up a key added later unless rebuilt.
+
+Verify after rebuild with `jim-signing-status`. A healthy state shows:
+```
+  gpg.format:         ssh
+  user.signingkey:    key::ssh-ed25519 AAAA...
+  commit.gpgsign:     true
+  environment:        local devcontainer (or other)
+  ssh agent:          forwarded, 1 key(s) loaded
+```
+
+**Registering your SSH key as a signing key on GitHub:**
+
+The same physical SSH key can be used for both authentication and signing, but GitHub tracks them as *separate key registrations*. If you have only added your key as an authentication key, commits will be signed but GitHub will display them as "Unverified". To fix:
+
+1. Visit https://github.com/settings/keys
+2. Click "New SSH key"
+3. Set "Key type" to **Signing Key** (not Authentication Key)
+4. Paste the same public key text as your authentication key
+5. Save
+
+Commits made with that key will then show as "Verified" on GitHub.
+
+**What the pre-commit hook checks:**
+
+The hook at `.githooks/pre-commit` runs automatically before every `git commit` (once `core.hooksPath=.githooks` is set, which the devcontainer setup script does). It verifies:
+
+1. `commit.gpgsign` is `true`
+2. A signing mechanism is currently available (SSH agent with keys, or `gh-gpgsign` in Codespaces)
+3. `user.signingkey` is set (for SSH signing)
+
+If any check fails, the hook prints a prominent error with recovery steps and refuses the commit. To bypass in a genuine emergency: `git commit --no-verify`. This should not become a habit; once branch protection enables `required_signatures`, unsigned commits will be rejected at push time regardless.
+
+**Working outside the devcontainer:**
+
+If you work directly against a local clone without the devcontainer (rare), you need to set up signing manually and install the hook:
+
+```bash
+git config --local core.hooksPath .githooks
+git config --global gpg.format ssh
+git config --global user.signingkey "key::$(ssh-add -L | head -1)"
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+```
+
 ## Testing Expectations
 
 ### Test-Driven Development (TDD)
@@ -1265,6 +1342,14 @@ Invoke-JIMApiRequest -Method Delete -Endpoint "api/v1/connected-systems/$id"
 - **PostgreSQL Memory**: If database crashes (OOM), check that `shm_size` and `shared_buffers` are tuned for your host - see [PostgreSQL Tuning](#postgresql-tuning-important) above
 - **Docker Issues**: Restart Codespace or rebuild container if Docker daemon issues occur
 - **Missing Aliases**: Run `source ~/.zshrc` or restart terminal if shell aliases not available
+
+**Commit Signing Issues**:
+- **"Commit signing is not enabled" when committing**: the pre-commit hook detected that `commit.gpgsign` is false. Run `jim-setup-signing` to reconfigure, or see [Commit Signing](#6-commit-signing-mandatory) for manual setup.
+- **"SSH agent not available or has no keys" when committing**: your host machine's SSH agent is not forwarding a key into the devcontainer. Follow the host-side prerequisites in the [Commit Signing](#6-commit-signing-mandatory) section for your OS, then rebuild the devcontainer. The hook will not run cleanly until the agent is fully configured.
+- **Commits show as "Unverified" on GitHub**: your SSH key is signing commits correctly but has not been registered as a *Signing Key* on GitHub. Visit https://github.com/settings/keys and add your public key a second time with type "Signing Key" (this is separate from the authentication key registration). See [Commit Signing](#6-commit-signing-mandatory) for details.
+- **Signing worked yesterday, fails today**: the host SSH agent may have been restarted or lost its keys. Run `ssh-add -l` on the host to check, add the key back if missing, then either rebuild the devcontainer or run `jim-setup-signing` inside the container to re-verify.
+
+**Works In Dev But Fails In CI**: the devcontainer image (`mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm`) is not digest-pinned; it tracks the upstream `:1-10.0-bookworm` tag which can change over time. If you see a build or test succeed in your devcontainer but fail in CI (or vice versa), check whether the devcontainer image has drifted from what CI is running. Rebuild the devcontainer to pick up the latest image. If this category of problem becomes frequent, consider revisiting whether to digest-pin the devcontainer image (currently left unpinned to reduce maintenance burden since dev-only images are not part of customer-shipped artefacts).
 
 ## Best Practices Summary
 


### PR DESCRIPTION
## Summary

Commit signing has been a documented expectation but was enforced only by a best-effort block inside \`.devcontainer/setup.sh\` that fell through silently when the host SSH agent was not forwarded. The silent failure produced unsigned commits that only became visible post-hoc during git history inspection, by which time they were already landed. This PR makes signing setup loud when it fails and refuses commits that would otherwise slip through.

## Why

Recent commits to \`main\` have been a mix of signed (\`E\`) and unsigned (\`N\`), where the unsigned cluster correlates with devcontainer rebuilds where the host-side SSH agent wasn't configured. The existing code in \`setup.sh\` detected this case but only printed a \`print_warning\` line that is easy to miss in a wall of setup output. Nothing caught the subsequent unsigned commits at commit time.

Signed commits are the foundation of verifiable code provenance. Enforcing them is one of the first-class controls JIM needs to satisfy UK Software Security Code of Practice Principle 6, NIST CSF PR.PS, and NIST SP 800-53 SI-7. It is also a prerequisite for enabling \`required_signatures\` on the \`main\` branch ruleset, which is scoped as a later phase of #521.

## What changes

### New: \`.devcontainer/configure-signing.sh\`

Standalone, idempotent signing configuration script. Detects environment and handles both:

- **GitHub Codespaces**: uses the built-in \`gh-gpgsign\` helper via the system gitconfig. Ensures \`commit.gpgsign=true\` and correctly leaves \`gpg.format\` unset (so git routes signing through \`gpg.program=/.codespaces/bin/gh-gpgsign\`, not native SSH signing which would require \`user.signingkey\` and break the chain).
- **Local devcontainers**: probes the forwarded SSH agent via \`ssh-add -l\`, extracts the public key via \`ssh-add -L\`, and configures git to sign using \`key::\`-prefixed inline public key value. Private key stays on the host; only signing requests are proxied through the forwarded agent.

When neither mechanism is available, the script prints a large boxed banner with per-OS recovery steps (macOS Keychain, Linux ssh-agent, Windows 11 OpenSSH Authentication Agent service) and exits 1.

Supports a \`--status\` subcommand for non-destructive health checks, used by the new \`jim-signing-status\` alias.

### Changed: \`.devcontainer/setup.sh\`

- Replaces the inline signing block (lines 146-174) with a call to \`configure-signing.sh\`.
- Adds a new step that sets \`core.hooksPath=.githooks\`, activating the pre-commit hook on every fresh devcontainer.
- Does not abort setup when signing fails. Rationale: the container may still be useful for non-commit work (browsing, running services), and the pre-commit hook will catch unsigned commit attempts at commit time with the same guidance.

### New: \`.githooks/pre-commit\`

Refuses commits when:

1. \`commit.gpgsign\` is not \`true\`
2. Signing mechanism is not currently available:
   - In Codespaces: \`/.codespaces/bin/gh-gpgsign\` missing
   - Locally: SSH agent not reachable, or \`user.signingkey\` not set

On refusal, prints a large boxed error banner with environment-specific recovery steps and the emergency bypass (\`git commit --no-verify\`).

The hook runs before git prompts for a commit message, so problems are caught before typing, not after.

### Changed: \`.devcontainer/jim-aliases.sh\`

Adds two aliases:
- \`jim-setup-signing\` — reconfigures signing via \`configure-signing.sh\`
- \`jim-signing-status\` — prints current signing state via \`configure-signing.sh --status\`

New \"Developer Setup\" section in the \`jim\` help output lists both.

### Changed: \`engineering/DEVELOPER_GUIDE.md\`

New subsection \"6. Commit Signing (Mandatory)\" under Security Considerations. Covers:
- Policy (all commits must be signed)
- Automated devcontainer setup
- Per-OS host-side SSH agent prerequisites
- Registering the SSH key as a GitHub Signing Key (distinct from Authentication Key)
- What the pre-commit hook checks
- Bypass mechanism for genuine emergencies
- Manual setup for working outside the devcontainer

Troubleshooting section gains:
- Entries for common signing issues (\"not enabled\", \"agent not available\", \"unverified on GitHub\", \"worked yesterday, fails today\")
- A \"Works In Dev But Fails In CI\" footnote covering devcontainer image drift, since the devcontainer base image is not digest-pinned

### Changed: \`engineering/COMPLIANCE_MAPPING.md\`

Version bumped 1.1 → 1.2. New subsections under Operational Considerations:

- **\"Controls scale with team size\"** — describes how automated review (\`claude-review\`), CI-enforced quality gates, signed commits, and scalable human review together provide consistent baseline enforcement at any team size, with additional human-review layers that can be added as the team grows.
- **\"Commit provenance and author attribution\"** — documents that commit signing is automated in \`setup.sh\`, enforced by the pre-commit hook, and supports NIST SP 800-53 SI-7 and NCSC Secure Development Principle \"Protect your code repository\".

## Explicit non-goals (deferred work)

- **Server-side \`required_signatures\` on main**: tracked in #521. Will be enabled after all contributor environments are reliably producing signed commits, to avoid locking out legitimate PRs.
- **Digest-pinning the devcontainer base image**: left intentionally unpinned. Dev-only images are not part of customer-shipped artefacts; the troubleshooting footnote documents the drift risk and the revisit trigger (if drift problems become frequent).

## Test plan

- [x] \`bash -n\` parses all new/modified shell scripts cleanly
- [x] \`configure-signing.sh --status\` correctly reports the current Codespace state
- [x] \`configure-signing.sh\` (no args) successfully reconfigures the Codespace
- [x] Pre-commit hook passes for a healthy Codespace state
- [x] Pre-commit hook refuses a commit when \`commit.gpgsign=false\` and prints the banner
- [x] A real \`git commit\` on this branch successfully fires the hook (which passes) AND produces a signed commit (verified via \`git log --pretty=format:'%h %G?'\`)
- [ ] CI build and tests pass
- [ ] Post-merge: next devcontainer rebuild correctly picks up \`core.hooksPath=.githooks\` and the new aliases

## Related

- Creates the foundation for the \"signed commits\" phase of #521 (branch protection hardening)
- Satisfies partial requirements from: UK Software Security Code of Practice Principle 6, NIST CSF PR.PS, NIST SP 800-53 SI-7, NCSC Secure Development Principles