### PR TITLE
perf(connected-systems): add GetConnectedSystemCoreAsync and flat container tree load (#494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ⚡ Connected System detail lookups are much cheaper on write-path and validation API calls: introduced a lightweight `GetConnectedSystemCoreAsync` retrieval variant that loads only essential properties, and migrated the API controllers that previously paid for the full schema, partition and container graph just to verify the system exists (#494)
 - ⚡ Connected System container hierarchy loading now handles arbitrary depth and avoids the cartesian-explosion risk of the previous 11-level hard-coded Include chain; containers are loaded flat and rebuilt into a tree in memory (#494)
+- ⚡ Full Connected System loads now issue one database query for object matching rules instead of four, eliminating the fan-out that split-query mode introduced when walking `Sources.ConnectedSystemAttribute`, `Sources.MetaverseAttribute`, `TargetMetaverseAttribute` and `MetaverseObjectType` as separate Include branches (#494)
 - ⚡ Default all EF Core queries to `AsNoTracking`, reducing memory and CPU overhead for read-heavy operations; write paths explicitly opt in to change tracking (#484)
 - ⚡ Enriched diagnostic spans with cumulative object count and wall-clock offset tags for throughput profiling (#476)
 - ⚡ Added MetricsCheckpoint log lines for guaranteed throughput tracking at any log level (#476)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- ⚡ Connected System detail lookups are much cheaper on write-path and validation API calls: introduced a lightweight `GetConnectedSystemCoreAsync` retrieval variant that loads only essential properties, and migrated the API controllers that previously paid for the full schema, partition and container graph just to verify the system exists (#494)
+- ⚡ Connected System container hierarchy loading now handles arbitrary depth and avoids the cartesian-explosion risk of the previous 11-level hard-coded Include chain; containers are loaded flat and rebuilt into a tree in memory (#494)
 - ⚡ Default all EF Core queries to `AsNoTracking`, reducing memory and CPU overhead for read-heavy operations; write paths explicitly opt in to change tracking (#484)
 - ⚡ Enriched diagnostic spans with cumulative object count and wall-clock offset tags for throughput profiling (#476)
 - ⚡ Added MetricsCheckpoint log lines for guaranteed throughput tracking at any log level (#476)

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -61,6 +61,28 @@
 - Classes: Full descriptive names (avoid abbreviations)
 - Properties: PascalCase with nullable reference types enabled
 
+**Entity Retrieval Naming Taxonomy:**
+
+Repository and server methods that load a single entity follow a weight-based taxonomy. Pick the lightest variant that satisfies the caller's needs so that expensive object graphs are only materialised when genuinely required.
+
+| Level       | Suffix                  | Returns                                                                                | Example                             | Use case                                                                 |
+|-------------|-------------------------|----------------------------------------------------------------------------------------|-------------------------------------|--------------------------------------------------------------------------|
+| **Summary** | `GetXxxSummaryAsync`    | Minimal scalar projection (a DTO of a handful of fields). No entity materialisation.   | `PendingExportSummary`              | High-scale filtering and reconciliation (100K+ objects).                 |
+| **Header**  | `GetXxxHeaderAsync`     | Lightweight DTO with denormalised FK names and aggregated counts.                      | `ConnectedSystemHeader`, `SyncRuleHeader` | List views, grids, dropdowns.                                     |
+| **Core**    | `GetXxxCoreAsync`       | Materialised entity with essential first-level navigation properties only.            | `GetConnectedSystemCoreAsync`       | API validation, write-path lookups, worker bootstrap, existence checks. |
+| **Detail**  | `GetXxxDetailAsync`     | Full entity wrapped in a result object with metadata (for example, capped MVA totals). | `CsoDetailResult`, `PendingExportDetailResult` | Detail pages that may need paging metadata alongside the entity.   |
+| **Full**    | `GetXxxAsync` (no suffix) | Complete entity graph with all relevant Includes and navigation properties.          | `GetConnectedSystemAsync`           | Sync engine, schema import, and other operations that genuinely need everything. |
+
+**Rules for picking a variant:**
+
+1. **Summary** (lightest): SQL projection into a flat DTO. No entity materialisation. Use when operating at extreme scale.
+2. **Header**: SQL projection into a DTO with denormalised names and aggregated counts. For list and grid display.
+3. **Core**: Materialised entity with first-level navigation properties only (no deep collection loading, no matching rules, no container trees). Use for operations that need the entity but not its full graph, such as null checks in API controllers before performing a dependent query.
+4. **Detail**: Full entity wrapped in a result object with metadata (for example, total attribute counts when capped). For UI detail pages.
+5. **Full** (no suffix, just `GetXxxAsync`): Complete entity graph with all Includes. Reserve for operations that genuinely need everything.
+
+**When adding a new retrieval method, start from the lightest variant that works**; only promote to a heavier one if the caller actually needs the additional data.
+
 **Tabs:**
 - Use `<NavigableMudTabs>` instead of `<MudTabs>` for all top-level page tabs; it syncs the active tab with a `?t=slug` query string, enabling browser back/forward navigation
 - Use plain `<MudTabs>` only for tabs inside dialogs or nested sub-tabs where URL navigation is not needed

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -3380,8 +3380,9 @@ public class ConnectedSystemServer
         Log.Information("ClearConnectedSystemObjectsAsync: Starting for Connected System {Id}, deleteChangeHistory={DeleteHistory}",
             connectedSystemId, deleteChangeHistory);
 
-        // Check for concurrency - don't clear if system is being deleted
-        var connectedSystem = await Application.Repository.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Check for concurrency — don't clear if the system is being deleted. We only need the
+        // Status scalar here, so use the lightweight Core retrieval variant.
+        var connectedSystem = await Application.Repository.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
         {
             Log.Warning("ClearConnectedSystemObjectsAsync: Connected System {Id} not found", connectedSystemId);

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -89,6 +89,16 @@ public class ConnectedSystemServer
         return await Application.Repository.ConnectedSystems.GetConnectedSystemAsync(id, withChangeTracking);
     }
 
+    /// <summary>
+    /// Loads a lightweight Connected System containing only <c>ConnectorDefinition</c>, <c>SettingValues</c>,
+    /// and shallow <c>RunProfiles</c>. Use for API existence checks, write-path lookups, and any other caller
+    /// that does not need the full schema, partition, or matching-rule graph.
+    /// </summary>
+    public async Task<ConnectedSystem?> GetConnectedSystemCoreAsync(int id, bool withChangeTracking = false)
+    {
+        return await Application.Repository.ConnectedSystems.GetConnectedSystemCoreAsync(id, withChangeTracking);
+    }
+
     public async Task<ConnectedSystemHeader?> GetConnectedSystemHeaderAsync(int id)
     {
         return await Application.Repository.ConnectedSystems.GetConnectedSystemHeaderAsync(id);

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -15,7 +15,31 @@ namespace JIM.Data.Repositories;
 
 public interface IConnectedSystemRepository
 {
+    /// <summary>
+    /// Loads a Connected System with its full object graph: <c>ConnectorDefinition</c>, <c>SettingValues</c>,
+    /// <c>RunProfiles</c>, <c>ObjectTypes</c> (with attributes and matching rules), and <c>Partitions</c> (with
+    /// containers arranged into a tree).
+    /// <para>
+    /// This is the heaviest retrieval variant. Prefer <see cref="GetConnectedSystemCoreAsync"/> when you only
+    /// need to verify existence or read basic properties, and <see cref="GetConnectedSystemHeaderAsync"/> for
+    /// list views. Reserve this method for sync engine, schema import, and other operations that genuinely
+    /// need the full graph.
+    /// </para>
+    /// </summary>
     public Task<ConnectedSystem?> GetConnectedSystemAsync(int id, bool withChangeTracking = false);
+
+    /// <summary>
+    /// Loads a lightweight Connected System containing only essential navigation properties:
+    /// <c>ConnectorDefinition</c>, <c>SettingValues</c>, and <c>RunProfiles</c> (shallow, without partition containers).
+    /// <para>
+    /// Use this for API validation, write-path lookups, worker bootstrap, and any other caller that needs the
+    /// entity but does not traverse <c>ObjectTypes</c>, <c>ObjectMatchingRules</c>, or the partition/container tree.
+    /// It avoids the expensive object-type and partition/container hierarchy queries performed by
+    /// <see cref="GetConnectedSystemAsync"/>.
+    /// </para>
+    /// </summary>
+    public Task<ConnectedSystem?> GetConnectedSystemCoreAsync(int id, bool withChangeTracking = false);
+
     public Task<ConnectedSystemHeader?> GetConnectedSystemHeaderAsync(int id);
     public Task<ConnectedSystemObject?> GetConnectedSystemObjectAsync(int connectedSystemId, Guid id);
 

--- a/src/JIM.PostgresData/JIM.PostgresData.csproj
+++ b/src/JIM.PostgresData/JIM.PostgresData.csproj
@@ -30,4 +30,10 @@
     <Folder Include="Migrations\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expose internal types (e.g. repository helpers) to the worker test assembly so they
+         can be unit-tested in isolation without widening their public API surface. -->
+    <InternalsVisibleTo Include="JIM.Worker.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -146,15 +146,55 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         }).SingleOrDefaultAsync(cs => cs.Id == id);
     }
 
+    /// <summary>
+    /// Loads a lightweight Connected System containing only <c>ConnectorDefinition</c>, <c>SettingValues</c>,
+    /// and shallow <c>RunProfiles</c>. Does not load <c>ObjectTypes</c>, <c>ObjectMatchingRules</c>, or the
+    /// partition/container tree.
+    /// <para>
+    /// See the entity retrieval naming taxonomy in <c>src/CLAUDE.md</c> for guidance on when to use Core vs.
+    /// the full <see cref="GetConnectedSystemAsync"/> variant.
+    /// </para>
+    /// </summary>
+    public async Task<ConnectedSystem?> GetConnectedSystemCoreAsync(int id, bool withChangeTracking = false)
+    {
+        IQueryable<ConnectedSystem> csQuery = Repository.Database.ConnectedSystems
+            .Include(cs => cs.ConnectorDefinition)
+            .Include(cs => cs.SettingValues)
+                .ThenInclude(sv => sv.Setting);
+
+        if (withChangeTracking)
+            csQuery = csQuery.AsTracking();
+
+        var connectedSystem = await csQuery.SingleOrDefaultAsync(x => x.Id == id);
+        if (connectedSystem == null)
+            return null;
+
+        // Load run profiles shallowly (with their partition reference, but without the container tree).
+        IQueryable<ConnectedSystemRunProfile> rpQuery = Repository.Database.ConnectedSystemRunProfiles
+            .Include(q => q.Partition)
+            .Where(q => q.ConnectedSystemId == id);
+
+        if (withChangeTracking)
+            rpQuery = rpQuery.AsTracking();
+
+        connectedSystem.RunProfiles = await rpQuery.ToListAsync();
+        return connectedSystem;
+    }
+
     public async Task<ConnectedSystem?> GetConnectedSystemAsync(int id, bool withChangeTracking = false)
     {
-        // retrieve a complex connected system object. break the query down into three parts for optimal performance.
-        // doing it in one giant include tree query will make it timeout.
+        // Retrieve a full Connected System graph. The previous implementation issued a heavy
+        // partition+container query with an 11-level hard-coded Include chain; that query is now
+        // replaced by a shallow partition query plus a single flat container query that is
+        // rebuilt into a tree in memory. This handles arbitrary hierarchy depth, avoids the
+        // cartesian explosion of deep joins, and removes a duplicate round-trip that used to
+        // load partitions twice (once via the run-profile Include, once via the expensive
+        // partition+containers query). See issue #494.
 
         IQueryable<ConnectedSystem> csQuery = Repository.Database.ConnectedSystems
             .Include(cs => cs.ConnectorDefinition)
             .Include(cs => cs.SettingValues)
-            .ThenInclude(sv => sv.Setting);
+                .ThenInclude(sv => sv.Setting);
 
         if (withChangeTracking)
             csQuery = csQuery.AsTracking();
@@ -164,7 +204,11 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         if (connectedSystem == null)
             return null;
 
-        var rpQuery = Repository.Database.ConnectedSystemRunProfiles
+        // Run profiles. We Include Partition shallowly so EF populates the navigation (plus its
+        // shadow FK column). These transient partition instances are replaced below via an
+        // in-memory fixup pass with the instances owned by the partition query, so consumers
+        // see the full container tree through either access path.
+        IQueryable<ConnectedSystemRunProfile> rpQuery = Repository.Database.ConnectedSystemRunProfiles
             .Include(q => q.Partition)
             .Where(q => q.ConnectedSystemId == id);
 
@@ -173,9 +217,13 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
 
         var runProfiles = await rpQuery.ToListAsync();
 
-        var otQuery = Repository.Database.ConnectedSystemObjectTypes
-            .AsSplitQuery() // Use split query to avoid cartesian explosion from multiple collection includes
-            .Include(ot => ot.Attributes.OrderBy(a => a.Name))
+        // Object types with attributes and object matching rules. Attributes are NOT sorted here
+        // (the previous OrderBy inside Include did not translate to SQL and sorted in memory after
+        // loading everything). Callers that care about presentation order sort in the UI/API layer
+        // where it matters. AsSplitQuery avoids cartesian explosion across the multiple Include branches.
+        IQueryable<ConnectedSystemObjectType> otQuery = Repository.Database.ConnectedSystemObjectTypes
+            .AsSplitQuery()
+            .Include(ot => ot.Attributes)
             .Include(ot => ot.ObjectMatchingRules)
                 .ThenInclude(omr => omr.Sources)
                     .ThenInclude(s => s.ConnectedSystemAttribute)
@@ -193,24 +241,11 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
 
         var types = await otQuery.ToListAsync();
 
-        // Load partitions with container hierarchy using a single joined query (no AsSplitQuery).
-        // AsSplitQuery() was removed because it causes EF Core identity fixup issues with
-        // self-referencing hierarchies — child containers were getting their PartitionId set
-        // incorrectly during fixup, causing them to appear as duplicates at the partition root.
-        // A single joined query avoids this because EF processes all results in one pass.
-        // Supporting 11 levels deep (arbitrary; increase if admins need deeper hierarchies).
-        var partQuery = Repository.Database.ConnectedSystemPartitions
-            .Include(p => p.Containers)!
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
-            .ThenInclude(c => c.ChildContainers)
+        // Partitions for this system, loaded once (shallow — containers are loaded in a separate
+        // flat query and attached below). This replaces the previous 11-level deep partition+
+        // container Include chain, which also left a residual "duplicate partition load" via the
+        // run profile Include above.
+        IQueryable<ConnectedSystemPartition> partQuery = Repository.Database.ConnectedSystemPartitions
             .Where(p => p.ConnectedSystem.Id == id);
 
         if (withChangeTracking)
@@ -218,21 +253,156 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
 
         var partitions = await partQuery.ToListAsync();
 
-        // collect and merge data
+        // Load all containers for the partitions in a single flat query, then rebuild the hierarchy
+        // in memory. This replaces the previous 11-level hard-coded Include chain, handles arbitrary
+        // hierarchy depth, and avoids the cartesian explosion that happens when a deeply joined
+        // query returns many duplicated rows. We only run the query when partitions exist, matching
+        // the prior behaviour of loading containers only through the partition graph.
+        //
+        // We load AsTracking so we can read the shadow FK properties (ParentContainerId, PartitionId)
+        // via the Entry API. If the caller requested no tracking, we detach the containers afterwards
+        // to preserve the overall contract of this method.
+        var partitionsById = partitions.ToDictionary(p => p.Id);
+        if (partitions.Count > 0)
+        {
+            var partitionIds = partitionsById.Keys.ToList();
+            var allContainers = await Repository.Database.ConnectedSystemContainers
+                .AsTracking()
+                .Where(c => c.Partition != null && partitionIds.Contains(c.Partition.Id))
+                .ToListAsync();
+
+            var parentIdByChildId = new Dictionary<int, int?>(allContainers.Count);
+            var partitionIdByContainerId = new Dictionary<int, int?>(allContainers.Count);
+            foreach (var container in allContainers)
+            {
+                var entry = Repository.Database.Entry(container);
+                parentIdByChildId[container.Id] = (int?)entry.Property("ParentContainerId").CurrentValue;
+                partitionIdByContainerId[container.Id] = (int?)entry.Property("PartitionId").CurrentValue;
+            }
+
+            // Rebuild the tree: every container gets its ChildContainers wired up, and roots
+            // (containers with no parent) are returned. We run this pass even though we only attach
+            // top-level roots to partitions below, because the ChildContainers collections on inner
+            // nodes must also be populated for consumers to traverse the hierarchy.
+            var rootContainers = BuildContainerTree(allContainers, parentIdByChildId);
+
+            // Group top-level containers (roots) by partition and attach them.
+            foreach (var root in rootContainers)
+            {
+                if (!partitionIdByContainerId.TryGetValue(root.Id, out var partitionId) || partitionId == null)
+                    continue;
+                if (!partitionsById.TryGetValue(partitionId.Value, out var partition))
+                    continue;
+
+                partition.Containers ??= new HashSet<ConnectedSystemContainer>();
+                partition.Containers.Add(root);
+            }
+
+            // If this connected system was loaded without tracking, detach the containers we just
+            // loaded with AsTracking so that subsequent operations on this context do not see
+            // residual tracking state (matching the semantics of the rest of this method when
+            // tracking is disabled).
+            if (!withChangeTracking)
+            {
+                foreach (var container in allContainers)
+                    Repository.Database.Entry(container).State = EntityState.Detached;
+            }
+        }
+
+        // Collect and merge data onto the connected system.
         connectedSystem.RunProfiles = runProfiles;
         connectedSystem.ObjectTypes = types;
         connectedSystem.Partitions = partitions;
 
         // With AsNoTracking, run profile Partition instances are separate from the partition
-        // instances loaded with Containers above. Wire them up so callers see Containers.
-        var partitionLookup = partitions.ToDictionary(p => p.Id);
+        // instances loaded above. Wire them up so callers see Containers via the run profile.
         foreach (var rp in runProfiles.Where(rp => rp.Partition != null))
         {
-            if (partitionLookup.TryGetValue(rp.Partition!.Id, out var fullPartition))
+            if (partitionsById.TryGetValue(rp.Partition!.Id, out var fullPartition))
                 rp.Partition = fullPartition;
         }
 
         return connectedSystem;
+    }
+
+    /// <summary>
+    /// Rebuilds a container hierarchy from a flat list, wiring each container into its parent's
+    /// <see cref="ConnectedSystemContainer.ChildContainers"/> collection and returning the roots.
+    /// <para>
+    /// This overload relies on <see cref="ConnectedSystemContainer.ParentContainer"/> being set on
+    /// each input container (e.g. after EF Core navigation fixup with change tracking enabled).
+    /// Use <see cref="BuildContainerTree(List{ConnectedSystemContainer}, IDictionary{int, int?})"/>
+    /// when the input was loaded without tracking or the nav property is not populated.
+    /// </para>
+    /// </summary>
+    internal static List<ConnectedSystemContainer> BuildContainerTree(List<ConnectedSystemContainer> flatContainers)
+    {
+        var roots = new List<ConnectedSystemContainer>();
+        if (flatContainers.Count == 0)
+            return roots;
+
+        // Reset ChildContainers so that re-building is idempotent, then populate based on parent refs.
+        foreach (var container in flatContainers)
+            container.ChildContainers.Clear();
+
+        foreach (var container in flatContainers)
+        {
+            var parent = container.ParentContainer;
+            if (parent != null)
+                parent.ChildContainers.Add(container);
+            else
+                roots.Add(container);
+        }
+
+        return roots;
+    }
+
+    /// <summary>
+    /// Rebuilds a container hierarchy from a flat list using an explicit parent-id lookup.
+    /// <para>
+    /// Use this overload when the input was materialised from EF Core via a shadow-property
+    /// projection and the <see cref="ConnectedSystemContainer.ParentContainer"/> navigation may
+    /// not be populated. The dictionary maps container id → parent container id (null for roots).
+    /// </para>
+    /// </summary>
+    internal static List<ConnectedSystemContainer> BuildContainerTree(
+        List<ConnectedSystemContainer> flatContainers,
+        IDictionary<int, int?> parentIdByChildId)
+    {
+        var roots = new List<ConnectedSystemContainer>();
+        if (flatContainers.Count == 0)
+            return roots;
+
+        var byId = flatContainers.ToDictionary(c => c.Id);
+
+        // Reset child collections (and parent references for children we will re-wire) so the build
+        // is idempotent even if called multiple times on the same inputs.
+        foreach (var container in flatContainers)
+            container.ChildContainers.Clear();
+
+        foreach (var container in flatContainers)
+        {
+            if (!parentIdByChildId.TryGetValue(container.Id, out var parentId) || parentId == null)
+            {
+                container.ParentContainer = null;
+                roots.Add(container);
+                continue;
+            }
+
+            if (byId.TryGetValue(parentId.Value, out var parent))
+            {
+                container.ParentContainer = parent;
+                parent.ChildContainers.Add(container);
+            }
+            else
+            {
+                // Parent is missing from the input — treat as a root so the container is not lost.
+                container.ParentContainer = null;
+                roots.Add(container);
+            }
+        }
+
+        return roots;
     }
 
     public async Task CreateConnectedSystemAsync(ConnectedSystem connectedSystem)

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -217,29 +217,65 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
 
         var runProfiles = await rpQuery.ToListAsync();
 
-        // Object types with attributes and object matching rules. Attributes are NOT sorted here
-        // (the previous OrderBy inside Include did not translate to SQL and sorted in memory after
-        // loading everything). Callers that care about presentation order sort in the UI/API layer
-        // where it matters. AsSplitQuery avoids cartesian explosion across the multiple Include branches.
+        // Object types with their attributes. Attributes are NOT sorted here (the previous OrderBy
+        // inside Include did not translate to SQL and sorted in memory after loading everything);
+        // callers that care about presentation order sort in the UI/API layer where it matters.
         IQueryable<ConnectedSystemObjectType> otQuery = Repository.Database.ConnectedSystemObjectTypes
-            .AsSplitQuery()
             .Include(ot => ot.Attributes)
-            .Include(ot => ot.ObjectMatchingRules)
-                .ThenInclude(omr => omr.Sources)
-                    .ThenInclude(s => s.ConnectedSystemAttribute)
-            .Include(ot => ot.ObjectMatchingRules)
-                .ThenInclude(omr => omr.Sources)
-                    .ThenInclude(s => s.MetaverseAttribute)
-            .Include(ot => ot.ObjectMatchingRules)
-                .ThenInclude(omr => omr.TargetMetaverseAttribute)
-            .Include(ot => ot.ObjectMatchingRules)
-                .ThenInclude(omr => omr.MetaverseObjectType)
             .Where(q => q.ConnectedSystemId == id);
 
         if (withChangeTracking)
             otQuery = otQuery.AsTracking();
 
         var types = await otQuery.ToListAsync();
+
+        // Object matching rules, loaded in a single keyed query and wired onto their owning object
+        // types in memory.
+        //
+        // Why not Include them as part of the query above? Before #494 we used four repeated
+        // .Include(ot => ot.ObjectMatchingRules).ThenInclude(...) branches inside AsSplitQuery —
+        // one per path into the rule graph (Sources.ConnectedSystemAttribute, Sources.MetaverseAttribute,
+        // TargetMetaverseAttribute, MetaverseObjectType). EF Core does not support chaining multiple
+        // ThenIncludes off the same collection navigation in one expression, so each branch has to be
+        // re-rooted on the collection, and under AsSplitQuery each branch is emitted as a separate
+        // SQL query (four round-trips for a single graph walk).
+        //
+        // Loading the rules directly from DbSet<ObjectMatchingRule> with one combined Include chain
+        // reduces the fan-out from four queries to one. We then bind rules back onto their owning
+        // object types via ConnectedSystemObjectTypeId in memory.
+        var typesById = types.ToDictionary(t => t.Id);
+        if (types.Count > 0)
+        {
+            var typeIds = typesById.Keys.ToList();
+            IQueryable<ObjectMatchingRule> omrQuery = Repository.Database.ObjectMatchingRules
+                .Include(omr => omr.Sources)
+                    .ThenInclude(s => s.ConnectedSystemAttribute)
+                .Include(omr => omr.Sources)
+                    .ThenInclude(s => s.MetaverseAttribute)
+                .Include(omr => omr.TargetMetaverseAttribute)
+                .Include(omr => omr.MetaverseObjectType)
+                .Where(omr => omr.ConnectedSystemObjectTypeId != null
+                              && typeIds.Contains(omr.ConnectedSystemObjectTypeId.Value));
+
+            if (withChangeTracking)
+                omrQuery = omrQuery.AsTracking();
+
+            var matchingRules = await omrQuery.ToListAsync();
+
+            // Reset each type's matching-rule collection and re-bind from the query result so the
+            // wire-up is deterministic regardless of any stale navigation state.
+            foreach (var type in types)
+                type.ObjectMatchingRules.Clear();
+
+            foreach (var rule in matchingRules)
+            {
+                if (rule.ConnectedSystemObjectTypeId.HasValue &&
+                    typesById.TryGetValue(rule.ConnectedSystemObjectTypeId.Value, out var ot))
+                {
+                    ot.ObjectMatchingRules.Add(rule);
+                }
+            }
+        }
 
         // Partitions for this system, loaded once (shallow — containers are loaded in a separate
         // flat query and attached below). This replaces the previous 11-level deep partition+

--- a/src/JIM.Web/Controllers/Api/HistoryController.cs
+++ b/src/JIM.Web/Controllers/Api/HistoryController.cs
@@ -114,8 +114,8 @@ public class HistoryController(ILogger<HistoryController> logger, JimApplication
     {
         _logger.LogDebug("Getting change history count for connected system {ConnectedSystemId}", connectedSystemId);
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — we only need Id and Name for the response).
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
         {
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));

--- a/src/JIM.Web/Controllers/Api/MetaverseController.cs
+++ b/src/JIM.Web/Controllers/Api/MetaverseController.cs
@@ -111,10 +111,10 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
 
         if (request.DeletionTriggerConnectedSystemIds != null)
         {
-            // Validate that the connected system IDs exist
+            // Validate that the connected system IDs exist (Core retrieval — we only need existence).
             foreach (var connectedSystemId in request.DeletionTriggerConnectedSystemIds)
             {
-                var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+                var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
                 if (connectedSystem == null)
                     return BadRequest(ApiErrorResponse.BadRequest($"Connected system with ID {connectedSystemId} not found."));
             }

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -146,8 +146,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — we only need existence, not the full graph)
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -211,8 +211,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — we only need existence, not the full graph)
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -329,8 +329,9 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — BulkUpdateAttributesAsync only reads
+        // the connected system's Id/Name for activity attribution, not its full graph).
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -606,7 +607,8 @@ public class SynchronisationController(
     {
         _logger.LogTrace("Requested partitions for connected system: {Id}", connectedSystemId);
 
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Core retrieval — partitions are then fetched separately with their own include chain.
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -644,8 +646,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — we only need existence, not the full graph)
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -695,8 +697,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — we only need existence, not the full graph)
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -1097,8 +1099,8 @@ public class SynchronisationController(
 
         try
         {
-            // Verify connected system exists
-            var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+            // Verify connected system exists (Core retrieval — we only need existence, not the full graph)
+            var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
             if (connectedSystem == null)
             {
                 return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
@@ -1199,7 +1201,8 @@ public class SynchronisationController(
     {
         _logger.LogTrace("Requested run profiles for connected system: {Id}", connectedSystemId);
 
-        var system = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Core retrieval — we only need to verify existence before listing run profiles.
+        var system = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (system == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -1232,8 +1235,8 @@ public class SynchronisationController(
         _logger.LogInformation("Run profile execution requested: ConnectedSystem={SystemId}, RunProfile={ProfileId}",
             connectedSystemId, runProfileId);
 
-        // Verify connected system exists
-        var system = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — the sync task only needs the id).
+        var system = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (system == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -1317,8 +1320,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var system = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — partitions are fetched separately below).
+        var system = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (system == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -1389,8 +1392,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var system = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — partitions are fetched separately below).
+        var system = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (system == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -1464,8 +1467,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var system = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Verify connected system exists (Core retrieval — we only need existence).
+        var system = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (system == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -1559,8 +1562,9 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        // Verify connected system exists
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(request.ConnectedSystemId);
+        // Verify connected system exists (Core retrieval — only used as a FK reference on the new
+        // sync rule; object types are fetched separately below).
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(request.ConnectedSystemId);
         if (connectedSystem == null)
             return BadRequest(ApiErrorResponse.BadRequest($"Connected system with ID {request.ConnectedSystemId} not found."));
 
@@ -2455,7 +2459,8 @@ public class SynchronisationController(
     {
         _logger.LogInformation("Getting object matching rule {RuleId} for connected system {SystemId}", ruleId, connectedSystemId);
 
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Core retrieval — the rule itself is loaded via its own repository method below.
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
@@ -2740,7 +2745,8 @@ public class SynchronisationController(
             return Unauthorized(ApiErrorResponse.Unauthorised("Could not identify user from authentication token."));
         }
 
-        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        // Core retrieval — the rule itself is loaded via its own repository method below.
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
         if (connectedSystem == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 

--- a/test/JIM.Web.Api.Tests/MetaverseControllerObjectTypeTests.cs
+++ b/test/JIM.Web.Api.Tests/MetaverseControllerObjectTypeTests.cs
@@ -237,9 +237,9 @@ public class MetaverseControllerObjectTypeTests
         MetaverseObjectType? capturedObjectType = null;
         _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectTypeAsync(1, false))
             .ReturnsAsync(objectType);
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(1))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem1);
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(2))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(2, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem2);
         _mockMetaverseRepo.Setup(r => r.UpdateMetaverseObjectTypeAsync(It.IsAny<MetaverseObjectType>()))
             .Callback<MetaverseObjectType>(ot => capturedObjectType = ot)
@@ -268,7 +268,7 @@ public class MetaverseControllerObjectTypeTests
 
         _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectTypeAsync(1, false))
             .ReturnsAsync(objectType);
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(999))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(999, It.IsAny<bool>()))
             .ReturnsAsync((JIM.Models.Staging.ConnectedSystem?)null);
 
         var request = new UpdateMetaverseObjectTypeRequest
@@ -432,7 +432,7 @@ public class MetaverseControllerObjectTypeTests
 
         _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectTypeAsync(1, false))
             .ReturnsAsync(objectType);
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(1))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockMetaverseRepo.Setup(r => r.UpdateMetaverseObjectTypeAsync(It.IsAny<MetaverseObjectType>()))
             .Returns(Task.CompletedTask);

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerClearTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerClearTests.cs
@@ -94,7 +94,7 @@ public class SynchronisationControllerClearTests
             Status = ConnectedSystemStatus.Active
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.DeleteAllConnectedSystemObjectsAndDependenciesAsync(1, true)).Returns(Task.CompletedTask);
 
         // Act
@@ -116,7 +116,7 @@ public class SynchronisationControllerClearTests
             Status = ConnectedSystemStatus.Active
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.DeleteAllConnectedSystemObjectsAndDependenciesAsync(1, false)).Returns(Task.CompletedTask);
 
         // Act
@@ -138,7 +138,7 @@ public class SynchronisationControllerClearTests
             Status = ConnectedSystemStatus.Active
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.DeleteAllConnectedSystemObjectsAndDependenciesAsync(1, true)).Returns(Task.CompletedTask);
 
         // Act — call without specifying deleteChangeHistory, should default to true
@@ -153,7 +153,7 @@ public class SynchronisationControllerClearTests
     public async Task ClearConnectorSpaceAsync_WithNonExistentSystem_ReturnsNotFoundAsync()
     {
         // Arrange
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(999)).ReturnsAsync((ConnectedSystem?)null);
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(999, It.IsAny<bool>())).ReturnsAsync((ConnectedSystem?)null);
 
         // Act
         var result = await _controller.ClearConnectorSpaceAsync(999);
@@ -173,7 +173,7 @@ public class SynchronisationControllerClearTests
             Status = ConnectedSystemStatus.Deleting
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
 
         // Act
         var result = await _controller.ClearConnectorSpaceAsync(1);

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerRunProfileTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerRunProfileTests.cs
@@ -80,7 +80,7 @@ public class SynchronisationControllerRunProfileTests
     {
         var connectedSystemId = 1;
         var connectedSystem = new ConnectedSystem { Id = connectedSystemId, Name = "Test System" };
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile>());
@@ -94,7 +94,7 @@ public class SynchronisationControllerRunProfileTests
     public async Task GetRunProfilesAsync_WithNonExistentConnectedSystem_ReturnsNotFound()
     {
         var connectedSystemId = 999;
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync((ConnectedSystem?)null);
 
         var result = await _controller.GetRunProfilesAsync(connectedSystemId);
@@ -126,7 +126,7 @@ public class SynchronisationControllerRunProfileTests
                 PageSize = 50
             }
         };
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(runProfiles);
@@ -157,7 +157,7 @@ public class SynchronisationControllerRunProfileTests
             Partition = partition,
             FilePath = "/data/export.csv"
         };
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile> { runProfile });
@@ -181,7 +181,7 @@ public class SynchronisationControllerRunProfileTests
     {
         var connectedSystemId = 1;
         var connectedSystem = new ConnectedSystem { Id = connectedSystemId, Name = "Test System" };
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile>());
@@ -219,7 +219,7 @@ public class SynchronisationControllerRunProfileTests
             FilePath = "/data/new.csv"
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile> { runProfile });
@@ -241,7 +241,7 @@ public class SynchronisationControllerRunProfileTests
         var connectedSystemId = 999;
         var request = new UpdateRunProfileRequest { Name = "Updated" };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync((ConnectedSystem?)null);
 
         var result = await _controller.UpdateRunProfileAsync(connectedSystemId, 1, request);
@@ -256,7 +256,7 @@ public class SynchronisationControllerRunProfileTests
         var connectedSystem = new ConnectedSystem { Id = connectedSystemId, Name = "Test System" };
         var request = new UpdateRunProfileRequest { Name = "Updated" };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile>());
@@ -287,7 +287,7 @@ public class SynchronisationControllerRunProfileTests
             // PageSize and FilePath not set — should remain unchanged
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile> { runProfile });
@@ -317,7 +317,7 @@ public class SynchronisationControllerRunProfileTests
         };
         var request = new UpdateRunProfileRequest { Name = "Updated" };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile> { runProfile });
