### PR TITLE
Fix claims table styling, auth role claims, and MVO change tracking

### DIFF
--- a/src/JIM.Models/Core/Constants.cs
+++ b/src/JIM.Models/Core/Constants.cs
@@ -157,7 +157,7 @@ public static class Constants
     {
         public static string Administrator => "Administrator";
         public static string User => "User";
-        public static string RoleClaimType => "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
+        public static string RoleClaimType => "role";
     }
 
     public static class BuiltInExampleDataSets

--- a/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
+++ b/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
@@ -517,11 +517,34 @@ public class MetaverseRepository : IMetaverseRepository
                 Repository.Database.MetaverseAttributes.Attach(av.Attribute);
         }
 
+        // Attach existing MetaverseAttribute entities referenced by change records so EF
+        // recognises them as existing (same pattern as attribute values above).
+        foreach (var change in metaverseObject.Changes)
+        {
+            foreach (var ac in change.AttributeChanges)
+            {
+                if (ac.Attribute != null && Repository.Database.Entry(ac.Attribute).State == EntityState.Detached)
+                    Repository.Database.MetaverseAttributes.Attach(ac.Attribute);
+            }
+        }
+
         // Use Entry().State instead of Add() to avoid graph traversal that would
         // override the Unchanged state of attached entities (Type, Attributes) to Added.
         Repository.Database.Entry(metaverseObject).State = EntityState.Added;
         foreach (var av in metaverseObject.AttributeValues)
             Repository.Database.Entry(av).State = EntityState.Added;
+
+        // Mark change history records as Added so they are persisted alongside the MVO.
+        foreach (var change in metaverseObject.Changes)
+        {
+            Repository.Database.Entry(change).State = EntityState.Added;
+            foreach (var ac in change.AttributeChanges)
+            {
+                Repository.Database.Entry(ac).State = EntityState.Added;
+                foreach (var vc in ac.ValueChanges)
+                    Repository.Database.Entry(vc).State = EntityState.Added;
+            }
+        }
 
         await Repository.Database.SaveChangesAsync();
     }

--- a/src/JIM.Web/Middleware/Api/ApiKeyAuthenticationHandler.cs
+++ b/src/JIM.Web/Middleware/Api/ApiKeyAuthenticationHandler.cs
@@ -138,7 +138,7 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthentic
             // Add the virtual "User" role for basic access (consistent with SSO auth)
             claims.Add(new Claim(Constants.BuiltInRoles.RoleClaimType, Constants.BuiltInRoles.User));
 
-            var identity = new ClaimsIdentity(claims, SchemeName);
+            var identity = new ClaimsIdentity(claims, SchemeName, nameType: ClaimTypes.Name, roleType: Constants.BuiltInRoles.RoleClaimType);
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, SchemeName);
 

--- a/src/JIM.Web/Middleware/Api/JimRoleEnrichmentMiddleware.cs
+++ b/src/JIM.Web/Middleware/Api/JimRoleEnrichmentMiddleware.cs
@@ -104,7 +104,7 @@ public class JimRoleEnrichmentMiddleware(RequestDelegate next)
             roleClaims.Add(new Claim(Constants.BuiltInClaims.MetaverseObjectId, user.Id.ToString()));
 
             // Create a new identity with JIM claims and add it to the principal
