### PR TITLE
chore(devcontainer): refresh VS Code extension list

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,13 +43,8 @@
         // Code quality
         "editorconfig.editorconfig",
         "streetsidesoftware.code-spell-checker",
-        // Testing
-        "formulahendry.dotnet-test-explorer",
-        // Utilities
-        "humao.rest-client",
-        "eamodio.gitlens",
-        // CSV viewing and editing
-        "mechatroner.rainbow-csv",
+        // GitHub Actions workflow support
+        "github.vscode-github-actions",
         // Mermaid diagrams
         "MermaidChart.vscode-mermaid-chart"
       ],


### PR DESCRIPTION
## Summary
- Add `github.vscode-github-actions` for workflow editing and run visibility
- Remove `eamodio.gitlens`, `humao.rest-client`, `mechatroner.rainbow-csv`, and `formulahendry.dotnet-test-explorer` which are no longer in active use

## Test plan
- [ ] Rebuild devcontainer and confirm the extension list matches expectations