### PR TITLE
Add count endpoints for metaverse and connector space objects

### DIFF
--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -178,6 +178,19 @@ public interface IConnectedSystemRepository
     public Task<int> GetPendingExportsCountAsync(int connectedSystemId);
 
     /// <summary>
+    /// Retrieves the count of Pending Export objects for a Connected System with optional filtering
+    /// by change type and status. Optimised for fast counting without loading entity data.
+    /// </summary>
+    /// <param name="connectedSystemId">The unique identifier for the Connected System.</param>
+    /// <param name="changeType">Optional change type to filter by (Create, Update, Delete).</param>
+    /// <param name="status">Optional status to filter by (Pending, Failed, etc.).</param>
+    /// <returns>The count of matching Pending Export objects.</returns>
+    public Task<int> GetPendingExportsFilteredCountAsync(
+        int connectedSystemId,
+        PendingExportChangeType? changeType = null,
+        PendingExportStatus? status = null);
+
+    /// <summary>
     /// Deletes a Pending Export object.
     /// </summary>
     /// <param name="pendingExport">The Pending Export to delete.</param>
@@ -635,8 +648,18 @@ public interface IConnectedSystemRepository
     /// <summary>
     /// Returns the count of Connected System Objects for a particular Connected System.
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier for the Connected System to find the object count for.</param>s
+    /// <param name="connectedSystemId">The unique identifier for the Connected System to find the object count for.</param>
     public Task<int> GetConnectedSystemObjectCountAsync(int connectedSystemId, int? partitionId = null);
+
+    /// <summary>
+    /// Returns the count of Connected System Objects for a particular Connected System with optional filtering
+    /// by object type and partition. Optimised for fast counting without loading entity data.
+    /// </summary>
+    /// <param name="connectedSystemId">The unique identifier for the Connected System.</param>
+    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="partitionId">Optional partition ID to filter by.</param>
+    /// <returns>The count of matching Connected System Objects.</returns>
+    public Task<int> GetConnectedSystemObjectCountAsync(int connectedSystemId, int? objectTypeId, int? partitionId);
 
     /// <summary>
     /// Returns the count of Connected System Objects for a particular Connected System, where the status is Obosolete.

--- a/src/JIM.Data/Repositories/IMetaverseRepository.cs
+++ b/src/JIM.Data/Repositories/IMetaverseRepository.cs
@@ -65,6 +65,21 @@ public interface IMetaverseRepository
 
     public Task<int> GetMetaverseObjectOfTypeCountAsync(int metaverseObjectTypeId);
 
+    /// <summary>
+    /// Gets the count of metaverse objects with optional filtering by type, search query, or specific attribute value.
+    /// Optimised for fast counting without loading entity data.
+    /// </summary>
+    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="searchQuery">Optional search query to filter by display name (partial match, case-insensitive).</param>
+    /// <param name="filterAttributeName">Optional attribute name to filter by (must be used with filterAttributeValue).</param>
+    /// <param name="filterAttributeValue">Optional attribute value to filter by (exact match, case-insensitive).</param>
+    /// <returns>The count of matching metaverse objects.</returns>
+    public Task<int> GetMetaverseObjectsCountAsync(
+        int? objectTypeId = null,
+        string? searchQuery = null,
+        string? filterAttributeName = null,
+        string? filterAttributeValue = null);
+
     public Task<PagedResultSet<MetaverseObject>> GetMetaverseObjectsOfTypeAsync(
         int metaverseObjectTypeId,
         int page,

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -1944,10 +1944,16 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             .Where(cso => cso.ConnectedSystemId == connectedSystemId);
 
         if (objectTypeId.HasValue)
-            query = query.Where(cso => cso.TypeId == objectTypeId.Value);
+        {
+            var typeId = objectTypeId.Value;
+            query = query.Where(cso => cso.TypeId == typeId);
+        }
 
         if (partitionId.HasValue)
-            query = query.Where(cso => cso.PartitionId == partitionId.Value);
+        {
+            var partition = partitionId.Value;
+            query = query.Where(cso => cso.PartitionId == partition);
+        }
 
         return await query.CountAsync();
     }
@@ -2695,10 +2701,16 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             .Where(pe => pe.ConnectedSystemId == connectedSystemId);
 
         if (changeType.HasValue)
