### PR TITLE
feat: UI improvements, density toggles, and spacing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,6 +417,8 @@ ASALocalRun/
 #  please consider a global .gitignore https://help.github.com/articles/ignoring-files
 .vagrant*
 bin
+bin\\Debug/
+bin\\Release/
 docker/docker
 .*.swp
 a.out

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "SCIM",
         "secretless",
         "serviceaccount",
-        "SPIFFE"
+        "SPIFFE",
+        "Tetron"
     ]
 }

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -83,6 +83,11 @@ Repository and server methods that load a single entity follow a weight-based ta
 
 **When adding a new retrieval method, start from the lightest variant that works**; only promote to a heavier one if the caller actually needs the additional data.
 
+**Razor Comments:**
+- **Section headers**: Use box-drawing delimiters: `@* ─── Section Title ─── *@` (U+2500 horizontal box-drawing character). One line, standing alone between markup blocks, to visually separate major page sections.
+- **Inline comments**: Use plain comments: `@* Explanation of what follows *@`. Brief, contextual, placed immediately above or beside the relevant markup.
+- Do NOT use multi-line banner comments (`===`, `amamam`, or similar filler characters). One line is enough.
+
 **Tabs:**
 - Use `<NavigableMudTabs>` instead of `<MudTabs>` for all top-level page tabs; it syncs the active tab with a `?t=slug` query string, enabling browser back/forward navigation
 - Use plain `<MudTabs>` only for tabs inside dialogs or nested sub-tabs where URL navigation is not needed

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -91,9 +91,12 @@ Repository and server methods that load a single entity follow a weight-based ta
 - ALWAYS use `Variant="Variant.Outlined"` on all `<MudAlert>` components
 - This ensures a consistent outlined style across the entire UI
 
-**Panel Spacing:**
+**Panel Spacing (target: uniform `mt-6` visual gaps between all block-level sections):**
 - Use `Class="pa-4 mt-6"` on `<MudPaper Outlined="true">` panels to ensure consistent vertical spacing between sections
 - Exception: the **first** panel on a page should omit `mt-6` (use just `Class="pa-4"`) so there is no unnecessary top margin
+- **After intro text**: `MudText` with `Typo.subtitle1` renders as a `<p>` with its own bottom margin (~16px). The first panel after intro text should use `mt-4` (not `mt-6`) so the combined gap matches `mt-6` visually
+- **Tab content spacing**: Use `TabPanelsClass="pa-0 mt-6"` on `NavigableMudTabs` / `MudTabs` so the gap between tab headers and tab panel content matches the surrounding spacing
+- **Tabs margin**: `NavigableMudTabs` may not honour `Class` for outer margin; wrap in `<div class="mt-6">` to guarantee spacing above the tab bar
 
 **Tooltips:**
 - ALWAYS use `Arrow="true" Placement="Placement.Top"` on all `<MudTooltip>` components

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -48,6 +48,14 @@
 - ALWAYS wrap nullable parameters with a typed `NpgsqlParameter`: `NullableParam(value, NpgsqlTypes.NpgsqlDbType.Text)` (see helper method in `ConnectedSystemRepository`, `ActivitiesRepository`, `MetaverseRepository`)
 - This applies to ALL nullable columns in raw SQL INSERT/UPDATE statements: string, int, Guid, DateTime, bool, etc.
 
+**Exception Handling:**
+- NEVER use generic `catch` or `catch (Exception)` clauses; always catch a specific exception type
+- For JS interop retry patterns in `OnAfterRenderAsync` (e.g. loading user preferences), catch `InvalidOperationException` specifically; this is the exception Blazor throws when JS interop is invoked before the runtime is ready
+- Do NOT use `?.` on a variable that has already been null-checked with an early return; the null-conditional is redundant and triggers code quality warnings
+
+**Nullable Dereference in Razor:**
+- When accessing a nullable `.Value` property in Razor markup (e.g. `context.LastUpdated.Value`), capture it into a local variable inside the `@if (x.HasValue)` block: `var lastUpdated = context.LastUpdated.Value;` then use the local variable in markup expressions. This avoids repeated nullable dereference warnings from code analysis.
+
 **File Organisation:**
 - One class per file - each class should have its own `.cs` file named after the class
 - Exception: Enums are grouped into a single file per area/folder (e.g., `ConnectedSystemEnums.cs`, `PendingExportEnums.cs`)
@@ -122,7 +130,7 @@ Repository and server methods that load a single entity follow a weight-based ta
 - Use `Dense="@_dense"` and `Class="@(_dense ? "dense-body-only" : "")"` on the `MudTable`; the `dense-body-only` CSS class keeps header rows at normal height while body rows are compact
 - Add a `MudButton` with `StartIcon` (not `MudIconButton`, which renders circular) in the `ToolBarContent` to toggle density, using `Icons.Material.Filled.DensitySmall` / `DensityMedium`
 - Persist the preference via `IUserPreferenceService.GetTableDenseAsync()` / `SetTableDenseAsync()` (stored in browser localStorage under a single shared key, so the setting applies globally across all pages)
-- Default to normal spacing (`_dense = false`); load the saved preference in `OnAfterRenderAsync`
+- Default to normal spacing (`_dense = false`); load the saved preference in `OnAfterRenderAsync` with `catch (InvalidOperationException)` for JS interop retry
 - See `Pages/Types/Index.razor` for the reference implementation
 
 ## Architecture Quick Reference

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -3124,13 +3124,15 @@ public class ConnectedSystemServer
     /// Creates an "Added" change record for a single CSO linked to a specific RPEI.
     /// Used for provisioning CSOs where the RPEI-to-CSO relationship is resolved externally
     /// (e.g., via MVO ID lookup) rather than via <c>rpei.ConnectedSystemObject</c>.
+    /// The RPEI's ConnectedSystemObjectId is intentionally NOT overwritten here; it must
+    /// continue to reference the source CSO that triggered the sync, not the provisioning CSO.
+    /// The CSO change record links to the provisioning CSO via its own ConnectedSystemObjectId.
     /// </summary>
     public void CreateChangeRecordForCso(
         ConnectedSystemObject cso,
         ActivityRunProfileExecutionItem rpei,
         bool changeTrackingEnabled)
     {
-        rpei.ConnectedSystemObjectId = cso.Id;
         AddConnectedSystemObjectChange(cso, rpei, changeTrackingEnabled);
     }
 

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -249,6 +249,7 @@
                              CsoId="@_activityRunProfileExecutionItem.ConnectedSystemObjectId"
                              CsoConnectedSystemId="@(_activityRunProfileExecutionItem.ConnectedSystemObject?.ConnectedSystemId ?? _connectedSystemHeader?.Id)"
                              MvoTypePluralName="@_metaverseObjectType?.PluralName"
+                             MvoTypeName="@_metaverseObjectType?.Name"
                              InitiallyExpanded="true" />
             </MudPaper>
         }

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -156,14 +156,24 @@
                                 <MudLink Href="@(Utilities.GetConnectedSystemObjectHref(_activityRunProfileExecutionItem.ConnectedSystemObject))"
                                          Underline="Underline.None" Class="jim-chip-link">
                                     <MudChip T="string" Color="Color.Default">