-            var jimIdentity = new ClaimsIdentity(roleClaims) { Label = "JIM.Web.Api" };
+            var jimIdentity = new ClaimsIdentity(roleClaims, authenticationType: null, nameType: null, roleType: Constants.BuiltInRoles.RoleClaimType) { Label = "JIM.Web.Api" };
             context.User.AddIdentity(jimIdentity);
 
             Log.Debug("JimRoleEnrichmentMiddleware: Enriched user with {RoleCount} roles: {Roles}",

--- a/src/JIM.Web/Pages/Claims.razor
+++ b/src/JIM.Web/Pages/Claims.razor
@@ -16,7 +16,7 @@
 
 @if (User != null)
 {
-    <MudTable Items="@User.Claims.OrderBy(q=> q.Type)" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5">
+    <MudTable Items="@User.Claims.OrderBy(q=> q.Type)" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5" Outlined="true" Elevation="0">
         <HeaderContent>
             <MudTh><MudText Typo="Typo.button">Claim Type</MudText></MudTh>
             <MudTh><MudText Typo="Typo.button">Claim Value</MudText></MudTh>
@@ -33,7 +33,7 @@
         about how your current session was authenticated. Secrets (client secret, tokens) are deliberately excluded.
     </MudText>
 
-    <MudTable Items="@_idpInfo" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5">
+    <MudTable Items="@_idpInfo" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm" HorizontalScrollbar="false" Class="mt-5" Outlined="true" Elevation="0">
         <HeaderContent>
             <MudTh><MudText Typo="Typo.button">Setting</MudText></MudTh>
             <MudTh><MudText Typo="Typo.button">Value</MudText></MudTh>

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -724,7 +724,7 @@ static async Task AuthoriseAndUpdateUserAsync(TicketReceivedContext context)
         userRoleClaims.Add(new Claim(Constants.BuiltInClaims.MetaverseObjectId, user.Id.ToString()));
 
         // the new JIM-specific identity is ready, now add it to the ASP.NET identity so it can be easily retrieved later.
-        var jimIdentity = new ClaimsIdentity(userRoleClaims) { Label = "JIM.Web" };
+        var jimIdentity = new ClaimsIdentity(userRoleClaims, authenticationType: null, nameType: null, roleType: Constants.BuiltInRoles.RoleClaimType) { Label = "JIM.Web" };
         context.Principal.AddIdentity(jimIdentity);
 
         // now see if we can supplement the JIM identity with any supplied from the IdP to more fully populate the user.

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -205,6 +205,7 @@ try
             // With MapInboundClaims disabled, Identity.Name won't resolve automatically because
             // .NET looks for the legacy XML URI by default. Point it at the standard OIDC claim.
             options.TokenValidationParameters.NameClaimType = "name";
+            options.TokenValidationParameters.RoleClaimType = Constants.BuiltInRoles.RoleClaimType;
 
             // By default, the ASP.NET Core OpenIdConnect handler drops a number of "protocol" claims
             // (iss, aud, azp, acr, auth_time, ...) after it has validated them, so they never reach
@@ -274,6 +275,8 @@ try
 
             // Preserve standard OIDC claim names for API requests
             options.MapInboundClaims = false;
+
+            options.TokenValidationParameters.RoleClaimType = Constants.BuiltInRoles.RoleClaimType;
         });
 
     // setup authorisation policies

--- a/src/JIM.Web/Shared/UserNotAuthorised.razor
+++ b/src/JIM.Web/Shared/UserNotAuthorised.razor
@@ -334,7 +334,7 @@
 
         // Get the user's roles for display
         var roles = user.Claims
-            .Where(c => c.Type == System.Security.Claims.ClaimTypes.Role || c.Type == "role")
+            .Where(c => c.Type == Constants.BuiltInRoles.RoleClaimType)
             .Select(c => c.Value)
             .ToList();
         _userRoles = roles.Count > 0 ? string.Join(", ", roles) : "(none)";

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -514,6 +514,11 @@ html[lang] .mud-tabs-tabbar.mud-tabs-border-top {
     background-color: var(--jim-nav-hover-bg, rgba(0, 0, 0, 0.04));
 }
 