-            query = query.Where(pe => pe.ChangeType == changeType.Value);
+        {
+            var type = changeType.Value;
+            query = query.Where(pe => pe.ChangeType == type);
+        }
 
         if (status.HasValue)
-            query = query.Where(pe => pe.Status == status.Value);
+        {
+            var statusValue = status.Value;
+            query = query.Where(pe => pe.Status == statusValue);
+        }
 
         return await query.CountAsync();
     }

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -1937,6 +1937,21 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         return await query.CountAsync();
     }
 
+    /// <inheritdoc />
+    public async Task<int> GetConnectedSystemObjectCountAsync(int connectedSystemId, int? objectTypeId, int? partitionId)
+    {
+        var query = Repository.Database.ConnectedSystemObjects
+            .Where(cso => cso.ConnectedSystemId == connectedSystemId);
+
+        if (objectTypeId.HasValue)
+            query = query.Where(cso => cso.TypeId == objectTypeId.Value);
+
+        if (partitionId.HasValue)
+            query = query.Where(cso => cso.PartitionId == partitionId.Value);
+
+        return await query.CountAsync();
+    }
+
     /// <summary>
     /// Returns the count of Connected System Objects for a particular Connected System, where the status is Obosolete.
     /// </summary>
@@ -2668,6 +2683,24 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     public async Task<int> GetPendingExportsCountAsync(int connectedSystemId)
     {
         return await Repository.Database.PendingExports.CountAsync(pe => pe.ConnectedSystemId == connectedSystemId);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetPendingExportsFilteredCountAsync(
+        int connectedSystemId,
+        PendingExportChangeType? changeType = null,
+        PendingExportStatus? status = null)
+    {
+        var query = Repository.Database.PendingExports
+            .Where(pe => pe.ConnectedSystemId == connectedSystemId);
+
+        if (changeType.HasValue)
+            query = query.Where(pe => pe.ChangeType == changeType.Value);
+
+        if (status.HasValue)
+            query = query.Where(pe => pe.Status == status.Value);
+
+        return await query.CountAsync();
     }
 
     public async Task DeletePendingExportAsync(PendingExport pendingExport)

--- a/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
+++ b/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
@@ -1640,7 +1640,8 @@ public class MetaverseRepository : IMetaverseRepository
 
         if (objectTypeId.HasValue)
         {
-            query = query.Where(mo => mo.Type.Id == objectTypeId.Value);
+            var typeId = objectTypeId.Value;
+            query = query.Where(mo => mo.Type.Id == typeId);
         }
 
         if (!string.IsNullOrWhiteSpace(searchQuery))

--- a/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
+++ b/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
@@ -1628,6 +1628,42 @@ public class MetaverseRepository : IMetaverseRepository
         };
     }
 