-                                        <b>@_activityRunProfileExecutionItem.ConnectedSystemObject.Type.Name:</b>&nbsp;@_externalIdAttributeValue.ToStringNoName()
+                                        <AvatarContent>
+                                            <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                        </AvatarContent>
+                                        <ChildContent>
+                                            <b>@_activityRunProfileExecutionItem.ConnectedSystemObject.Type.Name:</b>&nbsp;@_externalIdAttributeValue.ToStringNoName()
+                                        </ChildContent>
                                     </MudChip>
                                 </MudLink>
                             }
                             else
                             {
                                 <MudChip T="string" Color="Color.Default">
-                                    <b>@_activityRunProfileExecutionItem.ConnectedSystemObject.Type.Name</b>
+                                    <AvatarContent>
+                                        <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                    </AvatarContent>
+                                    <ChildContent>
+                                        <b>@_activityRunProfileExecutionItem.ConnectedSystemObject.Type.Name</b>
+                                    </ChildContent>
                                 </MudChip>
                                 <MudLink
                                     Href="@(Utilities.GetConnectedSystemObjectHref(_activityRunProfileExecutionItem.ConnectedSystemObject))">

--- a/src/JIM.Web/Pages/Admin/AdminIndex.razor
+++ b/src/JIM.Web/Pages/Admin/AdminIndex.razor
@@ -1,0 +1,141 @@
+@page "/admin"
+@attribute [Authorize(Roles = "Administrator")]
+@inject NavigationManager NavManager
+
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+<PageTitle>Administration</PageTitle>
+
+<MudText Typo="Typo.h4"><MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Size="Size.Large" Class="mr-2 mb-1" Style="vertical-align: middle;" />Administration</MudText>
+<MudBreadcrumbs Items="_breadcrumbs" Class="ps-0"></MudBreadcrumbs>
+<MudText Typo="Typo.subtitle1" Class="mud-text-secondary">
+    Manage system configuration, operations, and security.
+</MudText>
+
+@* ─── Operations & Monitoring ─── *@
+<MudText Typo="Typo.h5" Class="mt-8">Operations &amp; Monitoring</MudText>
+<MudGrid Class="mt-3" Spacing="4">
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/operations"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.PendingActions" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Operations</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Manage sync operations, schedules, and run history</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/logs"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Custom.FileFormats.FileDocument" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Logs</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">View application and synchronisation logs</MudText>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@* ─── Identity Configuration ─── *@
+<MudText Typo="Typo.h5" Class="mt-8">Identity Configuration</MudText>
+<MudGrid Class="mt-3" Spacing="4">
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/connected-systems"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Cable" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Connected Systems</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Configure external system connections</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/sync-rules"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Sync" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Synchronisation Rules</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Define how identities flow between systems</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/schema"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Schema" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Schema</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Manage object types and attributes</MudText>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@* ─── Data Management ─── *@
+<MudText Typo="Typo.h5" Class="mt-8">Data Management</MudText>
+<MudGrid Class="mt-3" Spacing="4">
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/predefined-searches"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.SavedSearch" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Predefined Searches</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Create and manage saved search queries</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/example-data"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Science" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Example Data</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Generate test data from templates</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/deleted-objects"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Delete" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Deleted Objects</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">View and restore deleted objects</MudText>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@* ─── Security & Settings ─── *@
+<MudText Typo="Typo.h5" Class="mt-8">Security &amp; Settings</MudText>
+<MudGrid Class="mt-3" Spacing="4">
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/apikeys"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Api" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">API Keys</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Manage API authentication keys</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/certificates"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.EnhancedEncryption" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Certificates</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Manage trusted certificates</MudText>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4 cursor-pointer jim-quick-link" Outlined="true" @onclick="@(() => NavManager.NavigateTo("/admin/settings"))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.DisplaySettings" Color="Color.Primary" />
+                <MudText Typo="Typo.body1" Style="font-weight: 500;">Settings</MudText>
+            </MudStack>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">Configure service settings</MudText>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private readonly List<BreadcrumbItem> _breadcrumbs = new()
+    {
+        new("Home", href: "/", icon: Icons.Material.Filled.Home),
+        new("Administration", href: null, disabled: true)
+    };
+}

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemObjectMatchingTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemObjectMatchingTab.razor
@@ -431,7 +431,7 @@ else
             </div>
         </MudPaper>
 
-        <MudText Typo="Typo.h6" Class="mb-3">Matching Rules for @objectType.Name</MudText>
+        <MudText Typo="Typo.h6" Class="mb-3">Matching Rules for <span class="jim-title-accent">@objectType.Name</span></MudText>
 
         @if (objectType.ObjectMatchingRules.Count == 0)
         {

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
@@ -11,6 +11,7 @@
 @inject IJimApplicationFactory JimFactory
 @inject NavigationManager NavManager
 @inject IDialogService DialogService
+@inject IUserPreferenceService PreferenceService
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -27,7 +28,7 @@
 
 @if (ConnectedSystemHeader != null && ConnectedSystemObject != null)
 {
-    <MudPaper Class="pa-4" Outlined="true">
+    <MudPaper Class="pa-4 mt-4" Outlined="true">
         @* First row: Type, Status, Created, Updated, MVO Link *@
         <MudStack Row="true" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="3">
             @* Object Type *@
@@ -160,11 +161,19 @@
         </MudPaper>
     }
 
-    <NavigableMudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="false" Outlined="true" TabPanelsClass="pa-0 mt-4">
+    <div class="mt-6">
+    <NavigableMudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="false" Outlined="true" TabPanelsClass="pa-0 mt-6">
         <MudTabPanel Text="Attributes">
             <MudPaper Class="pa-0" Outlined="true">
-                <MudTable Items="@GetGroupedAttributes()" Hover="true" Elevation="0" Class="jim-attribute-table"
+                <MudTable Items="@GetGroupedAttributes()" Hover="true" Dense="@_dense" Elevation="0"
+                    Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")"
                     Breakpoint="Breakpoint.None">
+                    <ToolBarContent>
+                        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+                            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+                        </MudTooltip>
+                    </ToolBarContent>
                     <HeaderContent>
                         <MudTh Class="jim-attr-header-name">
                             <MudTableSortLabel SortBy="@_sortByAttribute"
@@ -268,6 +277,7 @@
             }
         </MudTabPanel>
     </NavigableMudTabs>
+    </div>
 }
 
 @code {
@@ -303,6 +313,32 @@
     private List<ConnectedSystemObjectChange>? CsoChanges { get; set; }
 
     private List<BreadcrumbItem> Breadcrumbs { get; set; } = null!;
+
+    private bool _dense;
+    private bool _preferencesLoaded;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_preferencesLoaded)
+        {
+            try
+            {
+                _dense = await PreferenceService.GetTableDenseAsync() == true;
+                _preferencesLoaded = true;
+                StateHasChanged();
+            }
+            catch
+            {
+                // JS interop not yet available, will retry on next render
+            }
+        }
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
+    }
 
     protected override async Task OnParametersSetAsync()
     {

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
@@ -327,7 +327,7 @@
                 _preferencesLoaded = true;
                 StateHasChanged();
             }
-            catch
+            catch (InvalidOperationException)
             {
                 // JS interop not yet available, will retry on next render
             }

--- a/src/JIM.Web/Pages/Admin/DeletedObjects.razor
+++ b/src/JIM.Web/Pages/Admin/DeletedObjects.razor
@@ -14,7 +14,7 @@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
 
 <PageTitle>Deleted Objects</PageTitle>
-<MudText Typo="Typo.h4">Deleted Objects</MudText>
+<MudText Typo="Typo.h4"><MudIcon Icon="@Icons.Material.Filled.Delete" Size="Size.Large" Class="mr-2 mb-1" Style="vertical-align: middle;" />Deleted Objects</MudText>
 <MudBreadcrumbs Items="_breadcrumbs" Class="ps-0"></MudBreadcrumbs>
 <MudText Typo="Typo.subtitle1" Class="mud-text-secondary">
     When objects are deleted, their change history is preserved here for audit and compliance purposes.

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -375,7 +375,7 @@ else
                 _preferencesLoaded = true;
                 StateHasChanged();
             }