@@ -345,7 +345,7 @@ public class SynchronisationControllerRunProfileTests
         };
         var request = new UpdateRunProfileRequest { PartitionId = 999 };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemRunProfilesAsync(connectedSystemId))
             .ReturnsAsync(new List<ConnectedSystemRunProfile> { runProfile });

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerSchemaTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerSchemaTests.cs
@@ -115,7 +115,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystem = connectedSystem
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -132,7 +132,7 @@ public class SynchronisationControllerSchemaTests
         var connectedSystemId = 999;
         var objectTypeId = 5;
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync((ConnectedSystem?)null);
 
         var request = new UpdateConnectedSystemObjectTypeRequest { Selected = true };
@@ -148,7 +148,7 @@ public class SynchronisationControllerSchemaTests
         var objectTypeId = 999;
         var connectedSystem = new ConnectedSystem { Id = connectedSystemId, Name = "Test System" };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync((ConnectedSystemObjectType?)null);
@@ -174,7 +174,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystem = differentSystem
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -200,7 +200,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystem = connectedSystem
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -227,7 +227,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystem = connectedSystem
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -254,7 +254,7 @@ public class SynchronisationControllerSchemaTests
             Attributes = new List<ConnectedSystemObjectTypeAttribute>()
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -295,7 +295,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystemObjectType = objectType
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -315,7 +315,7 @@ public class SynchronisationControllerSchemaTests
         var objectTypeId = 5;
         var attributeId = 10;
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync((ConnectedSystem?)null);
 
         var request = new UpdateConnectedSystemAttributeRequest { Selected = true };
