### PR TITLE
chore(docker): bump cifs-utils (security) and libldap (non-security) apt pins

### DIFF
--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -25,8 +25,8 @@ EXPOSE 443
 # Note: libldap-2.5-0 was renamed to libldap2 in Ubuntu Noble (OpenLDAP 2.6)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libldap-common=2.6.7+dfsg-1~exp1ubuntu8 \
-        libldap2=2.6.7+dfsg-1~exp1ubuntu8 \
+        libldap-common=2.6.10+dfsg-0ubuntu0.24.04.1 \
+        libldap2=2.6.10+dfsg-0ubuntu0.24.04.1 \
     && apt-get install -y --no-install-recommends \
         iputils-ping \
         curl \

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libldap-common=2.6.7+dfsg-1~exp1ubuntu8 \
         libldap2=2.6.7+dfsg-1~exp1ubuntu8 \
-        cifs-utils=2:7.0-2build1 \
+        cifs-utils=2:7.0-2ubuntu0.2 \
         libgssapi-krb5-2=1.20.1-6ubuntu2.6 \
     && rm -rf /var/lib/apt/lists/* \
     # Symlink for System.DirectoryServices.Protocols compatibility

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 # Note: libldap-2.5-0 was renamed to libldap2 in Ubuntu Noble (OpenLDAP 2.6)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libldap-common=2.6.7+dfsg-1~exp1ubuntu8 \
-        libldap2=2.6.7+dfsg-1~exp1ubuntu8 \
+        libldap-common=2.6.10+dfsg-0ubuntu0.24.04.1 \
+        libldap2=2.6.10+dfsg-0ubuntu0.24.04.1 \
         cifs-utils=2:7.0-2ubuntu0.2 \
         libgssapi-krb5-2=1.20.1-6ubuntu2.6 \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

- Bump `cifs-utils` in `src/JIM.Worker/Dockerfile` from `2:7.0-2build1` to `2:7.0-2ubuntu0.2` (**security update** from `noble-security`).
- Bump `libldap-common` and `libldap2` in both `src/JIM.Web/Dockerfile` and `src/JIM.Worker/Dockerfile` from `2.6.7+dfsg-1~exp1ubuntu8` to `2.6.10+dfsg-0ubuntu0.24.04.1` (non-security update from `noble-updates`).

## Why

During today's \`/review-dependabot\` pass I ran the usual apt-pin verification against the new dotnet/runtime and dotnet/aspnet base digests and spotted that several pinned packages were on the base \`noble\` pocket version while newer versions were available in \`noble-updates\` (and in one case, \`noble-security\`):

| Package | Old pin | New pin | Source | Security? |
|---|---|---|---|---|
| \`cifs-utils\` | \`2:7.0-2build1\` | \`2:7.0-2ubuntu0.2\` | \`noble-updates\` + \`noble-security\` | ✅ |
| \`libldap-common\` | \`2.6.7+dfsg-1~exp1ubuntu8\` | \`2.6.10+dfsg-0ubuntu0.24.04.1\` | \`noble-updates\` only | ❌ |
| \`libldap2\` | \`2.6.7+dfsg-1~exp1ubuntu8\` | \`2.6.10+dfsg-0ubuntu0.24.04.1\` | \`noble-updates\` only | ❌ |

\`cifs-utils\` is the urgent one: JIM.Worker was not receiving Ubuntu security updates for it, which is a latent supply chain gap for a high-assurance product. The \`libldap*\` bumps are lower-urgency but bring JIM's pinning in line with the \`noble-updates\`-tracking policy already used for \`libgssapi-krb5-2\` in JIM.Worker.

\`libgssapi-krb5-2\` is already on the \`noble-security\` version (\`1.20.1-6ubuntu2.6\`), so no change needed there.

## Verification

Ran the standard apt-cache policy check against both base digests currently on main:

```bash
# dotnet/runtime (Worker) - verifies all four pinned packages
docker run --rm mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:d899417078f6f2ace195c70bd63c4851f4c2e29c38f50fcfb46f2be5f7e3638f \
  bash -c "apt-get update -qq && apt-cache policy libldap-common libldap2 cifs-utils libgssapi-krb5-2"

# dotnet/aspnet (Web) - verifies libldap pins
docker run --rm mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:c433886fdfe33c6427966a412328867b2be9a64f540a105d08943c2dc6fba39b \
  bash -c "apt-get update -qq && apt-cache policy libldap-common libldap2"
```

All new pin versions confirmed available in the correct pockets.

## Scope and risk

- No Dockerfile structural changes; pin values only
- No change to the base image digests (those were bumped earlier today by #527-#532)
- No behaviour change expected: all three packages are ABI-stable point updates within the same minor version
- CI's \`scan-base-images\` and \`build-and-test\` jobs will exercise the Docker builds end-to-end

## Test plan

- [ ] CI \`build-and-test\` passes (the \`jim.web\` and \`jim.worker\` Docker images build successfully with the new pins)
- [ ] CI \`scan-base-images\` passes (Trivy scan shows no new CVEs from the package changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)