### PR TITLE
fix: replace default CodeQL setup with custom workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# CodeQL static analysis - scans for security vulnerabilities and code quality issues
+# Replaces GitHub's default CodeQL setup to produce a single predictable workflow run
+# with stable check names for the branch protection ruleset.
+#
+# Languages: actions (GitHub Actions workflows), csharp, javascript-typescript
+
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'actions', 'csharp', 'javascript-typescript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -526,9 +526,9 @@ The `main` branch is protected by the **"Protect Main"** repository ruleset, whi
 | `build-and-test` | CI workflow | .NET build, .NET tests, PowerShell Pester tests |
 | `discover-base-images` | CI workflow | Production Dockerfile digest-pinning policy |
 | `scan-base-images-summary` | CI workflow | All base image vulnerability scans passed (aggregates dynamic matrix legs) |
-| `Analyze (actions)` | CodeQL default setup | Static analysis of GitHub Actions workflows |
-| `Analyze (csharp)` | CodeQL default setup | Static analysis of C# code |
-| `Analyze (javascript-typescript)` | CodeQL default setup | Static analysis of JavaScript/TypeScript code |
+| `Analyze (actions)` | CodeQL workflow (`.github/workflows/codeql.yml`) | Static analysis of GitHub Actions workflows |
+| `Analyze (csharp)` | CodeQL workflow (`.github/workflows/codeql.yml`) | Static analysis of C# code |
+| `Analyze (javascript-typescript)` | CodeQL workflow (`.github/workflows/codeql.yml`) | Static analysis of JavaScript/TypeScript code |
 | `claude-review` | Claude Code Review workflow | Automated code review on every PR |
 
 **Why `scan-base-images-summary` exists:** the `scan-base-images` job uses a dynamic matrix whose leg names embed image digests (e.g. `scan-base-images (src/JIM.Web/Dockerfile, 10, mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:...)`). These names change with every base image update, making them unsuitable as required status checks. The summary job aggregates all matrix legs into a single stable check name.


### PR DESCRIPTION
## Summary

- Replace GitHub's default CodeQL setup with a custom `.github/workflows/codeql.yml` workflow
- Update `DEVELOPER_GUIDE.md` to reflect the source change for CodeQL checks

## Problem

GitHub's default CodeQL setup creates two check suites per commit: one with all three Analyze jobs (actions, csharp, javascript-typescript) and another with only csharp and javascript-typescript. When the branch protection ruleset requires `Analyze (actions)` to pass with `strict_required_status_checks_policy: true`, GitHub can match against the incomplete suite and permanently block merges.

## Solution

Replace the default setup with a custom workflow (`codeql.yml`) that produces a single workflow run with all three languages, eliminating the duplicate suite issue. This also aligns with UK Software Security Code of Practice Principle 5 (explicit control over the analysis pipeline).

## Post-merge steps

After this PR merges, the custom CodeQL workflow will run on `main` and produce the three `Analyze (*)` check names. Once confirmed:
1. Re-add `Analyze (actions)`, `Analyze (csharp)`, and `Analyze (javascript-typescript)` to the required status checks in the branch protection ruleset
2. Verify a subsequent PR can merge with all checks passing

The Analyze checks have been temporarily removed from the required status checks to allow this migration PR to merge (the default setup has been disabled and the custom workflow only runs from `main`).

## Test plan

- [ ] CI passes on this PR (build-and-test, scan-base-images-summary, claude-review)
- [ ] After merge: verify `Analyze (actions)`, `Analyze (csharp)`, and `Analyze (javascript-typescript)` appear as checks from the custom workflow on `main`
- [ ] After merge: restore all three Analyze checks to the required status checks ruleset
- [ ] After ruleset restore: verify a PR can merge with all checks passing (no duplicate suite issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)