### PR TITLE
Standardise UI: outlined alerts, table density, styling improvements

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -87,6 +87,14 @@ Repository and server methods that load a single entity follow a weight-based ta
 - Use `<NavigableMudTabs>` instead of `<MudTabs>` for all top-level page tabs; it syncs the active tab with a `?t=slug` query string, enabling browser back/forward navigation
 - Use plain `<MudTabs>` only for tabs inside dialogs or nested sub-tabs where URL navigation is not needed
 
+**Alerts:**
+- ALWAYS use `Variant="Variant.Outlined"` on all `<MudAlert>` components
+- This ensures a consistent outlined style across the entire UI
+
+**Panel Spacing:**
+- Use `Class="pa-4 mt-6"` on `<MudPaper Outlined="true">` panels to ensure consistent vertical spacing between sections
+- Exception: the **first** panel on a page should omit `mt-6` (use just `Class="pa-4"`) so there is no unnecessary top margin
+
 **Tooltips:**
 - ALWAYS use `Arrow="true" Placement="Placement.Top"` on all `<MudTooltip>` components
 - This ensures tooltips appear above the element with a downward-pointing arrow, consistent across the entire UI

--- a/src/JIM.Application/Resources/Companies.en.txt
+++ b/src/JIM.Application/Resources/Companies.en.txt
@@ -1,25 +1,25 @@
-CHOAM
-Acme Corp
-Sirius Cybernetics Corp
-MomCorp
-Rich Industries
-Soylent Corp
-Very Big Corp. of America
-Frobozz Magic Co
-Warbucks Industries
-Tyrell Corp
-Wayne Enterprises
-Virtucon
-Globex
-Umbrella Corp
-Wonka Industries
-Stark Industries
-Clampett Oil
-Oceanic Airlines
-Yoyodyne Propulsion Sys
-Cyberdyne Systems Corp
-d'Anconia Copper
-Gringotts
-Oscorp
-Nakatomi Trading Corp
-Spacely Space Sprockets
+Panoply
+Nexus Dynamics
+Akinya
+Rockhopper
+Stellar Logistics
+Vertex Solutions
+Helios Systems
+Meridian Corp
+Caldera Group
+Outrider Industries
+Parallax Labs
+Gravitas Engineering
+Orbital Reach
+Solace Networks
+Kinetic Foundry
+Tenebris Analytics
+Vanguard Collective
+Aphelion Works
+Codex Ventures
+Helix Syndicate
+Dawnforge Technologies
+Frontier Assembly
+Cascade Dynamics
+Ironclad Systems
+Zenith Integrated

--- a/src/JIM.Application/Servers/SeedingServer.cs
+++ b/src/JIM.Application/Servers/SeedingServer.cs
@@ -1233,7 +1233,7 @@ internal class SeedingServer
             {
                 MetaverseAttribute = metaverseAttributes.Single(q => q.Name == Constants.BuiltInAttributes.Email),
                 PopulatedValuesPercentage = 100,
-                Pattern = "{First Name}.{Last Name}[UniqueInt]@demo.tetron.io"
+                Pattern = "{First Name}.{Last Name}[UniqueInt]@panoply.io"
             });
         }
 
@@ -1451,7 +1451,7 @@ internal class SeedingServer
                     StringValue = "Distribution"
                 },
                 PopulatedValuesPercentage = 100,
-                Pattern = "distro-[UniqueInt]@demo.tetron.io"
+                Pattern = "distro-[UniqueInt]@panoply.io"
             });
         }
 

--- a/src/JIM.Application/Servers/SeedingServer.cs
+++ b/src/JIM.Application/Servers/SeedingServer.cs
@@ -1233,7 +1233,7 @@ internal class SeedingServer
             {
                 MetaverseAttribute = metaverseAttributes.Single(q => q.Name == Constants.BuiltInAttributes.Email),
                 PopulatedValuesPercentage = 100,
-                Pattern = "{First Name}.{Last Name}[UniqueInt]@panoply.io"
+                Pattern = "{First Name}.{Last Name}[UniqueInt]@panoply.local"
             });
         }
 
@@ -1451,7 +1451,7 @@ internal class SeedingServer
                     StringValue = "Distribution"
                 },
                 PopulatedValuesPercentage = 100,
-                Pattern = "distro-[UniqueInt]@panoply.io"
+                Pattern = "distro-[UniqueInt]@panoply.local"
             });
         }
 

