### PR TITLE
chore(ci): poll Dependabot Docker updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,11 @@ updates:
   # Run: docker run --rm <image>@<new-digest> bash -c "apt-get update -qq && apt-cache policy <pkg>"
   #
   # Add new Dockerfile directories to the list below; Dependabot does not recurse.
+  #
+  # Polled daily so that upstream base image rebuilds (Microsoft rebuilds .NET
+  # images within 12 hours of an Ubuntu noble update, and on the second Tuesday
+  # of each month for lower-severity CVEs) are picked up promptly. JIM's own
+  # release cadence acts as the natural cooling-off window.
   - package-ecosystem: "docker"
     directories:
       - "/src/JIM.Web"
@@ -64,8 +69,7 @@ updates:
       - "/src/JIM.Scheduler"
       - "/.devcontainer"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
     reviewers:
@@ -84,11 +88,11 @@ updates:
   # Docker Compose images (PostgreSQL)
   # The digest-pinned postgres image in docker-compose.yml is the single source of truth —
   # Build-ReleaseBundle.ps1 reads it automatically, so updating here updates the bundle too.
+  # Polled daily for the same reason as the base images above.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
     reviewers:


### PR DESCRIPTION
## Summary

- Switch both Docker-ecosystem Dependabot blocks (.NET base images + `docker-compose.yml` PostgreSQL) from weekly Monday polling to daily polling.
- Add explanatory comments so future maintainers understand the rationale.
- NuGet and GitHub Actions ecosystems remain on weekly cadence (no urgent benefit to changing them).

## Why

Microsoft's published [Image Update Policy](https://github.com/dotnet/dotnet-docker#image-update-policy) for the .NET base images:

- Rebuilt within **12 hours** of an Ubuntu noble base image update
- Rebuilt on the **second Tuesday of each month** for lower-severity CVEs
- Rebuilt on-demand for Critical CVSS CVEs
- Rebuilt with each .NET servicing release

Weekly polling meant upstream rebuilds could sit undetected for up to 6 days. Daily polling picks them up within 24 hours. This matters for JIM because it is deployed in high-assurance environments (healthcare, financial services, government) where time-to-patch on base-image CVEs is a real concern.

The "noise" cost is zero: Dependabot only opens PRs when a digest actually changes, so daily vs weekly produces the same number of PRs, just sooner. JIM's own release cadence is the natural cooling-off window, so merging faster-arriving PRs does not reduce our ability to vet upstream changes before shipping.

## Context

This came out of a review of the current 36 open Trivy alerts on https://github.com/TetronIO/JIM/security/code-scanning, all of which trace back to unpatched `openssl` / `libssl3t64` (LOW/MEDIUM CVEs) in Microsoft's current `10.0-noble` base image digest. The fix for those specific alerts will land when Microsoft rebuilds the images; daily polling ensures we see that PR within a day rather than up to a week later.

## Test plan

- [ ] Confirm GitHub's Dependabot UI parses the updated `.github/dependabot.yml` without errors (visible at https://github.com/TetronIO/JIM/network/updates after merge)
- [ ] Observe that the next scheduled run happens the following morning at 09:00 Europe/London

🤖 Generated with [Claude Code](https://claude.com/claude-code)