-            catch
+            catch (InvalidOperationException)
             {
                 // JS interop not yet available, will retry on next render
             }

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -160,7 +160,7 @@
             <MudItem xs="12">
                 <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mt-0" Style="align-items: flex-start;">
                     <MudText Typo="Typo.h6" Class="mb-3" Style="line-height: 1.5rem;">Error Information</MudText>
-                    <MudSimpleTable Hover="true" Dense="true" Style="background: transparent;">
+                    <MudSimpleTable Hover="true" Dense="true" Elevation="0" Style="background: transparent;">
                         <tbody>
                             <tr>
                                 <td style="width: 200px;"><strong>Error Count</strong></td>

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -112,7 +112,12 @@
                                                      Style="margin: 0;">
                                                 <MudChip T="string" Color="Color.Default"
                                                          Style="margin: 0;">
-                                                    <b>@_pendingExport.ConnectedSystemObject.Type.Name:</b>&nbsp;@GetCsoDisplayName()
+                                                    <AvatarContent>
+                                                        <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                                    </AvatarContent>
+                                                    <ChildContent>
+                                                        <b>@_pendingExport.ConnectedSystemObject.Type.Name:</b>&nbsp;@GetCsoDisplayName()
+                                                    </ChildContent>
                                                 </MudChip>
                                             </MudLink>
                                         </MudStack>
@@ -134,7 +139,12 @@
                                                      Style="margin: 0;">
                                                 <MudChip T="string" Color="Color.Default"
                                                          Style="margin: 0;">
-                                                    <b>@_pendingExport.SourceMetaverseObject.Type.Name:</b>&nbsp;@GetMvoDisplayName()
+                                                    <AvatarContent>
+                                                        <MudAvatar Color="Color.Primary">MV</MudAvatar>
+                                                    </AvatarContent>
+                                                    <ChildContent>
+                                                        <b>@_pendingExport.SourceMetaverseObject.Type.Name:</b>&nbsp;@GetMvoDisplayName()
+                                                    </ChildContent>
                                                 </MudChip>
                                             </MudLink>
                                         </MudStack>
@@ -215,8 +225,18 @@
                     @if (_pendingExport.AttributeValueChanges.Count > 0)
                     {
                         <MudTable Items="@GetGroupedChanges()" Hover="true" Dense="@_dense" Elevation="0" Outlined="true"
+                                  Filter="new Func<AttributeChangeGroup, bool>(FilterFunc)"
                                   Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")" Breakpoint="Breakpoint.None">
                             <ToolBarContent>
+                                <MudTextField @bind-Value="_searchString"
+                                              Variant="Variant.Outlined"
+                                              Placeholder="Search attribute name or value"
+                                              Margin="Margin.Dense"
+                                              Adornment="Adornment.Start"
+                                              AdornmentIcon="@Icons.Material.Filled.Search"
+                                              IconSize="Size.Medium"
+                                              Class="mt-0" />
+                                <MudSpacer />
                                 <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
                                     <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
                                                    Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
@@ -343,6 +363,7 @@ else
     private bool _notFound;
     private bool _dense;
     private bool _preferencesLoaded;
+    private string _searchString = "";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -499,6 +520,17 @@ else
         };
 
         await DialogService.ShowAsync<PendingExportMvaDialog>(attributeName, parameters, options);