@@ -332,7 +332,7 @@ public class SynchronisationControllerSchemaTests
         var attributeId = 10;
         var connectedSystem = new ConnectedSystem { Id = connectedSystemId, Name = "Test System" };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync((ConnectedSystemObjectType?)null);
@@ -358,7 +358,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystem = connectedSystem
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -399,7 +399,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystemObjectType = differentObjectType
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -434,7 +434,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystemObjectType = objectType
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -470,7 +470,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystemObjectType = objectType
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -505,7 +505,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystemObjectType = objectType
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -543,7 +543,7 @@ public class SynchronisationControllerSchemaTests
             ConnectedSystemObjectType = objectType
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -578,7 +578,7 @@ public class SynchronisationControllerSchemaTests
     public async Task BulkUpdateAttributesAsync_WithNonExistentConnectedSystem_ReturnsNotFound()
     {
         var connectedSystemId = 999;
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync((ConnectedSystem?)null);
 
         var request = new BulkUpdateConnectedSystemAttributesRequest
@@ -600,7 +600,7 @@ public class SynchronisationControllerSchemaTests
         var objectTypeId = 999;
         var connectedSystem = new ConnectedSystem { Id = connectedSystemId, Name = "Test System" };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync((ConnectedSystemObjectType?)null);
@@ -644,7 +644,7 @@ public class SynchronisationControllerSchemaTests
             Attributes = new List<ConnectedSystemObjectTypeAttribute> { attribute1, attribute2 }
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -687,7 +687,7 @@ public class SynchronisationControllerSchemaTests
             Attributes = new List<ConnectedSystemObjectTypeAttribute> { attribute1 }
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -744,7 +744,7 @@ public class SynchronisationControllerSchemaTests
             Attributes = new List<ConnectedSystemObjectTypeAttribute> { attribute1, attribute2, attribute3 }
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -787,7 +787,7 @@ public class SynchronisationControllerSchemaTests
             Attributes = new List<ConnectedSystemObjectTypeAttribute> { attribute1 }
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);
@@ -833,7 +833,7 @@ public class SynchronisationControllerSchemaTests
             Attributes = new List<ConnectedSystemObjectTypeAttribute> { attribute1 }
         };
 
