### PR TITLE
fix: update basic-ftp to 5.2.2 (Dependabot alert #4)

### DIFF
--- a/engineering/diagrams/structurizr/package-lock.json
+++ b/engineering/diagrams/structurizr/package-lock.json
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- ⬆️ Updates `basic-ftp` from 5.2.1 to 5.2.2 to resolve high-severity CRLF injection vulnerability
- Transitive dependency of puppeteer in `engineering/diagrams/structurizr/`
- `npm audit` reports 0 vulnerabilities after update

## Test plan
- [x] `npm ls basic-ftp` confirms 5.2.2
- [x] `npm audit` reports 0 vulnerabilities
- [x] No .NET code affected; build/test not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)