+.jim-user-menu:hover .jim-user-name,
+.jim-user-menu:hover .jim-user-username {
+    color: var(--jim-nav-hover-color, var(--jim-nav-active-color)) !important;
+}
+
 /* Collapsed mode: centre the avatar */
 .jim-user-menu-collapsed {
     justify-content: center;

--- a/test/JIM.Models.Tests/Core/ConstantsBuiltInRolesTests.cs
+++ b/test/JIM.Models.Tests/Core/ConstantsBuiltInRolesTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+using NUnit.Framework;
+
+namespace JIM.Models.Tests.Core;
+
+[TestFixture]
+public class ConstantsBuiltInRolesTests
+{
+    [Test]
+    public void RoleClaimType_IsIdpAgnostic_UsesShortNameAsync()
+    {
+        Assert.That(Constants.BuiltInRoles.RoleClaimType, Is.EqualTo("role"));
+    }
+
+    [Test]
+    public void RoleClaimType_DoesNotContainLegacyMicrosoftUriAsync()
+    {
+        Assert.That(Constants.BuiltInRoles.RoleClaimType, Does.Not.Contain("schemas.microsoft.com"));
+    }
+}

--- a/test/JIM.Worker.Tests/Workflows/ChangeTrackingPersistenceWorkflowTests.cs
+++ b/test/JIM.Worker.Tests/Workflows/ChangeTrackingPersistenceWorkflowTests.cs
@@ -7,6 +7,7 @@ using JIM.Models.Enums;
 using JIM.Models.Logic;
 using JIM.Models.Staging;
 using JIM.Worker.Processors;
+using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 
 namespace JIM.Worker.Tests.Workflows;
@@ -302,6 +303,61 @@ public class ChangeTrackingPersistenceWorkflowTests : WorkflowTestBase
         // Assert
         Assert.That(mvo.CachedDisplayName, Is.EqualTo("New Name"),
             "CachedDisplayName should be updated when DisplayName attribute changes");
+    }
+
+    [Test]
+    public async Task CreateMetaverseObject_ChangeRecords_PersistedViaSingleObjectCreateAsync()
+    {
+        // Arrange: MVO with attributes created via the single-object path
+        // (CreateMetaverseObjectAsync), which uses explicit EntityState management
+        // rather than AddRange graph traversal.
+        var (mvType, displayNameAttr, employeeIdAttr) = await CreateMvTypeWithBuiltInDisplayNameAsync();
+
+        var mvo = new MetaverseObject
+        {
+            Id = Guid.NewGuid(),
+            Type = mvType,
+            Created = DateTime.UtcNow
+        };
+        mvo.AttributeValues.Add(new MetaverseObjectAttributeValue
+        {
+            Attribute = displayNameAttr,
+            AttributeId = displayNameAttr.Id,
+            StringValue = "Admin User"
+        });
+        mvo.AttributeValues.Add(new MetaverseObjectAttributeValue
+        {
+            Attribute = employeeIdAttr,
+            AttributeId = employeeIdAttr.Id,
+            StringValue = "EMP001"
+        });
+
+        // Act
+        await Jim.Metaverse.CreateMetaverseObjectAsync(
+            mvo,
+            changeInitiatorType: MetaverseObjectChangeInitiatorType.System);
+
+        // Assert: change records were persisted (not silently dropped)
+        var reloaded = await DbContext.MetaverseObjects
+            .Include(m => m.Changes)
+            .ThenInclude(c => c.AttributeChanges)
+            .ThenInclude(ac => ac.ValueChanges)
+            .SingleAsync(m => m.Id == mvo.Id);
+
+        Assert.That(reloaded.Changes, Has.Count.EqualTo(1),
+            "MVO should have one 'Created' change record persisted in the database");
+
+        var change = reloaded.Changes[0];
+        Assert.That(change.ChangeType, Is.EqualTo(ObjectChangeType.Created));
+        Assert.That(change.ChangeInitiatorType, Is.EqualTo(MetaverseObjectChangeInitiatorType.System));
+        Assert.That(change.AttributeChanges, Has.Count.EqualTo(2),
+            "Change record should capture both attribute additions");
+
+        // Verify attribute values were recorded
+        var displayNameChange = change.AttributeChanges.Single(ac => ac.AttributeName == displayNameAttr.Name);
+        Assert.That(displayNameChange.ValueChanges, Has.Count.EqualTo(1));
+        Assert.That(displayNameChange.ValueChanges[0].StringValue, Is.EqualTo("Admin User"));
+        Assert.That(displayNameChange.ValueChanges[0].ValueChangeType, Is.EqualTo(ValueChangeType.Add));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- **Claims page table styling**: match claims page table with the rest of JIM's UI
- **Auth role claims**: replace legacy Microsoft role claim URI with IdP-agnostic "role" claim type, and set RoleClaimType on all ClaimsIdentity constructors
- **Drawer hover**: add hover text colour change to drawer user menu
- **MVO change tracking**: fix change history not being persisted when creating MVOs via the single-object path (e.g. built-in admin user), caused by explicit EntityState management skipping the Changes entity graph
- **User not authorised page**: update to use new role claim type

## Test plan

- [x] All existing change tracking tests pass (35/35)
- [x] New workflow test verifies change records are persisted via single-object create path
- [ ] Reset JIM and verify the admin user now has a "Created" change history entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)