-        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(connectedSystemId))
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(connectedSystemId, It.IsAny<bool>()))
             .ReturnsAsync(connectedSystem);
         _mockConnectedSystemRepo.Setup(r => r.GetObjectTypeAsync(objectTypeId))
             .ReturnsAsync(objectType);

--- a/test/JIM.Worker.Tests/Activities/ActivityRunProfileExecutionItemTests.cs
+++ b/test/JIM.Worker.Tests/Activities/ActivityRunProfileExecutionItemTests.cs
@@ -99,6 +99,7 @@ public class ActivityRunProfileExecutionItemTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(MockDbSetConnectedSystemRunProfiles.Object);

--- a/test/JIM.Worker.Tests/Activities/ConfirmingImportOutcomeTests.cs
+++ b/test/JIM.Worker.Tests/Activities/ConfirmingImportOutcomeTests.cs
@@ -72,6 +72,7 @@ public class ConfirmingImportOutcomeTests
     private void InitialiseMockDbContext()
     {
         _mockDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(_mockDbContext);
 
         _mockDbContext.Setup(m => m.ConnectedSystems).Returns(_connectedSystemsData.BuildMockDbSet().Object);
         _mockDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(_runProfilesData.BuildMockDbSet().Object);

--- a/test/JIM.Worker.Tests/Activities/ImportExportOutcomeTests.cs
+++ b/test/JIM.Worker.Tests/Activities/ImportExportOutcomeTests.cs
@@ -65,6 +65,7 @@ public class ImportExportOutcomeTests
         _activitiesData = TestUtilities.GetActivityData(fullImportRunProfile.RunType, fullImportRunProfile.Id);
 
         _mockDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(_mockDbContext);
         _mockDbContext.Setup(m => m.Activities).Returns(_activitiesData.BuildMockDbSet().Object);
         _mockDbContext.Setup(m => m.ConnectedSystems).Returns(_connectedSystemsData.BuildMockDbSet().Object);
         _mockDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(_objectTypesData.BuildMockDbSet().Object);

--- a/test/JIM.Worker.Tests/OutboundSync/DriftDetectionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/DriftDetectionTests.cs
@@ -88,6 +88,7 @@ public class DriftDetectionTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ExportAttributeChangeStatusTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportAttributeChangeStatusTests.cs
@@ -67,6 +67,7 @@ public class ExportAttributeChangeStatusTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ExportEvaluationNoChangeTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportEvaluationNoChangeTests.cs
@@ -90,6 +90,7 @@ public class ExportEvaluationNoChangeTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectAttributeValues).Returns(MockDbSetConnectedSystemObjectAttributeValues.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ExportEvaluationTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportEvaluationTests.cs
@@ -104,6 +104,7 @@ public class ExportEvaluationTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionParallelBatchTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionParallelBatchTests.cs
@@ -100,6 +100,7 @@ public class ExportExecutionParallelBatchTests
         MockDbSetSyncRules = SyncRulesData.BuildMockDbSet();
 
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemAttributes).Returns(MockDbSetConnectedSystemAttributes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
@@ -108,6 +108,7 @@ public class ExportExecutionTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemAttributes).Returns(MockDbSetConnectedSystemAttributes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ObjectMatchingServerTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ObjectMatchingServerTests.cs
@@ -76,6 +76,7 @@ public class ObjectMatchingServerTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/PendingExportReconciliationTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/PendingExportReconciliationTests.cs
@@ -74,6 +74,7 @@ public class PendingExportReconciliationTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);

