### PR TITLE
chore(ci): pin all GitHub Actions by commit SHA (#517)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies
@@ -47,7 +47,7 @@ jobs:
         $config.TestResult.OutputFormat = "NUnitXml"
         Invoke-Pester -Configuration $config
     - name: Upload Pester Test Results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       if: always()
       with:
         name: pester-test-results
@@ -65,7 +65,7 @@ jobs:
       matrix: ${{ steps.discover.outputs.matrix }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
     - name: Discover production base images and enforce digest-pinning
       id: discover
@@ -90,7 +90,7 @@ jobs:
       matrix: ${{ fromJSON(needs.discover-base-images.outputs.matrix) }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
     # Pull the base image into the local Docker daemon so Trivy can read it via
     # source="docker". Without this step, Trivy on GitHub-hosted runners was
@@ -114,7 +114,7 @@ jobs:
       # have no upstream fix available.
       env:
         TRIVY_IGNORE_UNFIXED: 'true'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
       with:
         image-ref: ${{ matrix.image_ref }}
         format: 'sarif'
@@ -196,7 +196,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub code scanning
       if: always() && hashFiles('trivy-results.sarif') != ''
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
       with:
         sarif_file: trivy-results.sarif
         category: trivy-base-image-${{ matrix.dockerfile }}-line${{ matrix.line }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0  # v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0  # v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,16 +12,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/metrics-sync.yml
+++ b/.github/workflows/metrics-sync.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 2
 
@@ -53,7 +53,7 @@ jobs:
           echo "$DIFF_SUMMARY" > /tmp/diff_summary.txt
 
       - name: Dispatch to jim-metrics
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
         with:
           token: ${{ secrets.METRICS_REPO_DISPATCH_TOKEN }}
           repository: TetronIO/jim-metrics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       # Phase 1: Version validation gate
       - name: Validate version consistency
@@ -58,7 +58,7 @@ jobs:
           Write-Host "PowerShell manifest version validated: $numericVersion"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: 10.0.x
 
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set image prefix
         id: prefix
@@ -114,10 +114,10 @@ jobs:
 
       # Phase 8: Docker layer caching
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ steps.prefix.outputs.IMAGE_PREFIX }}/${{ matrix.image }}
           tags: |
@@ -135,7 +135,7 @@ jobs:
 
       # Phase 3 & 4: Build locally first, scan, smoke-test, then push
       - name: Build Docker image (local)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -149,7 +149,7 @@ jobs:
 
       # Phase 3: Container vulnerability scanning
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
         with:
           image-ref: ${{ steps.prefix.outputs.IMAGE_PREFIX }}/${{ matrix.image }}:${{ steps.version.outputs.VERSION }}
           format: 'table'
@@ -194,7 +194,7 @@ jobs:
       # Push the image (after scan and smoke test pass)
       - name: Push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -206,7 +206,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5  # v3.10.1
 
       - name: Sign container image
         run: |
@@ -215,7 +215,7 @@ jobs:
 
       # Phase 6a: SBOM generation
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           image: ${{ steps.prefix.outputs.IMAGE_PREFIX }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: spdx-json
@@ -230,7 +230,7 @@ jobs:
 
       # Phase 6b: SLSA provenance attestation
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
         with:
           subject-name: ${{ steps.prefix.outputs.IMAGE_PREFIX }}/${{ matrix.image }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -238,7 +238,7 @@ jobs:
 
       # Phase 6c: Upload SBOM as artifact for GitHub Release
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: sbom-${{ matrix.image }}
           path: sbom-${{ matrix.image }}.spdx.json
@@ -253,7 +253,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Get version from tag
         id: version
@@ -336,14 +336,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Get version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -360,14 +360,14 @@ jobs:
           echo "name=$bundleName" >> $env:GITHUB_OUTPUT
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-bundle
           path: ./release-output/jim-release-${{ steps.version.outputs.VERSION }}.tar.gz
           retention-days: 5
 
       - name: Upload checksums artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: checksums
           path: ./release-output/jim-release-${{ steps.version.outputs.VERSION }}/checksums.sha256
@@ -381,26 +381,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Get version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Download bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-bundle
           path: ./artifacts
 
       - name: Download checksums artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: checksums
           path: ./artifacts
 
       - name: Download SBOM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: sbom-*
           path: ./artifacts/sbom

--- a/engineering/COMPLIANCE_MAPPING.md
+++ b/engineering/COMPLIANCE_MAPPING.md
@@ -137,7 +137,7 @@ The UK Government's Software Security Code of Practice defines 14 principles acr
 
 | Principle | Requirement | JIM Alignment | Status |
 |-----------|-------------|---------------|--------|
-| 5 | Protect the build environment | GitHub Actions CI/CD, pinned action versions | Aligned |
+| 5 | Protect the build environment | GitHub Actions CI/CD with every action pinned by immutable 40-character commit SHA (not mutable version tags), preventing tag-rewrite supply chain attacks. Dependabot tracks SHA-pinned updates. See DEVELOPER_GUIDE.md "GitHub Actions" for the pinning procedure. | Aligned |
 | 6 | Secure the development tools and processes | Devcontainer with controlled toolchain, dependency pinning | Aligned |
 | 7 | Manage and secure third-party components | Dependency review policy, SBOM generation. Container base image vulnerability scanning runs on every push and PR with results surfaced to GitHub code scanning (SARIF). Digest-pinning of production base images is enforced by CI rather than by convention. | Aligned |
 

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -976,9 +976,30 @@ The choice between options 1-4 depends on the specific CVE, its CVSS score, the 
 
 #### GitHub Actions
 
-- Actions are pinned by major version tag (e.g., `actions/checkout@v4`)
-- Dependabot proposes weekly PRs for patch and minor version updates
-- Before merging, review the action's changelog for any changes to inputs, outputs, or behaviour
+Every third-party and first-party action in `.github/workflows/*.yml` is pinned by its full 40-character commit SHA, with the human-readable version tag preserved as a trailing comment:
+
+```yaml
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+```
+
+This protects against tag-rewrite attacks: the `v4` tag is mutable and can be silently moved to a malicious commit, but a 40-char commit SHA is immutable. SHA pinning is required for alignment with UK Software Security Code of Practice Principle 5 (Protect the build environment) and GitHub's own [security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) guidance.
+
+**Adding a new action:**
+
+1. Find the version tag you want to use (e.g., `v4.3.1`) on the action's repository.
+2. Resolve the tag to its commit SHA. For lightweight tags:
+   ```bash
+   git ls-remote --tags https://github.com/owner/repo.git v4.3.1
+   ```
+   For annotated tags, dereference with `^{}`:
+   ```bash
+   git ls-remote --tags https://github.com/owner/repo.git 'v4.3.1^{}'
+   ```
+   (If the first form returns a SHA and a `v4.3.1^{}` entry exists, the lightweight SHA is the tag object; use the dereferenced SHA as the commit.)
+3. Write the reference as `owner/repo@<40-char-sha>  # v4.3.1` (two spaces before the `#`, matching existing style).
+4. Pin to a tagged release, not to a moving major-version tag's tip. If a repo's major tag (e.g., `v3`) is ahead of the latest semver release, pin to the latest semver release instead; this is more auditable and matches what Dependabot will track.
+
+**Ongoing updates** are handled by Dependabot, which natively understands SHA-pinned actions. When a new version tag moves the underlying commit, Dependabot opens a PR that updates both the SHA and the version comment. Before merging, review the action's changelog for any changes to inputs, outputs, or behaviour.
 
 ### Migrations
 Apply migrations on first run:


### PR DESCRIPTION
## Summary

Closes #517.

Pins every action in `.github/workflows/*.yml` by its full 40-character commit SHA, with the human-readable version tag preserved as a trailing comment. 38 `uses:` lines across 6 workflows, covering 17 distinct actions (first-party and third-party alike).

This closes the tag-rewrite attack surface and brings the repository's actual CI configuration into line with the UK Software Security Code of Practice Principle 5 claim in `COMPLIANCE_MAPPING.md`, which was previously aspirational.

## Changes

- **6 workflow files** rewritten so every action is pinned as `owner/repo@<40-hex-sha>  # vX.Y.Z`
  - `ci.yml` (7), `release.yml` (22), `docs.yml` (3), `claude.yml` (2), `claude-code-review.yml` (2), `metrics-sync.yml` (2)
- **`engineering/DEVELOPER_GUIDE.md`**: rewrote the supply chain "GitHub Actions" section to describe SHA pinning, how to resolve a tag to a commit SHA (including the annotated-tag `^{}` dereference gotcha), and the rule of pinning to a tagged release rather than a moving major tag's tip.
- **`engineering/COMPLIANCE_MAPPING.md`**: updated Principle 5 row to accurately describe SHA pinning and reference the developer guide for the procedure.

## Notable implementation notes

1. **Annotated vs lightweight tags.** `git ls-remote --tags` returns the *tag-object* SHA for annotated tags, not the commit SHA. This affected `github/codeql-action`, `sigstore/cosign-installer`, `anthropics/claude-code-action`, and `actions/attest-build-provenance`. The dereference form `'v3^{}'` gives the real commit SHA; the developer guide captures this so future contributors don't trip on it.
2. **Moving major tags can be ahead of latest semver.** `sigstore/cosign-installer@v3` and `anthropics/claude-code-action@v1` both point to post-release commits. I pinned those to the most recent tagged release (`v3.10.1` and `v1.0.93`) rather than the moving tip, since auditors want to see "this is release X" not "a commit-that-happens-to-be-between-releases".
3. **No tool dependency introduced.** Considered `ratchet` and others; rejected on the grounds that adding a supply chain dependency in order to harden the supply chain is ironic, and Dependabot already handles ongoing updates natively.

## Dependabot behaviour

Dependabot understands SHA-pinned actions natively and will continue to open weekly update PRs, rewriting both the SHA and the version comment when an upstream tag moves. No `dependabot.yml` changes required.

## Test plan

- [x] All 38 `uses:` lines match the SHA-pinned pattern (regex-verified)
- [x] No naked tag pins remain anywhere in `.github/workflows/`
- [x] All 6 workflow files parse cleanly with `yaml.safe_load`
- [x] Total `uses:` count unchanged (38 before, 38 after)
- [x] **CI (`ci.yml`) runs green on this PR** — final run on merged HEAD had all 5 jobs green: `build-and-test`, `discover-base-images`, and 3× `scan-base-images`. This empirically verifies every pinned action SHA in `ci.yml` (actions/checkout, actions/setup-dotnet, actions/upload-artifact, aquasecurity/trivy-action, github/codeql-action/upload-sarif) resolves and runs correctly on GitHub's side.
- [x] `claude-code-review` workflow fires on this PR — the pinned `anthropics/claude-code-action@b47fd721...` **resolved and executed** (proving the SHA pin is valid), reaching the app's OIDC token exchange step. The job itself fails because Anthropic's GitHub App enforces workflow-file integrity: any PR that modifies a workflow file referencing `anthropics/claude-code-action` is blocked from token exchange until the change is on `main`. This is a known bootstrap dynamic explicitly called out in the app's own error message ("If you're seeing this on a PR when you first add a code review workflow file to your repository, this is normal and you should ignore this error"). It is not a defect in the SHA pinning and clears automatically once merged. Not a blocker.
- [x] Spot-check a few pins by clicking through to GitHub and confirming the SHA matches the version tag. Verified via GitHub API:
  - `actions/checkout@v4.3.1` -> `34e114876b0b11c390a56381ad16ebd13914f8d5` ✓
  - `aquasecurity/trivy-action@0.35.0` -> `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` ✓
  - `sigstore/cosign-installer@v3.10.1` -> `7e8b541eb2e61bf99390e1afd4be13a184e9ebc5` ✓

## Out of scope

- Docker base image digest pinning (already done in #520)
- NuGet package hash verification (separate compliance concern)

## No changelog entry

Supply chain CI hardening is not user-facing per `CLAUDE.md`'s changelog policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)