### PR TITLE
fix(devcontainer): make setup work on native arm64 Linux hosts

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,15 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm
+FROM mcr.microsoft.com/devcontainers/dotnet:1-10.0-noble
+
+# Install pinned .NET SDK version to match global.json.
+# The base image can ship with an SDK that predates global.json's pin
+# (e.g. 10.0.100-rc.2 on arm64 at time of writing), which fails
+# rollForward: latestFeature against 10.0.200. Layer the pinned SDK in
+# explicitly so builds are deterministic across architectures and image
+# refresh cycles, regardless of what the base image happens to bundle.
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --version 10.0.200 --install-dir /usr/share/dotnet --no-path \
+    && rm /tmp/dotnet-install.sh
 
 # Remove stale Yarn apt repo that breaks feature installs (expired GPG key)
 RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null; \
@@ -11,9 +22,15 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null; \
 #
 # Install Chromium shared libraries for Puppeteer (diagram export via jim-diagrams).
 # Puppeteer downloads its own Chrome binary, but needs these OS libraries at runtime.
+#
+# Install python3-pip for MkDocs Material install in setup.sh. The Noble base
+# image only ships python3-minimal, which lacks pip/ensurepip - so pip install
+# during setup silently fails without this. (Regression from the bookworm->noble
+# base image bump; bookworm shipped pip by default.)
 RUN apt-get install -y --no-install-recommends \
     socat \
+    python3-pip \
     libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \
-    libcairo2 libasound2 libxshmfence1 libxfixes3 \
+    libcairo2 libasound2t64 libxshmfence1 libxfixes3 \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,9 +27,19 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null; \
 # image only ships python3-minimal, which lacks pip/ensurepip - so pip install
 # during setup silently fails without this. (Regression from the bookworm->noble
 # base image bump; bookworm shipped pip by default.)
+#
+# Install ripgrep so Claude Code can use the distro binary instead of its
+# bundled vendor/ripgrep/arm64-linux/rg. The bundled binary assumes a 4K
+# memory page size and SIGABRTs on hosts running a 16K page-size kernel
+# (notably Asahi Linux on Apple Silicon, kernel suffix `+16k`), which crashes
+# Claude Code at startup when it scans for slash commands. Pairing this with
+# USE_BUILTIN_RIPGREP=0 in devcontainer.json forces every environment
+# (Codespaces, Docker Desktop on Windows/macOS, native Linux) onto the same
+# distro-built ripgrep, which is page-size agnostic.
 RUN apt-get install -y --no-install-recommends \
     socat \
     python3-pip \
+    ripgrep \
     libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \
     libcairo2 libasound2t64 libxshmfence1 libxfixes3 \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -14,11 +14,36 @@ This directory contains the configuration for GitHub Codespaces and VS Code Dev 
 
 ### Using VS Code Dev Containers (Local)
 
-1. Install Docker Desktop
+1. Install Docker Desktop (macOS/Windows) or Docker Engine (Linux)
 2. Install VS Code extension: "Dev Containers"
 3. Open JIM repository in VS Code
 4. Press `F1` → "Dev Containers: Reopen in Container"
 5. Wait for container to build and setup to complete
+
+### Native Linux Host Prerequisites
+
+If you're running the devcontainer on a **native Linux host** (as opposed to Docker Desktop on macOS/Windows or GitHub Codespaces), the host kernel must have the `iptable_nat` module loaded. Docker-in-Docker uses it to set up its internal container network, and on some distributions (including Fedora and Asahi Linux) the module isn't loaded by default. Without it, the inner `dockerd` crashes at startup and every `jim-*` command that talks to Docker fails with `Cannot connect to the Docker daemon`.
+
+Before opening the devcontainer, run this **on the host** (not inside any container):
+
+```bash
+# Load now
+sudo modprobe iptable_nat
+
+# Persist across host reboots
+echo iptable_nat | sudo tee /etc/modules-load.d/jim-devcontainer.conf
+```
+
+Verify:
+
+```bash
+lsmod | grep iptable_nat
+sudo iptables -t nat -L >/dev/null && echo "nat table OK"
+```
+
+Docker Desktop on macOS/Windows and GitHub Codespaces already have this configured; only native Linux hosts need the step.
+
+If you open the devcontainer without doing this first, `setup.sh` detects the dead dockerd and surfaces the fix at the end of its output. The container is still usable for `dotnet build`/`dotnet test` in that state; you just won't be able to run anything that needs Docker until you apply the fix and rebuild the container.
 
 ## ✨ What's Included
 