--- a/test/JIM.Worker.Tests/OutboundSync/ProvisioningFlowTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ProvisioningFlowTests.cs
@@ -112,6 +112,7 @@ public class ProvisioningFlowTests
         MockDbSetSyncRules = SyncRulesData.BuildMockDbSet();
 
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);

--- a/test/JIM.Worker.Tests/Repositories/ConnectedSystemRepositoryCoreTests.cs
+++ b/test/JIM.Worker.Tests/Repositories/ConnectedSystemRepositoryCoreTests.cs
@@ -190,6 +190,81 @@ public class ConnectedSystemRepositoryCoreTests
 
     #endregion
 
+    #region GetConnectedSystemAsync — object matching rule wire-up
+
+    [Test]
+    public async Task GetConnectedSystemAsync_WiresMatchingRulesOntoOwningObjectTypesAsync()
+    {
+        // Arrange: two object types, one with a matching rule, the other without.
+        // Previously this graph was loaded via four repeated .Include(ot => ot.ObjectMatchingRules)
+        // branches inside an .AsSplitQuery() — four separate SQL queries per call. The refactor
+        // collapses that to a single query keyed by object type ids, and wires the rules up in
+        // memory. This test guards against a regression in the wire-up.
+        var cs = CreateConnectedSystem(id: 1);
+        _connectedSystemsData.Add(cs);
+
+        var userType = new ConnectedSystemObjectType
+        {
+            Id = 10,
+            ConnectedSystemId = 1,
+            Name = "User",
+            ObjectMatchingRules = new List<ObjectMatchingRule>()
+        };
+        var groupType = new ConnectedSystemObjectType
+        {
+            Id = 11,
+            ConnectedSystemId = 1,
+            Name = "Group",
+            ObjectMatchingRules = new List<ObjectMatchingRule>()
+        };
+        _objectTypesData.Add(userType);
+        _objectTypesData.Add(groupType);
+
+        var rule = new ObjectMatchingRule
+        {
+            Id = 100,
+            Order = 0,
+            ConnectedSystemObjectTypeId = 10,
+            Sources = new List<ObjectMatchingRuleSource>()
+        };
+        _matchingRulesData.Add(rule);
+
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemAsync(1);
+
+        // Assert: the rule is attached to the User object type, and the Group type has no rules.
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.ObjectTypes, Is.Not.Null);
+
+        var loadedUser = result.ObjectTypes!.Single(t => t.Id == 10);
+        var loadedGroup = result.ObjectTypes!.Single(t => t.Id == 11);
+
+        Assert.That(loadedUser.ObjectMatchingRules, Has.Count.EqualTo(1));
+        Assert.That(loadedUser.ObjectMatchingRules[0].Id, Is.EqualTo(100));
+        Assert.That(loadedGroup.ObjectMatchingRules, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemAsync_WithNoObjectTypes_SkipsMatchingRulesQueryAsync()
+    {
+        // Arrange: a system with no object types at all. The matching-rules query must be
+        // skipped entirely so we do not issue a SELECT ... WHERE id IN () against an empty set.
+        var cs = CreateConnectedSystem(id: 1);
+        _connectedSystemsData.Add(cs);
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemAsync(1);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.ObjectTypes, Is.Empty);
+    }
+
+    #endregion
+
     #region BuildContainerTree helper
 
     [Test]

