### PR TITLE
docs: replace Swagger references with Scalar API reference

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -109,12 +109,12 @@ All dependency updates from Dependabot require human review before merging - the
 **Workflow 1 - Local Debugging (Recommended):**
 1. Run `jim-build-light` (starts db + Keycloak, waits for readiness, launches JIM.Web natively)
 2. Debug with breakpoints and hot reload
-3. Services: Web + API (https://localhost:7000), Swagger at `/api/swagger`
+3. Services: Web + API (https://localhost:7000), API reference at `/api/reference`
 
 **Workflow 2 - Full Docker Stack:**
 1. Start all services: `jim-stack`
 2. Access containerized services
-3. Services: Web + API (http://localhost:5200), Swagger at `/api/swagger`
+3. Services: Web + API (http://localhost:5200), API reference at `/api/reference`
 
 **Use Workflow 1** for active development and debugging.
 **Use Workflow 2** for integration testing or production-like environment.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -208,7 +208,7 @@ JIM supports two different development workflows. Choose the one that fits your 
 
 **Services run at:**
 - Database: `localhost:5432`
-- JIM Web + API: `https://localhost:7000` (API at `/api/`, Swagger at `/api/swagger`)
+- JIM Web + API: `https://localhost:7000` (API at `/api/`, API reference at `/api/reference`)
 
 ### Workflow 2: Full Docker Stack
 
@@ -225,7 +225,7 @@ JIM supports two different development workflows. Choose the one that fits your 
 
 **Services run at:**
 - Database: Internal (container network)
-- JIM Web + API: `http://localhost:5200` (API at `/api/`, Swagger at `/api/swagger`)
+- JIM Web + API: `http://localhost:5200` (API at `/api/`, API reference at `/api/reference`)
 
 **Note:** PostgreSQL is automatically tuned for your devcontainer's CPU and RAM during setup. If you later increase resources, run `jim-postgres-tune` to re-tune and restart the database.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ JIM is a container-based distributed application implementing the metaverse patt
 </a>
 
 **Components:**
-- **JIM.Web** - A website with integrated REST API, built using [ASP.NET](https://asp.net/) Blazor Server. The API is available at `/api/` with Swagger documentation at `/api/swagger`.
+- **JIM.Web** - A website with integrated REST API, built using [ASP.NET](https://asp.net/) Blazor Server. The API is available at `/api/`, with interactive [Scalar](https://scalar.com/) API documentation at `/api/reference` in development.
 - **JIM.Scheduler** - A background service that triggers synchronisation runs using cron or interval-based schedules, with multi-step sequential and parallel execution
 - **JIM.Worker** - A background service that processes import, sync, and export tasks with crash recovery and parallel execution support
 - **JIM.PowerShell** - A cross-platform PowerShell module (Windows, macOS, Linux) for full configuration and automation of JIM, enabling Identity as Code (IDaC)

--- a/docs/administration/deployment.md
+++ b/docs/administration/deployment.md
@@ -71,7 +71,7 @@ flowchart TD
 
 | Service            | Description                                                                           |
 |--------------------|---------------------------------------------------------------------------------------|
-| **jim.web**        | Blazor Server UI and REST API (`/api/` with Swagger at `/api/swagger`)                |
+| **jim.web**        | Blazor Server UI and REST API (`/api/`)                                               |
 | **jim.worker**     | Processes import, synchronisation, and export tasks                                   |
 | **jim.scheduler**  | Triggers synchronisation runs on cron or interval schedules                           |
 | **jim.database**   | PostgreSQL 18 (optional bundled container)                                            |

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -84,15 +84,20 @@ This step creates the API scope that JIM uses for JWT Bearer token validation (f
     - **State**: Enabled
 5. Click **Add scope**
 
-### Step 5a: Configure Swagger UI Authentication (Optional)
+### Step 5a: Configure Scalar API Reference Authentication (Development only, Optional)
 
-To enable OAuth authentication in the Swagger UI:
+JIM's interactive [Scalar](https://scalar.com/) API reference is only exposed in development environments (it is disabled in production to reduce the attack surface), so this step is only relevant if you are configuring SSO against a non-production JIM instance where you want to use the Scalar "try it out" flow with OAuth.
+
+To enable OAuth authentication in the Scalar API reference:
 
 1. Go to **Authentication**
 2. Click **Add Redirect URI**
 3. Select **Single-page application**
-4. Add redirect URI: `https://your-jim-url/api/swagger/oauth2-redirect.html`
+4. Add redirect URI: `https://your-jim-dev-url/api/reference` (Scalar uses the API reference page itself as the OAuth redirect target; there is no separate `oauth2-redirect.html` handler)
 5. Click **Configure**
+
+!!! note
+    For production deployments, use the JIM PowerShell module for interactive API testing instead. See Step 5b below.
 
 ### Step 5b: Configure PowerShell Module Authentication (Optional but recommended)
 
@@ -451,10 +456,14 @@ You should see a JSON response with endpoints for `authorization_endpoint`, `tok
 !!! tip "Hiding the sign-out button"
     For deployments where users cannot realistically sign out of their enterprise-managed SSO session (for example, on domain-joined devices with seamless SSO), administrators can hide the sign-out button entirely by setting the `SSO.EnableLogOut` service setting to `false`. See [Service Settings](configuration.md#service-settings) in the configuration reference.
 
-### 5. Test the API (Swagger)
+### 5. Test the API
 
-1. Navigate to `https://your-jim-url/api/swagger`
-2. Click **Authorise**
+In production, the recommended way to test API access with SSO is via the JIM PowerShell module (see Step 6 below), which supports interactive browser-based authentication.
+
+If you are configuring SSO against a non-production JIM instance and completed Step 5a above, you can also test the API interactively via the Scalar API reference:
+
+1. Navigate to `https://your-jim-dev-url/api/reference`
+2. Select an endpoint and choose the **OAuth2** security scheme
 3. Log in with your identity provider
 4. Try an API endpoint (e.g. `GET /api/v1/health`)
 

--- a/docs/api/connected-systems/create.md
+++ b/docs/api/connected-systems/create.md
@@ -18,7 +18,7 @@ POST /api/v1/synchronisation/connected-systems
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Display name for the connected system (1-200 characters) |
 | `description` | string | No | Optional description (max 1000 characters) |
-| `connectorDefinitionId` | integer | Yes | ID of the connector type to use. Available connectors can be listed via the Swagger UI. |
+| `connectorDefinitionId` | integer | Yes | ID of the connector type to use. Available connectors can be listed via the Scalar API reference at `/api/reference` (development only). |
 
 ## Examples
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -159,13 +159,16 @@ Some long-running operations (schema import, run profile execution, connected sy
 
 ## Interactive Documentation
 
-JIM includes Swagger UI for interactive API exploration:
+JIM includes a [Scalar](https://scalar.com/) API reference for interactive API exploration:
 
 ```
-https://jim.example.com/api/swagger
+https://jim.example.com/api/reference
 ```
 
-The Swagger UI provides a browsable list of all endpoints, request/response schemas, and the ability to execute API calls directly from the browser. It also exposes the OpenAPI specification for client code generation.
+The Scalar API reference provides a browsable list of all endpoints, request/response schemas, and the ability to execute API calls directly from the browser. The underlying OpenAPI specification is available at `/api/openapi/v1.json` for client code generation.
+
+!!! note
+    The interactive API reference is only enabled in development environments. Production deployments do not expose `/api/reference` or the OpenAPI JSON spec, to reduce the attack surface.
 
 !!! tip
-    Use this reference documentation for understanding how the API works and building integrations. Use Swagger UI when you need to quickly test an endpoint or generate a client library.
+    Use this reference documentation for understanding how the API works and building integrations. Use the Scalar API reference when you need to quickly test an endpoint or generate a client library.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -117,7 +117,7 @@ JIM runs as a set of Docker services:
 
 | Service | Description |
 |---------|-------------|
-| **jim.web** | Blazor Server UI with integrated REST API at `/api/`. Port 5200 (HTTP) / 5201 (HTTPS). Swagger available at `/api/swagger` in development. |
+| **jim.web** | Blazor Server UI with integrated REST API at `/api/`. Port 5200 (HTTP) / 5201 (HTTPS). Interactive [Scalar](https://scalar.com/) API reference available at `/api/reference` in development. |
 | **jim.worker** | Background task processor. Polls the task queue, processes sync/import/export operations. Uses `ISyncEngine`/`ISyncRepository` separation for testability. |
 | **jim.scheduler** | Schedule management with a 30-second polling cycle. Detects parallel step groups and queues them for concurrent worker dispatch. |
 | **jim.database** | PostgreSQL 18 database. |

--- a/docs/developer/dev-environment.md
+++ b/docs/developer/dev-environment.md
@@ -133,14 +133,14 @@ Choose one of two workflows depending on your task:
 Best for active development with breakpoints and hot reload.
 
 1. Run `jim-build-light` (starts db + Keycloak, waits for readiness, launches JIM.Web natively)
-2. Press **F5** in VS Code to launch with the debugger, or access JIM at `https://localhost:7000`, Swagger at `/api/swagger`
+2. Press **F5** in VS Code to launch with the debugger, or access JIM at `https://localhost:7000`, API reference at `/api/reference`
 
 ### Workflow 2: Full Docker Stack
 
 Best for integration testing or a production-like environment.
 
 1. Start all services: `jim-stack`
-2. Access JIM at `http://localhost:5200`, Swagger at `/api/swagger`
+2. Access JIM at `http://localhost:5200`, API reference at `/api/reference`
 
 !!! note "Rebuilding after code changes"
     When running the Docker stack, compiled code changes require a container rebuild. Use `jim-build-web`, `jim-build-worker`, or `jim-build-scheduler` to rebuild affected services. Simply refreshing the browser is not sufficient.
@@ -150,7 +150,7 @@ Best for integration testing or a production-like environment.
 | URL | Description |
 |-----|-------------|
 | `http://localhost:5200` | JIM Web UI (Docker stack) |
-| `http://localhost:5200/api/swagger` | Swagger API documentation |
+| `http://localhost:5200/api/reference` | Scalar API reference (development only) |
 | `http://localhost:8181` | Keycloak admin console (`admin` / `admin`) |
 | `https://localhost:7000` | JIM Web UI (local debugging) |
 | `http://localhost:8000` | MkDocs documentation preview |

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -233,7 +233,7 @@ builder.Services.AddSingleton<IConfiguration>(configuration);
 - Add `[ApiVersion("1.0")]` to mark controller version
 - Return `ActionResult<T>` for typed responses
 - Use DTOs for request/response bodies
-- Add XML comments for Swagger documentation
+- Add XML comments for OpenAPI documentation
 
 **Example**:
 ```csharp
@@ -774,7 +774,7 @@ JIM uses GitHub Codespaces to provide a fully configured development environment
 | URL | Description |
 |-----|-------------|
 | `http://localhost:5200` | JIM Web UI |
-| `http://localhost:5200/api/swagger` | Swagger API documentation |
+| `http://localhost:5200/api/reference` | Scalar API reference (development only) |
 | `http://localhost:5200/dev/error-pages` | Error page preview (Development only) |
 | `http://localhost:8181` | Keycloak admin console (`admin` / `admin`) |
 
@@ -849,7 +849,7 @@ JIM uses standard OIDC claims (`sub`, `name`, `given_name`, `family_name`, `pref
 ## Docker & Deployment
 
 ### Service Architecture
-- **jim.web**: Blazor Server UI with integrated REST API at `/api/` (port 5200 HTTP / 5201 HTTPS). Swagger available at `/api/swagger` in development.
+- **jim.web**: Blazor Server UI with integrated REST API at `/api/` (port 5200 HTTP / 5201 HTTPS). Interactive [Scalar](https://scalar.com/) API reference available at `/api/reference` in development (disabled in production).
 - **jim.worker**: Background task processor built on `ISyncEngine` / `ISyncRepository` separation (see [Background Processing](#7-background-processing)). Per-task DI isolation, `ParallelBatchWriter` for concurrent writes, and COPY binary protocol for bulk inserts. Supports parallel schedule step execution and configurable LDAP pipelining.
 - **jim.scheduler**: Schedule management service with 30-second polling cycle. Detects parallel step groups (steps sharing the same `StepIndex`) and queues them with `ExecutionMode = Parallel` for concurrent worker dispatch.
 - **jim.database**: PostgreSQL 18
@@ -1301,9 +1301,9 @@ Invoke-JIMApiRequest -Method Delete -Endpoint "api/v1/connected-systems/$id"
 ### Adding a New API Endpoint
 1. Add method to appropriate controller in `src/JIM.Web/Controllers/Api/`
 2. Use DTOs for request/response (in `src/JIM.Web/Models/Api/`)
-3. Add XML comments for Swagger
+3. Add XML comments for OpenAPI documentation
 4. Add authorisation attributes if needed
-5. Test via Swagger UI at `/api/swagger`
+5. Test via the Scalar API reference at `/api/reference` (development only)
 
 ### Modifying Database Schema
 1. Update entity classes in `src/JIM.Models/Models/`

--- a/engineering/JIM_AI_ASSISTANT_CONTEXT.md
+++ b/engineering/JIM_AI_ASSISTANT_CONTEXT.md
@@ -4,9 +4,9 @@
 >
 > **Repository**: https://github.com/TetronIO/JIM
 >
-> **Document Version**: 1.5
+> **Document Version**: 1.6
 >
-> **Last Updated**: 2026-04-08
+> **Last Updated**: 2026-04-10
 >
 > **Note**: This is a snapshot. For current implementation details, check the repository or ask the user to provide updated code/docs.
 
@@ -291,7 +291,7 @@ FormatDateTime(hireDate, "yyyy-MM-dd")
 | `GET /api/v1/logs` | Unified log viewer (app + PostgreSQL) |
 | `GET /api/v1/synchronisation/sync-rules/{id}/matching-rules` | Manage object matching rules |
 
-Full Swagger documentation available at `/api/swagger`.
+Full interactive Scalar API reference available at `/api/reference` (development only; disabled in production). The underlying OpenAPI JSON spec is served at `/api/openapi/v1.json`.
 
 ### PowerShell Module
 

--- a/engineering/JIM_AI_ASSISTANT_INSTRUCTIONS.md
+++ b/engineering/JIM_AI_ASSISTANT_INSTRUCTIONS.md
@@ -2,9 +2,9 @@
 
 > Copy the content below into the "Instructions" or "System Prompt" field when creating an AI assistant project for JIM.
 >
-> **Document Version**: 1.5
+> **Document Version**: 1.6
 >
-> **Last Updated**: 2026-04-08
+> **Last Updated**: 2026-04-10
 
 ---
 
@@ -26,7 +26,7 @@ JIM is a self-hosted, container-native identity management platform that synchro
 - .NET 10.0, C# 14, Entity Framework Core
 - PostgreSQL 18
 - Blazor Server with MudBlazor
-- REST API at /api/ with OpenAPI/Swagger
+- REST API at /api/ with OpenAPI and an interactive Scalar API reference (development only)
 - OpenID Connect (OIDC) authentication
 - Docker containerisation
 

--- a/engineering/plans/OWASP_TOP_10_ASSESSMENT.md
+++ b/engineering/plans/OWASP_TOP_10_ASSESSMENT.md
@@ -41,7 +41,7 @@ Core security configuration is sound: HSTS, HTTPS redirection, restricted develo
 |---------|----------|
 | HSTS enabled in production | `Program.cs:398` |
 | HTTPS redirection enabled | `Program.cs:414` |
-| OpenAPI/Swagger restricted to Development | `Program.cs:402-412` |
+| OpenAPI spec and Scalar API reference restricted to Development | `Program.cs:402-412` |
 | Stack traces suppressed in production | `GlobalExceptionHandler.cs:32` |
 | DbContext pooling prevents connection exhaustion | `Program.cs:76-80` |
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -155,8 +155,8 @@ var schedule = await Jim.Scheduler.GetScheduleAsync(id);
 **Adding API Endpoint:**
 1. Add method to controller in `JIM.Web/Controllers/Api/`
 2. Use DTOs for request/response (in `JIM.Web/Models/Api/`)
-3. Add XML comments for Swagger
-4. Test via Swagger UI at `/api/swagger`
+3. Add XML comments for OpenAPI documentation
+4. Test via the Scalar API reference at `/api/reference` (Development only)
 
 **Modifying Database Schema:**
 1. Update entity in `JIM.Models/`

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -2212,7 +2212,7 @@ if ($SetupOnly) {
     Write-Host "${GRAY}Services:${NC}"
     Write-Host "  JIM Web:            ${CYAN}http://localhost:5200${NC}"
     Write-Host "  JIM API:            ${CYAN}http://localhost:5200/api${NC}"
-    Write-Host "  Swagger:            ${CYAN}http://localhost:5200/api/swagger${NC}"
+    Write-Host "  API Reference:      ${CYAN}http://localhost:5200/api/reference${NC}"
     Write-Host ""
     Write-Host "${GRAY}API Key:${NC}"
     Write-Host "  ${CYAN}$apiKey${NC}"


### PR DESCRIPTION
## Summary

- Replace remaining Swagger / Swashbuckle references across user- and developer-facing documentation with the current Scalar API reference at `/api/reference`.
- Correct the SSO setup guide's Entra ID Step 5a: Scalar uses the API reference page itself as the OAuth2 redirect URI (there is no `oauth2-redirect.html` handler), and the interactive API reference is development-only, so the step now points admins at `https://your-jim-dev-url/api/reference` and is explicitly marked as not applicable to production.
- Bump `JIM_AI_ASSISTANT_CONTEXT.md` and `JIM_AI_ASSISTANT_INSTRUCTIONS.md` document versions to 1.6 per engineering/CLAUDE.md convention.

## Context

The .NET 10 migration (see [engineering/plans/done/DOTNET_10_MIGRATION.md](engineering/plans/done/DOTNET_10_MIGRATION.md)) replaced Swashbuckle with `Microsoft.AspNetCore.OpenApi` + `Scalar.AspNetCore`, but much of the documentation was not updated at the time. This was spotted during a Dependabot review pass.

Key facts used for the rewrite:

- API reference URL: `/api/reference` (Scalar), not `/api/swagger`
- OpenAPI JSON spec: `/api/openapi/v1.json` (served by Microsoft.AspNetCore.OpenApi)
- Both are mounted inside `if (app.Environment.IsDevelopment())` in [src/JIM.Web/Program.cs:401-411](src/JIM.Web/Program.cs#L401-L411), so they are disabled in production; this matches the existing OWASP assessment control.
- Scalar's OAuth2 redirect URI defaults to `window.location.origin + window.location.pathname`, i.e. the Scalar page itself. Confirmed via the Scalar source at [packages/types/src/entities/security-scheme.ts](https://github.com/scalar/scalar/blob/main/packages/types/src/entities/security-scheme.ts).

## Files changed

**User-facing docs**
- [README.md](README.md)
- [.devcontainer/README.md](.devcontainer/README.md)
- [docs/api/index.md](docs/api/index.md)
- [docs/api/connected-systems/create.md](docs/api/connected-systems/create.md)
- [docs/administration/deployment.md](docs/administration/deployment.md)
- [docs/administration/sso-setup.md](docs/administration/sso-setup.md)
- [docs/developer/architecture.md](docs/developer/architecture.md)
- [docs/developer/dev-environment.md](docs/developer/dev-environment.md)

**Developer guidance**
- [engineering/DEVELOPER_GUIDE.md](engineering/DEVELOPER_GUIDE.md)
- [engineering/JIM_AI_ASSISTANT_CONTEXT.md](engineering/JIM_AI_ASSISTANT_CONTEXT.md)
- [engineering/JIM_AI_ASSISTANT_INSTRUCTIONS.md](engineering/JIM_AI_ASSISTANT_INSTRUCTIONS.md)
- [engineering/plans/OWASP_TOP_10_ASSESSMENT.md](engineering/plans/OWASP_TOP_10_ASSESSMENT.md)
- [src/CLAUDE.md](src/CLAUDE.md)
- [.devcontainer/CLAUDE.md](.devcontainer/CLAUDE.md)

**Scripts**
- [test/integration/Run-IntegrationTests.ps1](test/integration/Run-IntegrationTests.ps1) — the "SetupOnly Complete" banner now prints the Scalar API reference URL instead of the old Swagger URL.

**Intentionally left alone**
- `CHANGELOG.md` (historical record)
- `engineering/plans/done/*.md` (completed plan history per [engineering/CLAUDE.md](engineering/CLAUDE.md) filing conventions)

## Test plan

- [ ] Build the docs site locally (`jim-docs-build` or `jim-docs`) and confirm no broken links or rendering issues on the updated pages
- [ ] Eyeball the updated SSO setup page to confirm the Step 5a rewrite reads cleanly and the Step 5 test section makes sense
- [ ] Confirm `/api/reference` loads against a local dev instance and renders the API reference (sanity check that the URL in the updated docs is correct)
- [ ] Verify `Run-IntegrationTests.ps1 -SetupOnly` prints the new URL correctly

No .NET build or tests required (docs and one PowerShell banner string only, per CLAUDE.md exceptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)