--- a/src/JIM.Web/Pages/ActivityDetail.razor
+++ b/src/JIM.Web/Pages/ActivityDetail.razor
@@ -23,8 +23,8 @@
 
 @if (_activity != null)
 {
-    <MudText Typo="Typo.h5" Class="mt-5">Summary</MudText>
     <MudPaper Class="pa-4" Outlined="true">
+        <MudText Typo="Typo.h5" Class="mb-4">Summary</MudText>
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
                 <MudText Typo="Typo.button" Class="mud-text-secondary">ID:</MudText>

--- a/src/JIM.Web/Pages/ActivityDetail.razor
+++ b/src/JIM.Web/Pages/ActivityDetail.razor
@@ -24,7 +24,7 @@
 @if (_activity != null)
 {
     <MudText Typo="Typo.h5" Class="mt-5">Summary</MudText>
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
                 <MudText Typo="Typo.button" Class="mud-text-secondary">ID:</MudText>
@@ -159,7 +159,7 @@
             : 0;
         var isIndeterminate = _activity.ObjectsToProcess == 0;
 
-        <MudPaper Class="pa-4 mt-4" Outlined="true">
+        <MudPaper Class="pa-4 mt-6" Outlined="true">
             <MudStack Spacing="2">
                 @if (!string.IsNullOrEmpty(_activity.Message))
                 {

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -365,7 +365,7 @@
                             }
                             else
                             {
-                                <MudAlert Severity="Severity.Warning" Variant="Variant.Text" Dense="true" Class="mt-2">
+                                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true" Class="mt-2">
                                     The Connected System Object has been deleted.
                                 </MudAlert>
                             }
@@ -485,7 +485,7 @@
                             }
                             else
                             {
-                                <MudAlert Severity="Severity.Warning" Variant="Variant.Text" Dense="true" Class="mt-2">
+                                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true" Class="mt-2">
                                     The Metaverse Object has been deleted.
                                 </MudAlert>
                             }

--- a/src/JIM.Web/Pages/Admin/ApiKeyDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyDetail.razor
@@ -27,7 +27,7 @@
 @if (_apiKey != null && _preferencesLoaded)
 {
     <MudText Typo="Typo.h5" Class="mt-3">Details</MudText>
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
                 <MudText Typo="Typo.button" Class="mud-text-secondary">ID:</MudText>

--- a/src/JIM.Web/Pages/Admin/ApiKeyList.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyList.razor
@@ -3,8 +3,10 @@
 @using JIM.Models.Security
 @using JIM.Web
 @using JIM.Web.Middleware.Api
+@using JIM.Web.Services
 @using Humanizer
 @inject IJimApplicationFactory JimFactory
+@inject IUserPreferenceService PreferenceService
 @inject NavigationManager NavManager
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
@@ -21,9 +23,14 @@
     integration testing, and automation scripts.
 </MudText>
 
-<MudTable Items="@_apiKeys" Hover="true" Breakpoint="Breakpoint.Sm" Class="mt-5 mb-5" SortLabel="Sort By"
+<MudTable Items="@_apiKeys" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
     Filter="new Func<ApiKey, bool>(FilterFunc)" Outlined="true" Elevation="0" Loading="@_loading">
     <ToolBarContent>
+        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+        </MudTooltip>
+        <MudText Class="mx-2 mud-text-disabled">|</MudText>
         <MudButton OnClick="ShowCreateDialog" StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled" Color="Color.Primary"
             DropShadow="false">Create API Key</MudButton>
         <MudSpacer />
@@ -74,10 +81,6 @@
                     </MudTooltip>
                 }
             </div>
-            @if (!string.IsNullOrEmpty(context.Description))
-            {
-                <span class="mud-text-secondary">@context.Description</span>
-            }
         </MudTd>
         <MudTd DataLabel="Key Prefix">
             <span class="jim-text-code">@context.KeyPrefix...</span>
@@ -278,6 +281,7 @@
     private List<Role> _availableRoles = new();
     private string _searchString = "";
     private bool _loading = true;
+    private bool _dense;
 
     private readonly List<BreadcrumbItem> _breadcrumbs = new()
     {
@@ -310,6 +314,15 @@
     private bool _editEnabled;
     private bool _saving;
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dense = await PreferenceService.GetTableDenseAsync() == true;
+            StateHasChanged();
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadDataAsync();
@@ -322,6 +335,12 @@
         _apiKeys = await jim.Repository.ApiKeys.GetAllAsync();
         _availableRoles = await jim.Security.GetRolesAsync();
         _loading = false;
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private bool FilterFunc(ApiKey element)

--- a/src/JIM.Web/Pages/Admin/ApiKeyList.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyList.razor
@@ -210,7 +210,7 @@
         </MudText>
     </TitleContent>
     <DialogContent>
-        <MudAlert Severity="Severity.Warning" Class="mb-4">
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mb-4">
             Copy this API key now. You won't be able to see it again!
         </MudAlert>
         <MudTextField T="string" Value="@_createdFullKey" Label="API Key" ReadOnly="true" Variant="Variant.Outlined"

--- a/src/JIM.Web/Pages/Admin/CertificateList.razor
+++ b/src/JIM.Web/Pages/Admin/CertificateList.razor
@@ -3,7 +3,9 @@
 @using JIM.Models.Core
 @using JIM.Models.Core.DTOs
 @using JIM.Web
+@using JIM.Web.Services
 @inject IJimApplicationFactory JimFactory
+@inject IUserPreferenceService PreferenceService
 @inject NavigationManager NavManager
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
@@ -19,9 +21,14 @@
     Certificates can be uploaded directly or referenced from the connector-files mount.
 </MudText>
 
-<MudTable Items="@_certificates" Hover="true" Breakpoint="Breakpoint.Sm" Class="mt-5 mb-5" SortLabel="Sort By"
+<MudTable Items="@_certificates" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
     Filter="new Func<TrustedCertificate, bool>(FilterFunc)" Outlined="true" Elevation="0" Loading="@_loading">
     <ToolBarContent>
+        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+        </MudTooltip>
+        <MudText Class="mx-2 mud-text-disabled">|</MudText>
         <MudButtonGroup Variant="Variant.Filled" Color="Color.Primary">
             <MudButton OnClick="ShowUploadDialog" StartIcon="@Icons.Material.Filled.Upload" DropShadow="false">Upload Certificate</MudButton>
             <MudButton OnClick="ShowFilePathDialog" StartIcon="@Icons.Material.Filled.Folder" DropShadow="false">Reference File Path</MudButton>
@@ -292,6 +299,7 @@
     private List<TrustedCertificate>? _certificates;
     private string _searchString = "";
     private bool _loading = true;
+    private bool _dense;
 
     private readonly List<BreadcrumbItem> _breadcrumbs = new()
 {
@@ -328,6 +336,15 @@ new("Certificates", href: null, disabled: true)
     private bool _editEnabled;
     private bool _saving;
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dense = await PreferenceService.GetTableDenseAsync() == true;
+            StateHasChanged();
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadCertificatesAsync();
@@ -339,6 +356,12 @@ new("Certificates", href: null, disabled: true)
         _loading = true;
         _certificates = await jim.Certificates.GetAllAsync();
         _loading = false;
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private bool FilterFunc(TrustedCertificate element)

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDangerZoneTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDangerZoneTab.razor
@@ -54,7 +54,7 @@
     <DialogContent>
         @if (_deletionPreview != null)
         {
-            <MudAlert Severity="Severity.Error" Class="mb-4">
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">
                 This action is <strong>permanent</strong> and cannot be undone!
             </MudAlert>
 
@@ -94,7 +94,7 @@
 
             @if (_deletionPreview.JoinedMvoCount > 0)
             {
-                <MudAlert Severity="Severity.Info" Class="mt-4">
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
                     @_deletionPreview.JoinedMvoCount.ToString("N0") Metaverse Object(s) will be disconnected from this system.
                 </MudAlert>
             }
@@ -112,7 +112,7 @@
 
             @if (_deletionPreview.WillRunAsBackgroundJob)
             {
-                <MudAlert Severity="Severity.Info" Class="mt-4">
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
                     Due to the size of this system, deletion will run as a background job.
                     Estimated time: @_deletionPreview.EstimatedDeletionTime.ToString(@"hh\:mm\:ss")
                 </MudAlert>

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemObjectMatchingTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemObjectMatchingTab.razor
@@ -97,7 +97,7 @@ else
             <MudText>
                 Switching to <strong>Advanced Mode</strong> will allow you to configure different matching rules for each sync rule.
             </MudText>
-            <MudAlert Severity="Severity.Info" Class="mt-4">
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
                 The current matching rules will be copied to all existing import sync rules for this Connected System, giving you a starting point to customise.
             </MudAlert>
         }
@@ -106,7 +106,7 @@ else
             <MudText>
                 Switching to <strong>Simple Mode</strong> will configure matching rules here, shared across all sync rules.
             </MudText>
-            <MudAlert Severity="Severity.Warning" Class="mt-4">
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-4">
                 <strong>Migration:</strong> Matching rules from sync rules will be analysed and migrated to the object type level:
                 <ul class="mt-2 mb-0">
                     <li>If all sync rules have the same matching rules, they will be used directly.</li>

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSchemaTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSchemaTab.razor
@@ -158,13 +158,13 @@
     <DialogContent>
         @if (!_objectTypeAttributeBeingEditedIsEditable)
         {
-            <MudAlert Severity="Severity.Error">
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">
                 This Connected System attribute cannot be edited as it is being referenced by either a synchronisation rule, or has values already populated.
             </MudAlert>
         }
         else
         {
-            <MudAlert Severity="Severity.Info">
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
                 This Connector supports changing the data type of a Connected System attribute. This might be because the data type
                 was detected automatically, and might need adjusting if not right.
             </MudAlert>

--- a/src/JIM.Web/Pages/Admin/Components/OperationsQueueTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsQueueTab.razor
@@ -48,7 +48,7 @@
 }
 else
 {
-    <MudAlert Class="mt-5" Severity="Severity.Warning">Please create a <MudLink Href="/admin/connected-systems/">Connected System</MudLink> first.</MudAlert>
+    <MudAlert Class="mt-5" Severity="Severity.Warning" Variant="Variant.Outlined">Please create a <MudLink Href="/admin/connected-systems/">Connected System</MudLink> first.</MudAlert>
 }
 
 @if (_workerTaskHeaders.Count == 0)

--- a/src/JIM.Web/Pages/Admin/Components/ScheduleEditorDialog.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ScheduleEditorDialog.razor
@@ -111,7 +111,7 @@
                                             </MudStack>
                                             @if (_runTimes.Count == 0)
                                             {
-                                                <MudAlert Severity="Severity.Warning" Dense="true">
+                                                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true">
                                                     Add at least one run time
                                                 </MudAlert>
                                             }
@@ -157,7 +157,7 @@
                                                       HelperText="Format: minute hour day-of-month month day-of-week (e.g., 0 9,12,15,18 * * 1-5)" />
                                     }
 
-                                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
+                                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true" Class="mt-2">
                                         <MudText Typo="Typo.body2">@GetSchedulePreview()</MudText>
                                     </MudAlert>
 
@@ -255,7 +255,7 @@
 
                             @if (_schedule.Steps.Count == 0)
                             {
-                                <MudAlert Severity="Severity.Info">
+                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
                                     No steps have been added yet. Click "Add Step" to create the first step.
                                 </MudAlert>
                             }

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemCreate.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemCreate.razor
@@ -16,7 +16,7 @@
     Provide some basic details here, and then we'll move on to configuring the Connected System.
 </MudText>
 
-<MudPaper Class="pa-4 mt-5" Outlined="true">
+<MudPaper Class="pa-4" Outlined="true">
     <MudForm @bind-IsValid="@_isFormValid" @bind-Errors="@_formErrors">
         <MudSelect T="string" Label="Connector" Placeholder="Please select a connector..." Required="true"
                    @bind-Value="_model.ConnectorId" AdornmentIcon="@Icons.Material.Filled.Power" Adornment="Adornment.Start"

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
@@ -27,7 +27,7 @@
 
 @if (ConnectedSystemHeader != null && ConnectedSystemObject != null)
 {
-    <MudPaper Class="pa-4 mt-4 mb-4" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         @* First row: Type, Status, Created, Updated, MVO Link *@
         <MudStack Row="true" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="3">
             @* Object Type *@
@@ -94,7 +94,7 @@
 
     @if (PendingExport != null && _pendingExportTotalCount > 0)
     {
-        <MudPaper Class="pa-5 mt-5 mb-5" Outlined="true">
+        <MudPaper Class="pa-4 mt-6" Outlined="true">
             <MudText Typo="Typo.h6">Pending Exports</MudText>
             <MudText Typo="Typo.subtitle1" Class="my-3">
                 The following attribute changes are pending for this connected system. These may be awaiting export, or have

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectList.razor
@@ -22,7 +22,7 @@
 <MudBreadcrumbs Items="_breadcrumbs" Class="ps-0"></MudBreadcrumbs>
 @if (_showIntro)
 {
-    <MudAlert Severity="Severity.Normal" Class="mt-3 mb-3" ShowCloseIcon="true" CloseIconClicked="() => _showIntro = false">
+    <MudAlert Severity="Severity.Normal" Variant="Variant.Outlined" Class="mt-3 mb-3" ShowCloseIcon="true" CloseIconClicked="() => _showIntro = false">
         This is the connector space for this Connected System. Inbound changes from the system are held here before being committed to the Metaverse. Outbound changes are held here ahead of synchronisation to the connected system.
     </MudAlert>
 }
@@ -267,7 +267,7 @@
             </MudText>
         </TitleContent>
         <DialogContent>
-            <MudAlert Severity="Severity.Warning" Class="mb-4">
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mb-4">
                 This action will delete all Connected System Objects from JIM.
             </MudAlert>
 

--- a/src/JIM.Web/Pages/Admin/ConnectorDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectorDetail.razor
@@ -21,7 +21,7 @@
 @if (_connector != null)
 {
     <MudText Typo="Typo.h5" Class="mt-3">Details</MudText>
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
                 <MudField Label="Description" Variant="Variant.Outlined">@_connector.Description</MudField>
@@ -36,7 +36,7 @@
     </MudPaper>
 
     <MudText Typo="Typo.h5" Class="mt-5">Capabilities</MudText>
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4 mt-6" Outlined="true">
         <MudText Typo="Typo.subtitle2" Class="mt-2">Import</MudText>
         <MudCheckBox @bind-Value="@_connector.SupportsFullImport" Disabled="true">Supports full import?</MudCheckBox>
         <MudCheckBox @bind-Value="@_connector.SupportsDeltaImport" Disabled="true">Supports delta import?</MudCheckBox>

--- a/src/JIM.Web/Pages/Admin/ConnectorDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectorDetail.razor
@@ -20,8 +20,8 @@
 
 @if (_connector != null)
 {
-    <MudText Typo="Typo.h5" Class="mt-3">Details</MudText>
     <MudPaper Class="pa-4" Outlined="true">
+        <MudText Typo="Typo.h5" Class="mb-4">Details</MudText>
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
                 <MudField Label="Description" Variant="Variant.Outlined">@_connector.Description</MudField>
@@ -35,27 +35,34 @@
         </MudGrid>
     </MudPaper>
 
-    <MudText Typo="Typo.h5" Class="mt-5">Capabilities</MudText>
     <MudPaper Class="pa-4 mt-6" Outlined="true">
-        <MudText Typo="Typo.subtitle2" Class="mt-2">Import</MudText>
-        <MudCheckBox @bind-Value="@_connector.SupportsFullImport" Disabled="true">Supports full import?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsDeltaImport" Disabled="true">Supports delta import?</MudCheckBox>
-
-        <MudText Typo="Typo.subtitle2" Class="mt-2">Export</MudText>
-        <MudCheckBox @bind-Value="@_connector.SupportsExport" Disabled="true">Supports export?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsAutoConfirmExport" Disabled="true">Supports auto-confirm export?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsParallelExport" Disabled="true">Supports parallel export?</MudCheckBox>
-
-        <MudText Typo="Typo.subtitle2" Class="mt-2">Hierarchy</MudText>
-        <MudCheckBox @bind-Value="@_connector.SupportsPartitions" Disabled="true">Supports partitions?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsPartitionContainers" Disabled="true">Supports partition containers?</MudCheckBox>
-
-        <MudText Typo="Typo.subtitle2" Class="mt-2">Data Handling</MudText>
-        <MudCheckBox @bind-Value="@_connector.SupportsFilePaths" Disabled="true">Supports file paths?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsPaging" Disabled="true">Supports paging?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsSecondaryExternalId" Disabled="true">Supports secondary external id?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsUserSelectedExternalId" Disabled="true">Supports user selected external id?</MudCheckBox>
-        <MudCheckBox @bind-Value="@_connector.SupportsUserSelectedAttributeTypes" Disabled="true">Supports user selected attribute types?</MudCheckBox>
+        <MudText Typo="Typo.h5" Class="mb-4">Capabilities</MudText>
+        <MudGrid Spacing="4">
+            <MudItem xs="12" sm="6" md="3">
+                <MudText Typo="Typo.subtitle2">Import</MudText>
+                <MudCheckBox @bind-Value="@_connector.SupportsFullImport" Disabled="true">Full import</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsDeltaImport" Disabled="true">Delta import</MudCheckBox>
+            </MudItem>
+            <MudItem xs="12" sm="6" md="3">
+                <MudText Typo="Typo.subtitle2">Export</MudText>
+                <MudCheckBox @bind-Value="@_connector.SupportsExport" Disabled="true">Export</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsAutoConfirmExport" Disabled="true">Auto-confirm export</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsParallelExport" Disabled="true">Parallel export</MudCheckBox>
+            </MudItem>
+            <MudItem xs="12" sm="6" md="3">
+                <MudText Typo="Typo.subtitle2">Hierarchy</MudText>
+                <MudCheckBox @bind-Value="@_connector.SupportsPartitions" Disabled="true">Partitions</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsPartitionContainers" Disabled="true">Partition containers</MudCheckBox>
+            </MudItem>
+            <MudItem xs="12" sm="6" md="3">
+                <MudText Typo="Typo.subtitle2">Data Handling</MudText>
+                <MudCheckBox @bind-Value="@_connector.SupportsFilePaths" Disabled="true">File paths</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsPaging" Disabled="true">Paging</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsSecondaryExternalId" Disabled="true">Secondary external ID</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsUserSelectedExternalId" Disabled="true">User selected external ID</MudCheckBox>
+                <MudCheckBox @bind-Value="@_connector.SupportsUserSelectedAttributeTypes" Disabled="true">User selected attribute types</MudCheckBox>
+            </MudItem>
+        </MudGrid>
     </MudPaper>
 
     <MudTable Items="@_connector.Files" Hover="true" Breakpoint="Breakpoint.Sm" Class="mt-5 mb-5" SortLabel="Sort By" Outlined="true" Elevation="0">

--- a/src/JIM.Web/Pages/Admin/ConnectorList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectorList.razor
@@ -33,7 +33,7 @@
         <MudTh><MudTableSortLabel SortBy="new Func<ConnectorDefinitionHeader, object>(x => x.Versions ?? string.Empty)"><MudText Typo="Typo.button">Version(s)</MudText></MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd DataLabel="Name"><MudLink Href="@("/admin/connected-systems/connectors/"+context.Id)">@context.Name</MudLink></MudTd>
+        <MudTd DataLabel="Name" Class="jim-nowrap"><MudLink Href="@("/admin/connected-systems/connectors/"+context.Id)">@context.Name</MudLink></MudTd>
         <MudTd DataLabel="Description">@context.Description</MudTd>
         <MudTd DataLabel="Built-in?">@(context.BuiltIn ? "Yes" : "No")</MudTd>
         <MudTd DataLabel="In-use?">@(context.InUse ? "Yes" : "No")</MudTd>

--- a/src/JIM.Web/Pages/Admin/ExampleDataSetDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ExampleDataSetDetail.razor
@@ -14,7 +14,7 @@
 @if (_exampleDataSet != null)
 {
     <MudText Typo="Typo.h5" Class="mt-5">Details</MudText>
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
                 <MudField Label="Created" Variant="Variant.Outlined">@_exampleDataSet.Created</MudField>
@@ -32,7 +32,7 @@
     </MudPaper>
 
     <MudText Typo="Typo.h5" Class="mt-5">Values</MudText>
-    <MudPaper Class="pa-4 mt-3 mb-5" Outlined="true">
+    <MudPaper Class="pa-4 mt-6 mb-5" Outlined="true">
         @foreach (var val in _exampleDataSet.Values)
         {
             <MudChip T="string" Variant="Variant.Filled" Color="Color.Default">@val.StringValue</MudChip>

--- a/src/JIM.Web/Pages/Admin/Logs.razor
+++ b/src/JIM.Web/Pages/Admin/Logs.razor
@@ -21,7 +21,7 @@
     View and search logs from all JIM services. Logs are stored for 31 days.
 </MudText>
 
-<MudPaper Elevation="0" Class="mt-5 pa-4" Outlined="true">
+<MudPaper Elevation="0" Class="pa-4" Outlined="true">
     <MudGrid>
         <MudItem xs="12" sm="6" md="3">
             <MudSelect T="string" @bind-Value="_selectedService" Label="Service" Variant="Variant.Outlined"

--- a/src/JIM.Web/Pages/Admin/MetaverseObjectTypeDetail.razor
+++ b/src/JIM.Web/Pages/Admin/MetaverseObjectTypeDetail.razor
@@ -93,7 +93,7 @@
                 }
                 else
                 {
-                    <MudAlert Severity="Severity.Warning" Variant="Variant.Text" Dense="true">
+                    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true">
                         No contributing systems found. Create inbound sync rules for this object type to enable authoritative source selection.
                     </MudAlert>
                 }

--- a/src/JIM.Web/Pages/Admin/MetaverseObjectTypeDetail.razor
+++ b/src/JIM.Web/Pages/Admin/MetaverseObjectTypeDetail.razor
@@ -24,7 +24,7 @@
 
 @if (_metaverseObjectType != null)
 {
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         <MudText Typo="Typo.h5" Class="mb-4">Details</MudText>
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
@@ -47,7 +47,7 @@
         </MudGrid>
     </MudPaper>
 
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4 mt-6" Outlined="true">
         <MudText Typo="Typo.h5" Class="mb-2">Deletion Rules</MudText>
         <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-4">Configure when metaverse objects of this type should be automatically deleted.</MudText>
         <MudGrid>
@@ -109,11 +109,12 @@
         </MudStack>
     </MudPaper>
 
-    <MudText Typo="Typo.h5" Class="mt-5">Attributes</MudText>
-    <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mt-2">These are the attributes bound to the metaverse object type:</MudText>
+    <MudPaper Class="pa-4 mt-6" Outlined="true">
+        <MudText Typo="Typo.h5" Class="mb-2">Attributes</MudText>
+        <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-4">These are the attributes bound to the metaverse object type:</MudText>
 
     @* Filter Chips Section *@
-    <MudStack Row="true" Spacing="6" Class="mt-3 mb-3 flex-wrap" AlignItems="AlignItems.Start">
+    <MudStack Row="true" Spacing="6" Class="mb-3 flex-wrap" AlignItems="AlignItems.Start">
         @* Type Filter *@
         <div>
             <MudText Typo="Typo.body2" Class="mud-text-secondary mb-2">Filter by Type:</MudText>
@@ -221,6 +222,7 @@
             <MudTablePager />
         </PagerContent>
     </MudTable>
+    </MudPaper>
 }
 
 @code {

--- a/src/JIM.Web/Pages/Admin/PendingExportList.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportList.razor
@@ -23,7 +23,7 @@
 
 @if (_connectedSystemHeader != null && _preferencesLoaded)
 {
-    <MudPaper Elevation="0" Class="mt-3 pa-4" Outlined="true">
+    <MudPaper Elevation="0" Class="pa-4" Outlined="true">
         <MudSelect T="PendingExportStatus" Label="Filter by Status" MultiSelection="true"
                    SelectedValues="_statusFilters" SelectedValuesChanged="OnStatusFiltersChanged"
                    MultiSelectionTextFunc="@GetStatusFilterText"

--- a/src/JIM.Web/Pages/Admin/PredefinedSearchDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PredefinedSearchDetail.razor
@@ -19,7 +19,7 @@
 
 @if (_predefinedSearch != null)
 {
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4" Outlined="true">
         <MudText Typo="Typo.h5" Class="mb-3">Details</MudText>
         <MudGrid Spacing="4">
             <MudItem xs="12" sm="6" md="4">
@@ -40,7 +40,7 @@
         </MudGrid>
     </MudPaper>
 
-    <MudPaper Class="pa-4 mt-3" Outlined="true">
+    <MudPaper Class="pa-4 mt-6" Outlined="true">
         <MudText Typo="Typo.h5">Metaverse Attributes</MudText>
         <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-3">These will be the attributes shown in the search results:</MudText>
         <div>
@@ -53,7 +53,7 @@
 
     @if (_predefinedSearch.CriteriaGroups.Count > 0)
     {
-        <MudPaper Class="pa-4 mt-3" Outlined="true">
+        <MudPaper Class="pa-4 mt-6" Outlined="true">
             <MudText Typo="Typo.h5">Criteria</MudText>
             <MudText Typo="Typo.subtitle1" Class="mud-text-secondary mb-3">This search has criteria to filter the results:</MudText>
             <MudStack>

--- a/src/JIM.Web/Pages/Admin/PredefinedSearchList.razor
+++ b/src/JIM.Web/Pages/Admin/PredefinedSearchList.razor
@@ -1,8 +1,10 @@
 @page "/admin/predefined-searches"
 @attribute [Authorize(Roles = "Administrator")]
 @using JIM.Models.Search.DTOs
+@using JIM.Web.Services
 @inject IJimApplicationFactory JimFactory
 @inject NavigationManager NavManager
+@inject IUserPreferenceService PreferenceService
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -15,8 +17,9 @@
 <MudTable Items="@_predefinedSearchHeaders"
           T="PredefinedSearchHeader"
           Hover="true"
+          Dense="@_dense"
           Breakpoint="Breakpoint.Sm"
-          Class="mt-5"
+          Class="@(_dense ? "mt-5 dense-body-only" : "mt-5")"
           Outlined="true"
           Elevation="0"
           Filter="new Func<PredefinedSearchHeader, bool>(FilterFunc)"
@@ -25,6 +28,10 @@
           Loading="@_loading"
           LoadingProgressColor="Color.Primary">
     <ToolBarContent>
+        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+        </MudTooltip>
         <MudSpacer />
         <MudTextField @bind-Value="_searchString"
                       Variant="Variant.Outlined"
@@ -97,11 +104,21 @@
     private IList<PredefinedSearchHeader>? _predefinedSearchHeaders;
     private string _searchString = "";
     private bool _loading = true;
+    private bool _dense;
     private readonly List<BreadcrumbItem> _breadcrumbs = new List<BreadcrumbItem>
     {
         new("Home", href: "/", icon: Icons.Material.Filled.Home),
         new("Predefined Searches", href: null, disabled: true)
     };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dense = await PreferenceService.GetTableDenseAsync() == true;
+            StateHasChanged();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -122,6 +139,12 @@
             return true;
 
         return false;
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private void HandleRowClick(TableRowClickEventArgs<PredefinedSearchHeader> args)

--- a/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
@@ -201,7 +201,7 @@ else if (_syncRule != null)
                             <MudSwitch @bind-Value="@_syncRule.EnforceState" Color="Color.Primary"
                                        Label="Enforce State (Auto-correct drift)" />
                         </MudTooltip>
-                        <MudAlert Severity="Severity.Normal" Variant="Variant.Text" Dense="true">
+                        <MudAlert Severity="Severity.Normal" Variant="Variant.Outlined" Dense="true">
                             <strong>Enforce State</strong> enables drift detection and automatic correction. When a target system
                             attribute differs from what this export rule dictates, JIM will create a corrective pending export
                             to restore the authoritative value. Disable this option only for scenarios where you need to allow

--- a/src/JIM.Web/Pages/Admin/SyncRuleDetailScopingCriteriaGroup.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleDetailScopingCriteriaGroup.razor
@@ -33,7 +33,7 @@
 
     @if (SyncRuleScopingCriteriaGroup.ChildGroups.Count == 0 && SyncRuleScopingCriteriaGroup.Criteria.Count == 0)
     {
-        <MudAlert Severity="Severity.Info" Class="mt-5">Add your first criteria...</MudAlert>
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-5">Add your first criteria...</MudAlert>
     }
 
     @foreach (var criteria in SyncRuleScopingCriteriaGroup.Criteria)
@@ -187,10 +187,10 @@
                     <MudCheckBox @bind-Value="_newSyncRuleScopingCriteria.BoolValue" TriState="true" Class="mt-5" Label="Boolean Value">: @(!_newSyncRuleScopingCriteria.BoolValue.HasValue ? "Null" : _newSyncRuleScopingCriteria.BoolValue.ToString())</MudCheckBox>
                     break;
                 case AttributeDataType.Reference:
-                    <MudAlert Severity="Severity.Warning" Class="mt-5">Apologies, references are not yet supported here.</MudAlert>
+                    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-5">Apologies, references are not yet supported here.</MudAlert>
                     break;
                 case AttributeDataType.Binary:
-                    <MudAlert Severity="Severity.Warning" Class="mt-5">Apologies, binary types are not yet supported here.</MudAlert>
+                    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-5">Apologies, binary types are not yet supported here.</MudAlert>
                     break;
                 case AttributeDataType.NotSet:
                 default:

--- a/src/JIM.Web/Pages/Admin/SyncRuleList.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleList.razor
@@ -2,7 +2,9 @@
 @attribute [Authorize(Roles = "Administrator")]
 @using JIM.Models.Logic;
 @using JIM.Models.Logic.DTOs
+@using JIM.Web.Services
 @inject IJimApplicationFactory JimFactory
+@inject IUserPreferenceService PreferenceService
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -20,9 +22,14 @@
         System</MudLink> first.</MudAlert>
     }
 
-    <MudTable Items="@_syncRuleHeaders" Hover="true" Breakpoint="Breakpoint.Sm" Class="mt-5 mb-5" SortLabel="Sort By"
+    <MudTable Items="@_syncRuleHeaders" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
               Filter="new Func<SyncRuleHeader, bool>(FilterFunc1)" Outlined="true" Elevation="0">
         <ToolBarContent>
+            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+            </MudTooltip>
+            <MudText Class="mx-2 mud-text-disabled">|</MudText>
             <MudButton StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled" Href="/admin/sync-rules/new"
                        Color="Color.Primary" Disabled="@(!_canCreateSyncRules)" DropShadow="false">Create Synchronisation Rule
             </MudButton>
@@ -176,12 +183,22 @@
     private IList<SyncRuleHeader>? _syncRuleHeaders;
     private string _searchString = "";
     private bool _canCreateSyncRules;
+    private bool _dense;
 
     private readonly List<BreadcrumbItem> _breadcrumbs = new List<BreadcrumbItem>
     {
         new("Home", href: "/", icon: Icons.Material.Filled.Home),
         new("Synchronisation Rules", href: null, disabled: true)
     };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dense = await PreferenceService.GetTableDenseAsync() == true;
+            StateHasChanged();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -199,6 +216,12 @@
         if (element.Direction == SyncRuleDirection.Export && element.ProvisionToConnectedSystem == true)
             return "Provisions";
         return "";
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private static bool FilterFunc(SyncRuleHeader element, string searchString)

--- a/src/JIM.Web/Pages/Admin/ThemePreview.razor
+++ b/src/JIM.Web/Pages/Admin/ThemePreview.razor
@@ -452,6 +452,9 @@
                     <MudTd DataLabel="Type">@row.Type</MudTd>
                     <MudTd DataLabel="Value">@row.Value</MudTd>
                 </RowTemplate>
+                <PagerContent>
+                    <MudTablePager />
+                </PagerContent>
             </MudTable>
             <MudText Typo="Typo.subtitle2" Class="mt-4 mb-2">MudSimpleTable</MudText>
             <MudSimpleTable Outlined="true" Hover="true">

--- a/src/JIM.Web/Pages/Dev/ErrorPagePreview.razor
+++ b/src/JIM.Web/Pages/Dev/ErrorPagePreview.razor
@@ -8,7 +8,7 @@
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
 {
-    <MudAlert Severity="Severity.Error">This page is only available in the Development environment.</MudAlert>
+    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">This page is only available in the Development environment.</MudAlert>
 }
 else
 {

--- a/src/JIM.Web/Pages/Index.razor
+++ b/src/JIM.Web/Pages/Index.razor
@@ -230,7 +230,7 @@
         }
         else
         {
-            <MudPaper Class="pa-5 mt-3" Outlined="true">
+            <MudPaper Class="pa-4 mt-6" Outlined="true">
                 <MudStack AlignItems="AlignItems.Center">
                     <MudIcon Icon="@Icons.Material.Outlined.Schedule" Size="Size.Large" Class="mud-text-disabled" />
                     <MudText Typo="Typo.body1" Class="mud-text-secondary">No schedules have been created yet.</MudText>

--- a/src/JIM.Web/Pages/Types/View.razor
+++ b/src/JIM.Web/Pages/Types/View.razor
@@ -67,7 +67,7 @@
         </MudTabPanel>
 
         <MudTabPanel Text="Properties" Icon="@Icons.Material.Filled.Assignment">
-            <MudPaper Class="mt-3 pa-4" Outlined="true">
+            <MudPaper Class="pa-4" Outlined="true">
                 <MudGrid Spacing="4">
                     <MudItem xs="12" sm="6" md="4">
                         <MudText Typo="Typo.caption" Class="mud-text-secondary">Id</MudText>

--- a/src/JIM.Web/Shared/CsvErrorDialog.razor
+++ b/src/JIM.Web/Shared/CsvErrorDialog.razor
@@ -12,7 +12,7 @@
     </TitleContent>
     <DialogContent>
         <MudStack Spacing="3">
-            <MudAlert Severity="Severity.Error" Dense="true">
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Dense="true">
                 @ErrorMessage
             </MudAlert>
 
@@ -40,7 +40,7 @@
 
             @if (!string.IsNullOrEmpty(Suggestion))
             {
-                <MudAlert Severity="Severity.Info" Dense="true" Icon="@Icons.Material.Filled.Lightbulb">
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Dense="true" Icon="@Icons.Material.Filled.Lightbulb">
                     <strong>Suggestion:</strong> @Suggestion
                 </MudAlert>
             }

--- a/src/JIM.Web/Shared/FileBrowserDialog.razor
+++ b/src/JIM.Web/Shared/FileBrowserDialog.razor
@@ -16,7 +16,7 @@
         <MudStack Spacing="3">
             @if (!string.IsNullOrEmpty(_errorMessage))
             {
-                <MudAlert Severity="Severity.Error" Dense="true">@_errorMessage</MudAlert>
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Dense="true">@_errorMessage</MudAlert>
             }
 
             @* Current path breadcrumb *@

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -82,11 +82,6 @@ html[lang] a.mud-link.mud-primary-text:visited:hover {
     padding-top: 0;
 }
 
-/* Dense body rows with normal-height header: override the reduced padding Dense applies to thead cells */
-.dense-body-only.mud-table-dense .mud-table-head .mud-table-cell {
-    padding-top: 16px;
-    padding-bottom: 16px;
-}
 
 /* Strip all border-radius from MudTable when sandwiched between external pager bars */
 .mud-table.no-border-radius,

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -245,7 +245,7 @@ html[lang] .jim-expansion-panel .mud-table .mud-table-pagination .mud-table-pagi
     background-color: var(--jim-inner-surface, transparent);
 }
 
-html[lang] .jim-expansion-panel .mud-table .mud-table-toolbar .mud-input {
+html[lang] .jim-expansion-panel .mud-table .mud-table-toolbar {
     background-color: var(--mud-palette-surface, #ffffff);
 }
 
@@ -381,8 +381,8 @@ html[lang] .mud-paper .mud-table .mud-table-pagination .mud-table-pagination-too
     background-color: var(--jim-inner-surface, transparent) !important;
 }
 
-/* Search inputs in nested table toolbars use the paper surface for contrast. */
-html[lang] .mud-paper .mud-table .mud-table-toolbar .mud-input {
+/* Toolbar row in nested tables uses the paper surface, matching data rows. */
+html[lang] .mud-paper .mud-table .mud-table-toolbar {
     background-color: var(--mud-palette-surface, #ffffff);
 }
 

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -238,6 +238,17 @@ html[lang] .jim-expansion-panel .mud-table .mud-table-body .mud-table-cell {
     background-color: var(--mud-palette-surface, #ffffff);
 }
 
+html[lang] .jim-expansion-panel .mud-table .mud-table-foot,
+html[lang] .jim-expansion-panel .mud-table .mud-table-foot .mud-table-cell,
+html[lang] .jim-expansion-panel .mud-table .mud-table-pagination,
+html[lang] .jim-expansion-panel .mud-table .mud-table-pagination .mud-table-pagination-toolbar {
+    background-color: var(--jim-inner-surface, transparent);
+}
+
+html[lang] .jim-expansion-panel .mud-table .mud-table-toolbar .mud-input {
+    background-color: var(--mud-palette-surface, #ffffff);
+}
+
 html[lang] .jim-expansion-panel .mud-table-outlined,
 html[lang] .jim-expansion-panel .mud-simple-table-outlined {
     border-color: var(--jim-inner-border-color, var(--jim-paper-border-color, transparent)) !important;
@@ -358,6 +369,20 @@ html[lang] .mud-paper .mud-simple-table {
    the shaded header row (table-level background bleeds through transparent rows). */
 html[lang] .mud-paper .mud-simple-table tbody td,
 html[lang] .mud-paper .mud-table .mud-table-body .mud-table-cell {
+    background-color: var(--mud-palette-surface, #ffffff);
+}
+
+/* Footer / pagination row in nested tables matches the header background.
+   Uses !important to override MudBlazor's inherited surface colour. */
+html[lang] .mud-paper .mud-table .mud-table-foot,
+html[lang] .mud-paper .mud-table .mud-table-foot .mud-table-cell,
+html[lang] .mud-paper .mud-table .mud-table-pagination,
+html[lang] .mud-paper .mud-table .mud-table-pagination .mud-table-pagination-toolbar {
+    background-color: var(--jim-inner-surface, transparent) !important;
+}
+
+/* Search inputs in nested table toolbars use the paper surface for contrast. */
+html[lang] .mud-paper .mud-table .mud-table-toolbar .mud-input {
     background-color: var(--mud-palette-surface, #ffffff);
 }
 

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -21,11 +21,13 @@
     border-bottom: 1px solid var(--mud-palette-table-lines, var(--mud-palette-lines-default));
 }
 
+/* Header row stays compact regardless of dense/normal toggle */
 .mud-table-root .mud-table-head .mud-table-cell {
     font-weight: 500;
     font-size: 0.875rem;
     text-transform: uppercase;
     letter-spacing: 0.02857em;
+    padding: 6px 16px;
 }
 
 /* Content/data links use --jim-link-color (softer than UI primary).

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -1180,11 +1180,18 @@ function Reset-JIMForNextScenario {
     $keyFilePath = Join-Path $ScriptRoot ".api-key"
     $newApiKey | Out-File -FilePath $keyFilePath -NoNewline -Encoding UTF8
 
-    # 5. Restart JIM containers
+    # 5. Pre-create bind-mount directories so Docker doesn't create them as root
+    # (see docker-compose.override.yml worker log volume mount)
+    $workerLogMount = Join-Path $ScriptRoot "results" "logs" "worker"
+    if (-not (Test-Path $workerLogMount)) {
+        New-Item -ItemType Directory -Path $workerLogMount -Force | Out-Null
+    }
+
+    # 6. Restart JIM containers
     Write-Host "${GRAY}  Starting JIM containers...${NC}"
     docker compose -f docker-compose.yml -f docker-compose.override.yml --profile with-db up -d 2>&1 | Out-Null
 
-    # 6. Wait for JIM API health check
+    # 7. Wait for JIM API health check
     Write-Host "${GRAY}  Waiting for JIM API...${NC}"
     $jimApiReady = $false
     $jimApiElapsed = 0
@@ -1775,6 +1782,16 @@ Write-Success "Saved API key to .api-key"
 # Step 3: Start services
 $step3Start = Get-Date
 Write-Section "Step 3: Starting Services"
+
+# Pre-create bind-mount directories so Docker doesn't create them as root.
+# docker-compose.override.yml mounts ./test/integration/results/logs/worker:/var/log/jim
+# and the test runner later writes scenario logs into results/logs/. If Docker creates
+# these directories first they end up root-owned, which blocks Start-Transcript (runs as
+# the current user) on Linux hosts.
+$workerLogMount = Join-Path $scriptRoot "results" "logs" "worker"
+if (-not (Test-Path $workerLogMount)) {
+    New-Item -ItemType Directory -Path $workerLogMount -Force | Out-Null
+}
 
 Write-Step "Starting JIM stack..."
 $jimResult = docker compose -f docker-compose.yml -f docker-compose.override.yml --profile with-db up -d 2>&1


### PR DESCRIPTION
## Summary

- Standardise all `MudAlert` components to use `Variant.Outlined` for consistent styling across the UI
- Add row density toggle to sync rules, predefined searches, API keys, and certificates tables
- Improve nested table styling (toolbar background, footer, search input contrast)
- Standardise `MudPaper` panel spacing (`mt-6`) across admin pages
- Improve Connector detail page layout with panels and consistent spacing
- Update example data company names and email domains to use `panoply.local`
- Fix bind-mount directory pre-creation in integration test runner

## Test plan

- [x] Build passes with zero warnings
- [ ] Verify outlined alert styling on pages with alerts (sync rules, API keys, certificates, error pages)
- [ ] Verify density toggle works on sync rules, predefined searches, API keys, and certificates pages
- [ ] Verify density preference persists across page navigations
- [ ] Verify nested table styling on connected system and theme preview pages
- [ ] Verify connector detail page layout improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)