@@ -306,6 +331,24 @@ Edit `devcontainer.json`:
 ```
 
 ## 🆘 Troubleshooting
+
+### "Cannot connect to the Docker daemon" (native Linux hosts)
+
+Symptom: `jim-db`, `jim-build`, `jim-stack`, or any `docker` command fails with:
+
+```
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+On a native Linux host this almost always means the inner `dockerd` (started by the docker-in-docker feature) failed to initialise because the host kernel is missing the `iptable_nat` module. Confirm by checking the inner daemon's log from inside the devcontainer:
+
+```bash
+sudo grep -i iptable /tmp/dockerd.log
+```
+
+If you see `Table does not exist (do you need to insmod?)`, apply the fix from [Native Linux Host Prerequisites](#native-linux-host-prerequisites) on the host, then rebuild the devcontainer (`F1` → **Dev Containers: Rebuild Container**).
+
+This only affects native Linux hosts. Docker Desktop on macOS/Windows and GitHub Codespaces preload the required kernel modules.
 
 ### Database Won't Start
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -143,7 +143,14 @@
   "containerEnv": {
     "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
     "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
-    "ASPNETCORE_ENVIRONMENT": "Development"
+    "ASPNETCORE_ENVIRONMENT": "Development",
+    // Force Claude Code to use the distro ripgrep installed in the Dockerfile
+    // instead of its bundled vendor/ripgrep binary. The bundled arm64 binary
+    // assumes a 4K page size and SIGABRTs on 16K page-size kernels (Asahi
+    // Linux on Apple Silicon), crashing Claude Code at startup. Using the
+    // distro binary works on every host (Codespaces, Docker Desktop on
+    // Windows/macOS, native Linux) regardless of page size.
+    "USE_BUILTIN_RIPGREP": "0"
   },
   // Enable privileged mode for Docker-in-Docker
   "privileged": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,14 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  // Explicit workspace mount + folder so behaviour is deterministic across all
+  // launchers (Codespaces, Docker Desktop on Mac/Windows, devcontainer CLI on
+  // Linux, attach-to-existing-container). Without these, the runtime falls
+  // back to the base image's WORKDIR (/home/vscode), which isn't a git repo -
+  // so VS Code's Source Control panel shows nothing and setup.sh's hardcoded
+  // /workspaces/JIM path disagrees with what VS Code has opened.
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/JIM,type=bind,consistency=cached",
+  "workspaceFolder": "/workspaces/JIM",
   // Features - pre-built development tools
   "features": {
     // Docker-in-Docker for running docker-compose

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -28,6 +28,14 @@ print_warning() {
     echo -e "${YELLOW}⚠${NC} $1"
 }
 
+# Accumulator for post-setup action items that need the user's attention.
+# Populated by individual steps (signing, gh auth, ...) when their own
+# automated setup can't complete - usually because the step needs
+# interactivity that postCreateCommand doesn't have (no TTY). Rendered as a
+# single banner at the end of the script so the user sees one consolidated
+# TODO list, not individual warnings scattered through the setup log.
+PENDING_ACTIONS=""
+
 # 1. Install .NET EF Core tools
 print_step "Installing .NET Entity Framework Core tools..."
 # Clean up any corrupted tool state first, then install fresh
@@ -162,14 +170,23 @@ if [ -x "$SIGNING_SCRIPT" ]; then
         print_success "Git commit signing configured"
     else
         # configure-signing.sh has already printed a detailed warning banner
-        # with recovery steps. Do not print another warning here (would be
-        # duplicate noise), but do leave a marker for setup completion to
-        # flag the overall state.
-        SIGNING_SETUP_FAILED=1
+        # with recovery steps. We don't print another warning inline (would be
+        # duplicate noise), but we DO record an action in PENDING_ACTIONS so
+        # the TODO is repeated in the final summary - in case the detailed
+        # banner scrolled off screen while the rest of setup ran.
+        PENDING_ACTIONS+="  ▶ Git commit signing is not configured.
+      Re-run: .devcontainer/configure-signing.sh
+      Until fixed, the pre-commit hook in .githooks/ will reject commits.
+
+"
     fi
 else
     print_warning "$SIGNING_SCRIPT not found or not executable - commit signing not configured"
-    SIGNING_SETUP_FAILED=1
+    PENDING_ACTIONS+="  ▶ Git commit signing script is missing or not executable:
+      $SIGNING_SCRIPT
+      Until fixed, the pre-commit hook in .githooks/ will reject commits.
+
+"
 fi
 
 # Install repo-local git hooks. Once configured, git uses .githooks/pre-commit
@@ -223,7 +240,35 @@ else
     print_warning "npm not found - skipping Claude Code CLI install"
 fi
 
-# 13. Display useful information
+# 13. Check gh CLI authentication
+# The gh CLI is used for PR/issue operations and other GitHub API calls.
+# It is NOT involved in git push/pull (SSH remote handles that) or commit
+# signing (SSH agent forward handles that), so a missing gh token is not
+# blocking for day-to-day dev - but it is blocking for gh pr create,
+# gh issue list, gh api, etc.
+#
+# On GitHub Codespaces this check passes automatically because Codespaces
+# injects GITHUB_TOKEN into the environment, which gh auth status honours.
+# On local devcontainers (Docker Desktop, Fedora, etc.) we can't prompt
+# interactively here - postCreateCommand runs without a TTY - so we record
+# an action for the final summary and let the user run the login command
+# themselves in the VS Code integrated terminal.
+print_step "Checking gh CLI authentication..."
+if ! command -v gh >/dev/null 2>&1; then
+    print_warning "gh CLI not found - skipping auth check"
+elif gh auth status >/dev/null 2>&1; then
+    print_success "gh CLI is authenticated"
+else
+    print_warning "gh CLI is not authenticated - gh commands will need login"
+    PENDING_ACTIONS+="  ▶ gh CLI is not authenticated. Run in the integrated terminal:
+      gh auth login --hostname github.com --git-protocol ssh --web
+      (Needed for: gh pr create, gh issue list, gh api, etc.
+       Not needed for git push/pull/commit - SSH remote handles those.)
+
+"
+fi
+
+# 14. Display useful information
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo -e "${GREEN}✓ JIM Development Environment Ready!${NC}"
@@ -285,3 +330,17 @@ echo "    2. Open: http://localhost:5200"
 echo "    3. Sign in with: admin / admin"
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Render any pending action items as the final thing on screen, so they
+# stay near the top of the user's scrollback after the help banner above
+# has filled the terminal. Deliberately uses yellow (warning) rather than
+# red (error) because the container is still usable - these are follow-up
+# steps, not blockers.
+if [ -n "$PENDING_ACTIONS" ]; then
+    echo ""
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}⚠ Action required before the environment is fully ready${NC}"
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "$PENDING_ACTIONS"
+fi

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -131,13 +131,17 @@ fi
 print_step "Setting up connector-files directory..."
 mkdir -p connector-files
 
-# Create symlink to test/Data directory (dynamic - new files appear automatically)
+# Create symlink to test/test-data directory (dynamic - new files appear automatically).
+# NOTE: the directory was renamed from test/Data to test/test-data in commit 90bc8b19
+# (Dec 2025). The old name survived silently on macOS hosts because HFS+/APFS is
+# case-insensitive by default, so "test/Data" still resolved to "test/test-data".
+# On case-sensitive filesystems (Linux) the check fails, so use the real name.
 if [ ! -L connector-files/test-data ]; then
-    if [ -d "test/Data" ]; then
-        ln -s "$(pwd)/test/Data" connector-files/test-data
-        print_success "Symlink created: connector-files/test-data -> test/Data"
+    if [ -d "test/test-data" ]; then
+        ln -s "$(pwd)/test/test-data" connector-files/test-data
+        print_success "Symlink created: connector-files/test-data -> test/test-data"
     else
-        print_warning "test/Data directory not found, skipping symlink"
+        print_warning "test/test-data directory not found, skipping symlink"
     fi
 else
     print_success "Symlink already exists: connector-files/test-data"
@@ -207,38 +211,51 @@ if ! grep -q "source.*jim-aliases.sh" ~/.bashrc; then
     echo "fi" >> ~/.bashrc
 fi
 
-# 12. Display useful information
+# 12. Install Claude Code CLI
+print_step "Installing Claude Code CLI..."
+if command -v npm >/dev/null 2>&1; then
+    if npm install -g @anthropic-ai/claude-code --silent 2>/dev/null; then
+        print_success "Claude Code CLI installed (run: claude)"
+    else
+        print_warning "Claude Code CLI install failed - run manually: npm install -g @anthropic-ai/claude-code"
+    fi
+else
+    print_warning "npm not found - skipping Claude Code CLI install"
+fi
+
+# 13. Display useful information
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo -e "${GREEN}✓ JIM Development Environment Ready!${NC}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "Quick Start Commands:"
-echo "  jim                - List all available jim aliases"
-echo "  jim-compile        - Build the entire solution"
-echo "  jim-test           - Run all tests"
-echo "  jim-web            - Run the Blazor web application (local, debuggable)"
-echo "  jim-db             - Start PostgreSQL"
+echo "  jim                 - List all available jim aliases"
+echo "  jim-compile         - Build the entire solution"
+echo "  jim-test            - Run all tests"
+echo "  jim-web             - Run JIM.Web locally (sources .env)"
+echo "  jim-db              - Start PostgreSQL"
 echo ""
-echo "Docker Stack Commands:"
-echo "  jim-stack          - Start Docker stack (production-like)"
-echo "  jim-stack-logs     - View Docker stack logs"
-echo "  jim-stack-down     - Stop Docker stack"
+echo "Docker Stack Management (auto-kills local JIM processes):"
+echo "  jim-stack           - Start Docker stack"
+echo "  jim-stack-logs      - View Docker stack logs"
+echo "  jim-stack-down      - Stop Docker stack"
 echo ""
-echo "Docker Builds (rebuild services):"
-echo "  jim-build          - Build all services + start"
-echo "  jim-build-web      - Build jim.web + start"
-echo "  jim-build-worker   - Build jim.worker + start"
-echo "  jim-build-scheduler - Build jim.scheduler + start"
+echo "Docker Builds (auto-kills local JIM processes, rebuild + start):"
+echo "  jim-build           - Rebuild all services + start"
+echo "  jim-build-light     - Start db + Keycloak, run JIM.Web natively"
+echo "  jim-build-web       - Rebuild jim.web + start"
+echo "  jim-build-worker    - Rebuild jim.worker + start"
+echo "  jim-build-scheduler - Rebuild jim.scheduler + start"
 echo ""
 echo "Reset:"
-echo "  jim-reset          - Reset JIM (delete database & logs volumes)"
+echo "  jim-reset           - Full reset (containers, images, volumes)"
 echo ""
 echo "Database Commands:"
-echo "  jim-migrate        - Apply pending migrations"
-echo "  jim-migration [N]  - Create a new migration"
-echo "  jim-db-logs        - View database logs"
-echo "  jim-db             - Start PostgreSQL"
+echo "  jim-migrate         - Apply pending migrations"
+echo "  jim-migration [N]   - Create a new migration"
+echo "  jim-db-logs         - View database logs"
+echo "  jim-db              - Start PostgreSQL"
 echo ""
 echo "Available Services:"
 echo "  PostgreSQL:        localhost:5432"
@@ -251,14 +268,14 @@ echo "  When running Docker stack:"
 echo "    JIM Web:         http://localhost:5200"
 echo ""
 echo "📖 Documentation:"
-echo "  jim-docs           - Preview docs site at http://localhost:8000"
+echo "  jim-docs            - Preview docs site at http://localhost:8000"
 echo "  Developer Guide:   docs/developer/"
 echo "  Quick Reference:   CLAUDE.md"
 echo ""
 echo "🚀 To start developing (choose one):"
 echo ""
 echo "  Option 1 - Local Debug (Recommended):"
-echo "    1. Run: jim-db && jim-keycloak"
+echo "    1. Run: jim-build-light"
 echo "    2. Press F5 in VS Code"
 echo "    3. Sign in with: admin / admin"
 echo ""

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -36,6 +36,43 @@ print_warning() {
 # TODO list, not individual warnings scattered through the setup log.
 PENDING_ACTIONS=""
 
+# Check Docker daemon health.
+# The docker-in-docker feature starts its own dockerd inside this container at
+# postCreate time. On some native Linux hosts (notably Fedora and Asahi Linux,
+# where the iptable_nat kernel module isn't loaded by default), dockerd crashes
+# during network init and leaves /var/run/docker.sock as a dead socket file.
+# All docker-using commands (jim-db, jim-build, jim-stack, ...) then fail with
+# "Cannot connect to the Docker daemon" until the user runs modprobe on the
+# host and rebuilds the container. We detect that case here and surface the
+# fix in the final summary banner so the user isn't left hunting through
+# dockerd.log to figure out what went wrong. This is a no-op on Docker Desktop
+# (macOS/Windows) and Codespaces, which preload the required kernel modules.
+print_step "Checking Docker daemon health..."
+if ! command -v docker >/dev/null 2>&1; then
+    print_warning "docker CLI not found - skipping daemon health check"
+elif docker info >/dev/null 2>&1; then
+    print_success "Docker daemon is running"
+else
+    DOCKER_ERR_HINT=""
+    if [ -r /tmp/dockerd.log ] && grep -qi "iptable" /tmp/dockerd.log 2>/dev/null; then
+        DOCKER_ERR_HINT=" (host kernel iptable_nat module missing)"
+    fi
+    print_warning "Docker daemon is not responding${DOCKER_ERR_HINT}"
+    PENDING_ACTIONS+="  ▶ Docker daemon inside the devcontainer is not running.
+      This is almost always because the host kernel is missing the iptable_nat
+      module. On the HOST (not inside this container), run:
+
+        sudo modprobe iptable_nat
+        echo iptable_nat | sudo tee /etc/modules-load.d/jim-devcontainer.conf
+
+      Then rebuild the devcontainer (F1 -> Dev Containers: Rebuild Container).
+      Until fixed, jim-db / jim-build / jim-stack will fail with
+      \"Cannot connect to the Docker daemon\".
+      See .devcontainer/README.md for background.
+
+"
+fi
+
 # 1. Install .NET EF Core tools
 print_step "Installing .NET Entity Framework Core tools..."
 # Clean up any corrupted tool state first, then install fresh


### PR DESCRIPTION
## Summary

Makes the devcontainer actually work on native arm64 Linux hosts (Fedora Asahi on Apple Silicon) where several implicit defaults that worked on Codespaces and Docker Desktop were silently broken. Zero impact on production images — everything here is scoped to [.devcontainer/](.devcontainer/).

- Deterministic setup on arm64: pinned `dotnet:1-10.0-noble` base + explicit SDK layer, noble transition packages (`python3-pip`, `libasound2t64`), explicit workspace mount, fixed `test/test-data` symlink target, Claude Code CLI install.
- 16K page-size fix: use the distro `ripgrep` with `USE_BUILTIN_RIPGREP=0` so Claude Code stops SIGABRTing at startup on Asahi (the bundled arm64 `rg` assumes 4K pages).
- Unified post-setup action banner that accumulates pending actions (git signing recovery, `gh auth login`, dead dockerd) into a single yellow TODO block printed after the help text, instead of warnings scrolling off-screen.
- `iptable_nat` detection: if the docker-in-docker daemon failed to start (common on Fedora/Asahi where the module isn't autoloaded), surface the host-side `modprobe iptable_nat` fix in the banner and document it in [.devcontainer/README.md](.devcontainer/README.md).

## Test plan

- [x] Devcontainer rebuilds cleanly on Fedora Asahi (arm64, 16K pages) with docker-in-docker working
- [x] Claude Code CLI launches without SIGABRT inside the container
- [x] `setup.sh` surfaces the iptable_nat fix in the final banner when dockerd is dead
- [ ] Codespaces rebuild still green (no regressions on the happy path)
- [ ] Docker Desktop on macOS rebuild still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)