+    }
+
+    private bool FilterFunc(AttributeChangeGroup group)
+    {
+        if (string.IsNullOrWhiteSpace(_searchString))
+            return true;
+        if (group.AttributeName.Contains(_searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (group.Values.Any(v => GetAttributeValue(v).Contains(_searchString, StringComparison.OrdinalIgnoreCase)))
+            return true;
+        return false;
     }
 
     private record AttributeChangeGroup(

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -8,6 +8,7 @@
 @inject NavigationManager NavManager
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject IUserPreferenceService PreferenceService
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -106,9 +107,13 @@
                                     @if (_pendingExport.ConnectedSystemObject != null)
                                     {
                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                            <MudChip T="string" Color="Color.Default">@_pendingExport.ConnectedSystemObject.Type.Name</MudChip>
-                                            <MudLink Href="@($"/admin/connected-systems/{ConnectedSystemId}/connector-space/{_pendingExport.ConnectedSystemObject.Id}")">
-                                                @GetCsoDisplayName()
+                                            <MudLink Href="@($"/admin/connected-systems/{ConnectedSystemId}/connector-space/{_pendingExport.ConnectedSystemObject.Id}")"
+                                                     Underline="Underline.None" Class="jim-chip-link"
+                                                     Style="margin: 0;">
+                                                <MudChip T="string" Color="Color.Default"
+                                                         Style="margin: 0;">
+                                                    <b>@_pendingExport.ConnectedSystemObject.Type.Name:</b>&nbsp;@GetCsoDisplayName()
+                                                </MudChip>
                                             </MudLink>
                                         </MudStack>
                                     }
@@ -124,9 +129,13 @@
                                     @if (_pendingExport.SourceMetaverseObject != null)
                                     {
                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                            <MudChip T="string" Color="Color.Default">@_pendingExport.SourceMetaverseObject.Type.Name</MudChip>
-                                            <MudLink Href="@Utilities.GetMetaverseObjectHref(_pendingExport.SourceMetaverseObject)">
-                                                @GetMvoDisplayName()
+                                            <MudLink Href="@Utilities.GetMetaverseObjectHref(_pendingExport.SourceMetaverseObject)"
+                                                     Underline="Underline.None" Class="jim-chip-link"
+                                                     Style="margin: 0;">
+                                                <MudChip T="string" Color="Color.Default"
+                                                         Style="margin: 0;">
+                                                    <b>@_pendingExport.SourceMetaverseObject.Type.Name:</b>&nbsp;@GetMvoDisplayName()
+                                                </MudChip>
                                             </MudLink>
                                         </MudStack>
                                     }
@@ -205,8 +214,14 @@
                 <MudCardContent>
                     @if (_pendingExport.AttributeValueChanges.Count > 0)
                     {
-                        <MudTable Items="@GetGroupedChanges()" Hover="true" Elevation="0" Outlined="true"
-                                  Class="jim-attribute-table" Breakpoint="Breakpoint.None">
+                        <MudTable Items="@GetGroupedChanges()" Hover="true" Dense="@_dense" Elevation="0" Outlined="true"
+                                  Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")" Breakpoint="Breakpoint.None">
+                            <ToolBarContent>
+                                <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+                                    <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                                                   Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+                                </MudTooltip>
+                            </ToolBarContent>
                             <HeaderContent>
                                 <MudTh Class="jim-attr-header-name"><MudText Typo="Typo.button">Attribute</MudText></MudTh>
                                 <MudTh><MudText Typo="Typo.button">Change Type</MudText></MudTh>
@@ -326,6 +341,31 @@ else
     private Dictionary<string, int> _attributeChangeTotalCounts = new();
     private List<BreadcrumbItem> _breadcrumbs = null!;
     private bool _notFound;
+    private bool _dense;
+    private bool _preferencesLoaded;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_preferencesLoaded)
+        {
+            try
+            {
+                _dense = await PreferenceService.GetTableDenseAsync() == true;
+                _preferencesLoaded = true;
+                StateHasChanged();
+            }
+            catch
+            {
+                // JS interop not yet available, will retry on next render
+            }
+        }
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
+    }
 
     protected override async Task OnParametersSetAsync()
     {

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -228,6 +228,11 @@
                                   Filter="new Func<AttributeChangeGroup, bool>(FilterFunc)"
                                   Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")" Breakpoint="Breakpoint.None">
                             <ToolBarContent>
+                                <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+                                    <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                                                   Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+                                </MudTooltip>
+                                <MudSpacer />
                                 <MudTextField @bind-Value="_searchString"
                                               Variant="Variant.Outlined"
                                               Placeholder="Search attribute name or value"
@@ -236,11 +241,6 @@
                                               AdornmentIcon="@Icons.Material.Filled.Search"
                                               IconSize="Size.Medium"
                                               Class="mt-0" />
-                                <MudSpacer />
-                                <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                                    <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                                                   Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-                                </MudTooltip>
                             </ToolBarContent>
                             <HeaderContent>
                                 <MudTh Class="jim-attr-header-name"><MudText Typo="Typo.button">Attribute</MudText></MudTh>

--- a/src/JIM.Web/Pages/Admin/PendingExportList.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportList.razor
@@ -23,7 +23,7 @@
 
 @if (_connectedSystemHeader != null && _preferencesLoaded)
 {
-    <MudPaper Elevation="0" Class="pa-4" Outlined="true">
+    <MudPaper Elevation="0" Class="pa-4 mt-4" Outlined="true">
         <MudSelect T="PendingExportStatus" Label="Filter by Status" MultiSelection="true"
                    SelectedValues="_statusFilters" SelectedValuesChanged="OnStatusFiltersChanged"
                    MultiSelectionTextFunc="@GetStatusFilterText"
@@ -42,9 +42,9 @@
               RowsPerPage="@_rowsPerPage"
               RowsPerPageChanged="OnRowsPerPageChanged"
               Hover="true"
-              Dense="true"
+              Dense="@_dense"
               Breakpoint="Breakpoint.Sm"
-              Class="mt-5"
+              Class="@(_dense ? "mt-5 dense-body-only" : "mt-5")"
               Outlined="true"
               Elevation="0"
               OnRowClick="HandleRowClick"
@@ -52,6 +52,10 @@
               Loading="@_loading"
               LoadingProgressColor="Color.Primary">
         <ToolBarContent>
+            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+            </MudTooltip>
             <MudSpacer />
             <MudTextField T="string"
                           ValueChanged="@(s => OnSearch(s))"
@@ -194,6 +198,7 @@ else
     private bool _loading;
     private int _rowsPerPage = 10;
     private bool _preferencesLoaded;
+    private bool _dense;
 
     protected override async Task OnInitializedAsync()
     {
@@ -222,6 +227,7 @@ else
             {
                 var preferredSize = await PreferenceService.GetRowsPerPageAsync();
                 _rowsPerPage = preferredSize;
+                _dense = await PreferenceService.GetTableDenseAsync() == true;
                 _preferencesLoaded = true;
                 StateHasChanged(); // Re-render to show the table now that preference is loaded
             }
@@ -230,6 +236,12 @@ else
                 // JS interop not yet available, will retry on next render
             }
         }
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private async Task OnRowsPerPageChanged(int newSize)

--- a/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
@@ -653,8 +653,9 @@ else if (_syncRule != null)
                 <MudTd DataLabel="Updated">
                     @if (context.LastUpdated.HasValue)
                     {
-                        <MudTooltip Text="@context.LastUpdated.Value.ToLocalTime().ToFriendlyDate()" Arrow="true" Placement="Placement.Top">
-                            <MudText Typo="Typo.body2">@context.LastUpdated.Value.ToLocalTime().ToRelativeTime()</MudText>
+                        var lastUpdated = context.LastUpdated.Value;
+                        <MudTooltip Text="@lastUpdated.ToLocalTime().ToFriendlyDate()" Arrow="true" Placement="Placement.Top">
+                            <MudText Typo="Typo.body2">@lastUpdated.ToLocalTime().ToRelativeTime()</MudText>
                         </MudTooltip>
                     }
                     else

--- a/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
@@ -572,6 +572,8 @@ else if (_syncRule != null)
                 <MudTh><MudTableSortLabel SortBy="new Func<SyncRuleMapping, object>(x => GetSortableSourceName(x))"><MudText Typo="Typo.button">Source</MudText></MudTableSortLabel></MudTh>
                 <MudTh></MudTh>
                 <MudTh><MudTableSortLabel SortBy="new Func<SyncRuleMapping, object>(x => GetSortableTargetName(x))"><MudText Typo="Typo.button">Target</MudText></MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel SortBy="new Func<SyncRuleMapping, object>(x => x.Created)"><MudText Typo="Typo.button">Created</MudText></MudTableSortLabel></MudTh>
+                <MudTh><MudTableSortLabel SortBy="new Func<SyncRuleMapping, object>(x => x.LastUpdated ?? DateTime.MinValue)"><MudText Typo="Typo.button">Updated</MudText></MudTableSortLabel></MudTh>
                 <MudTh></MudTh>
             </HeaderContent>
             <RowTemplate>
@@ -641,6 +643,23 @@ else if (_syncRule != null)
                                 <ChildContent>@context.TargetConnectedSystemAttribute.Name</ChildContent>
                             </MudChip>
                         </MudTooltip>
+                    }
+                </MudTd>
+                <MudTd DataLabel="Created">
+                    <MudTooltip Text="@context.Created.ToLocalTime().ToFriendlyDate()" Arrow="true" Placement="Placement.Top">
+                        <MudText Typo="Typo.body2">@context.Created.ToLocalTime().ToRelativeTime()</MudText>
+                    </MudTooltip>
+                </MudTd>
+                <MudTd DataLabel="Updated">
+                    @if (context.LastUpdated.HasValue)
+                    {
+                        <MudTooltip Text="@context.LastUpdated.Value.ToLocalTime().ToFriendlyDate()" Arrow="true" Placement="Placement.Top">
+                            <MudText Typo="Typo.body2">@context.LastUpdated.Value.ToLocalTime().ToRelativeTime()</MudText>
+                        </MudTooltip>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2">-</MudText>
                     }
                 </MudTd>
                 <MudTd>

--- a/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
@@ -659,7 +659,7 @@ else if (_syncRule != null)
                     }
                     else
                     {
-                        <MudText Typo="Typo.body2">-</MudText>
+                        <MudText Typo="Typo.body2" Class="mud-text-disabled">-</MudText>
                     }
                 </MudTd>
                 <MudTd>

--- a/src/JIM.Web/Pages/Admin/ThemePreview.razor
+++ b/src/JIM.Web/Pages/Admin/ThemePreview.razor
@@ -12,9 +12,7 @@
     Toggle dark mode to verify visual consistency across both modes.
 </MudText>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 1: Typography *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Typography ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Typography</MudText>
 
@@ -45,9 +43,7 @@
     </MudStack>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 2: Buttons *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Buttons ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Buttons</MudText>
 
@@ -140,9 +136,7 @@
     </MudStack>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 3: Chips *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Chips ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Chips</MudText>
 
@@ -213,9 +207,7 @@
     </MudStack>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 4: Alerts *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Alerts ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Alerts</MudText>
 
@@ -258,9 +250,7 @@
     </MudAlert>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 5: Form Controls *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Form Controls ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Form Controls</MudText>
 
@@ -327,9 +317,7 @@
     </MudGrid>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 6: Tables *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Tables ─── *@
 <MudText Typo="Typo.h5" Class="mt-8 mb-4">Tables</MudText>
 
 <MudText Typo="Typo.h6" Class="mb-3">MudTable</MudText>
@@ -387,9 +375,7 @@
     </tbody>
 </MudSimpleTable>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 7: Papers and Cards *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Papers and Cards ─── *@
 <MudText Typo="Typo.h5" Class="mt-8 mb-4">Papers and Cards</MudText>
 
 <MudGrid Class="mb-5">
@@ -489,9 +475,7 @@
     </MudItem>
 </MudGrid>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 8: Navigation Components *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Navigation Components ─── *@
 <MudText Typo="Typo.h5" Class="mt-8 mb-4">Navigation Components</MudText>
 
 <MudText Typo="Typo.h6" Class="mb-3">Tabs</MudText>
@@ -523,9 +507,7 @@
     <MudPagination Count="10" ShowFirstButton="true" ShowLastButton="true" Rectangular="true" DropShadow="false" />
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 9: Feedback and Status *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Feedback and Status ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Feedback and Status</MudText>
 
@@ -597,9 +579,7 @@
     </MudStack>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 10: Advanced Components *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Advanced Components ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Advanced Components</MudText>
 
@@ -678,9 +658,7 @@
     </MudMenu>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 11: Layout Components *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── Layout Components ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">Layout Components</MudText>
 
@@ -752,9 +730,7 @@
     <MudText>Content below divider</MudText>
 </MudPaper>
 
-@* amamamamamamamamamamamamamamamamam *@
-@* Section 12: JIM Custom CSS *@
-@* amamamamamamamamamamamamamamamamam *@
+@* ─── JIM Custom CSS ─── *@
 <MudPaper Class="pa-5 mt-5" Outlined="true" Elevation="0">
     <MudText Typo="Typo.h5" Class="mb-4">JIM Custom CSS</MudText>
 

--- a/src/JIM.Web/Pages/Types/Index.razor
+++ b/src/JIM.Web/Pages/Types/Index.razor
@@ -51,7 +51,17 @@
             </MudTd>
             @foreach (var psa in PredefinedSearch.Attributes.Where(q => q.MetaverseAttribute.Name != Constants.BuiltInAttributes.DisplayName))
             {
-                <MudTd DataLabel="@psa.MetaverseAttribute.Name">@context.GetAttributeValue(psa.MetaverseAttribute.Name)?.StringValue</MudTd>
+                var value = context.GetAttributeValue(psa.MetaverseAttribute.Name)?.StringValue;
+                <MudTd DataLabel="@psa.MetaverseAttribute.Name">
+                    @if (string.IsNullOrEmpty(value))
+                    {
+                        <span class="mud-text-disabled">-</span>
+                    }
+                    else
+                    {
+                        @value
+                    }
+                </MudTd>
             }
         </RowTemplate>
         <NoRecordsContent>

--- a/src/JIM.Web/Pages/Types/View.razor
+++ b/src/JIM.Web/Pages/Types/View.razor
@@ -283,7 +283,7 @@
                 SyncRuleName = change.SyncRuleName,
                 // Activity link for drill-down (optional - RPEI may be cleaned up)
                 ActivityRunProfileExecutionItemId = change.ActivityRunProfileExecutionItemId,
-                // CSO context for Joined changes (from RPEI snapshot)
+                // CSO context for Joined/Projected changes (from RPEI snapshot)
                 CsoId = change.ActivityRunProfileExecutionItem?.ConnectedSystemObjectId,
                 CsoExternalId = change.ActivityRunProfileExecutionItem?.ExternalIdSnapshot,
                 AttributeChanges = change.AttributeChanges

--- a/src/JIM.Web/Shared/ChangeHistoryTimeline.razor
+++ b/src/JIM.Web/Shared/ChangeHistoryTimeline.razor
@@ -50,7 +50,8 @@ else
                                     <MudText Typo="Typo.body1" Style="margin-right: 14px;">
                                         <strong>@changeGroup.ChangeType</strong>
                                     </MudText>
-                                    @if (changeGroup.ChangeType == ObjectChangeType.Joined &&
+                                    @if ((changeGroup.ChangeType == ObjectChangeType.Joined ||
+                                                                 changeGroup.ChangeType == ObjectChangeType.Projected) &&
                                                                 !string.IsNullOrEmpty(changeGroup.CsoExternalId))
                                     {
                                         <span style="margin-right: 12px;">
@@ -529,7 +530,7 @@ else
         /// </summary>
         public string? RunProfileName { get; set; }
         /// <summary>
-        /// For Joined changes: the CSO ID that joined (from RPEI snapshot).
+        /// For Joined/Projected changes: the CSO ID (from RPEI snapshot).
         /// </summary>
         public Guid? CsoId { get; set; }
         /// <summary>

--- a/src/JIM.Web/Shared/MvoDetailsPanel.razor
+++ b/src/JIM.Web/Shared/MvoDetailsPanel.razor
@@ -65,7 +65,7 @@
     </MudExpansionPanels>
 }
 
-@* ========================== Render Fragments ========================== *@
+@* ─── Render Fragments ─── *@
 
 @* Renders a single-valued attribute value with type-appropriate formatting *@
 @{

--- a/src/JIM.Web/Shared/MvoDetailsTable.razor
+++ b/src/JIM.Web/Shared/MvoDetailsTable.razor
@@ -1,6 +1,7 @@
 @using JIM.Models.Core
 @using Utilities
 @inject IDialogService DialogService
+@inject IUserPreferenceService PreferenceService
 
 @if (MetaverseObject != null)
 
@@ -8,7 +9,13 @@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
 {
     <MudPaper Class="pa-0 mt-3" Outlined="true">
-        <MudSimpleTable Hover="true" Elevation="0" Class="jim-attribute-table">
+        <div class="d-flex justify-start pa-2">
+            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+            </MudTooltip>
+        </div>
+        <MudSimpleTable Hover="true" Dense="@_dense" Elevation="0" Class="jim-attribute-table">
             <thead>
                 <tr>
                     <th class="jim-attr-header-name">Attribute</th>
@@ -171,6 +178,32 @@
     /// Maximum number of multi-valued attribute values to show inline before truncating.
     /// </summary>
     private const int MvaInlineThreshold = 10;
+
+    private bool _dense;
+    private bool _preferencesLoaded;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_preferencesLoaded)
+        {
+            try
+            {
+                _dense = await PreferenceService.GetTableDenseAsync() == true;
+                _preferencesLoaded = true;
+                StateHasChanged();
+            }
+            catch
+            {
+                // JS interop not yet available, will retry on next render
+            }
+        }
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
+    }
 
     private record MvoAttributeTableGroup(
         string AttributeName,

--- a/src/JIM.Web/Shared/MvoDetailsTable.razor
+++ b/src/JIM.Web/Shared/MvoDetailsTable.razor
@@ -192,7 +192,7 @@
                 _preferencesLoaded = true;
                 StateHasChanged();
             }
-            catch
+            catch (InvalidOperationException)
             {
                 // JS interop not yet available, will retry on next render
             }

--- a/src/JIM.Web/Shared/MvoDetailsTable.razor
+++ b/src/JIM.Web/Shared/MvoDetailsTable.razor
@@ -97,7 +97,7 @@
     </MudPaper>
 }
 
-@* ========================== Render Fragments ========================== *@
+@* ─── Render Fragments ─── *@
 
 @{
     RenderFragment RenderValue(MetaverseObjectAttributeValue attributeValue) => __builder =>

--- a/src/JIM.Web/Shared/MvoDetailsTabs.razor
+++ b/src/JIM.Web/Shared/MvoDetailsTabs.razor
@@ -55,7 +55,7 @@
     </NavigableMudTabs>
 }
 
-@* ========================== Render Fragments ========================== *@
+@* ─── Render Fragments ─── *@
 
 @* Renders a single-valued attribute value with type-appropriate formatting *@
 @{

--- a/src/JIM.Web/Shared/NavMenu.razor
+++ b/src/JIM.Web/Shared/NavMenu.razor
@@ -43,14 +43,7 @@
             <MudNavLink Href="/admin/operations" Match="NavLinkMatch.Prefix" Class="jim-nav-child">Operations</MudNavLink>
             <MudNavLink Href="/admin/connected-systems" Match="NavLinkMatch.Prefix" Class="jim-nowrap jim-nav-child">Connected Systems</MudNavLink>
             <MudNavLink Href="/admin/sync-rules" Match="NavLinkMatch.Prefix" Class="jim-nowrap jim-nav-child">Synchronisation Rules</MudNavLink>
-            <MudNavLink Href="/admin/schema" Match="NavLinkMatch.Prefix" Class="jim-nav-child">Schema</MudNavLink>
-            <MudNavLink Href="/admin/predefined-searches" Match="NavLinkMatch.Prefix" Class="jim-nowrap jim-nav-child">Predefined Searches</MudNavLink>
-            <MudNavLink Href="/admin/example-data" Match="NavLinkMatch.Prefix" Class="jim-nowrap jim-nav-child">Example Data</MudNavLink>
-            <MudNavLink Href="/admin/certificates" Match="NavLinkMatch.Prefix" Class="jim-nav-child">Certificates</MudNavLink>
-            <MudNavLink Href="/admin/apikeys" Match="NavLinkMatch.Prefix" Class="jim-nowrap jim-nav-child">API Keys</MudNavLink>
-            <MudNavLink Href="/admin/deleted-objects" Match="NavLinkMatch.Prefix" Class="jim-nowrap jim-nav-child">Deleted Objects</MudNavLink>
-            <MudNavLink Href="/admin/logs" Match="NavLinkMatch.Prefix" Class="jim-nav-child">Logs</MudNavLink>
-            <MudNavLink Href="/admin/settings" Match="NavLinkMatch.Prefix" Class="jim-nav-child">Settings</MudNavLink>
+            <MudNavLink Href="/admin" Match="NavLinkMatch.All" Class="jim-nav-child">Administration</MudNavLink>
         </MudNavGroup>
     </AuthorizeView>
 </MudNavMenu>

--- a/src/JIM.Web/Shared/OutcomeTree.razor
+++ b/src/JIM.Web/Shared/OutcomeTree.razor
@@ -41,7 +41,7 @@ else
                             @if (!string.IsNullOrEmpty(RunProfileName))
                             {
                                 <MudText Typo="Typo.body1" Class="mud-text-secondary">
-                                    — @RunProfileName
+                                    : @RunProfileName
                                 </MudText>
                             }
                         </MudStack>
@@ -114,7 +114,7 @@ else
                                 @if (!string.IsNullOrEmpty(CsoDisplayName) && CsoDisplayName != CsoExternalId)
                                 {
                                     <MudText Typo="Typo.body1" Class="mud-text-secondary"
-                                             Style="margin: 0;">— @CsoDisplayName</MudText>
+                                             Style="margin: 0;">: @CsoDisplayName</MudText>
                                 }
                             </div>
                         </MudStack>
@@ -127,6 +127,7 @@ else
                                                  AttributeChanges="AttributeChanges"
                                                  MvoAttributeChanges="MvoAttributeChanges"
                                                  MvoTypePluralName="@MvoTypePluralName"
+                                                 MvoTypeName="@MvoTypeName"
                                                  InitiallyExpanded="InitiallyExpanded" />
                             }
                         </div>
@@ -220,6 +221,12 @@ else
     /// </summary>
     [Parameter]
     public string? MvoTypePluralName { get; set; }
+
+    /// <summary>
+    /// Singular name of the MVO type (e.g., "Person"), used for MVO chip display.
+    /// </summary>
+    [Parameter]
+    public string? MvoTypeName { get; set; }
 
     /// <summary>
     /// When true, root outcome nodes start with their attribute detail expanded.

--- a/src/JIM.Web/Shared/OutcomeTree.razor
+++ b/src/JIM.Web/Shared/OutcomeTree.razor
@@ -62,7 +62,12 @@ else
                                              Style="margin: 0;">
                                         <MudChip T="string" Color="Color.Default" Size="Size.Medium"
                                                  Style="margin: 0;">
-                                            <b>@CsoObjectTypeName:</b>&nbsp;@CsoExternalId
+                                            <AvatarContent>
+                                                <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                            </AvatarContent>
+                                            <ChildContent>
+                                                <b>@CsoObjectTypeName:</b>&nbsp;@CsoExternalId
+                                            </ChildContent>
                                         </MudChip>
                                     </MudLink>
                                 }
