### PR TITLE
fix(ci): skip metrics-sync dispatch when token secret is missing

### DIFF
--- a/.github/workflows/metrics-sync.yml
+++ b/.github/workflows/metrics-sync.yml
@@ -52,7 +52,18 @@ jobs:
           # Write diff to file to avoid shell escaping issues
           echo "$DIFF_SUMMARY" > /tmp/diff_summary.txt
 
+      - name: Check for dispatch token
+        id: check_token
+        run: |
+          if [ -z "${{ secrets.METRICS_REPO_DISPATCH_TOKEN }}" ]; then
+            echo "::warning::METRICS_REPO_DISPATCH_TOKEN secret is not configured. Skipping dispatch to TetronIO/jim-metrics. This is expected if the jim-metrics repo has not yet been created. Configure the secret once jim-metrics exists to enable cross-repo sync."
+            echo "token_available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "token_available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Dispatch to jim-metrics
+        if: steps.check_token.outputs.token_available == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.METRICS_REPO_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

- The `metrics-sync.yml` workflow added in #476 is failing on every push that touches span enrichment files because `METRICS_REPO_DISPATCH_TOKEN` is not yet configured (the `TetronIO/jim-metrics` repo does not exist yet).
- Adds a pre-flight check that emits a warning and sets an output flag when the secret is empty, so the dispatch step is skipped cleanly instead of failing.
- The workflow stays wired up and ready; once `jim-metrics` is created and the secret is added, dispatches will start flowing automatically with no further code changes.

Example failed run: https://github.com/TetronIO/JIM/actions/runs/24210597188

## Test plan

- [ ] Merge this PR and confirm the next push to `main` that touches span enrichment files runs the workflow to completion with a warning annotation instead of failing.
- [ ] Once `TetronIO/jim-metrics` exists and `METRICS_REPO_DISPATCH_TOKEN` is configured in repo secrets, confirm dispatches resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)