--- a/test/JIM.Worker.Tests/Repositories/ConnectedSystemRepositoryCoreTests.cs
+++ b/test/JIM.Worker.Tests/Repositories/ConnectedSystemRepositoryCoreTests.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Staging;
+using JIM.PostgresData;
+using JIM.PostgresData.Repositories;
+using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
+using Moq;
+
+namespace JIM.Worker.Tests.Repositories;
+
+/// <summary>
+/// Tests for <see cref="ConnectedSystemRepository.GetConnectedSystemCoreAsync"/> and the
+/// flat container tree build helper introduced in issue #494.
+/// </summary>
+[TestFixture]
+public class ConnectedSystemRepositoryCoreTests
+{
+    private Mock<JimDbContext> _mockDbContext = null!;
+    private PostgresDataRepository _repository = null!;
+
+    private List<ConnectedSystem> _connectedSystemsData = null!;
+    private List<ConnectedSystemRunProfile> _runProfilesData = null!;
+    private List<ConnectedSystemObjectType> _objectTypesData = null!;
+    private List<ConnectedSystemPartition> _partitionsData = null!;
+    private List<ConnectedSystemContainer> _containersData = null!;
+    private List<ObjectMatchingRule> _matchingRulesData = null!;
+
+    private Mock<DbSet<ConnectedSystem>> _mockDbSetConnectedSystems = null!;
+    private Mock<DbSet<ConnectedSystemRunProfile>> _mockDbSetRunProfiles = null!;
+    private Mock<DbSet<ConnectedSystemObjectType>> _mockDbSetObjectTypes = null!;
+    private Mock<DbSet<ConnectedSystemPartition>> _mockDbSetPartitions = null!;
+    private Mock<DbSet<ConnectedSystemContainer>> _mockDbSetContainers = null!;
+    private Mock<DbSet<ObjectMatchingRule>> _mockDbSetMatchingRules = null!;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _repository?.Dispose();
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _connectedSystemsData = new List<ConnectedSystem>();
+        _runProfilesData = new List<ConnectedSystemRunProfile>();
+        _objectTypesData = new List<ConnectedSystemObjectType>();
+        _partitionsData = new List<ConnectedSystemPartition>();
+        _containersData = new List<ConnectedSystemContainer>();
+        _matchingRulesData = new List<ObjectMatchingRule>();
+    }
+
+    private void BuildMocks()
+    {
+        _mockDbSetConnectedSystems = _connectedSystemsData.BuildMockDbSet();
+        _mockDbSetRunProfiles = _runProfilesData.BuildMockDbSet();
+        _mockDbSetObjectTypes = _objectTypesData.BuildMockDbSet();
+        _mockDbSetPartitions = _partitionsData.BuildMockDbSet();
+        _mockDbSetContainers = _containersData.BuildMockDbSet();
+        _mockDbSetMatchingRules = _matchingRulesData.BuildMockDbSet();
+
+        _mockDbContext = new Mock<JimDbContext>();
+        _mockDbContext.Setup(m => m.ConnectedSystems).Returns(_mockDbSetConnectedSystems.Object);
+        _mockDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(_mockDbSetRunProfiles.Object);
+        _mockDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(_mockDbSetObjectTypes.Object);
+        _mockDbContext.Setup(m => m.ConnectedSystemPartitions).Returns(_mockDbSetPartitions.Object);
+        _mockDbContext.Setup(m => m.ConnectedSystemContainers).Returns(_mockDbSetContainers.Object);
+        _mockDbContext.Setup(m => m.ObjectMatchingRules).Returns(_mockDbSetMatchingRules.Object);
+
+        _repository = new PostgresDataRepository(_mockDbContext.Object);
+    }
+
+    private ConnectedSystem CreateConnectedSystem(int id = 1, string name = "Test System")
+    {
+        var connectorDefinition = new ConnectorDefinition
+        {
+            Id = 10,
+            Name = "Test Connector"
+        };
+        return new ConnectedSystem
+        {
+            Id = id,
+            Name = name,
+            ConnectorDefinitionId = connectorDefinition.Id,
+            ConnectorDefinition = connectorDefinition,
+            SettingValues = new List<ConnectedSystemSettingValue>()
+        };
+    }
+
+    #region GetConnectedSystemCoreAsync
+
+    [Test]
+    public async Task GetConnectedSystemCoreAsync_WithValidId_ReturnsSystemAsync()
+    {
+        // Arrange
+        _connectedSystemsData.Add(CreateConnectedSystem(id: 1, name: "CS-One"));
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemCoreAsync(1);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Id, Is.EqualTo(1));
+        Assert.That(result.Name, Is.EqualTo("CS-One"));
+    }
+
+    [Test]
+    public async Task GetConnectedSystemCoreAsync_WithInvalidId_ReturnsNullAsync()
+    {
+        // Arrange
+        _connectedSystemsData.Add(CreateConnectedSystem(id: 1));
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemCoreAsync(999);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemCoreAsync_IncludesConnectorDefinitionAsync()
+    {
+        // Arrange
+        _connectedSystemsData.Add(CreateConnectedSystem(id: 1));
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemCoreAsync(1);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.ConnectorDefinition, Is.Not.Null);
+        Assert.That(result.ConnectorDefinition.Name, Is.EqualTo("Test Connector"));
+    }
+
+    [Test]
+    public async Task GetConnectedSystemCoreAsync_DoesNotLoadObjectTypesAsync()
+    {
+        // Arrange: an object type exists in the data source, but Core should not populate it.
+        var cs = CreateConnectedSystem(id: 1);
+        _connectedSystemsData.Add(cs);
+        _objectTypesData.Add(new ConnectedSystemObjectType
+        {
+            Id = 100,
+            ConnectedSystemId = 1,
+            Name = "User"
+        });
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemCoreAsync(1);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        // Core is a lightweight variant: ObjectTypes should not be populated (left at the model's
+        // default empty list since Core never queries the ObjectTypes DbSet).
+        Assert.That(result!.ObjectTypes, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemCoreAsync_DoesNotLoadPartitionsAsync()
+    {
+        // Arrange
+        var cs = CreateConnectedSystem(id: 1);
+        _connectedSystemsData.Add(cs);
+        _partitionsData.Add(new ConnectedSystemPartition
+        {
+            Id = 200,
+            ConnectedSystem = cs,
+            ExternalId = "DC=example,DC=com",
+            Name = "Root"
+        });
+        BuildMocks();
+
+        // Act
+        var result = await _repository.ConnectedSystems.GetConnectedSystemCoreAsync(1);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        // Core leaves Partitions at the model default (null) — it never queries the partition DbSet.
+        Assert.That(result!.Partitions, Is.Null);
+    }
+
+    #endregion
+
+    #region BuildContainerTree helper
+
+    [Test]
+    public void BuildContainerTree_WithEmptyList_YieldsNoRoots()
+    {
+        // Arrange
+        var flat = new List<ConnectedSystemContainer>();
+
+        // Act
+        var roots = ConnectedSystemRepository.BuildContainerTree(flat);
+
+        // Assert
+        Assert.That(roots, Is.Empty);
+    }
+
+    [Test]
+    public void BuildContainerTree_WithSingleRoot_ReturnsRoot()
+    {
+        // Arrange
+        var flat = new List<ConnectedSystemContainer>
+        {
+            new() { Id = 1, Name = "Root", ExternalId = "OU=Root" }
+        };
+
+        // Act
+        var roots = ConnectedSystemRepository.BuildContainerTree(flat);
+
+        // Assert
+        Assert.That(roots, Has.Count.EqualTo(1));
+        Assert.That(roots[0].Id, Is.EqualTo(1));
+        Assert.That(roots[0].ChildContainers, Is.Empty);
+    }
+
+    [Test]
+    public void BuildContainerTree_WithDeepHierarchy_BuildsTreeBeyond11Levels()
+    {
+        // Arrange: construct a 15-level deep hierarchy (1 -> 2 -> 3 -> ... -> 15).
+        // This proves the flat-load approach handles arbitrary depth, unlike the
+        // previous 11-level hard-coded Include chain.
+        var flat = new List<ConnectedSystemContainer>();
+        ConnectedSystemContainer? previous = null;
+        for (var i = 1; i <= 15; i++)
+        {
+            var container = new ConnectedSystemContainer
+            {
+                Id = i,
+                Name = $"Level {i}",
+                ExternalId = $"OU=Level{i}",
+                ParentContainer = previous
+            };
+            flat.Add(container);
+            previous = container;
+        }
+
+        // Act
+        var roots = ConnectedSystemRepository.BuildContainerTree(flat);
+
+        // Assert: only one root, and we can walk all 15 levels via ChildContainers.
+        Assert.That(roots, Has.Count.EqualTo(1));
+        var depth = 0;
+        var cursor = roots[0];
+        while (cursor != null)
+        {
+            depth++;
+            cursor = cursor.ChildContainers.FirstOrDefault();
+        }
+        Assert.That(depth, Is.EqualTo(15));
+    }
+
+    [Test]
+    public void BuildContainerTree_WithMultipleRoots_ReturnsAllRoots()
+    {
+        // Arrange
+        var flat = new List<ConnectedSystemContainer>
+        {
+            new() { Id = 1, Name = "Root A", ExternalId = "OU=A" },
+            new() { Id = 2, Name = "Root B", ExternalId = "OU=B" },
+            new() { Id = 3, Name = "Child of A", ExternalId = "OU=A.Child", ParentContainer = null }
+        };
+        // Wire the child: has a parent reference (by object), but flat list lacks FK.
+        // BuildContainerTree must rely on ParentContainer reference equality.
+        flat[2].ParentContainer = flat[0];
+
+        // Act
+        var roots = ConnectedSystemRepository.BuildContainerTree(flat);
+
+        // Assert: two roots, Root A has one child.
+        Assert.That(roots, Has.Count.EqualTo(2));
+        var rootA = roots.Single(r => r.Id == 1);
+        var rootB = roots.Single(r => r.Id == 2);
+        Assert.That(rootA.ChildContainers, Has.Count.EqualTo(1));
+        Assert.That(rootA.ChildContainers.First().Id, Is.EqualTo(3));
+        Assert.That(rootB.ChildContainers, Is.Empty);
+    }
+
+    [Test]
+    public void BuildContainerTree_WireUpsChildrenViaParentId_WhenReferenceNotSet()
+    {
+        // Arrange: flat list where only PK/FK are present (no object reference).
+        // Simulates the exact state after EF Core materialises rows without
+        // navigation fixup — which is what happens when ChildContainers is not
+        // Included and ParentContainer comes back null.
+        //
+        // The helper accepts an id-lookup strategy so it can still rebuild the tree.
+        var root = new ConnectedSystemContainer { Id = 1, Name = "Root", ExternalId = "OU=R" };
+        var child = new ConnectedSystemContainer { Id = 2, Name = "Child", ExternalId = "OU=C" };
+        var flat = new List<ConnectedSystemContainer> { root, child };
+        var parentIdByChildId = new Dictionary<int, int?> { { 1, null }, { 2, 1 } };
+
+        // Act
+        var roots = ConnectedSystemRepository.BuildContainerTree(flat, parentIdByChildId);
+
+        // Assert
+        Assert.That(roots, Has.Count.EqualTo(1));
+        Assert.That(roots[0].Id, Is.EqualTo(1));
+        Assert.That(roots[0].ChildContainers, Has.Count.EqualTo(1));
+        Assert.That(roots[0].ChildContainers.First().Id, Is.EqualTo(2));
+        Assert.That(roots[0].ChildContainers.First().ParentContainer, Is.SameAs(roots[0]));
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionTests.cs
@@ -830,7 +830,7 @@ public class ConnectedSystemDeletionTests
             Status = ConnectedSystemStatus.Active
         };
 
-        _mockCsRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockCsRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
         _mockCsRepo.Setup(r => r.DeleteAllConnectedSystemObjectsAndDependenciesAsync(1, It.IsAny<bool>())).Returns(Task.CompletedTask);
 
         // Act
@@ -851,7 +851,7 @@ public class ConnectedSystemDeletionTests
             Status = ConnectedSystemStatus.Deleting
         };
 
-        _mockCsRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockCsRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
 
         // Act & Assert
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -864,7 +864,7 @@ public class ConnectedSystemDeletionTests
     public void ClearConnectedSystemObjectsAsync_WithNonExistentSystem_ThrowsException()
     {
         // Arrange
-        _mockCsRepo.Setup(r => r.GetConnectedSystemAsync(999)).ReturnsAsync((ConnectedSystem?)null);
+        _mockCsRepo.Setup(r => r.GetConnectedSystemCoreAsync(999, It.IsAny<bool>())).ReturnsAsync((ConnectedSystem?)null);
 
         // Act & Assert
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -884,7 +884,7 @@ public class ConnectedSystemDeletionTests
             Status = ConnectedSystemStatus.Active
         };
 
-        _mockCsRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockCsRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
         _mockCsRepo.Setup(r => r.DeleteAllConnectedSystemObjectsAndDependenciesAsync(1, true)).Returns(Task.CompletedTask);
 
         // Act
@@ -905,7 +905,7 @@ public class ConnectedSystemDeletionTests
             Status = ConnectedSystemStatus.Active
         };
 