@@ -70,14 +75,24 @@ else
                                 {
                                     <MudChip T="string" Color="Color.Default" Size="Size.Medium"
                                              Style="margin: 0;">
-                                        <b>@CsoObjectTypeName:</b>&nbsp;@CsoExternalId
+                                        <AvatarContent>
+                                            <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                        </AvatarContent>
+                                        <ChildContent>
+                                            <b>@CsoObjectTypeName:</b>&nbsp;@CsoExternalId
+                                        </ChildContent>
                                     </MudChip>
                                 }
                                 else if (!string.IsNullOrEmpty(CsoObjectTypeName))
                                 {
                                     <MudChip T="string" Color="Color.Default" Size="Size.Medium"
                                              Style="margin: 0;">
-                                        <b>@CsoObjectTypeName</b>
+                                        <AvatarContent>
+                                            <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                        </AvatarContent>
+                                        <ChildContent>
+                                            <b>@CsoObjectTypeName</b>
+                                        </ChildContent>
                                     </MudChip>
                                 }
                                 else if (!string.IsNullOrEmpty(CsoExternalId))

--- a/src/JIM.Web/Shared/OutcomeTreeNode.razor
+++ b/src/JIM.Web/Shared/OutcomeTreeNode.razor
@@ -18,9 +18,25 @@
                 </MudText>
                 @if (HasInlineTargetDescription)
                 {
-                    @* Inline target entity shown on the same row as the outcome type (e.g., Projected → MVO name, Provisioned → CS name) *@
+                    @* Inline target entity shown on the same row as the outcome type (e.g., Projected → MVO chip, Provisioned → CS name) *@
                     <MudText Typo="Typo.body1" Class="mud-text-secondary">@GetInlineSeparator()</MudText>
-                    @if (HasCsLink)
+                    @if (HasMvoLink && !string.IsNullOrEmpty(MvoTypeName))
+                    {
+                        <MudLink Href="@GetMvoHref(Outcome.TargetEntityId!.Value)"
+                                 Underline="Underline.None" Class="jim-chip-link"
+                                 Style="margin: 0;">
+                            <MudChip T="string" Color="Color.Default" Size="Size.Medium"
+                                     Style="margin: 0;">
+                                <AvatarContent>
+                                    <MudAvatar Color="Color.Primary">MV</MudAvatar>
+                                </AvatarContent>
+                                <ChildContent>
+                                    <b>@MvoTypeName:</b>&nbsp;@Outcome.TargetEntityDescription
+                                </ChildContent>
+                            </MudChip>
+                        </MudLink>
+                    }
+                    else if (HasCsLink)
                     {
                         <MudLink Href="@GetCsHref()" Typo="Typo.body1" Class="mud-text-secondary">
                             @Outcome.TargetEntityDescription
@@ -109,7 +125,8 @@
                                  ParentOutcomeType="Outcome.OutcomeType"
                                  AttributeChanges="AttributeChanges"
                                  MvoAttributeChanges="MvoAttributeChanges"
-                                 MvoTypePluralName="@MvoTypePluralName" />
+                                 MvoTypePluralName="@MvoTypePluralName"
+                                 MvoTypeName="@MvoTypeName" />
             }
         </div>
     }
