### PR TITLE
chore(ci): fix silently-failing Dependabot compose tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -148,12 +148,31 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  # Docker Compose images (PostgreSQL)
-  # The digest-pinned postgres image in docker-compose.yml is the single source of truth —
-  # Build-ReleaseBundle.ps1 reads it automatically, so updating here updates the bundle too.
+  # Docker Compose: PostgreSQL (in docker-compose.yml) and Keycloak (in
+  # docker-compose.override.yml, used for development SSO).
+  #
+  # Uses the GA `docker-compose` ecosystem, which shipped on 2025-02-25. The
+  # previous `docker` ecosystem block failed every scheduled run because
+  # Dependabot's `docker` ecosystem only scans Dockerfiles and Kubernetes YAML;
+  # it never read compose files, despite the comment claiming otherwise. The
+  # digest-pinned postgres image in docker-compose.yml is the single source of
+  # truth for the release bundle (Build-ReleaseBundle.ps1 reads it directly).
+  #
+  # Scoped via `exclude-paths` to only `docker-compose.yml` (postgres digest
+  # updates) and `docker-compose.override.yml` (Keycloak SSO version updates).
+  # The integration-tests, local, and production compose files are deliberately
+  # not tracked; integration-tests images are chosen for compatibility testing
+  # and should not be auto-bumped, and local/production contain no trackable
+  # pinned images. Remove a filename from exclude-paths if you want its images
+  # monitored too.
+  #
   # Polled daily for the same reason as the base images above.
-  - package-ecosystem: "docker"
+  - package-ecosystem: "docker-compose"
     directory: "/"
+    exclude-paths:
+      - "docker-compose.integration-tests.yml"
+      - "docker-compose.local.yml"
+      - "docker-compose.production.yml"
     schedule:
       interval: "daily"
       time: "09:00"


### PR DESCRIPTION
## Summary

- Replace the failing `package-ecosystem: docker` + `directory: "/"` block with a new `package-ecosystem: docker-compose` block.
- Scoped via `exclude-paths` to `docker-compose.yml` (postgres digest) and `docker-compose.override.yml` (Keycloak SSO).
- Fixes a latent supply-chain monitoring gap that has existed since whoever added the original block.

## Context

The \"Dependabot Updates\" workflow has been failing on a \"docker in /.\" job on every scheduled run, reporting:

> `ERROR Error during file fetching; aborting: No Dockerfiles nor Kubernetes YAML found in /`

Example failing run: https://github.com/TetronIO/JIM/actions/runs/24257105936

Root cause: Dependabot's `docker` ecosystem only scans Dockerfiles and Kubernetes YAML. It has never read docker-compose files. The comment on the old block (\"The digest-pinned postgres image in docker-compose.yml is the single source of truth; Build-ReleaseBundle.ps1 reads it automatically, so updating here updates the bundle too\") was aspirational — Dependabot was never actually tracking that image.

## The fix

Switch to the `docker-compose` ecosystem, which [shipped in GA on 2025-02-25](https://github.blog/changelog/2025-02-25-dependabot-version-updates-now-support-docker-compose-in-general-availability/) and handles digest updates correctly.

## Scope: what gets tracked

| File | Tracked? | Why |
|------|---------|-----|
| `docker-compose.yml` | ✅ | Contains `postgres:18@sha256:...` — the original intent |
| `docker-compose.override.yml` | ✅ | Contains `quay.io/keycloak/keycloak:26.0` — Keycloak is a security-sensitive SSO dependency, CVE visibility is worth having |
| `docker-compose.integration-tests.yml` | ❌ | Contains mssql/mysql/oracle/postgres16 version pins chosen deliberately for compatibility testing; auto-bumps would be disruptive |
| `docker-compose.local.yml` | ❌ | Generated by `jim-postgres-tune`; contains no trackable pinned images |
| `docker-compose.production.yml` | ❌ | Contains no trackable pinned images |

If you later want integration-tests, local, or production tracked, remove the relevant filename from `exclude-paths`.

## Important nuance about Keycloak tracking

The Keycloak image in [docker-compose.override.yml](docker-compose.override.yml#L61) is pinned as `quay.io/keycloak/keycloak:26.0` — a **tag**, not a digest. Dependabot will propose version bumps (e.g. `26.0` → `26.1` → `26.2` → `27.0`), ignoring majors per the existing `ignore` rule. Note that `26.0` is a minor-granularity tag, so Dependabot may or may not surface patch updates depending on what Keycloak publishes. This is a development-only file (Keycloak is bundled for dev SSO, not for production), so the blast radius of an unwelcome bump is low.

## Test plan

- [ ] Confirm GitHub's Dependabot UI parses the new config without errors (visible at https://github.com/TetronIO/JIM/network/updates after merge)
- [ ] Observe the next scheduled Dependabot Updates run: the `docker in /. - Update` job should be replaced by a `docker_compose in /. - Update` job that succeeds
- [ ] YAML syntax validated locally with `python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"`

## Follow-up (not in this PR)

The 36 open Trivy alerts on https://github.com/TetronIO/JIM/security/code-scanning are still waiting on Microsoft's next .NET base image rebuild. This PR does not affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)