-        _mockCsRepo.Setup(r => r.GetConnectedSystemAsync(1)).ReturnsAsync(connectedSystem);
+        _mockCsRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(connectedSystem);
         _mockCsRepo.Setup(r => r.DeleteAllConnectedSystemObjectsAndDependenciesAsync(1, false)).Returns(Task.CompletedTask);
 
         // Act

--- a/test/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
@@ -162,6 +162,7 @@ public class FullSyncTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportBatchPrefetchTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportBatchPrefetchTests.cs
@@ -84,6 +84,7 @@ public class ImportBatchPrefetchTests
         MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
 
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportCreateObjectTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportCreateObjectTests.cs
@@ -85,6 +85,7 @@ public class ImportCreateObjectTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportDeduplicationTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportDeduplicationTests.cs
@@ -94,6 +94,7 @@ public class ImportDeduplicationTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportDeleteObjectTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportDeleteObjectTests.cs
@@ -85,6 +85,7 @@ public class ImportDeleteObjectTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportReferenceMatchingTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportReferenceMatchingTests.cs
@@ -82,6 +82,7 @@ public class ImportReferenceMatchingTests
         MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
 
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectMvaTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectMvaTests.cs
@@ -86,6 +86,7 @@ public class ImportUpdateObjectMvaTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectSvaTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportUpdateObjectSvaTests.cs
@@ -86,6 +86,7 @@ public class ImportUpdateObjectSvaTests
 
         // mock entity framework calls to use our data sources above
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);