@@ -138,6 +155,12 @@
     /// </summary>
     [Parameter]
     public string? MvoTypePluralName { get; set; }
+
+    /// <summary>
+    /// Singular name of the MVO type (e.g., "Person"), used for MVO chip display.
+    /// </summary>
+    [Parameter]
+    public string? MvoTypeName { get; set; }
 
     /// <summary>
     /// The outcome type of this node's parent, passed down from the parent OutcomeTreeNode.
@@ -223,11 +246,11 @@
     private string GetInlineSeparator() =>
         Outcome.OutcomeType switch
         {
-            ActivityRunProfileExecutionItemSyncOutcomeType.Joined => "\u2014 to",
+            ActivityRunProfileExecutionItemSyncOutcomeType.Joined => ": to",
             ActivityRunProfileExecutionItemSyncOutcomeType.Disconnected
                 or ActivityRunProfileExecutionItemSyncOutcomeType.DisconnectedOutOfScope
-                => "\u2014 from",
-            _ => "\u2014"
+                => ": from",
+            _ => ":"
         };
 
     private void ToggleExpand()

--- a/src/JIM.Web/Shared/OutcomeTreeNode.razor
+++ b/src/JIM.Web/Shared/OutcomeTreeNode.razor
@@ -36,6 +36,31 @@
                             </MudChip>
                         </MudLink>
                     }