+    /// <inheritdoc />
+    public async Task<int> GetMetaverseObjectsCountAsync(
+        int? objectTypeId = null,
+        string? searchQuery = null,
+        string? filterAttributeName = null,
+        string? filterAttributeValue = null)
+    {
+        // Build a lean count query: no Includes, no AsSplitQuery, no Select projections.
+        var query = Repository.Database.MetaverseObjects.AsQueryable();
+
+        if (objectTypeId.HasValue)
+        {
+            query = query.Where(mo => mo.Type.Id == objectTypeId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(searchQuery))
+        {
+            query = query.Where(mo =>
+                mo.AttributeValues.Any(av =>
+                    av.Attribute.Name == Constants.BuiltInAttributes.DisplayName &&
+                    av.StringValue != null &&
+                    EF.Functions.ILike(av.StringValue, $"%{searchQuery}%")));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filterAttributeName) && filterAttributeValue != null)
+        {
+            query = query.Where(mo =>
+                mo.AttributeValues.Any(av =>
+                    av.Attribute.Name == filterAttributeName &&
+                    av.StringValue != null &&
+                    EF.Functions.ILike(av.StringValue, filterAttributeValue)));
+        }
+
+        return await query.CountAsync();
+    }
+
     public async Task<int> GetMetaverseObjectsPendingDeletionCountAsync(int? objectTypeId = null)
     {
         var query = Repository.Database.MetaverseObjects

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
@@ -57,6 +57,21 @@ function Get-JIMConnectedSystemObject {
 
         Searches "member" attribute values containing "admin".
 
+    .EXAMPLE
+        Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count
+
+        Gets the total count of objects in the connector space for Connected System 1.
+
+    .EXAMPLE
+        Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count -ObjectTypeId 2
+
+        Gets the count of objects of type 2 in Connected System 1.
+
+    .EXAMPLE
+        Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count -PartitionId 5
+
+        Gets the count of objects in partition 5 of Connected System 1.
+
     .LINK
         Get-JIMConnectedSystem
         Get-JIMPendingExport
@@ -65,9 +80,12 @@ function Get-JIMConnectedSystemObject {
     [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Count', ValueFromPipelineByPropertyName)]
         [int]$ConnectedSystemId,
 
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AttributeValues', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AttributeValuesAll', ValueFromPipelineByPropertyName)]
         [guid]$Id,
 
         [Parameter(Mandatory, ParameterSetName = 'AttributeValues')]
@@ -89,11 +107,42 @@ function Get-JIMConnectedSystemObject {
         [int]$PageSize = 50,
 
         [Parameter(Mandatory, ParameterSetName = 'AttributeValuesAll')]
-        [switch]$All
+        [switch]$All,
+
+        [Parameter(Mandatory, ParameterSetName = 'Count')]
+        [switch]$Count,
+
+        [Parameter(ParameterSetName = 'Count')]
+        [int]$ObjectTypeId,
+
+        [Parameter(ParameterSetName = 'Count')]
+        [int]$PartitionId
     )
 
     process {
         switch ($PSCmdlet.ParameterSetName) {
+            'Count' {
+                Write-Verbose "Getting connector space count for Connected System $ConnectedSystemId"
+
+                $queryParams = @()
+
+                if ($PSBoundParameters.ContainsKey('ObjectTypeId')) {
+                    $queryParams += "objectTypeId=$ObjectTypeId"
+                }
+
+                if ($PSBoundParameters.ContainsKey('PartitionId')) {
+                    $queryParams += "partitionId=$PartitionId"
+                }
+
+                $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space/count"
+                if ($queryParams.Count -gt 0) {
+                    $endpoint += "?" + ($queryParams -join '&')
+                }
+
+                $result = Invoke-JIMApi -Endpoint $endpoint
+                $result
+            }
+
             'ById' {
                 Write-Verbose "Getting Connected System Object $Id from Connected System $ConnectedSystemId"
                 $result = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space/$Id"

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
@@ -79,7 +79,9 @@ function Get-JIMConnectedSystemObject {
     [CmdletBinding(DefaultParameterSetName = 'ById')]
     [OutputType([PSCustomObject])]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AttributeValues', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'AttributeValuesAll', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'Count', ValueFromPipelineByPropertyName)]
         [int]$ConnectedSystemId,
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMPendingExport.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMPendingExport.ps1
@@ -66,6 +66,21 @@ function Get-JIMPendingExport {
 
         Gets all attribute changes for the "member" attribute (auto-paginates).
 
+    .EXAMPLE
+        Get-JIMPendingExport -ConnectedSystemId 2 -Count
+
+        Gets the total count of pending exports for Connected System 2.
+
+    .EXAMPLE
+        Get-JIMPendingExport -ConnectedSystemId 2 -Count -ChangeType Create
+
+        Gets the count of pending Create exports for Connected System 2.
+
+    .EXAMPLE
+        Get-JIMPendingExport -ConnectedSystemId 2 -Count -Status Failed
+
+        Gets the count of failed pending exports for Connected System 2.
+
     .LINK
         Get-JIMConnectedSystem
     #>
@@ -74,6 +89,7 @@ function Get-JIMPendingExport {
     param(
         [Parameter(Mandatory, ParameterSetName = 'List', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'ListAll', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Count', ValueFromPipelineByPropertyName)]
         [int]$ConnectedSystemId,
 
         [Parameter(Mandatory, ParameterSetName = 'ById')]
@@ -106,11 +122,44 @@ function Get-JIMPendingExport {
 
         [Parameter(Mandatory, ParameterSetName = 'ListAll')]
         [Parameter(Mandatory, ParameterSetName = 'AttributeChangesAll')]
-        [switch]$All
+        [switch]$All,
+
+        [Parameter(Mandatory, ParameterSetName = 'Count')]
+        [switch]$Count,
+
+        [Parameter(ParameterSetName = 'Count')]
+        [ValidateSet('Create', 'Update', 'Delete')]
+        [string]$ChangeType,
+
+        [Parameter(ParameterSetName = 'Count')]
+        [ValidateSet('Pending', 'ExportNotConfirmed', 'Executing', 'Failed', 'Exported')]
+        [string]$Status
     )
 
     process {
         switch ($PSCmdlet.ParameterSetName) {
+            'Count' {
+                Write-Verbose "Getting pending exports count for Connected System $ConnectedSystemId"
+
+                $queryParams = @()
+
+                if ($ChangeType) {
+                    $queryParams += "changeType=$ChangeType"
+                }
+
+                if ($Status) {
+                    $queryParams += "status=$Status"
+                }
+
+                $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/pending-exports/count"
+                if ($queryParams.Count -gt 0) {
+                    $endpoint += "?" + ($queryParams -join '&')
+                }
+
+                $result = Invoke-JIMApi -Endpoint $endpoint
+                $result
+            }
+
             'ById' {
                 Write-Verbose "Getting Pending Export: $Id"
                 $result = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/pending-exports/$Id"

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObject.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObject.ps1
@@ -106,6 +106,21 @@ function Get-JIMMetaverseObject {
 
         Gets all User objects with Training Status attribute, automatically paginating.
 
+    .EXAMPLE
+        Get-JIMMetaverseObject -Count
+
+        Gets the total count of all Metaverse Objects.
+
+    .EXAMPLE
+        Get-JIMMetaverseObject -Count -ObjectTypeName 'Person'
+
+        Gets the count of Person objects in the metaverse.
+
+    .EXAMPLE
+        Get-JIMMetaverseObject -Count -AttributeName "Department" -AttributeValue "IT"
+
+        Gets the count of objects where Department equals "IT".
+
     .LINK
         Get-JIMMetaverseObjectType
         Get-JIMMetaverseAttribute
@@ -118,25 +133,30 @@ function Get-JIMMetaverseObject {
 
         [Parameter(ParameterSetName = 'List')]
         [Parameter(ParameterSetName = 'ListAll')]
+        [Parameter(ParameterSetName = 'Count')]
         [int]$ObjectTypeId,
 
         [Parameter(ParameterSetName = 'List')]
         [Parameter(ParameterSetName = 'ListAll')]
+        [Parameter(ParameterSetName = 'Count')]
         [ValidateNotNullOrEmpty()]
         [string]$ObjectTypeName,
 
         [Parameter(ParameterSetName = 'List')]
         [Parameter(ParameterSetName = 'ListAll')]
+        [Parameter(ParameterSetName = 'Count')]
         [SupportsWildcards()]
         [string]$Search,
 
         [Parameter(ParameterSetName = 'List')]
         [Parameter(ParameterSetName = 'ListAll')]
+        [Parameter(ParameterSetName = 'Count')]
         [ValidateNotNullOrEmpty()]
         [string]$AttributeName,
 
         [Parameter(ParameterSetName = 'List')]
         [Parameter(ParameterSetName = 'ListAll')]
+        [Parameter(ParameterSetName = 'Count')]
         [string]$AttributeValue,
 
         [Parameter(ParameterSetName = 'List')]
@@ -145,6 +165,9 @@ function Get-JIMMetaverseObject {
 
         [Parameter(Mandatory, ParameterSetName = 'ListAll')]
         [switch]$All,
+
+        [Parameter(Mandatory, ParameterSetName = 'Count')]
+        [switch]$Count,
 
         [Parameter(ParameterSetName = 'List')]
         [ValidateRange(1, [int]::MaxValue)]
@@ -173,6 +196,43 @@ function Get-JIMMetaverseObject {
             'ById' {
                 Write-Verbose "Getting Metaverse Object with ID: $Id"
                 $result = Invoke-JIMApi -Endpoint "/api/v1/metaverse/objects/$Id"
+                $result
+            }
+
+            'Count' {
+                Write-Verbose "Getting count of Metaverse Objects"
+
+                # Validate AttributeName and AttributeValue are used together
+                if ($AttributeName -and -not $PSBoundParameters.ContainsKey('AttributeValue')) {
+                    Write-Error "AttributeName requires AttributeValue to be specified"
+                    return
+                }
+                if ($PSBoundParameters.ContainsKey('AttributeValue') -and -not $AttributeName) {
+                    Write-Error "AttributeValue requires AttributeName to be specified"
+                    return
+                }
+
+                $queryParams = @()
+
+                if ($PSBoundParameters.ContainsKey('ObjectTypeId') -or $ObjectTypeName) {
+                    $queryParams += "objectTypeId=$ObjectTypeId"
+                }
+
+                if ($Search) {
+                    $queryParams += "search=$([System.Uri]::EscapeDataString($Search))"
+                }
+
+                if ($AttributeName) {
+                    $queryParams += "filterAttributeName=$([System.Uri]::EscapeDataString($AttributeName))"
+                    $queryParams += "filterAttributeValue=$([System.Uri]::EscapeDataString($AttributeValue))"
+                }
+
+                $endpoint = "/api/v1/metaverse/objects/count"
+                if ($queryParams.Count -gt 0) {
+                    $endpoint += "?" + ($queryParams -join '&')
+                }
+
+                $result = Invoke-JIMApi -Endpoint $endpoint
                 $result
             }
 

--- a/src/JIM.PowerShell/Tests/Get-JIMConnectedSystemObject.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Get-JIMConnectedSystemObject.Tests.ps1
@@ -37,6 +37,10 @@ Describe 'Get-JIMConnectedSystemObject' {
         It 'Should have an AttributeValuesAll parameter set' {
             $command.ParameterSets.Name | Should -Contain 'AttributeValuesAll'
         }
+
+        It 'Should have a Count parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'Count'
+        }
     }
 
     Context 'Parameter Validation' {
@@ -86,6 +90,18 @@ Describe 'Get-JIMConnectedSystemObject' {
         It 'Should have Search as an optional string parameter' {
             $command.Parameters['Search'].ParameterType.Name | Should -Be 'String'
         }
+
+        It 'Should have Count as a switch parameter' {
+            $command.Parameters['Count'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should have ObjectTypeId as an optional int parameter' {
+            $command.Parameters['ObjectTypeId'].ParameterType.Name | Should -Be 'Int32'
+        }
+
+        It 'Should have PartitionId as an optional int parameter' {
+            $command.Parameters['PartitionId'].ParameterType.Name | Should -Be 'Int32'
+        }
     }
 
     Context 'Requires Connection' {
@@ -96,6 +112,10 @@ Describe 'Get-JIMConnectedSystemObject' {
 
         It 'Should throw when not connected' {
             { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Id ([guid]::NewGuid()) } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with Count' {
+            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.Web/Controllers/Api/MetaverseController.cs
+++ b/src/JIM.Web/Controllers/Api/MetaverseController.cs
@@ -435,6 +435,35 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
+    /// Gets the count of metaverse objects with optional filtering.
+    /// </summary>
+    /// <remarks>
+    /// Returns a simple integer count. Supports the same filters as the paginated objects endpoint
+    /// but is significantly faster as it only executes a COUNT query without loading entity data.
+    /// </remarks>
+    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="search">Optional search text to filter by display name (partial match, case-insensitive).</param>
+    /// <param name="filterAttributeName">Optional attribute name to filter by (must be used with filterAttributeValue).</param>
+    /// <param name="filterAttributeValue">Optional attribute value to filter by (exact match, case-insensitive).</param>
+    /// <returns>The count of matching metaverse objects.</returns>
+    [HttpGet("objects/count", Name = "GetObjectsCount")]
+    [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetObjectsCountAsync(
+        [FromQuery] int? objectTypeId = null,
+        [FromQuery] string? search = null,
+        [FromQuery] string? filterAttributeName = null,
+        [FromQuery] string? filterAttributeValue = null)
+    {
+        _logger.LogDebug("Getting metaverse objects count (TypeId: {TypeId}, Search: {Search}, FilterAttr: {FilterAttr}={FilterValue})",
+            objectTypeId, LogSanitiser.Sanitise(search), LogSanitiser.Sanitise(filterAttributeName), LogSanitiser.Sanitise(filterAttributeValue));
+
+        var count = await _application.Repository.Metaverse.GetMetaverseObjectsCountAsync(
+            objectTypeId, search, filterAttributeName, filterAttributeValue);
+        return Ok(count);
+    }
+
+    /// <summary>
     /// Searches for metaverse objects using a predefined search, returning lightweight headers
     /// with only the attributes defined in the search. Optimised for fast response at scale (100k+ objects).
     /// </summary>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -14,6 +14,7 @@ using JIM.Models.Logic.DTOs;
 using JIM.Models.Search;
 using JIM.Models.Staging;
 using JIM.Models.Staging.DTOs;
+using JIM.Models.Transactional;
 using JIM.Models.Transactional.DTOs;
 using JIM.Models.Tasking;
 using JIM.Utilities;
@@ -484,6 +485,31 @@ public class SynchronisationController(
         return Ok(count);
     }
 
+    /// <summary>
+    /// Gets the count of Connected System Objects in the connector space with optional filtering.
+    /// </summary>
+    /// <remarks>
+    /// Returns a simple integer count. Optimised for fast counting without loading entity data.
+    /// </remarks>
+    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="partitionId">Optional partition ID to filter by.</param>
+    /// <returns>The count of matching Connected System Objects.</returns>
+    [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/count", Name = "GetConnectorSpaceCount")]
+    [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetConnectorSpaceCountAsync(
+        int connectedSystemId,
+        [FromQuery] int? objectTypeId = null,
+        [FromQuery] int? partitionId = null)
+    {
+        _logger.LogDebug("Getting connector space count for connected system {ConnectedSystemId} (TypeId: {TypeId}, PartitionId: {PartitionId})",
+            connectedSystemId, objectTypeId, partitionId);
+        var count = await _application.Repository.ConnectedSystems.GetConnectedSystemObjectCountAsync(
+            connectedSystemId, objectTypeId, partitionId);
+        return Ok(count);
+    }
+
     #region Pending Exports
 
     /// <summary>
@@ -521,6 +547,31 @@ public class SynchronisationController(
             Page = result.CurrentPage,
             PageSize = result.PageSize
         });
+    }
+
+    /// <summary>
+    /// Gets the count of Pending Exports for a Connected System with optional filtering.
+    /// </summary>
+    /// <remarks>
+    /// Returns a simple integer count. Optimised for fast counting without loading entity data.
+    /// </remarks>
+    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="changeType">Optional change type to filter by (Create = 0, Update = 1, Delete = 2).</param>
+    /// <param name="status">Optional status to filter by (Pending = 0, ExportNotConfirmed = 1, Executing = 2, Failed = 3, Exported = 4).</param>
+    /// <returns>The count of matching Pending Export objects.</returns>
+    [HttpGet("connected-systems/{connectedSystemId:int}/pending-exports/count", Name = "GetPendingExportsCount")]
+    [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetPendingExportsCountAsync(
+        int connectedSystemId,
+        [FromQuery] PendingExportChangeType? changeType = null,
+        [FromQuery] PendingExportStatus? status = null)
+    {
+        _logger.LogDebug("Getting pending exports count for connected system {ConnectedSystemId} (ChangeType: {ChangeType}, Status: {Status})",
+            connectedSystemId, changeType, status);
+        var count = await _application.Repository.ConnectedSystems.GetPendingExportsFilteredCountAsync(
+            connectedSystemId, changeType, status);
+        return Ok(count);
     }
 
     /// <summary>

--- a/test/JIM.Web.Api.Tests/CsoDetailAndPaginationTests.cs
+++ b/test/JIM.Web.Api.Tests/CsoDetailAndPaginationTests.cs
@@ -18,6 +18,7 @@ using JIM.Models.Core;
 using JIM.Models.Interfaces;
 using JIM.Models.Staging;
 using JIM.Models.Staging.DTOs;
+using JIM.Models.Transactional;
 using JIM.Models.Utility;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -400,6 +401,114 @@ public class CsoDetailAndPaginationTests
         Assert.That(Enum.IsDefined(typeof(CsoAttributeLoadStrategy), CsoAttributeLoadStrategy.CappedMva));
         Assert.That((int)CsoAttributeLoadStrategy.All, Is.EqualTo(0));
         Assert.That((int)CsoAttributeLoadStrategy.CappedMva, Is.EqualTo(1));
+    }
+
+    #endregion
+
+    #region GetConnectorSpaceCountAsync tests
+
+    [Test]
+    public async Task GetConnectorSpaceCountAsync_ReturnsOkWithIntAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectCountAsync(1, It.IsAny<int?>(), It.IsAny<int?>()))
+            .ReturnsAsync(500);
+
+        var result = await _controller.GetConnectorSpaceCountAsync(1);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = (OkObjectResult)result;
+        Assert.That(okResult.Value, Is.EqualTo(500));
+    }
+
+    [Test]
+    public async Task GetConnectorSpaceCountAsync_WithObjectTypeFilter_PassesToRepositoryAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectCountAsync(1, 3, It.IsAny<int?>()))
+            .ReturnsAsync(150);
+
+        await _controller.GetConnectorSpaceCountAsync(1, objectTypeId: 3);
+
+        _mockConnectedSystemRepo.Verify(r => r.GetConnectedSystemObjectCountAsync(1, 3, It.IsAny<int?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetConnectorSpaceCountAsync_WithPartitionFilter_PassesToRepositoryAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectCountAsync(1, It.IsAny<int?>(), 7))
+            .ReturnsAsync(80);
+
+        await _controller.GetConnectorSpaceCountAsync(1, partitionId: 7);
+
+        _mockConnectedSystemRepo.Verify(r => r.GetConnectedSystemObjectCountAsync(1, It.IsAny<int?>(), 7), Times.Once);
+    }
+
+    [Test]
+    public async Task GetConnectorSpaceCountAsync_WithAllFilters_PassesAllToRepositoryAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectCountAsync(1, 3, 7))
+            .ReturnsAsync(25);
+
+        var result = await _controller.GetConnectorSpaceCountAsync(1, objectTypeId: 3, partitionId: 7) as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value, Is.EqualTo(25));
+    }
+
+    #endregion
+
+    #region GetPendingExportsCountAsync tests
+
+    [Test]
+    public async Task GetPendingExportsCountAsync_ReturnsOkWithIntAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetPendingExportsFilteredCountAsync(1, null, null))
+            .ReturnsAsync(100);
+
+        var result = await _controller.GetPendingExportsCountAsync(1);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = (OkObjectResult)result;
+        Assert.That(okResult.Value, Is.EqualTo(100));
+    }
+
+    [Test]
+    public async Task GetPendingExportsCountAsync_WithChangeTypeFilter_PassesToRepositoryAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetPendingExportsFilteredCountAsync(
+                1, PendingExportChangeType.Create, It.IsAny<PendingExportStatus?>()))
+            .ReturnsAsync(30);
+
+        await _controller.GetPendingExportsCountAsync(1, changeType: PendingExportChangeType.Create);
+
+        _mockConnectedSystemRepo.Verify(r => r.GetPendingExportsFilteredCountAsync(
+            1, PendingExportChangeType.Create, It.IsAny<PendingExportStatus?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetPendingExportsCountAsync_WithStatusFilter_PassesToRepositoryAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetPendingExportsFilteredCountAsync(
+                1, It.IsAny<PendingExportChangeType?>(), PendingExportStatus.Failed))
+            .ReturnsAsync(5);
+
+        await _controller.GetPendingExportsCountAsync(1, status: PendingExportStatus.Failed);
+
+        _mockConnectedSystemRepo.Verify(r => r.GetPendingExportsFilteredCountAsync(
+            1, It.IsAny<PendingExportChangeType?>(), PendingExportStatus.Failed), Times.Once);
+    }
+
+    [Test]
+    public async Task GetPendingExportsCountAsync_WithAllFilters_PassesAllToRepositoryAsync()
+    {
+        _mockConnectedSystemRepo.Setup(r => r.GetPendingExportsFilteredCountAsync(
+                1, PendingExportChangeType.Update, PendingExportStatus.Pending))
+            .ReturnsAsync(12);
+
+        var result = await _controller.GetPendingExportsCountAsync(
+            1, changeType: PendingExportChangeType.Update, status: PendingExportStatus.Pending) as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value, Is.EqualTo(12));
     }
 
     #endregion

--- a/test/JIM.Web.Api.Tests/MetaverseControllerObjectsTests.cs
+++ b/test/JIM.Web.Api.Tests/MetaverseControllerObjectsTests.cs
@@ -318,4 +318,74 @@ public class MetaverseControllerObjectsTests
     }
 
     #endregion
+
+    #region GetObjectsCountAsync tests
+
+    [Test]
+    public async Task GetObjectsCountAsync_ReturnsOkWithIntAsync()
+    {
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectsCountAsync(
+                It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(42);
+
+        var result = await _controller.GetObjectsCountAsync();
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = (OkObjectResult)result;
+        Assert.That(okResult.Value, Is.EqualTo(42));
+    }
+
+    [Test]
+    public async Task GetObjectsCountAsync_WithObjectTypeFilter_PassesTypeIdToRepositoryAsync()
+    {
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectsCountAsync(
+                It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(10);
+
+        await _controller.GetObjectsCountAsync(objectTypeId: 5);
+
+        _mockMetaverseRepo.Verify(r => r.GetMetaverseObjectsCountAsync(
+            5, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetObjectsCountAsync_WithSearch_PassesSearchToRepositoryAsync()
+    {
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectsCountAsync(
+                It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(3);
+
+        await _controller.GetObjectsCountAsync(search: "john");
+
+        _mockMetaverseRepo.Verify(r => r.GetMetaverseObjectsCountAsync(
+            It.IsAny<int?>(), "john", It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetObjectsCountAsync_WithAttributeFilter_PassesFilterToRepositoryAsync()
+    {
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectsCountAsync(
+                It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(7);
+
+        await _controller.GetObjectsCountAsync(filterAttributeName: "Department", filterAttributeValue: "IT");
+
+        _mockMetaverseRepo.Verify(r => r.GetMetaverseObjectsCountAsync(
+            It.IsAny<int?>(), It.IsAny<string?>(), "Department", "IT"), Times.Once);
+    }
+
+    [Test]
+    public async Task GetObjectsCountAsync_NoFilters_ReturnsZeroForEmptyMetaverseAsync()
+    {
+        _mockMetaverseRepo.Setup(r => r.GetMetaverseObjectsCountAsync(
+                It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(0);
+
+        var result = await _controller.GetObjectsCountAsync() as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value, Is.EqualTo(0));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
This PR adds optimized count endpoints across the API and PowerShell modules for retrieving object counts without loading full entity data. These endpoints support the same filtering options as their paginated counterparts but execute lightweight COUNT queries for significantly better performance.

## Key Changes

### API Endpoints
- **MetaverseController**: Added `GetObjectsCountAsync` endpoint (`GET /api/v1/metaverse/objects/count`) with support for filtering by object type, search query, and attribute values
- **SynchronisationController**: Added two new count endpoints:
  - `GetConnectorSpaceCountAsync` (`GET /api/v1/synchronisation/connected-systems/{id}/connector-space/count`) with optional object type and partition filtering
  - `GetPendingExportsCountAsync` (`GET /api/v1/synchronisation/connected-systems/{id}/pending-exports/count`) with optional change type and status filtering

### Repository Methods
- **MetaverseRepository**: Implemented `GetMetaverseObjectsCountAsync` with support for type, search, and attribute filtering
- **ConnectedSystemRepository**: Implemented two new methods:
  - `GetConnectedSystemObjectCountAsync` (overload) with object type and partition filtering
  - `GetPendingExportsFilteredCountAsync` with change type and status filtering

### Repository Interfaces
- Updated `IMetaverseRepository` and `IConnectedSystemRepository` with new method signatures and comprehensive XML documentation

### PowerShell Cmdlets
- **Get-JIMMetaverseObject**: Added `-Count` parameter set with support for object type, search, and attribute filtering
- **Get-JIMConnectedSystemObject**: Added `-Count` parameter set with support for object type and partition filtering
- **Get-JIMPendingExport**: Added `-Count` parameter set with support for change type and status filtering
- All cmdlets include new examples demonstrating count functionality

### Testing
- Added comprehensive unit tests for all new count endpoints in `CsoDetailAndPaginationTests.cs` and `MetaverseControllerObjectsTests.cs`
- Tests verify correct parameter passing, filtering behavior, and response types

## Implementation Details
- Count queries are optimized to avoid loading entity data, using only `CountAsync()` operations
- All endpoints support the same filter combinations as their paginated counterparts for consistency
- PowerShell cmdlets include validation to ensure attribute filters are used together (AttributeName requires AttributeValue)
- Comprehensive logging added to all new API endpoints for debugging and monitoring

https://claude.ai/code/session_01UCFzB8kWrvwDz2SRN1Kmbp