--- a/test/JIM.Worker.Tests/TestUtilities.cs
+++ b/test/JIM.Worker.Tests/TestUtilities.cs
@@ -8,8 +8,12 @@ using JIM.Models.Logic;
 using JIM.Models.Staging;
 using JIM.Models.Tasking;
 using JIM.Models.Transactional;
+using JIM.PostgresData;
 using JIM.Utilities;
 using JIM.Worker.Tests.Models;
+using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
+using Moq;
 
 namespace JIM.Worker.Tests;
 
@@ -105,6 +109,28 @@ public static class TestUtilities
         Environment.SetEnvironmentVariable(Constants.Config.DatabaseName, "dummy");
         Environment.SetEnvironmentVariable(Constants.Config.DatabaseUsername, "dummy");
         Environment.SetEnvironmentVariable(Constants.Config.DatabasePassword, "dummy");
+    }
+
+    /// <summary>
+    /// Attaches empty <see cref="JimDbContext.ObjectMatchingRules"/> and
+    /// <see cref="JimDbContext.ConnectedSystemContainers"/> mocks to the supplied
+    /// <paramref name="mockDbContext"/>. These DbSets are queried by
+    /// <see cref="JIM.PostgresData.Repositories.ConnectedSystemRepository.GetConnectedSystemAsync"/>
+    /// (the object-matching-rules single-query wire-up, and the flat container tree load),
+    /// so every test that directly or indirectly triggers a full Connected System load must
+    /// have them mocked; otherwise the repository hits a <see cref="NullReferenceException"/>
+    /// dereferencing the unset virtual DbSet property.
+    /// <para>
+    /// Call this after you have wired up all of your own mocks on <paramref name="mockDbContext"/>.
+    /// Tests that want non-empty data should set up their own DbSet mocks instead.
+    /// </para>
+    /// </summary>
+    public static void SetUpEmptyConnectedSystemGraphMocks(Mock<JimDbContext> mockDbContext)
+    {
+        var emptyMatchingRules = new List<ObjectMatchingRule>().BuildMockDbSet();
+        var emptyContainers = new List<ConnectedSystemContainer>().BuildMockDbSet();
+        mockDbContext.Setup(m => m.ObjectMatchingRules).Returns(emptyMatchingRules.Object);
+        mockDbContext.Setup(m => m.ConnectedSystemContainers).Returns(emptyContainers.Object);
     }
 
     public static MetaverseObject GetInitiatedBy()

--- a/test/JIM.Worker.Tests/Workflows/ExportConfirmationWorkflowTests.cs
+++ b/test/JIM.Worker.Tests/Workflows/ExportConfirmationWorkflowTests.cs
@@ -75,6 +75,7 @@ public class ExportConfirmationWorkflowTests
 
         // Mock entity framework calls
         MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
         MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);


### PR DESCRIPTION
Introduces a lightweight GetConnectedSystemCoreAsync retrieval variant that
loads only the essential connected system graph (ConnectorDefinition,
SettingValues, shallow RunProfiles) for API callers that only need to verify
existence or read basic properties. Most API validation paths, existence
checks and write-path lookups have been migrated to this new variant so they
no longer pay for the full schema, partition and container hierarchy.

The full GetConnectedSystemAsync has also been hardened:

- The 11-level hard-coded ChildContainers Include chain has been replaced
  with a single flat container query that is rebuilt into a tree in memory
  by a new BuildContainerTree helper. This handles arbitrary hierarchy depth
  and avoids the cartesian explosion risk of deep joins.
- The expensive duplicate partition round-trip (Query 4 in the old code) is
  eliminated; partitions are now loaded once shallowly, and containers are
  attached via the flat-load pass.
- The no-op .OrderBy(a => a.Name) inside the Attributes Include (which was
  silently sorting in memory after the fact) has been removed; presentation
  ordering is now handled by callers that actually need it.

Also adds an entity retrieval naming taxonomy (Summary / Header / Core /
Detail / Full) in src/CLAUDE.md so future repository methods follow a
consistent weight-based convention.

Test coverage includes unit tests for GetConnectedSystemCoreAsync and the
BuildContainerTree helper (including a 15-level deep hierarchy that would
not be reachable with the previous Include-based approach). Controller
tests that previously mocked GetConnectedSystemAsync for migrated endpoints
have been updated to mock GetConnectedSystemCoreAsync.

Note: this commit was prepared in an environment without dotnet tooling,
so local dotnet build and dotnet test runs have not been executed. A
full pre-merge build/test pass is required before merge.

https://claude.ai/code/session_011FkpBnqeHAmbcWC6HbRNxP