+                    else if (HasProvisionedCsoLink)
+                    {
+                        var csoTypeName = GetCsoTypeNameFromDetailMessage();
+                        <MudLink Href="@GetCsHref()" Typo="Typo.body1" Class="mud-text-secondary">
+                            @Outcome.TargetEntityDescription
+                        </MudLink>
+                        <MudText Typo="Typo.body1" Class="mud-text-secondary">:</MudText>
+                        <MudLink Href="@GetProvisionedCsoHref()"
+                                 Underline="Underline.None" Class="jim-chip-link"
+                                 Style="margin: 0;">
+                            <MudChip T="string" Color="Color.Default" Size="Size.Medium"
+                                     Style="margin: 0;">
+                                <AvatarContent>
+                                    <MudAvatar Color="Color.Tertiary">CS</MudAvatar>
+                                </AvatarContent>
+                                <ChildContent>
+                                    @if (!string.IsNullOrEmpty(csoTypeName))
+                                    {
+                                        <b>@csoTypeName:</b><text>&nbsp;</text>
+                                    }
+                                    @Outcome.TargetEntityId
+                                </ChildContent>
+                            </MudChip>
+                        </MudLink>
+                    }
                     else if (HasCsLink)
                     {
                         <MudLink Href="@GetCsHref()" Typo="Typo.body1" Class="mud-text-secondary">
@@ -225,23 +250,35 @@
 
     /// <summary>
     /// Whether this outcome node has a connected system link available.
-    /// The CS integer ID is stored in DetailMessage as a convention for Provisioned and PendingExportCreated outcomes.
+    /// The CS integer ID is stored in DetailMessage, either as a plain integer ("4") or
+    /// as "csId|csoTypeName" for Provisioned outcomes ("4|person").
     /// </summary>
     private bool HasCsLink =>
         Outcome.OutcomeType is ActivityRunProfileExecutionItemSyncOutcomeType.Provisioned
             or ActivityRunProfileExecutionItemSyncOutcomeType.PendingExportCreated
         && !string.IsNullOrEmpty(Outcome.DetailMessage)
-        && int.TryParse(Outcome.DetailMessage, out _);
+        && int.TryParse(GetCsIdFromDetailMessage(), out _);
 
     /// <summary>
     /// Whether this outcome has an MVO link (Guid target entity ID that isn't empty).
     /// Excluded when the MVO no longer exists: MvoDeleted outcomes themselves, or parent
     /// outcomes (e.g. Disconnected) that have an MvoDeleted child in their causality tree.
+    /// Provisioned outcomes store the CSO ID in TargetEntityId, not an MVO ID.
     /// </summary>
     private bool HasMvoLink =>
         Outcome.TargetEntityId.HasValue && Outcome.TargetEntityId.Value != Guid.Empty
         && Outcome.OutcomeType != ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted
+        && Outcome.OutcomeType != ActivityRunProfileExecutionItemSyncOutcomeType.Provisioned
         && !Outcome.Children.Any(c => c.OutcomeType == ActivityRunProfileExecutionItemSyncOutcomeType.MvoDeleted);
+
+    /// <summary>
+    /// Whether this Provisioned outcome has a CSO link available.
+    /// Provisioned outcomes store the new CSO's GUID in TargetEntityId and the CS integer ID in DetailMessage.
+    /// </summary>
+    private bool HasProvisionedCsoLink =>
+        Outcome.OutcomeType == ActivityRunProfileExecutionItemSyncOutcomeType.Provisioned
+        && Outcome.TargetEntityId.HasValue && Outcome.TargetEntityId.Value != Guid.Empty
+        && HasCsLink;
 
     private string GetInlineSeparator() =>
         Outcome.OutcomeType switch
@@ -339,9 +376,32 @@
             : $"/identity/search/{mvoId}";
 
     /// <summary>
-    /// Builds the connected system href for Provisioned and PendingExportCreated outcomes.
-    /// The CS integer ID is stored in DetailMessage by convention.
+    /// Extracts the CS integer ID from DetailMessage, which may be a plain integer ("4")
+    /// or "csId|csoTypeName" for Provisioned outcomes ("4|person").
     /// </summary>
-    private string GetCsHref() => $"/admin/connected-systems/{Outcome.DetailMessage}";
+    private string GetCsIdFromDetailMessage() =>
+        Outcome.DetailMessage?.Split('|')[0] ?? "";
+
+    /// <summary>
+    /// Extracts the CSO type name from DetailMessage for Provisioned outcomes.
+    /// Format: "csId|csoTypeName" (e.g. "4|person"). Returns null if not available.
+    /// </summary>
+    private string? GetCsoTypeNameFromDetailMessage()
+    {
+        var parts = Outcome.DetailMessage?.Split('|');
+        return parts is { Length: > 1 } ? parts[1] : null;
+    }
+
+    /// <summary>
+    /// Builds the connected system href for Provisioned and PendingExportCreated outcomes.
+    /// </summary>
+    private string GetCsHref() => $"/admin/connected-systems/{GetCsIdFromDetailMessage()}";
+
+    /// <summary>
+    /// Builds the CSO detail href for Provisioned outcomes.
+    /// The CS integer ID is in DetailMessage and the CSO GUID is in TargetEntityId.
+    /// </summary>
+    private string GetProvisionedCsoHref() =>
+        Utilities.GetConnectedSystemObjectHref(int.Parse(GetCsIdFromDetailMessage()), Outcome.TargetEntityId!.Value);
 
 }

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1167,6 +1167,11 @@ html[lang] .mud-alert-position {
     font-size: 1rem;
 }
 
