### PR TITLE
chore(ci): split Dependabot docker config into per-Dockerfile blocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,23 +51,29 @@ updates:
           - "Microsoft.Azure.WebJobs*"
 
   # Docker base images (digest-pinned for reproducible builds)
-  # Dependabot will propose PRs to update digests when new images are published.
-  # IMPORTANT: When a digest update is merged, you must also update the pinned
-  # apt package versions in the corresponding Dockerfile to match the new base image.
-  # Run: docker run --rm <image>@<new-digest> bash -c "apt-get update -qq && apt-cache policy <pkg>"
   #
-  # Add new Dockerfile directories to the list below; Dependabot does not recurse.
+  # Each production Dockerfile has its own `package-ecosystem: docker` block
+  # below. This is intentional: the earlier `directories:` (plural) form with
+  # a single group was producing one PR per FROM line (six PRs per upstream
+  # rebuild) because of dependabot-core#10428, where the docker ecosystem
+  # intermittently fails to apply group configuration across multiple
+  # directories. Splitting into one block per Dockerfile sidesteps that bug
+  # and guarantees one grouped PR per Dockerfile. When #10428 is fixed, this
+  # can be collapsed back into a single block.
+  #
+  # IMPORTANT: When a digest update is merged, you must also update the pinned
+  # apt package versions in the corresponding Dockerfile to match the new base
+  # image. Run:
+  #   docker run --rm <image>@<new-digest> bash -c "apt-get update -qq && apt-cache policy <pkg>"
   #
   # Polled daily so that upstream base image rebuilds (Microsoft rebuilds .NET
   # images within 12 hours of an Ubuntu noble update, and on the second Tuesday
   # of each month for lower-severity CVEs) are picked up promptly. JIM's own
   # release cadence acts as the natural cooling-off window.
+
+  # JIM.Web Dockerfile (dotnet/aspnet + dotnet/sdk)
   - package-ecosystem: "docker"
-    directories:
-      - "/src/JIM.Web"
-      - "/src/JIM.Worker"
-      - "/src/JIM.Scheduler"
-      - "/.devcontainer"
+    directory: "/src/JIM.Web"
     schedule:
       interval: "daily"
       time: "09:00"
@@ -84,6 +90,63 @@ updates:
       dotnet-base-images:
         patterns:
           - "mcr.microsoft.com/dotnet/*"
+
+  # JIM.Worker Dockerfile (dotnet/runtime + dotnet/sdk)
+  - package-ecosystem: "docker"
+    directory: "/src/JIM.Worker"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    reviewers:
+      - "TetronIO/jim-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      dotnet-base-images:
+        patterns:
+          - "mcr.microsoft.com/dotnet/*"
+
+  # JIM.Scheduler Dockerfile (dotnet/runtime + dotnet/sdk)
+  - package-ecosystem: "docker"
+    directory: "/src/JIM.Scheduler"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    reviewers:
+      - "TetronIO/jim-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      dotnet-base-images:
+        patterns:
+          - "mcr.microsoft.com/dotnet/*"
+
+  # .devcontainer Dockerfile: single image (mcr.microsoft.com/devcontainers/dotnet);
+  # no group needed, and it does not match the dotnet-base-images pattern above.
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    reviewers:
+      - "TetronIO/jim-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Docker Compose images (PostgreSQL)
   # The digest-pinned postgres image in docker-compose.yml is the single source of truth —


### PR DESCRIPTION
## Summary

- Replace the single `docker` block with `directories:` (plural) with four separate `docker` blocks, one per Dockerfile (`src/JIM.Web`, `src/JIM.Worker`, `src/JIM.Scheduler`, `.devcontainer`).
- Each production Dockerfile block keeps the `dotnet-base-images` group so aspnet+sdk or runtime+sdk updates collapse into one PR per service.
- `.devcontainer` has no group (single-image Dockerfile, and its image does not match the `mcr.microsoft.com/dotnet/*` pattern).
- No change to the docker-compose postgres block or the NuGet / GitHub Actions ecosystems.

## Why

Today's daily run (first run after TetronIO/JIM#526 switched Docker polling to daily) produced **six separate, ungrouped PRs** — one per `FROM` line across the three production Dockerfiles — rather than the expected three grouped PRs (one per Dockerfile). Investigation traced this to [dependabot/dependabot-core#10428](https://github.com/dependabot/dependabot-core/issues/10428), an open upstream bug where the docker ecosystem intermittently fails to apply group configuration when `directories:` (plural) is used.

The singular `directory:` form is not affected by this bug. Splitting into one block per Dockerfile is the most reliable workaround until #10428 is fixed upstream.

## Trade-offs

- **Cost:** ~4× config duplication for boilerplate fields (`schedule`, `reviewers`, `commit-message`, `ignore`). This is ugly but explicit and grep-friendly.
- **Benefit:** guaranteed one grouped PR per Dockerfile. Maps 1:1 to the `/review-dependabot` skill's per-Dockerfile apt-pin verification step, which is the natural unit of review for base image digest updates.
- **Revert path:** when #10428 is fixed, collapse the four blocks back into one with `directories:` (plural). A comment in the file documents this.

## What to expect after merge

The next scheduled daily run (09:00 Europe/London tomorrow, or sooner if Dependabot re-evaluates on config change) should produce **at most 3 grouped PRs** for the currently-pending digest updates, instead of the 6 ungrouped PRs currently open. The 6 already-open PRs (#527, #528, #529, #530, #531, #532) are not affected by this config change — they were opened under the old config and need to be handled separately via `/review-dependabot`.

## Test plan

- [ ] Confirm GitHub's Dependabot UI parses the new `.github/dependabot.yml` without errors (visible at https://github.com/TetronIO/JIM/network/updates)
- [ ] After merge, observe the next scheduled run and verify that new digest updates are now delivered as grouped PRs per Dockerfile
- [ ] YAML parses cleanly: verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)