+/* Dense mode: reduce body cell padding while keeping header at normal height */
+.jim-attribute-table.mud-table-dense tbody tr td {
+    padding: 4px 16px !important;
+}
+
 
 .jim-attr-name {
     background-color: var(--jim-attr-name-bg, var(--mud-palette-background-grey));

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1350,11 +1350,12 @@ html[lang] .mud-alert-position {
 /* Clickable chip link - hover effect for chips wrapped in links */
 .jim-chip-link .mud-chip {
     cursor: pointer;
-    transition: background-color 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.jim-chip-link .mud-chip:hover {
-    background-color: var(--mud-palette-action-default-hover);
+.jim-chip-link:hover .mud-chip {
+    background-color: var(--mud-palette-primary);
+    color: var(--mud-palette-primary-text);
 }
 
 /* Schedule Step Drag and Drop Styles */

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -1237,11 +1237,21 @@ public abstract class SyncTaskProcessorBase
                     .ToDictionary(g => g.Key, g => g.First().ConnectedSystem.Name)
                     ?? new Dictionary<int, string>();
 
+                // Build CSO type name lookup from export rules (the provisioning CSO doesn't have the Type nav property loaded)
+                var csoTypeNameLookup = _exportEvaluationCache?.ExportRulesByMvoTypeId.Values
+                    .SelectMany(rules => rules)
+                    .Where(sr => sr.ConnectedSystemObjectType != null)
+                    .GroupBy(sr => sr.ConnectedSystemId)
+                    .ToDictionary(g => g.Key, g => g.First().ConnectedSystemObjectType!.Name)
+                    ?? new Dictionary<int, string>();
+
                 foreach (var provisioningCso in result.ProvisioningCsosToCreate)
                 {
-                    // Store CS integer ID in DetailMessage for hyperlinking in the UI
-                    var csIdString = provisioningCso.ConnectedSystemId > 0
-                        ? provisioningCso.ConnectedSystemId.ToString()
+                    // Store CS integer ID and CSO type name in DetailMessage for hyperlinking in the UI
+                    // Format: "csId|csoTypeName" (e.g. "4|person")
+                    csoTypeNameLookup.TryGetValue(provisioningCso.ConnectedSystemId, out var csoTypeName);
+                    var detailMessage = provisioningCso.ConnectedSystemId > 0
+                        ? $"{provisioningCso.ConnectedSystemId}|{csoTypeName}"
                         : null;
 
                     csNameLookup.TryGetValue(provisioningCso.ConnectedSystemId, out var csName);
@@ -1251,15 +1261,17 @@ public abstract class SyncTaskProcessorBase
                     {
                         provisionedOutcome = SyncOutcomeBuilder.AddChildOutcome(originatingRpei, exportParent,
                             ActivityRunProfileExecutionItemSyncOutcomeType.Provisioned,
+                            targetEntityId: provisioningCso.Id,
                             targetEntityDescription: csName,
-                            detailMessage: csIdString);
+                            detailMessage: detailMessage);
                     }
                     else
                     {
                         provisionedOutcome = SyncOutcomeBuilder.AddRootOutcome(originatingRpei,
                             ActivityRunProfileExecutionItemSyncOutcomeType.Provisioned,
+                            targetEntityId: provisioningCso.Id,
                             targetEntityDescription: csName,
-                            detailMessage: csIdString);
+                            detailMessage: detailMessage);
                     }
 
                     provisionedByCs[provisioningCso.ConnectedSystemId] = provisionedOutcome;

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -1230,7 +1230,7 @@ public abstract class SyncTaskProcessorBase
 
                 // Build CS ID → name lookup from the export evaluation cache (the provisioning CSO
                 // intentionally does not have the ConnectedSystem nav property loaded).
-                var csNameLookup = _exportEvaluationCache?.ExportRulesByMvoTypeId.Values
+                var csNameLookup = _exportEvaluationCache.ExportRulesByMvoTypeId.Values
                     .SelectMany(rules => rules)
                     .Where(sr => sr.ConnectedSystem != null)
                     .GroupBy(sr => sr.ConnectedSystemId)
@@ -1238,7 +1238,7 @@ public abstract class SyncTaskProcessorBase
                     ?? new Dictionary<int, string>();
 
                 // Build CSO type name lookup from export rules (the provisioning CSO doesn't have the Type nav property loaded)
-                var csoTypeNameLookup = _exportEvaluationCache?.ExportRulesByMvoTypeId.Values
+                var csoTypeNameLookup = _exportEvaluationCache.ExportRulesByMvoTypeId.Values
                     .SelectMany(rules => rules)
                     .Where(sr => sr.ConnectedSystemObjectType != null)
                     .GroupBy(sr => sr.ConnectedSystemId)

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemServerChangeTrackingTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemServerChangeTrackingTests.cs
@@ -319,4 +319,72 @@ public class ConnectedSystemServerChangeTrackingTests
     }
 
     #endregion
+
+    #region RPEI ConnectedSystemObjectId preservation
+
+    /// <summary>
+    /// Verifies that CreateChangeRecordForCso does NOT overwrite the RPEI's ConnectedSystemObjectId
+    /// when creating a change record for a provisioning CSO.
+    ///
+    /// Bug: When a CSO is projected from CS 1, the RPEI is created with ConnectedSystemObjectId
+    /// pointing to the source CSO. Later, when export evaluation provisions a new CSO in CS 2,
+    /// CreateChangeRecordForCso was overwriting rpei.ConnectedSystemObjectId with the provisioning
+    /// CSO's ID. Since the RPEI is stored by reference in _pendingMvoChanges, the MVO change record
+    /// ended up pointing to the wrong CSO (provisioning CSO in CS 2 instead of source CSO in CS 1).
+    /// </summary>
+    [Test]
+    public void CreateChangeRecordForCso_DoesNotOverwriteRpeiConnectedSystemObjectId_PreservesSourceCsoAsync()
+    {
+        // Arrange
+        var sourceCsoId = Guid.NewGuid();
+        var provisioningCsoId = Guid.NewGuid();
+
+        var personType = new ConnectedSystemObjectType
+        {
+            Id = 1,
+            Name = "person",
+            Attributes = new List<ConnectedSystemObjectTypeAttribute> { _externalIdAttr }
+        };
+
+        // Source CSO from CS 1 (the one that triggered projection)
+        var sourceCso = new ConnectedSystemObject
+        {
+            Id = sourceCsoId,
+            ConnectedSystemId = 1,
+            TypeId = 1,
+            Type = personType,
+            ExternalIdAttributeId = _externalIdAttr.Id
+        };
+
+        // Provisioning CSO in CS 2 (created by export evaluation)
+        var provisioningCso = new ConnectedSystemObject
+        {
+            Id = provisioningCsoId,
+            ConnectedSystemId = 2,
+            TypeId = 1,
+            Type = personType,
+            ExternalIdAttributeId = _externalIdAttr.Id
+        };
+
+        // RPEI created during projection, pointing to source CSO
+        var rpei = new ActivityRunProfileExecutionItem
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemObject = sourceCso,
+            ConnectedSystemObjectId = sourceCsoId
+        };
+
+        // Act - create change record for the provisioning CSO using the same RPEI
+        _jim.ConnectedSystems.CreateChangeRecordForCso(provisioningCso, rpei, changeTrackingEnabled: true);
+
+        // Assert - RPEI must still point to the source CSO, not the provisioning CSO
+        Assert.That(rpei.ConnectedSystemObjectId, Is.EqualTo(sourceCsoId),
+            "RPEI's ConnectedSystemObjectId must not be overwritten by CreateChangeRecordForCso; " +
+            "it must continue to reference the source CSO that triggered the sync");
+
+        Assert.That(rpei.ConnectedSystemObject, Is.EqualTo(sourceCso),
+            "RPEI's ConnectedSystemObject navigation must still reference the source CSO");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- ✨ Add row density toggle to MvoDetailsTable, CSO detail, pending export list, and pending export detail pages
- 🖥️ Fix vertical spacing between page sections on CSO detail page for visual consistency
- 🖥️ Add spacing between subtitle text and filter panel on pending export list
- 📝 Expand panel spacing guidelines in src/CLAUDE.md with lessons learned (intro text margin compensation, TabPanelsClass, NavigableMudTabs wrapper)
- ✨ Add admin landing page and optimise sidebar navigation
- 🐛 Fix RPEI ConnectedSystemObjectId overwrite during provisioning CSO change tracking
- 🖥️ Standardise Razor comment conventions to box-drawing section headers
- ✨ Add Created and Updated columns to attribute flow table
- 🖥️ Various styling improvements (clickable chips, disabled text, drop shadows)
- ✨ Add search filter to attribute changes table on pending export detail
- 🐛 Fix Roslyn build artifacts with backslash paths in .gitignore

## Test plan

- [ ] Verify density toggle works on MVO table view, CSO detail attributes tab, pending export list, and pending export detail
- [ ] Verify density preference persists across page navigations (shared localStorage key)
- [ ] Verify uniform mt-6 spacing between page sections on CSO detail page
- [ ] Verify admin landing page renders and sidebar navigation is correct
- [ ] Verify attribute flow table shows Created/Updated columns
- [ ] Verify search filter works on pending export detail attribute changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)