### PR TITLE
feat: Scalar API reference with build-time OpenAPI generation

### DIFF
--- a/.claude/skills/review-dependabot/SKILL.md
+++ b/.claude/skills/review-dependabot/SKILL.md
@@ -91,11 +91,15 @@ Recommendations should be one of:
 
 Unless running in review-only mode:
 
-1. Identify any merge ordering constraints (multiple PRs touching the same file)
-2. Merge approved PRs in the correct order using `gh pr merge <number> --merge`
-3. Include a merge comment noting what was verified (pinning, security advisory, etc.)
-4. If a PR has merge conflicts after earlier merges, comment `@dependabot rebase` and wait for the rebase before merging
-5. Report final status of all PRs
+1. **Check branch is up to date**: Before merging, check whether the PR branch is behind `main` (`gh pr view <number> --json mergeStateStatus`). Branch protection requires the branch to be current. If the branch is behind:
+   - Comment `@dependabot rebase` on the PR
+   - Tell the user the rebase has been requested and that CI will re-run on the updated branch
+   - Once Dependabot rebases and CI passes, the merge can proceed (the user can re-run this skill or merge manually)
+2. Identify any merge ordering constraints (multiple PRs touching the same file)
+3. Merge approved PRs in the correct order using `gh pr merge <number> --merge`
+4. Include a merge comment noting what was verified (pinning, security advisory, etc.)
+5. If a PR has merge conflicts after earlier merges, comment `@dependabot rebase` and wait for the rebase before merging
+6. Report final status of all PRs
 
 ## Reference: JIM's Supply Chain Security Requirements
 

--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -58,6 +58,9 @@ Documentation:
 Diagrams:
   jim-diagrams       - Export Structurizr C4 diagrams as SVG
 
+OpenAPI:
+  jim-openapi-generate - Generate static OpenAPI document (no DB/IdP required)
+
 Planning:
   jim-prd            - Create a new PRD from template
 
@@ -537,6 +540,13 @@ jim-postgres-tune() {
   fi
 
   "${script_path}" "$@"
+}
+
+# Generate static OpenAPI document (no DB or IdP required)
+jim-openapi-generate() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo '/workspaces/JIM')"
+  pwsh -File "${repo_root}/scripts/Generate-OpenApiDoc.ps1" "$@"
 }
 
 # Wipe JIM data (reset to initial state without destroying database)

--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,15 @@ JIM_LOG_REQUESTS=false
 # JIM_THEME=navy-o6
 
 # =============================================================================
+# OpenAPI Documentation (Optional)
+# =============================================================================
+# JIM_OPENAPI_GENERATE=true      - Run in lightweight mode: generate OpenAPI doc and exit
+#                                   (no DB or IdP required). Used by jim-openapi-generate
+#                                   and the Docker build.
+# JIM_OPENAPI_OUTPUT_PATH=<path> - Override the output path for the generated document.
+#                                   Default: wwwroot/api/openapi/v1.json
+
+# =============================================================================
 # Infrastructure API Key (Optional - for CI/CD automation)
 # =============================================================================
 # Set this to create an API key on startup for automated configuration.

--- a/.gitignore
+++ b/.gitignore
@@ -476,5 +476,8 @@ engineering/diagrams/structurizr/node_modules/
 # MkDocs build output
 site/
 
+# Generated OpenAPI document (built by jim-openapi-generate or Docker build)
+src/JIM.Web/wwwroot/api/openapi/
+
 # Dev notes
 dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ✨ Interactive API reference powered by Scalar, available at `/api/reference` in all environments including air-gapped deployments; OpenAPI document is pre-generated at build time for instant loading with zero runtime overhead
 - ✨ Clear Connected System activity now tracks and displays removal statistics, showing how many pending exports and connected system objects were removed (#74)
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ JIM is a container-based distributed application implementing the metaverse patt
 </a>
 
 **Components:**
-- **JIM.Web** - A website with integrated REST API, built using [ASP.NET](https://asp.net/) Blazor Server. The API is available at `/api/`, with interactive [Scalar](https://scalar.com/) API documentation at `/api/reference` in development.
+- **JIM.Web** - A website with integrated REST API, built using [ASP.NET](https://asp.net/) Blazor Server. The API is available at `/api/`, with interactive [Scalar](https://scalar.com/) API documentation at `/api/reference`.
 - **JIM.Scheduler** - A background service that triggers synchronisation runs using cron or interval-based schedules, with multi-step sequential and parallel execution
 - **JIM.Worker** - A background service that processes import, sync, and export tasks with crash recovery and parallel execution support
 - **JIM.PowerShell** - A cross-platform PowerShell module (Windows, macOS, Linux) for full configuration and automation of JIM, enabling Identity as Code (IDaC)

--- a/README.md
+++ b/README.md
@@ -23,20 +23,15 @@ JIM is a modern Identity Management system designed for organisations with compl
 - Hub-and-spoke architecture using a central metaverse for identity correlation
 - Bidirectional synchronisation of Users, Groups, and custom object types (e.g., Departments, Roles, Computers)
 - Multi-directory LDAP support: Active Directory, OpenLDAP, 389 Directory Server, and other RFC 4512-compliant directories
+- Build-in scheduler that supports parallel operations
 - Tested at 100K+ object scale with bounded memory pipelines
-- Transform data using expressions with built-in functions for common identity operations
-- Extensible with custom connectors (fully unit-testable)
+- Transform data using expressions with extensive built-in functions for common identity operations
+- Extensible with custom Connectors (fully testable)
 - Modern Web Portal and REST API with OpenAPI documentation
-- Service Settings REST API and PowerShell automation for scripted configuration
-- Activity monitoring with auto-refresh and run profile editing
-- Safe cancellation for synchronisation and import operations with no data loss
-- Partition-scoped deletion detection for precise object lifecycle management
-- Data integrity validation for metaverse attribute operations
-- LDAP export concurrency auto-tuning by directory type
-- Object type icons for visual clarity across the portal
-- Docker container hardening: non-root execution, read-only root filesystem, dropped capabilities
-- Docker healthchecks on Worker and Scheduler for reliable orchestration
+- PowerShell automation for Identity as Code (IDaC) - deploy JIM instances in minutes, not months
+- Realtime activity monitoring
 - Single Sign-On (SSO) using OpenID Connect
+- Dark/Light mode
 
 ![A screenshot of JIM running](https://tetron.io/images/jim/0.8.0/homepage-dark.png "JIM Screenshot")
 

--- a/engineering/JIM_AI_ASSISTANT_CONTEXT.md
+++ b/engineering/JIM_AI_ASSISTANT_CONTEXT.md
@@ -291,7 +291,7 @@ FormatDateTime(hireDate, "yyyy-MM-dd")
 | `GET /api/v1/logs` | Unified log viewer (app + PostgreSQL) |
 | `GET /api/v1/synchronisation/sync-rules/{id}/matching-rules` | Manage object matching rules |
 
-Full interactive Scalar API reference available at `/api/reference` (development only; disabled in production). The underlying OpenAPI JSON spec is served at `/api/openapi/v1.json`.
+Full interactive Scalar API reference available at `/api/reference` in all environments, including air-gapped deployments. The OpenAPI document is pre-generated at build time and served as a static file at `/api/openapi/v1.json`.
 
 ### PowerShell Module
 

--- a/scripts/Generate-OpenApiDoc.ps1
+++ b/scripts/Generate-OpenApiDoc.ps1
@@ -1,0 +1,69 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Generates the OpenAPI document for JIM.Web in lightweight mode.
+
+.DESCRIPTION
+    Runs JIM.Web with JIM_OPENAPI_GENERATE=true, which skips database,
+    SSO, and authentication initialisation. The app generates the OpenAPI
+    JSON document and exits immediately.
+
+    No external services (database, Keycloak) are required.
+
+.PARAMETER OutputPath
+    Where to write the OpenAPI JSON. Defaults to
+    src/JIM.Web/wwwroot/api/openapi/v1.json.
+
+.EXAMPLE
+    ./scripts/Generate-OpenApiDoc.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path $PSScriptRoot
+$projectPath = Join-Path $repoRoot "src/JIM.Web/JIM.Web.csproj"
+
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $repoRoot "src/JIM.Web/wwwroot/api/openapi/v1.json"
+}
+
+# Set lightweight generation mode
+$env:JIM_OPENAPI_GENERATE = "true"
+$env:JIM_OPENAPI_OUTPUT_PATH = $OutputPath
+
+# Provide minimal placeholder env vars for any that are not already set
+if (-not $env:JIM_LOG_LEVEL)         { $env:JIM_LOG_LEVEL = "Warning" }
+if (-not $env:JIM_LOG_PATH)          { $env:JIM_LOG_PATH = "/tmp/jim-openapi-gen" }
+if (-not $env:JIM_SSO_AUTHORITY)     { $env:JIM_SSO_AUTHORITY = "http://localhost:8181/realms/jim" }
+if (-not $env:JIM_SSO_CLIENT_ID)     { $env:JIM_SSO_CLIENT_ID = "jim-web" }
+if (-not $env:JIM_SSO_SECRET)        { $env:JIM_SSO_SECRET = "placeholder" }
+if (-not $env:JIM_SSO_API_SCOPE)     { $env:JIM_SSO_API_SCOPE = "jim-api" }
+if (-not $env:JIM_SSO_CLAIM_TYPE)    { $env:JIM_SSO_CLAIM_TYPE = "sub" }
+if (-not $env:JIM_SSO_MV_ATTRIBUTE)  { $env:JIM_SSO_MV_ATTRIBUTE = "Subject Identifier" }
+if (-not $env:JIM_SSO_INITIAL_ADMIN) { $env:JIM_SSO_INITIAL_ADMIN = "placeholder" }
+if (-not $env:JIM_DB_HOSTNAME)       { $env:JIM_DB_HOSTNAME = "localhost" }
+if (-not $env:JIM_DB_NAME)           { $env:JIM_DB_NAME = "jim" }
+if (-not $env:JIM_DB_USERNAME)       { $env:JIM_DB_USERNAME = "jim" }
+if (-not $env:JIM_DB_PASSWORD)       { $env:JIM_DB_PASSWORD = "placeholder" }
+
+Write-Host "Generating OpenAPI document..." -ForegroundColor Cyan
+dotnet run --project $projectPath --no-launch-profile
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "OpenAPI generation failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+if (Test-Path $OutputPath) {
+    $size = (Get-Item $OutputPath).Length
+    Write-Host "OpenAPI document generated: $OutputPath ($size bytes)" -ForegroundColor Green
+} else {
+    Write-Error "Expected output file not found: $OutputPath"
+    exit 1
+}

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -202,7 +202,7 @@ var schedule = await Jim.Scheduler.GetScheduleAsync(id);
 1. Add method to controller in `JIM.Web/Controllers/Api/`
 2. Use DTOs for request/response (in `JIM.Web/Models/Api/`)
 3. Add XML comments for OpenAPI documentation
-4. Test via the Scalar API reference at `/api/reference` (Development only)
+4. Test via the Scalar API reference at `/api/reference`
 
 **Modifying Database Schema:**
 1. Update entity in `JIM.Models/`

--- a/src/JIM.Models/Core/Constants.cs
+++ b/src/JIM.Models/Core/Constants.cs
@@ -37,6 +37,10 @@ public static class Constants
 
         // UI
         public static string Theme => "JIM_THEME";
+
+        // OpenAPI
+        public static string OpenApiGenerate => "JIM_OPENAPI_GENERATE";
+        public static string OpenApiOutputPath => "JIM_OPENAPI_OUTPUT_PATH";
     }
 
     public static class BuiltInObjectTypes

--- a/src/JIM.Web/Controllers/Api/ActivitiesController.cs
+++ b/src/JIM.Web/Controllers/Api/ActivitiesController.cs
@@ -13,12 +13,12 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for viewing activity history and monitoring sync operations.
+/// API controller for viewing Activity history and monitoring sync operations.
 /// </summary>
 /// <remarks>
 /// Activities track all operations performed in JIM, including sync runs, data generation,
 /// certificate management, and other administrative actions. This controller provides
-/// read-only access to the activity history for monitoring and audit purposes.
+/// read-only access to the Activity history for monitoring and audit purposes.
 /// </remarks>
 [Route("api/v{version:apiVersion}/[controller]")]
 [ApiController]
@@ -31,12 +31,12 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// List activities
+    /// List Activities
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <param name="search">Optional search query to filter by target name or type.</param>
-    /// <returns>A paginated list of activity headers.</returns>
-    /// <response code="200">Returns the paginated list of activities.</response>
+    /// <returns>A paginated list of Activity headers.</returns>
+    /// <response code="200">Returns the paginated list of Activities.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet(Name = "GetActivities")]
     [ProducesResponseType(typeof(PaginatedResponse<ActivityHeader>), StatusCodes.Status200OK)]
@@ -73,12 +73,12 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     }
 
     /// <summary>
-    /// Get activity details
+    /// Get Activity details
     /// </summary>
-    /// <param name="id">The unique identifier (GUID) of the activity.</param>
-    /// <returns>The activity details including error information and execution statistics.</returns>
-    /// <response code="200">Returns the activity details.</response>
-    /// <response code="404">If the activity is not found.</response>
+    /// <param name="id">The unique identifier (GUID) of the Activity.</param>
+    /// <returns>The Activity details including error information and execution statistics.</returns>
+    /// <response code="200">Returns the Activity details.</response>
+    /// <response code="404">If the Activity is not found.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("{id:guid}", Name = "GetActivity")]
     [ProducesResponseType(typeof(ActivityDetailDto), StatusCodes.Status200OK)]
@@ -107,11 +107,11 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     /// <summary>
     /// Get Run Profile execution statistics
     /// </summary>
-    /// <param name="id">The unique identifier (GUID) of the activity.</param>
-    /// <returns>The execution statistics for the activity.</returns>
+    /// <param name="id">The unique identifier (GUID) of the Activity.</param>
+    /// <returns>The execution statistics for the Activity.</returns>
     /// <response code="200">Returns the execution statistics.</response>
-    /// <response code="404">If the activity is not found.</response>
-    /// <response code="400">If the activity is not a Run Profile activity.</response>
+    /// <response code="404">If the Activity is not found.</response>
+    /// <response code="400">If the Activity is not a Run Profile Activity.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("{id:guid}/stats", Name = "GetActivityStats")]
     [ProducesResponseType(typeof(ActivityRunProfileExecutionStatsDto), StatusCodes.Status200OK)]
@@ -140,12 +140,12 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     /// <summary>
     /// List Run Profile Execution Items
     /// </summary>
-    /// <param name="id">The unique identifier (GUID) of the activity.</param>
+    /// <param name="id">The unique identifier (GUID) of the Activity.</param>
     /// <param name="pagination">Pagination parameters.</param>
     /// <returns>A paginated list of Execution Item headers.</returns>
     /// <response code="200">Returns the paginated list of Execution Items.</response>
-    /// <response code="404">If the activity is not found.</response>
-    /// <response code="400">If the activity is not a Run Profile activity.</response>
+    /// <response code="404">If the Activity is not found.</response>
+    /// <response code="400">If the Activity is not a Run Profile Activity.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("{id:guid}/items", Name = "GetActivityExecutionItems")]
     [ProducesResponseType(typeof(PaginatedResponse<ActivityRunProfileExecutionItemHeader>), StatusCodes.Status200OK)]
@@ -185,12 +185,12 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     }
 
     /// <summary>
-    /// List child activities
+    /// List child Activities
     /// </summary>
-    /// <param name="id">The unique identifier (GUID) of the parent activity.</param>
-    /// <returns>A list of child activity headers, ordered by creation date ascending.</returns>
-    /// <response code="200">Returns the child activities (empty list if none).</response>
-    /// <response code="404">If the parent activity is not found.</response>
+    /// <param name="id">The unique identifier (GUID) of the parent Activity.</param>
+    /// <returns>A list of child Activity headers, ordered by creation date ascending.</returns>
+    /// <response code="200">Returns the child Activities (empty list if none).</response>
+    /// <response code="404">If the parent Activity is not found.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("{id:guid}/children", Name = "GetChildActivities")]
     [ProducesResponseType(typeof(IEnumerable<ActivityHeader>), StatusCodes.Status200OK)]

--- a/src/JIM.Web/Controllers/Api/ActivitiesController.cs
+++ b/src/JIM.Web/Controllers/Api/ActivitiesController.cs
@@ -31,7 +31,7 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets a paginated list of activities with optional filtering and sorting.
+    /// List activities
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <param name="search">Optional search query to filter by target name or type.</param>
@@ -73,7 +73,7 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     }
 
     /// <summary>
-    /// Gets detailed information about a specific activity.
+    /// Get activity details
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the activity.</param>
     /// <returns>The activity details including error information and execution statistics.</returns>
@@ -105,13 +105,13 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     }
 
     /// <summary>
-    /// Gets execution statistics for a run profile activity.
+    /// Get Run Profile execution statistics
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the activity.</param>
     /// <returns>The execution statistics for the activity.</returns>
     /// <response code="200">Returns the execution statistics.</response>
     /// <response code="404">If the activity is not found.</response>
-    /// <response code="400">If the activity is not a run profile activity.</response>
+    /// <response code="400">If the activity is not a Run Profile activity.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("{id:guid}/stats", Name = "GetActivityStats")]
     [ProducesResponseType(typeof(ActivityRunProfileExecutionStatsDto), StatusCodes.Status200OK)]
@@ -138,14 +138,14 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     }
 
     /// <summary>
-    /// Gets a paginated list of execution items for a run profile activity.
+    /// List Run Profile Execution Items
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the activity.</param>
     /// <param name="pagination">Pagination parameters.</param>
-    /// <returns>A paginated list of execution item headers.</returns>
-    /// <response code="200">Returns the paginated list of execution items.</response>
+    /// <returns>A paginated list of Execution Item headers.</returns>
+    /// <response code="200">Returns the paginated list of Execution Items.</response>
     /// <response code="404">If the activity is not found.</response>
-    /// <response code="400">If the activity is not a run profile activity.</response>
+    /// <response code="400">If the activity is not a Run Profile activity.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("{id:guid}/items", Name = "GetActivityExecutionItems")]
     [ProducesResponseType(typeof(PaginatedResponse<ActivityRunProfileExecutionItemHeader>), StatusCodes.Status200OK)]
@@ -185,7 +185,7 @@ public class ActivitiesController(ILogger<ActivitiesController> logger, JimAppli
     }
 
     /// <summary>
-    /// Gets the direct child activities for a given activity.
+    /// List child activities
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the parent activity.</param>
     /// <returns>A list of child activity headers, ordered by creation date ascending.</returns>

--- a/src/JIM.Web/Controllers/Api/ApiKeysController.cs
+++ b/src/JIM.Web/Controllers/Api/ApiKeysController.cs
@@ -33,7 +33,7 @@ public class ApiKeysController(ILogger<ApiKeysController> logger, JimApplication
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all API keys.
+    /// List API keys
     /// </summary>
     /// <remarks>
     /// Returns all API keys with their metadata. The full key value is never returned;
@@ -53,7 +53,7 @@ public class ApiKeysController(ILogger<ApiKeysController> logger, JimApplication
     }
 
     /// <summary>
-    /// Gets a specific API key by ID.
+    /// Get an API key
     /// </summary>
     /// <param name="id">The unique identifier of the API key.</param>
     /// <returns>The API key details.</returns>
@@ -76,7 +76,7 @@ public class ApiKeysController(ILogger<ApiKeysController> logger, JimApplication
     }
 
     /// <summary>
-    /// Creates a new API key.
+    /// Create an API key
     /// </summary>
     /// <remarks>
     /// The full API key is returned only in this response. Store it securely as it
@@ -152,12 +152,8 @@ public class ApiKeysController(ILogger<ApiKeysController> logger, JimApplication
     }
 
     /// <summary>
-    /// Updates an existing API key.
+    /// Update an API key
     /// </summary>
-    /// <remarks>
-    /// Updates the API key's name, description, roles, expiry, and enabled status.
-    /// The key value itself cannot be changed.
-    /// </remarks>
     /// <param name="id">The unique identifier of the API key.</param>
     /// <param name="request">The update request.</param>
     /// <returns>The updated API key details.</returns>
@@ -210,11 +206,8 @@ public class ApiKeysController(ILogger<ApiKeysController> logger, JimApplication
     }
 
     /// <summary>
-    /// Deletes an API key.
+    /// Delete an API key
     /// </summary>
-    /// <remarks>
-    /// Permanently deletes the API key. Any requests using this key will fail immediately.
-    /// </remarks>
     /// <param name="id">The unique identifier of the API key to delete.</param>
     /// <returns>No content on success.</returns>
     [HttpDelete("{id:guid}", Name = "DeleteApiKey")]

--- a/src/JIM.Web/Controllers/Api/AuthController.cs
+++ b/src/JIM.Web/Controllers/Api/AuthController.cs
@@ -23,7 +23,7 @@ namespace JIM.Web.Controllers.Api;
 public class AuthController : ControllerBase
 {
     /// <summary>
-    /// Gets the OAuth/OIDC configuration for interactive authentication.
+    /// Get OAuth/OIDC configuration
     /// </summary>
     /// <remarks>
     /// Returns the OAuth configuration needed by clients (e.g., PowerShell module) to perform

--- a/src/JIM.Web/Controllers/Api/CertificatesController.cs
+++ b/src/JIM.Web/Controllers/Api/CertificatesController.cs
@@ -31,7 +31,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all trusted certificates with optional pagination, sorting, and filtering.
+    /// List trusted certificates
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <returns>A paginated list of certificate headers.</returns>
@@ -53,7 +53,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Gets all enabled trusted certificates.
+    /// List enabled trusted certificates
     /// </summary>
     /// <returns>A list of enabled certificate headers.</returns>
     [HttpGet("enabled", Name = "GetEnabledCertificates")]
@@ -68,7 +68,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Gets a trusted certificate by ID.
+    /// Get a trusted certificate
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the certificate.</param>
     /// <returns>The certificate details including metadata but not the raw certificate bytes.</returns>
@@ -87,7 +87,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Adds a certificate from uploaded data (Base64 encoded PEM or DER).
+    /// Add a certificate from uploaded data
     /// </summary>
     /// <remarks>
     /// The certificate data should be Base64 encoded. Both PEM and DER formats are supported.
@@ -139,7 +139,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Adds a certificate from a file path in the connector-files mount.
+    /// Add a certificate from a file path
     /// </summary>
     /// <remarks>
     /// The file path should be relative to the connector-files volume mount.
@@ -188,7 +188,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Updates a certificate's editable properties (name, notes, enabled state).
+    /// Update a certificate
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the certificate to update.</param>
     /// <param name="request">The properties to update (all optional).</param>
@@ -223,7 +223,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Deletes a trusted certificate from the store.
+    /// Delete a trusted certificate
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the certificate to delete.</param>
     /// <returns>204 No Content on success.</returns>
@@ -252,7 +252,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Validates a certificate and returns any issues found.
+    /// Validate a certificate
     /// </summary>
     /// <remarks>
     /// Checks include expiry date, chain validation, and other certificate properties.
@@ -278,7 +278,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Downloads the raw certificate data in DER format.
+    /// Download certificate data
     /// </summary>
     /// <remarks>
     /// Returns the certificate as a binary file download. The certificate is returned

--- a/src/JIM.Web/Controllers/Api/CertificatesController.cs
+++ b/src/JIM.Web/Controllers/Api/CertificatesController.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for managing trusted certificates in the JIM certificate store.
+/// API controller for managing Trusted Certificates in the JIM certificate store.
 /// </summary>
 /// <remarks>
 /// Certificates stored here are used for establishing trust with external systems,
@@ -31,7 +31,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// List trusted certificates
+    /// List Trusted Certificates
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <returns>A paginated list of certificate headers.</returns>
@@ -53,7 +53,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// List enabled trusted certificates
+    /// List enabled Trusted Certificates
     /// </summary>
     /// <returns>A list of enabled certificate headers.</returns>
     [HttpGet("enabled", Name = "GetEnabledCertificates")]
@@ -68,7 +68,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Get a trusted certificate
+    /// Get a Trusted Certificate
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the certificate.</param>
     /// <returns>The certificate details including metadata but not the raw certificate bytes.</returns>
@@ -223,7 +223,7 @@ public class CertificatesController(ILogger<CertificatesController> logger, JimA
     }
 
     /// <summary>
-    /// Delete a trusted certificate
+    /// Delete a Trusted Certificate
     /// </summary>
     /// <param name="id">The unique identifier (GUID) of the certificate to delete.</param>
     /// <returns>204 No Content on success.</returns>

--- a/src/JIM.Web/Controllers/Api/ExampleDataController.cs
+++ b/src/JIM.Web/Controllers/Api/ExampleDataController.cs
@@ -32,12 +32,8 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all example data sets with optional pagination, sorting, and filtering.
+    /// List example data sets
     /// </summary>
-    /// <remarks>
-    /// Example data sets contain pre-defined identity data that can be used for
-    /// testing and demonstration purposes.
-    /// </remarks>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <returns>A paginated list of example data set headers.</returns>
     [HttpGet("example-data-sets", Name = "GetExampleDataSets")]
@@ -57,12 +53,8 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     }
 
     /// <summary>
-    /// Gets all data generation templates with optional pagination, sorting, and filtering.
+    /// List data generation templates
     /// </summary>
-    /// <remarks>
-    /// Templates define how test data should be generated, including which object types
-    /// to create and how many instances of each.
-    /// </remarks>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <returns>A paginated list of template headers.</returns>
     [HttpGet("templates", Name = "GetExampleDataTemplates")]
@@ -82,10 +74,10 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     }
 
     /// <summary>
-    /// Gets a specific data generation template by ID.
+    /// Get a data generation template
     /// </summary>
     /// <param name="id">The unique identifier of the template.</param>
-    /// <returns>The full template details including nested object type configurations.</returns>
+    /// <returns>The full template details including nested Object Type configurations.</returns>
     [HttpGet("templates/{id:int}", Name = "GetExampleDataTemplate")]
     [ProducesResponseType(typeof(ExampleDataTemplate), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -102,13 +94,8 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     }
 
     /// <summary>
-    /// Executes a data generation template to create test data.
+    /// Execute a data generation template
     /// </summary>
-    /// <remarks>
-    /// This operation runs asynchronously and creates identity objects in the Metaverse
-    /// according to the template configuration. The operation may take some time to complete
-    /// depending on the number of objects being generated.
-    /// </remarks>
     /// <param name="id">The unique identifier of the template to execute.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
     /// <returns>202 Accepted if the template execution has started.</returns>

--- a/src/JIM.Web/Controllers/Api/ExampleDataController.cs
+++ b/src/JIM.Web/Controllers/Api/ExampleDataController.cs
@@ -13,12 +13,12 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for data generation operations including templates and example data sets.
+/// API controller for data generation operations including templates and Example Data Sets.
 /// </summary>
 /// <remarks>
 /// This controller provides endpoints for:
-/// - Browsing available data generation templates
-/// - Viewing example data sets that can be used for testing
+/// - Browsing available Data Generation Templates
+/// - Viewing Example Data Sets that can be used for testing
 /// - Executing templates to generate test data in the Metaverse
 /// </remarks>
 [Route("api/v{version:apiVersion}/example-data")]
@@ -32,10 +32,10 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// List example data sets
+    /// List Example Data Sets
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
-    /// <returns>A paginated list of example data set headers.</returns>
+    /// <returns>A paginated list of Example Data Set headers.</returns>
     [HttpGet("example-data-sets", Name = "GetExampleDataSets")]
     [ProducesResponseType(typeof(PaginatedResponse<ExampleDataSetHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -53,7 +53,7 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     }
 
     /// <summary>
-    /// List data generation templates
+    /// List Data Generation Templates
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <returns>A paginated list of template headers.</returns>
@@ -74,7 +74,7 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     }
 
     /// <summary>
-    /// Get a data generation template
+    /// Get a Data Generation Template
     /// </summary>
     /// <param name="id">The unique identifier of the template.</param>
     /// <returns>The full template details including nested Object Type configurations.</returns>
@@ -94,7 +94,7 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
     }
 
     /// <summary>
-    /// Execute a data generation template
+    /// Execute a Data Generation Template
     /// </summary>
     /// <param name="id">The unique identifier of the template to execute.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>

--- a/src/JIM.Web/Controllers/Api/FileSystemController.cs
+++ b/src/JIM.Web/Controllers/Api/FileSystemController.cs
@@ -32,6 +32,12 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     /// <summary>
     /// List directory contents
     /// </summary>
+    /// <remarks>
+    /// Browse files and directories within the JIM container's allowed mount points.
+    /// Used when configuring file-based connectors (e.g. CSV) to select import/export paths.
+    /// Omit the path parameter to list the allowed root directories.
+    /// Only paths within the configured allowed roots are accessible; all other paths return 403.
+    /// </remarks>
     /// <param name="path">The directory path to list. If not specified, returns the allowed root directories.</param>
     /// <returns>A list of files and directories in the specified path.</returns>
     /// <response code="200">Returns the directory listing.</response>
@@ -65,6 +71,10 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     /// <summary>
     /// List allowed root directories
     /// </summary>
+    /// <remarks>
+    /// Returns the root directories that JIM is permitted to browse.
+    /// These correspond to Docker volume mounts configured for file-based connectors.
+    /// </remarks>
     /// <returns>A list of allowed root directory paths.</returns>
     [HttpGet("roots")]
     [ProducesResponseType(typeof(IReadOnlyList<string>), StatusCodes.Status200OK)]
@@ -78,6 +88,10 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     /// <summary>
     /// Validate a file system path
     /// </summary>
+    /// <remarks>
+    /// Check whether a given path falls within the allowed root directories.
+    /// Use this before attempting to configure a connector with a file path.
+    /// </remarks>
     /// <param name="path">The path to validate.</param>
     /// <returns>True if the path is allowed, false otherwise.</returns>
     [HttpGet("validate")]

--- a/src/JIM.Web/Controllers/Api/FileSystemController.cs
+++ b/src/JIM.Web/Controllers/Api/FileSystemController.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for browsing the container file system.
+/// API controller for browsing the Container file system.
 /// Provides endpoints for listing directories and files within allowed paths.
 /// </summary>
 /// <remarks>
@@ -33,7 +33,7 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     /// List directory contents
     /// </summary>
     /// <remarks>
-    /// Browse files and directories within the JIM container's allowed mount points.
+    /// Browse files and directories within the JIM Container's allowed mount points.
     /// Used when configuring file-based connectors (e.g. CSV) to select import/export paths.
     /// Omit the path parameter to list the allowed root directories.
     /// Only paths within the configured allowed roots are accessible; all other paths return 403.

--- a/src/JIM.Web/Controllers/Api/FileSystemController.cs
+++ b/src/JIM.Web/Controllers/Api/FileSystemController.cs
@@ -30,7 +30,7 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Lists the contents of a directory within allowed paths.
+    /// List directory contents
     /// </summary>
     /// <param name="path">The directory path to list. If not specified, returns the allowed root directories.</param>
     /// <returns>A list of files and directories in the specified path.</returns>
@@ -63,7 +63,7 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     }
 
     /// <summary>
-    /// Gets the list of allowed root directories that can be browsed.
+    /// List allowed root directories
     /// </summary>
     /// <returns>A list of allowed root directory paths.</returns>
     [HttpGet("roots")]
@@ -76,7 +76,7 @@ public class FileSystemController(ILogger<FileSystemController> logger, JimAppli
     }
 
     /// <summary>
-    /// Validates whether a given path is within the allowed directories.
+    /// Validate a file system path
     /// </summary>
     /// <param name="path">The path to validate.</param>
     /// <returns>True if the path is allowed, false otherwise.</returns>

--- a/src/JIM.Web/Controllers/Api/HealthController.cs
+++ b/src/JIM.Web/Controllers/Api/HealthController.cs
@@ -26,7 +26,7 @@ public class HealthController(JimApplication application) : ControllerBase
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Basic health check - returns 200 OK if the service is running.
+    /// Get service health status
     /// </summary>
     /// <returns>Health status and timestamp.</returns>
     [HttpGet(Name = "GetHealth")]
@@ -37,7 +37,7 @@ public class HealthController(JimApplication application) : ControllerBase
     }
 
     /// <summary>
-    /// Readiness check - confirms the service is ready to accept requests.
+    /// Get service readiness status
     /// </summary>
     /// <remarks>
     /// Verifies the application is ready by checking database connectivity
@@ -83,7 +83,7 @@ public class HealthController(JimApplication application) : ControllerBase
     }
 
     /// <summary>
-    /// Liveness check - confirms the service process is alive.
+    /// Get service liveness status
     /// </summary>
     /// <remarks>
     /// Used by orchestrators to determine if the service needs to be restarted.
@@ -98,12 +98,8 @@ public class HealthController(JimApplication application) : ControllerBase
     }
 
     /// <summary>
-    /// Returns the JIM application version.
+    /// Get application version
     /// </summary>
-    /// <remarks>
-    /// Reads the version from the assembly's InformationalVersion attribute,
-    /// which is set at build time from the VERSION file.
-    /// </remarks>
     /// <returns>Product name and version string.</returns>
     [HttpGet("version", Name = "GetHealthVersion")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/JIM.Web/Controllers/Api/HistoryController.cs
+++ b/src/JIM.Web/Controllers/Api/HistoryController.cs
@@ -33,7 +33,7 @@ public class HistoryController(ILogger<HistoryController> logger, JimApplication
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Manually triggers change history cleanup based on retention policy.
+    /// Trigger change history cleanup
     /// </summary>
     /// <remarks>
     /// Deletes expired CSO changes, MVO changes, and Activities older than the configured
@@ -99,12 +99,12 @@ public class HistoryController(ILogger<HistoryController> logger, JimApplication
     }
 
     /// <summary>
-    /// Gets the count of change history records for a specific connected system.
+    /// Get change history count for a Connected System
     /// </summary>
-    /// <param name="connectedSystemId">The connected system ID.</param>
+    /// <param name="connectedSystemId">The Connected System ID.</param>
     /// <returns>Count of CSO change records for the system.</returns>
     /// <response code="200">Returns the count of change records.</response>
-    /// <response code="404">If the connected system is not found.</response>
+    /// <response code="404">If the Connected System is not found.</response>
     /// <response code="401">If the user is not authenticated.</response>
     [HttpGet("connected-systems/{connectedSystemId:int}/count", Name = "GetConnectedSystemChangeCount")]
     [ProducesResponseType(typeof(HistoryCountResponse), StatusCodes.Status200OK)]
@@ -134,7 +134,7 @@ public class HistoryController(ILogger<HistoryController> logger, JimApplication
     }
 
     /// <summary>
-    /// Gets a paginated list of deleted CSOs (Connected System Objects).
+    /// List deleted Connected System Objects
     /// </summary>
     /// <remarks>
     /// Returns CSOs that have been deleted, with their identity preserved at deletion time.
@@ -201,7 +201,7 @@ public class HistoryController(ILogger<HistoryController> logger, JimApplication
     }
 
     /// <summary>
-    /// Gets a paginated list of deleted MVOs (Metaverse Objects).
+    /// List deleted Metaverse Objects
     /// </summary>
     /// <remarks>
     /// Returns MVOs that have been deleted, with their identity preserved at deletion time.

--- a/src/JIM.Web/Controllers/Api/LogsController.cs
+++ b/src/JIM.Web/Controllers/Api/LogsController.cs
@@ -30,12 +30,8 @@ public class LogsController(ILogger<LogsController> logger, LogReaderService log
     private readonly LogReaderService _logReaderService = logReaderService;
 
     /// <summary>
-    /// Gets all available log files.
+    /// List available log files
     /// </summary>
-    /// <remarks>
-    /// Returns information about all log files in the log directory, including
-    /// file name, service, date, and size. Files are sorted by date descending.
-    /// </remarks>
     /// <returns>A list of available log files.</returns>
     [HttpGet("files", Name = "GetLogFiles")]
     [ProducesResponseType(typeof(IEnumerable<LogFileDto>), StatusCodes.Status200OK)]
@@ -59,12 +55,8 @@ public class LogsController(ILogger<LogsController> logger, LogReaderService log
     }
 
     /// <summary>
-    /// Gets log entries with optional filtering.
+    /// List log entries
     /// </summary>
-    /// <remarks>
-    /// Returns log entries matching the specified criteria. Results are sorted by
-    /// timestamp descending (newest first) and limited to prevent excessive data transfer.
-    /// </remarks>
     /// <param name="request">The query parameters for filtering logs.</param>
     /// <returns>A list of log entries matching the criteria.</returns>
     [HttpGet(Name = "GetLogEntries")]
@@ -103,11 +95,8 @@ public class LogsController(ILogger<LogsController> logger, LogReaderService log
     }
 
     /// <summary>
-    /// Gets the available log levels.
+    /// List available log levels
     /// </summary>
-    /// <remarks>
-    /// Returns the list of log levels in order of severity, from Verbose to Fatal.
-    /// </remarks>
     /// <returns>A list of log level names.</returns>
     [HttpGet("levels", Name = "GetLogLevels")]
     [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
@@ -120,11 +109,8 @@ public class LogsController(ILogger<LogsController> logger, LogReaderService log
     }
 
     /// <summary>
-    /// Gets the available service names.
+    /// List available log services
     /// </summary>
-    /// <remarks>
-    /// Returns the list of JIM services that generate logs.
-    /// </remarks>
     /// <returns>A list of service names.</returns>
     [HttpGet("services", Name = "GetLogServices")]
     [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]

--- a/src/JIM.Web/Controllers/Api/MetaverseController.cs
+++ b/src/JIM.Web/Controllers/Api/MetaverseController.cs
@@ -21,7 +21,7 @@ namespace JIM.Web.Controllers.Api;
 /// </summary>
 /// <remarks>
 /// The Metaverse is the central identity store in JIM. This controller provides
-/// endpoints for managing object types, attributes, and individual metaverse objects.
+/// endpoints for managing Object Types, attributes, and individual Metaverse Objects.
 /// </remarks>
 [Route("api/v{version:apiVersion}/[controller]")]
 [ApiController]
@@ -34,11 +34,11 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all metaverse object types with optional pagination, sorting, and filtering.
+    /// List Metaverse Object Types
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
     /// <param name="includeChildObjects">Whether to include child object counts in the response.</param>
-    /// <returns>A paginated list of metaverse object type headers.</returns>
+    /// <returns>A paginated list of Metaverse Object Type headers.</returns>
     [HttpGet("object-types", Name = "GetObjectTypes")]
     [ProducesResponseType(typeof(PaginatedResponse<MetaverseObjectTypeHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -56,11 +56,11 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets a specific metaverse object type by ID.
+    /// Get a Metaverse Object Type
     /// </summary>
-    /// <param name="id">The unique identifier of the object type.</param>
+    /// <param name="id">The unique identifier of the Object Type.</param>
     /// <param name="includeChildObjects">Whether to include child object details in the response.</param>
-    /// <returns>The object type details.</returns>
+    /// <returns>The Object Type details.</returns>
     [HttpGet("object-types/{id:int}", Name = "GetObjectType")]
     [ProducesResponseType(typeof(MetaverseObjectTypeDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -76,14 +76,14 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Updates a metaverse object type's deletion rules.
+    /// Update a Metaverse Object Type
     /// </summary>
-    /// <param name="id">The unique identifier of the object type.</param>
+    /// <param name="id">The unique identifier of the Object Type.</param>
     /// <param name="request">The update request containing deletion rule settings.</param>
-    /// <returns>The updated object type details.</returns>
-    /// <response code="200">Object type updated successfully.</response>
+    /// <returns>The updated Object Type details.</returns>
+    /// <response code="200">Object Type updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Object type not found.</response>
+    /// <response code="404">Object Type not found.</response>
     /// <response code="401">User not authenticated.</response>
     [HttpPut("object-types/{id:int}", Name = "UpdateObjectType")]
     [ProducesResponseType(typeof(MetaverseObjectTypeDetailDto), StatusCodes.Status200OK)]
@@ -140,10 +140,10 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets all metaverse attributes with optional pagination, sorting, and filtering.
+    /// List Metaverse Attributes
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
-    /// <returns>A paginated list of metaverse attribute headers.</returns>
+    /// <returns>A paginated list of Metaverse Attribute headers.</returns>
     [HttpGet("attributes", Name = "GetAttributes")]
     [ProducesResponseType(typeof(PaginatedResponse<MetaverseAttributeHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -161,7 +161,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets a specific metaverse attribute by ID.
+    /// Get a Metaverse Attribute
     /// </summary>
     /// <param name="id">The unique identifier of the attribute.</param>
     /// <returns>The attribute details.</returns>
@@ -180,7 +180,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Creates a new metaverse attribute.
+    /// Create a Metaverse Attribute
     /// </summary>
     /// <param name="request">The attribute creation request.</param>
     /// <returns>The created attribute details.</returns>
@@ -237,7 +237,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Updates an existing metaverse attribute.
+    /// Update a Metaverse Attribute
     /// </summary>
     /// <param name="id">The unique identifier of the attribute.</param>
     /// <param name="request">The attribute update request.</param>
@@ -323,7 +323,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Deletes a metaverse attribute.
+    /// Delete a Metaverse Attribute
     /// </summary>
     /// <param name="id">The unique identifier of the attribute to delete.</param>
     /// <returns>No content on success.</returns>
@@ -371,7 +371,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets a paginated list of metaverse objects with optional filtering.
+    /// List Metaverse Objects
     /// </summary>
     /// <remarks>
     /// The DisplayName attribute is always included in the response. Use the `attributes` parameter
@@ -390,12 +390,12 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// - `?filterAttributeName=Account Name&amp;filterAttributeValue=jsmith` - Find by account name
     /// </remarks>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection).</param>
-    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <param name="search">Optional search query to filter by display name.</param>
     /// <param name="attributes">Optional list of attribute names to include in the response. Use "*" for all attributes. DisplayName is always included.</param>
     /// <param name="filterAttributeName">Optional attribute name to filter by (must be used with filterAttributeValue).</param>
-    /// <param name="filterAttributeValue">Optional attribute value to filter by (exact match, case-insensitive).</param>
-    /// <returns>A paginated list of metaverse object headers.</returns>
+    /// <param name="filterAttributeValue">Optional Attribute Value to filter by (exact match, case-insensitive).</param>
+    /// <returns>A paginated list of Metaverse Object headers.</returns>
     [HttpGet("objects", Name = "GetObjects")]
     [ProducesResponseType(typeof(PaginatedResponse<MetaverseObjectHeaderDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -435,17 +435,13 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets the count of metaverse objects with optional filtering.
+    /// Count Metaverse Objects
     /// </summary>
-    /// <remarks>
-    /// Returns a simple integer count. Supports the same filters as the paginated objects endpoint
-    /// but is significantly faster as it only executes a COUNT query without loading entity data.
-    /// </remarks>
-    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <param name="search">Optional search text to filter by display name (partial match, case-insensitive).</param>
     /// <param name="filterAttributeName">Optional attribute name to filter by (must be used with filterAttributeValue).</param>
-    /// <param name="filterAttributeValue">Optional attribute value to filter by (exact match, case-insensitive).</param>
-    /// <returns>The count of matching metaverse objects.</returns>
+    /// <param name="filterAttributeValue">Optional Attribute Value to filter by (exact match, case-insensitive).</param>
+    /// <returns>The count of matching Metaverse Objects.</returns>
     [HttpGet("objects/count", Name = "GetObjectsCount")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -464,19 +460,17 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Searches for metaverse objects using a predefined search, returning lightweight headers
-    /// with only the attributes defined in the search. Optimised for fast response at scale (100k+ objects).
+    /// Search Metaverse Objects using a predefined search
     /// </summary>
     /// <remarks>
-    /// This endpoint uses raw SQL queries optimised for large datasets. It returns only the attributes
-    /// configured in the predefined search definition, making it significantly faster than the general
-    /// objects endpoint for list views. Use the general GET /objects endpoint when you need full object
-    /// details or custom attribute selection.
+    /// Returns only the attributes configured in the predefined search definition, making it significantly
+    /// faster than the general objects endpoint for list views at scale (100k+ objects). Use the general
+    /// GET /objects endpoint when you need full object details or custom attribute selection.
     /// </remarks>
     /// <param name="predefinedSearchUri">The URI identifier of the predefined search (e.g. "users", "groups").</param>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection).</param>
-    /// <param name="search">Optional search query to filter across all string attribute values (case-insensitive).</param>
-    /// <returns>A paginated list of metaverse object headers with the predefined search attributes.</returns>
+    /// <param name="search">Optional search query to filter across all string Attribute Values (case-insensitive).</param>
+    /// <returns>A paginated list of Metaverse Object headers with the predefined search attributes.</returns>
     [HttpGet("objects/search/{predefinedSearchUri}", Name = "SearchObjects")]
     [ProducesResponseType(typeof(PaginatedResponse<MetaverseObjectHeaderDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -515,10 +509,10 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets a specific metaverse object by ID.
+    /// Get a Metaverse Object
     /// </summary>
-    /// <param name="id">The unique identifier (GUID) of the metaverse object.</param>
-    /// <returns>The metaverse object details including all attribute values.</returns>
+    /// <param name="id">The unique identifier (GUID) of the Metaverse Object.</param>
+    /// <returns>The Metaverse Object details including all Attribute Values.</returns>
     [HttpGet("objects/{id:guid}", Name = "GetObject")]
     [ProducesResponseType(typeof(MetaverseObjectDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -534,7 +528,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets a paginated list of metaverse objects pending deletion.
+    /// List Metaverse Objects pending deletion
     /// </summary>
     /// <remarks>
     /// Returns MVOs that have been disconnected from their last connector and are awaiting
@@ -542,7 +536,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// identities scheduled for cleanup.
     /// </remarks>
     /// <param name="pagination">Pagination parameters (page, pageSize).</param>
-    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <returns>A paginated list of MVOs pending deletion.</returns>
     [HttpGet("pending-deletions", Name = "GetPendingDeletions")]
     [ProducesResponseType(typeof(PaginatedResponse<PendingDeletionDto>), StatusCodes.Status200OK)]
@@ -573,9 +567,9 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets the count of metaverse objects pending deletion.
+    /// Count Metaverse Objects pending deletion
     /// </summary>
-    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <returns>The count of MVOs pending deletion.</returns>
     [HttpGet("pending-deletions/count", Name = "GetPendingDeletionsCount")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
@@ -588,7 +582,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets summary statistics for pending deletions.
+    /// Get pending deletion summary statistics
     /// </summary>
     /// <remarks>
     /// Provides an overview of deletion status including total count and counts by status:

--- a/src/JIM.Web/Controllers/Api/MetaverseController.cs
+++ b/src/JIM.Web/Controllers/Api/MetaverseController.cs
@@ -21,7 +21,7 @@ namespace JIM.Web.Controllers.Api;
 /// </summary>
 /// <remarks>
 /// The Metaverse is the central identity store in JIM. This controller provides
-/// endpoints for managing Object Types, attributes, and individual Metaverse Objects.
+/// endpoints for managing Object Types, Attributes, and individual Metaverse Objects.
 /// </remarks>
 [Route("api/v{version:apiVersion}/[controller]")]
 [ApiController]
@@ -163,8 +163,8 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// <summary>
     /// Get a Metaverse Attribute
     /// </summary>
-    /// <param name="id">The unique identifier of the attribute.</param>
-    /// <returns>The attribute details.</returns>
+    /// <param name="id">The unique identifier of the Attribute.</param>
+    /// <returns>The Attribute details.</returns>
     [HttpGet("attributes/{id:int}", Name = "GetAttribute")]
     [ProducesResponseType(typeof(MetaverseAttributeDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -182,8 +182,8 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// <summary>
     /// Create a Metaverse Attribute
     /// </summary>
-    /// <param name="request">The attribute creation request.</param>
-    /// <returns>The created attribute details.</returns>
+    /// <param name="request">The Attribute creation request.</param>
+    /// <returns>The created Attribute details.</returns>
     /// <response code="201">Attribute created successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
     /// <response code="401">User not authenticated.</response>
@@ -239,9 +239,9 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// <summary>
     /// Update a Metaverse Attribute
     /// </summary>
-    /// <param name="id">The unique identifier of the attribute.</param>
-    /// <param name="request">The attribute update request.</param>
-    /// <returns>The updated attribute details.</returns>
+    /// <param name="id">The unique identifier of the Attribute.</param>
+    /// <param name="request">The Attribute update request.</param>
+    /// <returns>The updated Attribute details.</returns>
     /// <response code="200">Attribute updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
     /// <response code="404">Attribute not found.</response>
@@ -325,10 +325,10 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// <summary>
     /// Delete a Metaverse Attribute
     /// </summary>
-    /// <param name="id">The unique identifier of the attribute to delete.</param>
+    /// <param name="id">The unique identifier of the Attribute to delete.</param>
     /// <returns>No content on success.</returns>
     /// <response code="204">Attribute deleted successfully.</response>
-    /// <response code="400">Cannot delete built-in or in-use attribute.</response>
+    /// <response code="400">Cannot delete built-in or in-use Attribute.</response>
     /// <response code="404">Attribute not found.</response>
     /// <response code="401">User not authenticated.</response>
     [HttpDelete("attributes/{id:int}", Name = "DeleteAttribute")]
@@ -374,26 +374,26 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// List Metaverse Objects
     /// </summary>
     /// <remarks>
-    /// The DisplayName attribute is always included in the response. Use the `attributes` parameter
-    /// to request additional attributes to be included. This follows a common pattern in APIs and
+    /// The DisplayName Attribute is always included in the response. Use the `attributes` parameter
+    /// to request additional Attributes to be included. This follows a common pattern in APIs and
     /// PowerShell modules where clients can specify which properties to retrieve.
     ///
-    /// Use `?attributes=*` to include all attributes.
+    /// Use `?attributes=*` to include all Attributes.
     ///
     /// **Filtering:**
     /// - `search` - Searches display name (partial match, case-insensitive)
-    /// - `filterAttributeName` + `filterAttributeValue` - Filters by specific attribute (exact match, case-insensitive)
+    /// - `filterAttributeName` + `filterAttributeValue` - Filters by specific Attribute (exact match, case-insensitive)
     ///
     /// Examples:
-    /// - `?attributes=FirstName&amp;attributes=LastName&amp;attributes=Email` - Include specific attributes
-    /// - `?attributes=*` - Include all attributes
+    /// - `?attributes=FirstName&amp;attributes=LastName&amp;attributes=Email` - Include specific Attributes
+    /// - `?attributes=*` - Include all Attributes
     /// - `?filterAttributeName=Account Name&amp;filterAttributeValue=jsmith` - Find by account name
     /// </remarks>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection).</param>
     /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <param name="search">Optional search query to filter by display name.</param>
-    /// <param name="attributes">Optional list of attribute names to include in the response. Use "*" for all attributes. DisplayName is always included.</param>
-    /// <param name="filterAttributeName">Optional attribute name to filter by (must be used with filterAttributeValue).</param>
+    /// <param name="attributes">Optional list of Attribute names to include in the response. Use "*" for all Attributes. DisplayName is always included.</param>
+    /// <param name="filterAttributeName">Optional Attribute name to filter by (must be used with filterAttributeValue).</param>
     /// <param name="filterAttributeValue">Optional Attribute Value to filter by (exact match, case-insensitive).</param>
     /// <returns>A paginated list of Metaverse Object headers.</returns>
     [HttpGet("objects", Name = "GetObjects")]
@@ -439,7 +439,7 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// </summary>
     /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <param name="search">Optional search text to filter by display name (partial match, case-insensitive).</param>
-    /// <param name="filterAttributeName">Optional attribute name to filter by (must be used with filterAttributeValue).</param>
+    /// <param name="filterAttributeName">Optional Attribute name to filter by (must be used with filterAttributeValue).</param>
     /// <param name="filterAttributeValue">Optional Attribute Value to filter by (exact match, case-insensitive).</param>
     /// <returns>The count of matching Metaverse Objects.</returns>
     [HttpGet("objects/count", Name = "GetObjectsCount")]
@@ -463,14 +463,14 @@ public class MetaverseController(ILogger<MetaverseController> logger, JimApplica
     /// Search Metaverse Objects using a predefined search
     /// </summary>
     /// <remarks>
-    /// Returns only the attributes configured in the predefined search definition, making it significantly
+    /// Returns only the Attributes configured in the predefined search definition, making it significantly
     /// faster than the general objects endpoint for list views at scale (100k+ objects). Use the general
-    /// GET /objects endpoint when you need full object details or custom attribute selection.
+    /// GET /objects endpoint when you need full object details or custom Attribute selection.
     /// </remarks>
     /// <param name="predefinedSearchUri">The URI identifier of the predefined search (e.g. "users", "groups").</param>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection).</param>
     /// <param name="search">Optional search query to filter across all string Attribute Values (case-insensitive).</param>
-    /// <returns>A paginated list of Metaverse Object headers with the predefined search attributes.</returns>
+    /// <returns>A paginated list of Metaverse Object headers with the predefined search Attributes.</returns>
     [HttpGet("objects/search/{predefinedSearchUri}", Name = "SearchObjects")]
     [ProducesResponseType(typeof(PaginatedResponse<MetaverseObjectHeaderDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]

--- a/src/JIM.Web/Controllers/Api/ScheduleExecutionsController.cs
+++ b/src/JIM.Web/Controllers/Api/ScheduleExecutionsController.cs
@@ -14,10 +14,10 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for managing schedule executions.
+/// API controller for managing Schedule Executions.
 /// </summary>
 /// <remarks>
-/// Schedule executions track the progress of running schedules,
+/// Schedule Executions track the progress of running schedules,
 /// including which steps have completed and any errors encountered.
 /// </remarks>
 [Route("api/v{version:apiVersion}/schedule-executions")]
@@ -31,14 +31,14 @@ public class ScheduleExecutionsController(ILogger<ScheduleExecutionsController> 
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets schedule executions with pagination.
+    /// List Schedule Executions
     /// </summary>
     /// <param name="scheduleId">Optional filter by schedule ID.</param>
     /// <param name="page">The page number (1-based).</param>
     /// <param name="pageSize">The number of items per page.</param>
     /// <param name="sortBy">Optional field to sort by (queuedAt, startedAt, completedAt, status).</param>
     /// <param name="sortDescending">Whether to sort in descending order (default: true for newest first).</param>
-    /// <returns>A paginated list of schedule executions.</returns>
+    /// <returns>A paginated list of Schedule Executions.</returns>
     [HttpGet(Name = "GetScheduleExecutions")]
     [ProducesResponseType(typeof(PaginatedResponse<ScheduleExecutionDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -62,7 +62,7 @@ public class ScheduleExecutionsController(ILogger<ScheduleExecutionsController> 
     }
 
     /// <summary>
-    /// Gets a specific schedule execution by ID.
+    /// Get Schedule Execution details
     /// </summary>
     /// <param name="id">The unique identifier of the execution.</param>
     /// <returns>The execution details including step progress.</returns>
@@ -144,7 +144,7 @@ public class ScheduleExecutionsController(ILogger<ScheduleExecutionsController> 
     }
 
     /// <summary>
-    /// Cancels a running schedule execution.
+    /// Cancel a Schedule Execution
     /// </summary>
     /// <param name="id">The unique identifier of the execution to cancel.</param>
     /// <returns>The updated execution status.</returns>
@@ -181,7 +181,7 @@ public class ScheduleExecutionsController(ILogger<ScheduleExecutionsController> 
     }
 
     /// <summary>
-    /// Gets currently active (running) schedule executions.
+    /// List active Schedule Executions
     /// </summary>
     /// <returns>A list of active executions.</returns>
     [HttpGet("active", Name = "GetActiveScheduleExecutions")]

--- a/src/JIM.Web/Controllers/Api/SchedulesController.cs
+++ b/src/JIM.Web/Controllers/Api/SchedulesController.cs
@@ -30,7 +30,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all schedules with pagination.
+    /// List schedules
     /// </summary>
     /// <param name="page">The page number (1-based).</param>
     /// <param name="pageSize">The number of items per page.</param>
@@ -58,7 +58,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Gets a specific schedule by ID.
+    /// Get schedule details
     /// </summary>
     /// <param name="id">The unique identifier of the schedule.</param>
     /// <returns>The schedule details including steps.</returns>
@@ -81,7 +81,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Creates a new schedule.
+    /// Create a schedule
     /// </summary>
     /// <param name="request">The schedule creation request.</param>
     /// <returns>The created schedule.</returns>
@@ -140,11 +140,10 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Updates an existing schedule.
+    /// Update a schedule
     /// </summary>
     /// <remarks>
-    /// Updates the schedule properties and replaces all steps with the provided list.
-    /// Steps not included in the request will be deleted.
+    /// Replaces all schedule steps with the provided list; steps not included in the request will be deleted.
     /// </remarks>
     /// <param name="id">The unique identifier of the schedule.</param>
     /// <param name="request">The update request.</param>
@@ -254,7 +253,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Deletes a schedule.
+    /// Delete a schedule
     /// </summary>
     /// <param name="id">The unique identifier of the schedule to delete.</param>
     /// <returns>No content on success.</returns>
@@ -280,7 +279,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Enables a schedule.
+    /// Enable a schedule
     /// </summary>
     /// <param name="id">The unique identifier of the schedule.</param>
     /// <returns>The updated schedule.</returns>
@@ -314,7 +313,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Disables a schedule.
+    /// Disable a schedule
     /// </summary>
     /// <param name="id">The unique identifier of the schedule.</param>
     /// <returns>The updated schedule.</returns>
@@ -348,7 +347,7 @@ public class SchedulesController(ILogger<SchedulesController> logger, JimApplica
     }
 
     /// <summary>
-    /// Manually triggers a schedule execution.
+    /// Run a schedule
     /// </summary>
     /// <param name="id">The unique identifier of the schedule.</param>
     /// <returns>The execution ID and status.</returns>

--- a/src/JIM.Web/Controllers/Api/SecurityController.cs
+++ b/src/JIM.Web/Controllers/Api/SecurityController.cs
@@ -27,12 +27,8 @@ public class SecurityController(ILogger<SecurityController> logger, JimApplicati
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all security roles defined in the system.
+    /// List security roles
     /// </summary>
-    /// <remarks>
-    /// Roles define permissions that can be assigned to users or groups
-    /// to control access to JIM functionality.
-    /// </remarks>
     /// <returns>A list of all role definitions.</returns>
     [HttpGet("roles", Name = "GetRoles")]
     [ProducesResponseType(typeof(IEnumerable<RoleDto>), StatusCodes.Status200OK)]

--- a/src/JIM.Web/Controllers/Api/SecurityController.cs
+++ b/src/JIM.Web/Controllers/Api/SecurityController.cs
@@ -10,11 +10,11 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for managing security-related configuration such as roles.
+/// API controller for managing security-related configuration such as Roles.
 /// </summary>
 /// <remarks>
 /// This controller provides endpoints for:
-/// - Retrieving role definitions used for access control
+/// - Retrieving Role definitions used for access control
 /// </remarks>
 [Route("api/v{version:apiVersion}/[controller]")]
 [ApiController]
@@ -27,9 +27,9 @@ public class SecurityController(ILogger<SecurityController> logger, JimApplicati
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// List security roles
+    /// List security Roles
     /// </summary>
-    /// <returns>A list of all role definitions.</returns>
+    /// <returns>A list of all Role definitions.</returns>
     [HttpGet("roles", Name = "GetRoles")]
     [ProducesResponseType(typeof(IEnumerable<RoleDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/JIM.Web/Controllers/Api/ServiceSettingsController.cs
+++ b/src/JIM.Web/Controllers/Api/ServiceSettingsController.cs
@@ -34,7 +34,7 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets all service settings.
+    /// List service settings
     /// </summary>
     /// <returns>A list of all service settings with their current and default values.</returns>
     [HttpGet(Name = "GetServiceSettings")]
@@ -50,7 +50,7 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     }
 
     /// <summary>
-    /// Gets a specific service setting by key.
+    /// Get a service setting
     /// </summary>
     /// <param name="key">The setting key using dot notation (e.g., "ChangeTracking.CsoChanges.Enabled").</param>
     /// <returns>The service setting details.</returns>
@@ -73,11 +73,10 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     }
 
     /// <summary>
-    /// Updates a service setting value.
+    /// Update a service setting
     /// </summary>
     /// <remarks>
-    /// Sets the value for a configurable service setting. Read-only settings
-    /// (mirrored from environment variables) cannot be modified through this endpoint.
+    /// Read-only settings (mirrored from environment variables) cannot be modified through this endpoint.
     /// </remarks>
     /// <param name="key">The setting key using dot notation.</param>
     /// <param name="request">The update request containing the new value.</param>
@@ -122,10 +121,9 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     }
 
     /// <summary>
-    /// Reverts a service setting to its default value.
+    /// Revert a service setting to its default
     /// </summary>
     /// <remarks>
-    /// Clears any override and restores the setting to its default value.
     /// Read-only settings cannot be reverted through this endpoint.
     /// </remarks>
     /// <param name="key">The setting key using dot notation.</param>

--- a/src/JIM.Web/Controllers/Api/ServiceSettingsController.cs
+++ b/src/JIM.Web/Controllers/Api/ServiceSettingsController.cs
@@ -16,7 +16,7 @@ namespace JIM.Web.Controllers.Api;
 /// API controller for managing service-wide configuration settings.
 /// </summary>
 /// <remarks>
-/// Service settings control behaviour such as change tracking, sync page sizes,
+/// Service Settings control behaviour such as change tracking, sync page sizes,
 /// history retention, and other operational parameters. Settings are identified
 /// by dot-notation keys (e.g., "ChangeTracking.CsoChanges.Enabled").
 ///
@@ -34,9 +34,9 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// List service settings
+    /// List Service Settings
     /// </summary>
-    /// <returns>A list of all service settings with their current and default values.</returns>
+    /// <returns>A list of all Service Settings with their current and default values.</returns>
     [HttpGet(Name = "GetServiceSettings")]
     [ProducesResponseType(typeof(IEnumerable<ServiceSettingDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -50,10 +50,10 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     }
 
     /// <summary>
-    /// Get a service setting
+    /// Get a Service Setting
     /// </summary>
     /// <param name="key">The setting key using dot notation (e.g., "ChangeTracking.CsoChanges.Enabled").</param>
-    /// <returns>The service setting details.</returns>
+    /// <returns>The Service Setting details.</returns>
     [HttpGet("{key}", Name = "GetServiceSetting")]
     [ProducesResponseType(typeof(ServiceSettingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -73,14 +73,14 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     }
 
     /// <summary>
-    /// Update a service setting
+    /// Update a Service Setting
     /// </summary>
     /// <remarks>
     /// Read-only settings (mirrored from environment variables) cannot be modified through this endpoint.
     /// </remarks>
     /// <param name="key">The setting key using dot notation.</param>
     /// <param name="request">The update request containing the new value.</param>
-    /// <returns>The updated service setting.</returns>
+    /// <returns>The updated Service Setting.</returns>
     [HttpPut("{key}", Name = "UpdateServiceSetting")]
     [ProducesResponseType(typeof(ServiceSettingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -121,13 +121,13 @@ public class ServiceSettingsController(ILogger<ServiceSettingsController> logger
     }
 
     /// <summary>
-    /// Revert a service setting to its default
+    /// Revert a Service Setting to its default
     /// </summary>
     /// <remarks>
     /// Read-only settings cannot be reverted through this endpoint.
     /// </remarks>
     /// <param name="key">The setting key using dot notation.</param>
-    /// <returns>The reverted service setting.</returns>
+    /// <returns>The reverted Service Setting.</returns>
     [HttpDelete("{key}", Name = "RevertServiceSetting")]
     [ProducesResponseType(typeof(ServiceSettingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -50,10 +50,10 @@ public class SynchronisationController(
     #region Connected Systems
 
     /// <summary>
-    /// Gets all connected systems with optional pagination, sorting, and filtering.
+    /// List Connected Systems
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
-    /// <returns>A paginated list of connected system headers.</returns>
+    /// <returns>A paginated list of Connected System headers.</returns>
     [HttpGet("connected-systems", Name = "GetConnectedSystems")]
     [ProducesResponseType(typeof(PaginatedResponse<ConnectedSystemHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -73,10 +73,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific connected system by ID.
+    /// Get a Connected System
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <returns>The connected system details including configuration and schema.</returns>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <returns>The Connected System details including configuration and schema.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}", Name = "GetConnectedSystem")]
     [ProducesResponseType(typeof(ConnectedSystemDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -96,10 +96,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets all object types defined in a connected system's schema.
+    /// List Object Types for a Connected System
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <returns>A list of object types with their attributes.</returns>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <returns>A list of Object Types with their attributes.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/object-types", Name = "GetConnectedSystemObjectTypes")]
     [ProducesResponseType(typeof(IEnumerable<ConnectedSystemObjectTypeDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -116,20 +116,20 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates a Connected System Object Type.
+    /// Update an Object Type
     /// </summary>
     /// <remarks>
-    /// Use this endpoint to update properties of an object type, such as:
-    /// - Selected: Whether the object type is managed by JIM
+    /// Use this endpoint to update properties of an Object Type, such as:
+    /// - Selected: Whether the Object Type is managed by JIM
     /// - RemoveContributedAttributesOnObsoletion: Whether MVO attributes are removed when CSO is obsoleted
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="objectTypeId">The unique identifier of the object type.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="objectTypeId">The unique identifier of the Object Type.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated object type details.</returns>
-    /// <response code="200">Object type updated successfully.</response>
+    /// <returns>The updated Object Type details.</returns>
+    /// <response code="200">Object Type updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Connected system or object type not found.</response>
+    /// <response code="404">Connected System or Object Type not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/object-types/{objectTypeId:int}", Name = "UpdateConnectedSystemObjectType")]
     [ProducesResponseType(typeof(ConnectedSystemObjectTypeDto), StatusCodes.Status200OK)]
@@ -179,7 +179,7 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates a Connected System Attribute.
+    /// Update an attribute
     /// </summary>
     /// <remarks>
     /// Use this endpoint to update properties of an attribute, such as:
@@ -187,14 +187,14 @@ public class SynchronisationController(
     /// - IsExternalId: Whether this is the unique identifier for objects
     /// - IsSecondaryExternalId: Whether this is a secondary identifier (e.g., DN for LDAP)
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="objectTypeId">The unique identifier of the object type.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="objectTypeId">The unique identifier of the Object Type.</param>
     /// <param name="attributeId">The unique identifier of the attribute.</param>
     /// <param name="request">The update request with new values.</param>
     /// <returns>The updated attribute details.</returns>
     /// <response code="200">Attribute updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Connected system, object type, or attribute not found.</response>
+    /// <response code="404">Connected System, Object Type, or attribute not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/object-types/{objectTypeId:int}/attributes/{attributeId:int}", Name = "UpdateConnectedSystemAttribute")]
     [ProducesResponseType(typeof(ConnectedSystemAttributeDto), StatusCodes.Status200OK)]
@@ -292,17 +292,18 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Bulk updates multiple Connected System Attributes in a single operation.
-    /// This creates a single Activity record for the entire batch operation, rather than
-    /// individual activities for each attribute update.
+    /// Bulk update attributes for an Object Type
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="objectTypeId">The unique identifier of the object type containing the attributes.</param>
+    /// <remarks>
+    /// Updates multiple attributes in a single operation, creating one Activity record for the entire batch rather than individual records per attribute.
+    /// </remarks>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="objectTypeId">The unique identifier of the Object Type containing the attributes.</param>
     /// <param name="request">Dictionary of attribute updates keyed by attribute ID.</param>
     /// <returns>Response containing the activity ID, updated count, updated attributes, and any errors.</returns>
     /// <response code="200">Attributes updated successfully (may include partial success with errors).</response>
     /// <response code="400">Invalid request or empty attributes dictionary.</response>
-    /// <response code="404">Connected system or object type not found.</response>
+    /// <response code="404">Connected System or Object Type not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/object-types/{objectTypeId:int}/attributes", Name = "BulkUpdateConnectedSystemAttributes")]
     [ProducesResponseType(typeof(BulkUpdateConnectedSystemAttributesResponse), StatusCodes.Status200OK)]
@@ -373,11 +374,11 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific connected system object by ID.
+    /// Get a Connected System Object
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="id">The unique identifier (GUID) of the connected system object.</param>
-    /// <returns>The connected system object details with capped MVA values and per-attribute summaries.</returns>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="id">The unique identifier (GUID) of the Connected System Object.</param>
+    /// <returns>The Connected System Object details with capped MVA values and per-attribute summaries.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/{id:guid}", Name = "GetConnectedSystemObject")]
     [ProducesResponseType(typeof(ConnectedSystemObjectDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -394,20 +395,20 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a paginated list of attribute values for a specific attribute on a Connected System Object.
+    /// List Attribute Values for a Connected System Object
     /// </summary>
     /// <remarks>
     /// Use this endpoint to retrieve large multi-valued attribute data (e.g. group members)
     /// with server-side search and pagination. The CSO detail endpoint caps MVA values;
     /// use this endpoint to page through all values.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="csoId">The unique identifier (GUID) of the connected system object.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="csoId">The unique identifier (GUID) of the Connected System Object.</param>
     /// <param name="attributeName">The attribute name to retrieve values for.</param>
     /// <param name="page">Page number (1-based). Default: 1.</param>
     /// <param name="pageSize">Number of values per page (1-100). Default: 50.</param>
     /// <param name="search">Optional search text to filter values.</param>
-    /// <returns>A paginated set of attribute values with total count.</returns>
+    /// <returns>A paginated set of Attribute Values with total count.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/{csoId:guid}/attributes/{attributeName}/values", Name = "GetAttributeValuesPaged")]
     [ProducesResponseType(typeof(PaginatedResponse<ConnectedSystemObjectAttributeValueDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -436,17 +437,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a preview of what will be affected by deleting a Connected System.
+    /// Get a deletion preview for a Connected System
     /// </summary>
     /// <remarks>
-    /// Call this before DeleteConnectedSystemAsync to inform the user of the impact.
-    /// The preview includes counts of:
-    /// - Connected System Objects that will be deleted
-    /// - Sync Rules that will be removed
-    /// - Metaverse Objects that will be disconnected
-    /// - Pending exports that will be cancelled
+    /// Call this before deleting a Connected System to understand the impact. The preview includes counts of Connected System Objects, Sync Rules, Metaverse Objects, and Pending Exports that will be affected.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>A preview showing counts of affected objects and any warnings.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/deletion-preview", Name = "GetConnectedSystemDeletionPreview")]
     [ProducesResponseType(typeof(ConnectedSystemDeletionPreview), StatusCodes.Status200OK)]
@@ -464,17 +460,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets the count of unresolved reference attribute values across all objects in a connected system.
+    /// Get the unresolved reference count for a Connected System
     /// </summary>
     /// <remarks>
-    /// An unresolved reference occurs when a reference attribute (e.g. group 'member') contains a value
-    /// that could not be matched to another Connected System Object during the last import run.
-    /// This typically happens when the referenced object is outside the configured container scope
-    /// or has not been imported yet.
-    /// A non-zero count indicates data integrity issues that should be investigated.
+    /// An unresolved reference occurs when a reference attribute (e.g. group 'member') contains a value that could not be matched to another Connected System Object during the last import run. A non-zero count indicates data integrity issues that should be investigated.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <returns>The count of unresolved reference attribute values.</returns>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <returns>The count of unresolved reference Attribute Values.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/unresolved-references/count", Name = "GetUnresolvedReferenceCount")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -486,13 +478,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets the count of Connected System Objects in the connector space with optional filtering.
+    /// Get the connector space object count for a Connected System
     /// </summary>
-    /// <remarks>
-    /// Returns a simple integer count. Optimised for fast counting without loading entity data.
-    /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="objectTypeId">Optional object type ID to filter by.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
     /// <param name="partitionId">Optional partition ID to filter by.</param>
     /// <returns>The count of matching Connected System Objects.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/count", Name = "GetConnectorSpaceCount")]
@@ -513,17 +502,16 @@ public class SynchronisationController(
     #region Pending Exports
 
     /// <summary>
-    /// Gets a paginated list of Pending Exports for a Connected System.
+    /// List Pending Exports for a Connected System
     /// </summary>
     /// <remarks>
-    /// Returns lightweight header objects suitable for list views. Use the detail endpoint
-    /// to retrieve full attribute change data for a specific pending export.
+    /// Returns lightweight header objects. Use the detail endpoint to retrieve full attribute change data for a specific Pending Export.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="page">Page number (1-based). Default: 1.</param>
     /// <param name="pageSize">Number of items per page (1-100). Default: 50.</param>
     /// <param name="search">Optional search text to filter by target object, source MVO, or error message.</param>
-    /// <returns>A paginated set of pending export headers.</returns>
+    /// <returns>A paginated set of Pending Export headers.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/pending-exports", Name = "GetPendingExports")]
     [ProducesResponseType(typeof(PaginatedResponse<PendingExportHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -550,12 +538,9 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets the count of Pending Exports for a Connected System with optional filtering.
+    /// Get the Pending Export count for a Connected System
     /// </summary>
-    /// <remarks>
-    /// Returns a simple integer count. Optimised for fast counting without loading entity data.
-    /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="changeType">Optional change type to filter by (Create = 0, Update = 1, Delete = 2).</param>
     /// <param name="status">Optional status to filter by (Pending = 0, ExportNotConfirmed = 1, Executing = 2, Failed = 3, Exported = 4).</param>
     /// <returns>The count of matching Pending Export objects.</returns>
@@ -575,15 +560,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific Pending Export by ID with capped multi-valued attribute changes.
+    /// Get a Pending Export
     /// </summary>
     /// <remarks>
-    /// Multi-valued attribute changes are capped at 10 per attribute. Use the
-    /// <c>attributeChangeSummaries</c> array to identify truncated attributes, then
-    /// call the paged attribute changes endpoint to retrieve all values.
+    /// Multi-valued attribute changes are capped at 10 per attribute. Use the <c>attributeChangeSummaries</c> array to identify truncated attributes, then call the paged attribute changes endpoint to retrieve all values.
     /// </remarks>
-    /// <param name="pendingExportId">The unique identifier (GUID) of the pending export.</param>
-    /// <returns>The pending export details with capped attribute changes and per-attribute summaries.</returns>
+    /// <param name="pendingExportId">The unique identifier (GUID) of the Pending Export.</param>
+    /// <returns>The Pending Export details with capped attribute changes and per-attribute summaries.</returns>
     [HttpGet("pending-exports/{pendingExportId:guid}", Name = "GetPendingExport")]
     [ProducesResponseType(typeof(PendingExportDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -599,19 +582,17 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a paginated list of attribute value changes for a specific attribute on a Pending Export.
+    /// List Attribute Value changes for a Pending Export
     /// </summary>
     /// <remarks>
-    /// Use this endpoint to retrieve large multi-valued attribute change data (e.g. group member additions)
-    /// with server-side search and pagination. The pending export detail endpoint caps multi-valued attribute
-    /// changes; use this endpoint to page through all changes for a specific attribute.
+    /// Use this endpoint to page through large multi-valued attribute changes (e.g. group member additions). The Pending Export detail endpoint caps multi-valued attribute changes; use this endpoint to retrieve all values for a specific attribute.
     /// </remarks>
-    /// <param name="pendingExportId">The unique identifier (GUID) of the pending export.</param>
+    /// <param name="pendingExportId">The unique identifier (GUID) of the Pending Export.</param>
     /// <param name="attributeName">The attribute name to retrieve changes for.</param>
     /// <param name="page">Page number (1-based). Default: 1.</param>
     /// <param name="pageSize">Number of changes per page (1-100). Default: 50.</param>
     /// <param name="search">Optional search text to filter changes by value.</param>
-    /// <returns>A paginated set of attribute value changes with total count.</returns>
+    /// <returns>A paginated set of Attribute Value changes with total count.</returns>
     [HttpGet("pending-exports/{pendingExportId:guid}/attribute-changes/{attributeName}/values", Name = "GetPendingExportAttributeChangesPaged")]
     [ProducesResponseType(typeof(PaginatedResponse<PendingExportAttributeValueChangeDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -642,13 +623,9 @@ public class SynchronisationController(
 
     #region Partitions and Containers
     /// <summary>
-    /// Gets all partitions for a Connected System.
+    /// List partitions for a Connected System
     /// </summary>
-    /// <remarks>
-    /// Partitions represent logical divisions within a connected system (e.g., LDAP naming contexts).
-    /// Each partition contains containers that can be selected for import operations.
-    /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>A list of partitions with their containers.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/partitions", Name = "GetConnectedSystemPartitions")]
     [ProducesResponseType(typeof(IEnumerable<ConnectedSystemPartitionDto>), StatusCodes.Status200OK)]
@@ -669,18 +646,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates a Connected System Partition.
+    /// Update a partition
     /// </summary>
-    /// <remarks>
-    /// Use this endpoint to select or deselect a partition for import operations.
-    /// When a partition is selected, objects within it (and its selected containers) will be imported during sync.
-    /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="partitionId">The unique identifier of the partition.</param>
     /// <param name="request">The update request with new values.</param>
     /// <returns>The updated partition details.</returns>
     /// <response code="200">Partition updated successfully.</response>
-    /// <response code="404">Connected system or partition not found.</response>
+    /// <response code="404">Connected System or partition not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/partitions/{partitionId:int}", Name = "UpdateConnectedSystemPartition")]
     [ProducesResponseType(typeof(ConnectedSystemPartitionDto), StatusCodes.Status200OK)]
@@ -719,19 +692,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates a Connected System Container.
+    /// Update a container
     /// </summary>
-    /// <remarks>
-    /// Use this endpoint to select or deselect a container for import operations.
-    /// When a container is selected, objects within it will be imported during sync.
-    /// The parent partition must also be selected for the container selection to take effect.
-    /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="containerId">The unique identifier of the container.</param>
     /// <param name="request">The update request with new values.</param>
     /// <returns>The updated container details.</returns>
     /// <response code="200">Container updated successfully.</response>
-    /// <response code="404">Connected system or container not found.</response>
+    /// <response code="404">Connected System or container not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/containers/{containerId:int}", Name = "UpdateConnectedSystemContainer")]
     [ProducesResponseType(typeof(ConnectedSystemContainerDto), StatusCodes.Status200OK)]
@@ -776,15 +744,14 @@ public class SynchronisationController(
     #endregion
 
     /// <summary>
-    /// Creates a new Connected System.
+    /// Create a Connected System
     /// </summary>
     /// <remarks>
-    /// Creates a new Connected System with the specified connector type. The connector's default settings
-    /// will be applied automatically. Use the Update endpoint to configure the settings after creation.
+    /// The connector's default settings are applied automatically. Use the Update endpoint to configure settings after creation.
     /// </remarks>
-    /// <param name="request">The connected system creation request.</param>
-    /// <returns>The created connected system details.</returns>
-    /// <response code="201">Connected system created successfully.</response>
+    /// <param name="request">The Connected System creation request.</param>
+    /// <returns>The created Connected System details.</returns>
+    /// <response code="201">Connected System created successfully.</response>
     /// <response code="400">Invalid request or connector definition not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems", Name = "CreateConnectedSystem")]
@@ -845,18 +812,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates an existing Connected System.
+    /// Update a Connected System
     /// </summary>
-    /// <remarks>
-    /// Updates the name, description, and/or setting values of an existing Connected System.
-    /// Only the fields provided in the request will be updated.
-    /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system to update.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System to update.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated connected system details.</returns>
-    /// <response code="200">Connected system updated successfully.</response>
+    /// <returns>The updated Connected System details.</returns>
+    /// <response code="200">Connected System updated successfully.</response>
     /// <response code="400">Invalid request.</response>
-    /// <response code="404">Connected system not found.</response>
+    /// <response code="404">Connected System not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}", Name = "UpdateConnectedSystem")]
     [ProducesResponseType(typeof(ConnectedSystemDetailDto), StatusCodes.Status200OK)]
@@ -937,20 +900,16 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Imports the schema from the Connected System.
+    /// Import schema from a Connected System
     /// </summary>
     /// <remarks>
-    /// Connects to the external system and retrieves its schema (object types and attributes).
-    /// This is required before creating sync rules, as sync rules reference object type IDs.
-    ///
-    /// **Note:** This operation is destructive - it will replace any existing schema configuration.
-    /// Any sync rules referencing removed object types/attributes will need to be updated.
+    /// Connects to the external system and retrieves its Object Types and attributes. This is required before creating Sync Rules. Existing schema configuration will be replaced; Sync Rules referencing removed Object Types or attributes will need to be updated.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <returns>The updated connected system with imported schema.</returns>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <returns>The updated Connected System with imported schema.</returns>
     /// <response code="200">Schema imported successfully.</response>
     /// <response code="400">Schema import failed (e.g., connection error, invalid settings).</response>
-    /// <response code="404">Connected system not found.</response>
+    /// <response code="404">Connected System not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/import-schema", Name = "ImportConnectedSystemSchema")]
     [ProducesResponseType(typeof(ConnectedSystemDetailDto), StatusCodes.Status200OK)]
@@ -998,27 +957,16 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Imports hierarchy (partitions and containers) from the connected system.
+    /// Import hierarchy from a Connected System
     /// </summary>
     /// <remarks>
-    /// This endpoint connects to the external system and retrieves its partition and container hierarchy.
-    /// For LDAP connectors, this retrieves naming contexts and organisational units.
-    ///
-    /// After importing the hierarchy, you can select which partitions and containers to include
-    /// in import operations using the partition and container update endpoints.
-    ///
-    /// This operation uses a match-and-merge approach that preserves existing partition and container
-    /// selections where possible. Items are matched by their ExternalId (e.g., LDAP DN). The response
-    /// includes details about what changed: added items, removed items, renamed items, and moved containers.
-    ///
-    /// If any previously selected items were removed (no longer exist in the external system),
-    /// the `hasSelectedItemsRemoved` flag will be true in the response as a warning.
+    /// Connects to the external system and retrieves its partition and container hierarchy. Existing selections are preserved where possible using a match-and-merge approach. If previously selected items were removed, the <c>hasSelectedItemsRemoved</c> flag will be set in the response.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>A result object describing what changed during the hierarchy refresh.</returns>
     /// <response code="200">Hierarchy imported successfully.</response>
     /// <response code="400">Hierarchy import failed (e.g., connection error, invalid settings).</response>
-    /// <response code="404">Connected system not found.</response>
+    /// <response code="404">Connected System not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/import-hierarchy", Name = "ImportConnectedSystemHierarchy")]
     [ProducesResponseType(typeof(HierarchyRefreshResultDto), StatusCodes.Status200OK)]
@@ -1065,17 +1013,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes a Connected System and all its related data.
+    /// Delete a Connected System
     /// </summary>
     /// <remarks>
-    /// This operation may execute synchronously or be queued as a background job depending on system size:
-    /// - Small systems (less than 1000 CSOs): Deleted immediately, returns 200 OK
-    /// - Large systems: Queued as background job, returns 202 Accepted with tracking IDs
-    /// - Systems with running sync: Queued to run after sync completes, returns 202 Accepted
-    ///
-    /// Use the deletion-preview endpoint first to understand the impact before calling this endpoint.
+    /// Small systems (fewer than 1,000 CSOs) are deleted immediately and return 200 OK. Larger systems, or systems with a running sync, are queued as a background job and return 202 Accepted with tracking IDs. Use the deletion-preview endpoint first to understand the impact.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system to delete.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System to delete.</param>
     /// <param name="deleteChangeHistory">Whether to delete change history for the deleted CSOs. Default: false (preserves audit trail).</param>
     /// <returns>The result of the deletion request including outcome and tracking IDs.</returns>
     /// <response code="200">Deletion completed immediately.</response>
@@ -1121,21 +1064,17 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Clears all Connected System Objects from a connected system's connector space.
+    /// Clear the connector space for a Connected System
     /// </summary>
     /// <remarks>
-    /// This operation removes all CSOs and their attributes from the connector space,
-    /// typically used before re-importing data from the connected system. By default,
-    /// change history is also deleted since the objects will be re-imported.
-    ///
-    /// This is a destructive operation and should be used with caution.
+    /// Removes all Connected System Objects and their attributes from the connector space. Typically used before re-importing data. This is a destructive operation.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system to clear.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System to clear.</param>
     /// <param name="deleteChangeHistory">Whether to delete change history for the cleared CSOs. Default: true (recommended for re-import scenarios).</param>
     /// <response code="200">Connector space cleared successfully.</response>
     /// <response code="400">Clear operation failed.</response>
     /// <response code="401">User is not authenticated.</response>
-    /// <response code="404">Connected system not found.</response>
+    /// <response code="404">Connected System not found.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/clear", Name = "ClearConnectorSpace")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -1180,12 +1119,8 @@ public class SynchronisationController(
     #region Connector Definitions
 
     /// <summary>
-    /// Gets all available connector definitions.
+    /// List connector definitions
     /// </summary>
-    /// <remarks>
-    /// Connector definitions describe the available connector types that can be used when creating Connected Systems.
-    /// Each connector definition includes metadata about capabilities, settings, and configuration options.
-    /// </remarks>
     /// <returns>A list of all available connector definitions.</returns>
     [HttpGet("connector-definitions", Name = "GetConnectorDefinitions")]
     [ProducesResponseType(typeof(IEnumerable<ConnectorDefinitionHeader>), StatusCodes.Status200OK)]
@@ -1198,7 +1133,7 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific connector definition by ID.
+    /// Get a connector definition
     /// </summary>
     /// <param name="id">The unique identifier of the connector definition.</param>
     /// <returns>The connector definition details including all settings and capabilities.</returns>
@@ -1217,7 +1152,7 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific connector definition by name.
+    /// Get a connector definition by name
     /// </summary>
     /// <param name="name">The name of the connector definition (e.g., "CSV File", "LDAP").</param>
     /// <returns>The connector definition details including all settings and capabilities.</returns>
@@ -1240,10 +1175,10 @@ public class SynchronisationController(
     #region Run Profiles
 
     /// <summary>
-    /// Gets all run profiles for a connected system.
+    /// List Run Profiles for a Connected System
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <returns>A list of run profiles configured for the connected system.</returns>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <returns>A list of Run Profiles configured for the Connected System.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/run-profiles", Name = "GetRunProfiles")]
     [ProducesResponseType(typeof(IEnumerable<RunProfileDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1263,19 +1198,16 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Executes a run profile to trigger a synchronisation operation.
+    /// Execute a Run Profile
     /// </summary>
     /// <remarks>
-    /// This endpoint queues a synchronisation task (Full Import, Delta Import, Full Sync, Delta Sync, or Export)
-    /// for execution by the worker service. The task runs asynchronously and can be monitored via the Activities API.
-    ///
-    /// Returns 202 Accepted with the Activity ID and Task ID for tracking the execution.
+    /// Queues a synchronisation task for execution by the worker service. Returns 202 Accepted with the Activity ID and Task ID for tracking.
     /// </remarks>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="runProfileId">The unique identifier of the run profile to execute.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="runProfileId">The unique identifier of the Run Profile to execute.</param>
     /// <returns>The execution response with activity and task IDs for tracking.</returns>
-    /// <response code="202">Run profile execution has been queued.</response>
-    /// <response code="404">Connected system or run profile not found.</response>
+    /// <response code="202">Run Profile execution has been queued.</response>
+    /// <response code="404">Connected System or Run Profile not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/run-profiles/{runProfileId:int}/execute", Name = "ExecuteRunProfile")]
     [ProducesResponseType(typeof(RunProfileExecutionResponse), StatusCodes.Status202Accepted)]
@@ -1345,14 +1277,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new Run Profile for a Connected System.
+    /// Create a Run Profile
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="request">The run profile creation request.</param>
-    /// <returns>The created run profile details.</returns>
-    /// <response code="201">Run profile created successfully.</response>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="request">The Run Profile creation request.</param>
+    /// <returns>The created Run Profile details.</returns>
+    /// <response code="201">Run Profile created successfully.</response>
     /// <response code="400">Invalid request or run type not supported by connector.</response>
-    /// <response code="404">Connected system not found.</response>
+    /// <response code="404">Connected System not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/run-profiles", Name = "CreateRunProfile")]
     [ProducesResponseType(typeof(RunProfileDto), StatusCodes.Status201Created)]
@@ -1416,15 +1348,15 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates an existing Run Profile.
+    /// Update a Run Profile
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="runProfileId">The unique identifier of the run profile to update.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="runProfileId">The unique identifier of the Run Profile to update.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated run profile details.</returns>
-    /// <response code="200">Run profile updated successfully.</response>
+    /// <returns>The updated Run Profile details.</returns>
+    /// <response code="200">Run Profile updated successfully.</response>
     /// <response code="400">Invalid request.</response>
-    /// <response code="404">Connected system or run profile not found.</response>
+    /// <response code="404">Connected System or Run Profile not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/run-profiles/{runProfileId:int}", Name = "UpdateRunProfile")]
     [ProducesResponseType(typeof(RunProfileDto), StatusCodes.Status200OK)]
@@ -1494,13 +1426,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes a Run Profile.
+    /// Delete a Run Profile
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="runProfileId">The unique identifier of the run profile to delete.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="runProfileId">The unique identifier of the Run Profile to delete.</param>
     /// <returns>No content on success.</returns>
-    /// <response code="204">Run profile deleted successfully.</response>
-    /// <response code="404">Connected system or run profile not found.</response>
+    /// <response code="204">Run Profile deleted successfully.</response>
+    /// <response code="404">Connected System or Run Profile not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("connected-systems/{connectedSystemId:int}/run-profiles/{runProfileId:int}", Name = "DeleteRunProfile")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -1545,10 +1477,10 @@ public class SynchronisationController(
     #region Sync Rules
 
     /// <summary>
-    /// Gets all synchronisation rules with optional pagination, sorting, and filtering.
+    /// List Sync Rules
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
-    /// <returns>A paginated list of sync rule headers.</returns>
+    /// <returns>A paginated list of Sync Rule headers.</returns>
     [HttpGet("sync-rules", Name = "GetSyncRules")]
     [ProducesResponseType(typeof(PaginatedResponse<SyncRuleHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1566,10 +1498,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific synchronisation rule by ID.
+    /// Get a Sync Rule
     /// </summary>
-    /// <param name="id">The unique identifier of the sync rule.</param>
-    /// <returns>The sync rule details including attribute flow configuration.</returns>
+    /// <param name="id">The unique identifier of the Sync Rule.</param>
+    /// <returns>The Sync Rule details including attribute flow configuration.</returns>
     [HttpGet("sync-rules/{id:int}", Name = "GetSyncRule")]
     [ProducesResponseType(typeof(SyncRuleHeader), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1585,16 +1517,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new Sync Rule.
+    /// Create a Sync Rule
     /// </summary>
     /// <remarks>
-    /// Creates a sync rule that defines how data flows between a Connected System and the Metaverse.
-    /// For Import rules, set ProjectToMetaverse to true to create Metaverse objects from imported data.
-    /// For Export rules, set ProvisionToConnectedSystem to true to create Connected System objects.
+    /// For Import rules, set <c>ProjectToMetaverse</c> to true to create Metaverse objects from imported data. For Export rules, set <c>ProvisionToConnectedSystem</c> to true to create Connected System Objects.
     /// </remarks>
-    /// <param name="request">The sync rule creation request.</param>
-    /// <returns>The created sync rule details.</returns>
-    /// <response code="201">Sync rule created successfully.</response>
+    /// <param name="request">The Sync Rule creation request.</param>
+    /// <returns>The created Sync Rule details.</returns>
+    /// <response code="201">Sync Rule created successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules", Name = "CreateSyncRule")]
@@ -1668,14 +1598,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates an existing Sync Rule.
+    /// Update a Sync Rule
     /// </summary>
-    /// <param name="id">The unique identifier of the sync rule to update.</param>
+    /// <param name="id">The unique identifier of the Sync Rule to update.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated sync rule details.</returns>
-    /// <response code="200">Sync rule updated successfully.</response>
+    /// <returns>The updated Sync Rule details.</returns>
+    /// <response code="200">Sync Rule updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Sync rule not found.</response>
+    /// <response code="404">Sync Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("sync-rules/{id:int}", Name = "UpdateSyncRule")]
     [ProducesResponseType(typeof(SyncRuleHeader), StatusCodes.Status200OK)]
@@ -1736,12 +1666,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes a Sync Rule.
+    /// Delete a Sync Rule
     /// </summary>
-    /// <param name="id">The unique identifier of the sync rule to delete.</param>
+    /// <param name="id">The unique identifier of the Sync Rule to delete.</param>
     /// <returns>No content on success.</returns>
-    /// <response code="204">Sync rule deleted successfully.</response>
-    /// <response code="404">Sync rule not found.</response>
+    /// <response code="204">Sync Rule deleted successfully.</response>
+    /// <response code="404">Sync Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("sync-rules/{id:int}", Name = "DeleteSyncRule")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -1780,9 +1710,9 @@ public class SynchronisationController(
     #region Sync Rule Mappings
 
     /// <summary>
-    /// Gets all attribute flow mappings for a sync rule.
+    /// List attribute flow mappings for a Sync Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <returns>A list of attribute flow mappings.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/mappings", Name = "GetSyncRuleMappings")]
     [ProducesResponseType(typeof(IEnumerable<SyncRuleMappingDto>), StatusCodes.Status200OK)]
@@ -1802,9 +1732,9 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific attribute flow mapping by ID.
+    /// Get an attribute flow mapping
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="mappingId">The unique identifier of the mapping.</param>
     /// <returns>The attribute flow mapping details.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/mappings/{mappingId:int}", Name = "GetSyncRuleMapping")]
@@ -1827,18 +1757,17 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new attribute flow mapping for a sync rule.
+    /// Create an attribute flow mapping
     /// </summary>
     /// <remarks>
-    /// For Import rules (direction = Import), specify TargetMetaverseAttributeId and source ConnectedSystemAttributeIds.
-    /// For Export rules (direction = Export), specify TargetConnectedSystemAttributeId and source MetaverseAttributeIds.
+    /// For Import rules, specify <c>TargetMetaverseAttributeId</c> and source <c>ConnectedSystemAttributeIds</c>. For Export rules, specify <c>TargetConnectedSystemAttributeId</c> and source <c>MetaverseAttributeIds</c>.
     /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="request">The mapping creation request.</param>
     /// <returns>The created attribute flow mapping.</returns>
     /// <response code="201">Mapping created successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Sync rule or referenced attributes not found.</response>
+    /// <response code="404">Sync Rule or referenced attributes not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/mappings", Name = "CreateSyncRuleMapping")]
     [ProducesResponseType(typeof(SyncRuleMappingDto), StatusCodes.Status201Created)]
@@ -1977,13 +1906,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes an attribute flow mapping.
+    /// Delete an attribute flow mapping
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="mappingId">The unique identifier of the mapping to delete.</param>
     /// <returns>No content on success.</returns>
     /// <response code="204">Mapping deleted successfully.</response>
-    /// <response code="404">Sync rule or mapping not found.</response>
+    /// <response code="404">Sync Rule or mapping not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("sync-rules/{syncRuleId:int}/mappings/{mappingId:int}", Name = "DeleteSyncRuleMapping")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -2025,17 +1954,13 @@ public class SynchronisationController(
     #region Sync Rule Scoping Criteria
 
     /// <summary>
-    /// Gets all scoping criteria groups for a sync rule.
+    /// List Scoping Criteria groups for a Sync Rule
     /// </summary>
-    /// <remarks>
-    /// Scoping criteria define which Metaverse objects are included in an export sync rule.
-    /// Only export sync rules support scoping criteria.
-    /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
-    /// <returns>A list of scoping criteria groups with their criteria.</returns>
-    /// <response code="200">Returns the list of scoping criteria groups.</response>
-    /// <response code="400">Sync rule is not an export rule.</response>
-    /// <response code="404">Sync rule not found.</response>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <returns>A list of Scoping Criteria groups with their criteria.</returns>
+    /// <response code="200">Returns the list of Scoping Criteria groups.</response>
+    /// <response code="400">Sync Rule is not an export rule.</response>
+    /// <response code="404">Sync Rule not found.</response>
     [HttpGet("sync-rules/{syncRuleId:int}/scoping-criteria", Name = "GetScopingCriteriaGroups")]
     [ProducesResponseType(typeof(IEnumerable<SyncRuleScopingCriteriaGroupDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -2056,11 +1981,11 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific scoping criteria group by ID.
+    /// Get a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
-    /// <returns>The scoping criteria group details.</returns>
+    /// <returns>The Scoping Criteria group details.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/scoping-criteria/{groupId:int}", Name = "GetScopingCriteriaGroup")]
     [ProducesResponseType(typeof(SyncRuleScopingCriteriaGroupDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2080,17 +2005,17 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new root scoping criteria group for a sync rule.
+    /// Create a root Scoping Criteria group
     /// </summary>
     /// <remarks>
-    /// Creates a new criteria group at the root level. Use the child-groups endpoint to create nested groups.
+    /// Creates a group at the root level. Use the child-groups endpoint to create nested groups.
     /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="request">The criteria group creation request.</param>
-    /// <returns>The created scoping criteria group.</returns>
+    /// <returns>The created Scoping Criteria group.</returns>
     /// <response code="201">Group created successfully.</response>
     /// <response code="400">Invalid request.</response>
-    /// <response code="404">Sync rule not found.</response>
+    /// <response code="404">Sync Rule not found.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/scoping-criteria", Name = "CreateScopingCriteriaGroup")]
     [ProducesResponseType(typeof(SyncRuleScopingCriteriaGroupDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -2137,12 +2062,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new child scoping criteria group nested within a parent group.
+    /// Create a child Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="parentGroupId">The unique identifier of the parent criteria group.</param>
     /// <param name="request">The criteria group creation request.</param>
-    /// <returns>The created scoping criteria group.</returns>
+    /// <returns>The created Scoping Criteria group.</returns>
     [HttpPost("sync-rules/{syncRuleId:int}/scoping-criteria/{parentGroupId:int}/child-groups", Name = "CreateChildScopingCriteriaGroup")]
     [ProducesResponseType(typeof(SyncRuleScopingCriteriaGroupDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -2194,12 +2119,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates a scoping criteria group's type or position.
+    /// Update a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <param name="request">The update request.</param>
-    /// <returns>The updated scoping criteria group.</returns>
+    /// <returns>The updated Scoping Criteria group.</returns>
     [HttpPut("sync-rules/{syncRuleId:int}/scoping-criteria/{groupId:int}", Name = "UpdateScopingCriteriaGroup")]
     [ProducesResponseType(typeof(SyncRuleScopingCriteriaGroupDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -2249,9 +2174,9 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes a scoping criteria group and all its contents.
+    /// Delete a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group to delete.</param>
     /// <returns>No content on success.</returns>
     [HttpDelete("sync-rules/{syncRuleId:int}/scoping-criteria/{groupId:int}", Name = "DeleteScopingCriteriaGroup")]
@@ -2298,13 +2223,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Adds a criterion to a scoping criteria group.
+    /// Add a criterion to a Scoping Criteria group
     /// </summary>
     /// <remarks>
-    /// For Export sync rules: provide MetaverseAttributeId to evaluate MVO attributes.
-    /// For Import sync rules: provide ConnectedSystemAttributeId to evaluate CSO attributes.
+    /// For Export Sync Rules, provide <c>MetaverseAttributeId</c>. For Import Sync Rules, provide <c>ConnectedSystemAttributeId</c>.
     /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <param name="request">The criterion creation request.</param>
     /// <returns>The created criterion.</returns>
@@ -2393,9 +2317,9 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes a criterion from a scoping criteria group.
+    /// Delete a criterion from a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <param name="criterionId">The unique identifier of the criterion to delete.</param>
     /// <returns>No content on success.</returns>
@@ -2443,7 +2367,7 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Recursively finds a scoping criteria group by ID within a collection.
+    /// Recursively finds a Scoping Criteria group by ID within a collection.
     /// </summary>
     private static SyncRuleScopingCriteriaGroup? FindScopingCriteriaGroup(IEnumerable<SyncRuleScopingCriteriaGroup> groups, int groupId)
     {
@@ -2465,13 +2389,13 @@ public class SynchronisationController(
     #region Object Matching Rules
 
     /// <summary>
-    /// Gets all object matching rules for a Connected System Object Type.
+    /// List Object Matching Rules for an Object Type
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="objectTypeId">The unique identifier of the object type.</param>
-    /// <returns>A list of object matching rules.</returns>
-    /// <response code="200">Returns the list of object matching rules.</response>
-    /// <response code="404">Connected system or object type not found.</response>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="objectTypeId">The unique identifier of the Object Type.</param>
+    /// <returns>A list of Object Matching Rules.</returns>
+    /// <response code="200">Returns the list of Object Matching Rules.</response>
+    /// <response code="404">Connected System or Object Type not found.</response>
     [HttpGet("connected-systems/{connectedSystemId:int}/object-types/{objectTypeId:int}/matching-rules", Name = "GetObjectMatchingRules")]
     [ProducesResponseType(typeof(IEnumerable<ObjectMatchingRuleDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2496,13 +2420,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific object matching rule by ID.
+    /// Get an Object Matching Rule
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="ruleId">The unique identifier of the matching rule.</param>
-    /// <returns>The object matching rule.</returns>
-    /// <response code="200">Returns the object matching rule.</response>
-    /// <response code="404">Connected system or matching rule not found.</response>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
+    /// <returns>The Object Matching Rule.</returns>
+    /// <response code="200">Returns the Object Matching Rule.</response>
+    /// <response code="404">Connected System or Matching Rule not found.</response>
     [HttpGet("connected-systems/{connectedSystemId:int}/matching-rules/{ruleId:int}", Name = "GetObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2527,14 +2451,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new object matching rule.
+    /// Create an Object Matching Rule
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="request">The rule creation request.</param>
-    /// <returns>The created object matching rule.</returns>
-    /// <response code="201">Object matching rule created successfully.</response>
+    /// <returns>The created Object Matching Rule.</returns>
+    /// <response code="201">Object Matching Rule created successfully.</response>
     /// <response code="400">Invalid request data.</response>
-    /// <response code="404">Connected system or referenced entities not found.</response>
+    /// <response code="404">Connected System or referenced entities not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/matching-rules", Name = "CreateObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status201Created)]
@@ -2642,15 +2566,15 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates an existing object matching rule.
+    /// Update an Object Matching Rule
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="ruleId">The unique identifier of the matching rule.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <param name="request">The update request.</param>
-    /// <returns>The updated object matching rule.</returns>
-    /// <response code="200">Object matching rule updated successfully.</response>
+    /// <returns>The updated Object Matching Rule.</returns>
+    /// <response code="200">Object Matching Rule updated successfully.</response>
     /// <response code="400">Invalid request data.</response>
-    /// <response code="404">Connected system or matching rule not found.</response>
+    /// <response code="404">Connected System or Matching Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/matching-rules/{ruleId:int}", Name = "UpdateObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status200OK)]
@@ -2773,13 +2697,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes an object matching rule.
+    /// Delete an Object Matching Rule
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
-    /// <param name="ruleId">The unique identifier of the matching rule.</param>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <returns>No content on success.</returns>
-    /// <response code="204">Object matching rule deleted successfully.</response>
-    /// <response code="404">Connected system or matching rule not found.</response>
+    /// <response code="204">Object Matching Rule deleted successfully.</response>
+    /// <response code="404">Connected System or Matching Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("connected-systems/{connectedSystemId:int}/matching-rules/{ruleId:int}", Name = "DeleteObjectMatchingRule")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -2825,12 +2749,12 @@ public class SynchronisationController(
     #region Sync Rule Object Matching Rules (Advanced Mode)
 
     /// <summary>
-    /// Gets all object matching rules for a sync rule (advanced mode).
+    /// List Object Matching Rules for a Sync Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
-    /// <returns>A list of object matching rules.</returns>
-    /// <response code="200">Returns the list of object matching rules.</response>
-    /// <response code="404">Sync rule not found.</response>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <returns>A list of Object Matching Rules.</returns>
+    /// <response code="200">Returns the list of Object Matching Rules.</response>
+    /// <response code="404">Sync Rule not found.</response>
     [HttpGet("sync-rules/{syncRuleId:int}/matching-rules", Name = "GetSyncRuleObjectMatchingRules")]
     [ProducesResponseType(typeof(IEnumerable<ObjectMatchingRuleDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2851,13 +2775,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Gets a specific object matching rule on a sync rule by ID (advanced mode).
+    /// Get an Object Matching Rule for a Sync Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
-    /// <param name="ruleId">The unique identifier of the matching rule.</param>
-    /// <returns>The object matching rule.</returns>
-    /// <response code="200">Returns the object matching rule.</response>
-    /// <response code="404">Sync rule or matching rule not found.</response>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
+    /// <returns>The Object Matching Rule.</returns>
+    /// <response code="200">Returns the Object Matching Rule.</response>
+    /// <response code="404">Sync Rule or Matching Rule not found.</response>
     [HttpGet("sync-rules/{syncRuleId:int}/matching-rules/{ruleId:int}", Name = "GetSyncRuleObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2877,14 +2801,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Creates a new object matching rule on a sync rule (advanced mode).
+    /// Create an Object Matching Rule on a Sync Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="request">The rule creation request.</param>
-    /// <returns>The created object matching rule.</returns>
-    /// <response code="201">Object matching rule created successfully.</response>
+    /// <returns>The created Object Matching Rule.</returns>
+    /// <response code="201">Object Matching Rule created successfully.</response>
     /// <response code="400">Invalid request data.</response>
-    /// <response code="404">Sync rule or referenced entities not found.</response>
+    /// <response code="404">Sync Rule or referenced entities not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/matching-rules", Name = "CreateSyncRuleObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status201Created)]
@@ -2982,15 +2906,15 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Updates an existing object matching rule on a sync rule (advanced mode).
+    /// Update an Object Matching Rule on a Sync Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
-    /// <param name="ruleId">The unique identifier of the matching rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <param name="request">The update request.</param>
-    /// <returns>The updated object matching rule.</returns>
-    /// <response code="200">Object matching rule updated successfully.</response>
+    /// <returns>The updated Object Matching Rule.</returns>
+    /// <response code="200">Object Matching Rule updated successfully.</response>
     /// <response code="400">Invalid request data.</response>
-    /// <response code="404">Sync rule or matching rule not found.</response>
+    /// <response code="404">Sync Rule or Matching Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("sync-rules/{syncRuleId:int}/matching-rules/{ruleId:int}", Name = "UpdateSyncRuleObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status200OK)]
@@ -3101,13 +3025,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Deletes an object matching rule from a sync rule (advanced mode).
+    /// Delete an Object Matching Rule from a Sync Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the sync rule.</param>
-    /// <param name="ruleId">The unique identifier of the matching rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <returns>No content on success.</returns>
-    /// <response code="204">Object matching rule deleted successfully.</response>
-    /// <response code="404">Sync rule or matching rule not found.</response>
+    /// <response code="204">Object Matching Rule deleted successfully.</response>
+    /// <response code="404">Sync Rule or Matching Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("sync-rules/{syncRuleId:int}/matching-rules/{ruleId:int}", Name = "DeleteSyncRuleObjectMatchingRule")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -3152,16 +3076,17 @@ public class SynchronisationController(
     #region Object Matching Mode Switching
 
     /// <summary>
-    /// Switches the object matching rule mode for a connected system.
-    /// When switching to advanced mode, matching rules are copied from object types to sync rules.
-    /// When switching to simple mode, matching rules are migrated from sync rules to object types.
+    /// Switch the Object Matching mode for a Connected System
     /// </summary>
-    /// <param name="connectedSystemId">The unique identifier of the connected system.</param>
+    /// <remarks>
+    /// When switching to advanced mode, Matching Rules are copied from Object Types to Sync Rules. When switching to simple mode, Matching Rules are migrated from Sync Rules to Object Types.
+    /// </remarks>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="request">The mode switch request.</param>
     /// <returns>The result of the mode switch operation.</returns>
     /// <response code="200">Mode switched successfully.</response>
     /// <response code="400">Mode switch failed.</response>
-    /// <response code="404">Connected system not found.</response>
+    /// <response code="404">Connected System not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems/{connectedSystemId:int}/matching-mode", Name = "SwitchObjectMatchingMode")]
     [ProducesResponseType(typeof(ObjectMatchingModeSwitchResult), StatusCodes.Status200OK)]
@@ -3202,9 +3127,9 @@ public class SynchronisationController(
     #region Expression Testing
 
     /// <summary>
-    /// Tests an expression with sample attribute data.
+    /// Test an expression with sample attribute data
     /// </summary>
-    /// <param name="request">The test expression request containing the expression and sample attribute values.</param>
+    /// <param name="request">The test expression request containing the expression and sample Attribute Values.</param>
     /// <returns>The result of evaluating the expression.</returns>
     /// <response code="200">Expression evaluated successfully.</response>
     /// <response code="400">Invalid expression or test data.</response>
@@ -3344,11 +3269,11 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Checks if a container belongs to a connected system, traversing the parent container chain if necessary.
+    /// Checks if a container belongs to a Connected System, traversing the parent container chain if necessary.
     /// </summary>
     /// <param name="container">The container to check.</param>
-    /// <param name="connectedSystemId">The connected system ID to check against.</param>
-    /// <returns>True if the container belongs to the connected system.</returns>
+    /// <param name="connectedSystemId">The Connected System ID to check against.</param>
+    /// <returns>True if the container belongs to the Connected System.</returns>
     private static bool ContainerBelongsToConnectedSystem(ConnectedSystemContainer container, int connectedSystemId)
     {
         // Check if directly connected to the system

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -300,7 +300,7 @@ public class SynchronisationController(
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="objectTypeId">The unique identifier of the Object Type containing the Attributes.</param>
     /// <param name="request">Dictionary of Attribute updates keyed by Attribute ID.</param>
-    /// <returns>Response containing the activity ID, updated count, updated Attributes, and any errors.</returns>
+    /// <returns>Response containing the Activity ID, updated count, updated Attributes, and any errors.</returns>
     /// <response code="200">Attributes updated successfully (may include partial success with errors).</response>
     /// <response code="400">Invalid request or empty Attributes dictionary.</response>
     /// <response code="404">Connected System or Object Type not found.</response>
@@ -1205,7 +1205,7 @@ public class SynchronisationController(
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="runProfileId">The unique identifier of the Run Profile to execute.</param>
-    /// <returns>The execution response with activity and task IDs for tracking.</returns>
+    /// <returns>The execution response with Activity and task IDs for tracking.</returns>
     /// <response code="202">Run Profile execution has been queued.</response>
     /// <response code="404">Connected System or Run Profile not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -24,12 +24,12 @@ using Microsoft.AspNetCore.Mvc;
 namespace JIM.Web.Controllers.Api;
 
 /// <summary>
-/// API controller for managing synchronisation configuration including Connected Systems and Sync Rules.
+/// API controller for managing synchronisation configuration including Connected Systems and Synchronisation Rules.
 /// </summary>
 /// <remarks>
 /// This controller provides endpoints for managing the synchronisation infrastructure:
 /// - Connected Systems: External identity stores that sync with the Metaverse
-/// - Sync Rules: Configuration for how data flows between Connected Systems and the Metaverse
+/// - Synchronisation Rules: Configuration for how data flows between Connected Systems and the Metaverse
 /// </remarks>
 [Route("api/v{version:apiVersion}/[controller]")]
 [ApiController]
@@ -440,7 +440,7 @@ public class SynchronisationController(
     /// Get a deletion preview for a Connected System
     /// </summary>
     /// <remarks>
-    /// Call this before deleting a Connected System to understand the impact. The preview includes counts of Connected System Objects, Sync Rules, Metaverse Objects, and Pending Exports that will be affected.
+    /// Call this before deleting a Connected System to understand the impact. The preview includes counts of Connected System Objects, Synchronisation Rules, Metaverse Objects, and Pending Exports that will be affected.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>A preview showing counts of affected objects and any warnings.</returns>
@@ -903,7 +903,7 @@ public class SynchronisationController(
     /// Import schema from a Connected System
     /// </summary>
     /// <remarks>
-    /// Connects to the external system and retrieves its Object Types and Attributes. This is required before creating Sync Rules. Existing schema configuration will be replaced; Sync Rules referencing removed Object Types or Attributes will need to be updated.
+    /// Connects to the external system and retrieves its Object Types and Attributes. This is required before creating Synchronisation Rules. Existing schema configuration will be replaced; Synchronisation Rules referencing removed Object Types or Attributes will need to be updated.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>The updated Connected System with imported schema.</returns>
@@ -1477,10 +1477,10 @@ public class SynchronisationController(
     #region Sync Rules
 
     /// <summary>
-    /// List Sync Rules
+    /// List Synchronisation Rules
     /// </summary>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
-    /// <returns>A paginated list of Sync Rule headers.</returns>
+    /// <returns>A paginated list of Synchronisation Rule headers.</returns>
     [HttpGet("sync-rules", Name = "GetSyncRules")]
     [ProducesResponseType(typeof(PaginatedResponse<SyncRuleHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1498,10 +1498,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Get a Sync Rule
+    /// Get a Synchronisation Rule
     /// </summary>
-    /// <param name="id">The unique identifier of the Sync Rule.</param>
-    /// <returns>The Sync Rule details including Attribute flow configuration.</returns>
+    /// <param name="id">The unique identifier of the Synchronisation Rule.</param>
+    /// <returns>The Synchronisation Rule details including Attribute flow configuration.</returns>
     [HttpGet("sync-rules/{id:int}", Name = "GetSyncRule")]
     [ProducesResponseType(typeof(SyncRuleHeader), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1517,14 +1517,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Create a Sync Rule
+    /// Create a Synchronisation Rule
     /// </summary>
     /// <remarks>
     /// For Import rules, set <c>ProjectToMetaverse</c> to true to create Metaverse objects from imported data. For Export rules, set <c>ProvisionToConnectedSystem</c> to true to create Connected System Objects.
     /// </remarks>
-    /// <param name="request">The Sync Rule creation request.</param>
-    /// <returns>The created Sync Rule details.</returns>
-    /// <response code="201">Sync Rule created successfully.</response>
+    /// <param name="request">The Synchronisation Rule creation request.</param>
+    /// <returns>The created Synchronisation Rule details.</returns>
+    /// <response code="201">Synchronisation Rule created successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules", Name = "CreateSyncRule")]
@@ -1598,14 +1598,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Update a Sync Rule
+    /// Update a Synchronisation Rule
     /// </summary>
-    /// <param name="id">The unique identifier of the Sync Rule to update.</param>
+    /// <param name="id">The unique identifier of the Synchronisation Rule to update.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated Sync Rule details.</returns>
-    /// <response code="200">Sync Rule updated successfully.</response>
+    /// <returns>The updated Synchronisation Rule details.</returns>
+    /// <response code="200">Synchronisation Rule updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Sync Rule not found.</response>
+    /// <response code="404">Synchronisation Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("sync-rules/{id:int}", Name = "UpdateSyncRule")]
     [ProducesResponseType(typeof(SyncRuleHeader), StatusCodes.Status200OK)]
@@ -1666,12 +1666,12 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Delete a Sync Rule
+    /// Delete a Synchronisation Rule
     /// </summary>
-    /// <param name="id">The unique identifier of the Sync Rule to delete.</param>
+    /// <param name="id">The unique identifier of the Synchronisation Rule to delete.</param>
     /// <returns>No content on success.</returns>
-    /// <response code="204">Sync Rule deleted successfully.</response>
-    /// <response code="404">Sync Rule not found.</response>
+    /// <response code="204">Synchronisation Rule deleted successfully.</response>
+    /// <response code="404">Synchronisation Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("sync-rules/{id:int}", Name = "DeleteSyncRule")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -1710,9 +1710,9 @@ public class SynchronisationController(
     #region Sync Rule Mappings
 
     /// <summary>
-    /// List Attribute Flow Mappings for a Sync Rule
+    /// List Attribute Flow Mappings for a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <returns>A list of Attribute Flow Mappings.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/mappings", Name = "GetSyncRuleMappings")]
     [ProducesResponseType(typeof(IEnumerable<SyncRuleMappingDto>), StatusCodes.Status200OK)]
@@ -1734,7 +1734,7 @@ public class SynchronisationController(
     /// <summary>
     /// Get an Attribute Flow Mapping
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="mappingId">The unique identifier of the mapping.</param>
     /// <returns>The Attribute Flow Mapping details.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/mappings/{mappingId:int}", Name = "GetSyncRuleMapping")]
@@ -1762,12 +1762,12 @@ public class SynchronisationController(
     /// <remarks>
     /// For Import rules, specify <c>TargetMetaverseAttributeId</c> and source <c>ConnectedSystemAttributeIds</c>. For Export rules, specify <c>TargetConnectedSystemAttributeId</c> and source <c>MetaverseAttributeIds</c>.
     /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="request">The mapping creation request.</param>
     /// <returns>The created Attribute Flow Mapping.</returns>
     /// <response code="201">Mapping created successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Sync Rule or referenced Attributes not found.</response>
+    /// <response code="404">Synchronisation Rule or referenced Attributes not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/mappings", Name = "CreateSyncRuleMapping")]
     [ProducesResponseType(typeof(SyncRuleMappingDto), StatusCodes.Status201Created)]
@@ -1908,11 +1908,11 @@ public class SynchronisationController(
     /// <summary>
     /// Delete an Attribute Flow Mapping
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="mappingId">The unique identifier of the mapping to delete.</param>
     /// <returns>No content on success.</returns>
     /// <response code="204">Mapping deleted successfully.</response>
-    /// <response code="404">Sync Rule or mapping not found.</response>
+    /// <response code="404">Synchronisation Rule or mapping not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("sync-rules/{syncRuleId:int}/mappings/{mappingId:int}", Name = "DeleteSyncRuleMapping")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -1954,13 +1954,13 @@ public class SynchronisationController(
     #region Sync Rule Scoping Criteria
 
     /// <summary>
-    /// List Scoping Criteria groups for a Sync Rule
+    /// List Scoping Criteria groups for a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <returns>A list of Scoping Criteria groups with their criteria.</returns>
     /// <response code="200">Returns the list of Scoping Criteria groups.</response>
-    /// <response code="400">Sync Rule is not an export rule.</response>
-    /// <response code="404">Sync Rule not found.</response>
+    /// <response code="400">Synchronisation Rule is not an export rule.</response>
+    /// <response code="404">Synchronisation Rule not found.</response>
     [HttpGet("sync-rules/{syncRuleId:int}/scoping-criteria", Name = "GetScopingCriteriaGroups")]
     [ProducesResponseType(typeof(IEnumerable<SyncRuleScopingCriteriaGroupDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -1983,7 +1983,7 @@ public class SynchronisationController(
     /// <summary>
     /// Get a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <returns>The Scoping Criteria group details.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/scoping-criteria/{groupId:int}", Name = "GetScopingCriteriaGroup")]
@@ -2010,12 +2010,12 @@ public class SynchronisationController(
     /// <remarks>
     /// Creates a group at the root level. Use the child-groups endpoint to create nested groups.
     /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="request">The criteria group creation request.</param>
     /// <returns>The created Scoping Criteria group.</returns>
     /// <response code="201">Group created successfully.</response>
     /// <response code="400">Invalid request.</response>
-    /// <response code="404">Sync Rule not found.</response>
+    /// <response code="404">Synchronisation Rule not found.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/scoping-criteria", Name = "CreateScopingCriteriaGroup")]
     [ProducesResponseType(typeof(SyncRuleScopingCriteriaGroupDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -2064,7 +2064,7 @@ public class SynchronisationController(
     /// <summary>
     /// Create a child Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="parentGroupId">The unique identifier of the parent criteria group.</param>
     /// <param name="request">The criteria group creation request.</param>
     /// <returns>The created Scoping Criteria group.</returns>
@@ -2121,7 +2121,7 @@ public class SynchronisationController(
     /// <summary>
     /// Update a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <param name="request">The update request.</param>
     /// <returns>The updated Scoping Criteria group.</returns>
@@ -2176,7 +2176,7 @@ public class SynchronisationController(
     /// <summary>
     /// Delete a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group to delete.</param>
     /// <returns>No content on success.</returns>
     [HttpDelete("sync-rules/{syncRuleId:int}/scoping-criteria/{groupId:int}", Name = "DeleteScopingCriteriaGroup")]
@@ -2226,9 +2226,9 @@ public class SynchronisationController(
     /// Add a criterion to a Scoping Criteria group
     /// </summary>
     /// <remarks>
-    /// For Export Sync Rules, provide <c>MetaverseAttributeId</c>. For Import Sync Rules, provide <c>ConnectedSystemAttributeId</c>.
+    /// For Export Synchronisation Rules, provide <c>MetaverseAttributeId</c>. For Import Synchronisation Rules, provide <c>ConnectedSystemAttributeId</c>.
     /// </remarks>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <param name="request">The criterion creation request.</param>
     /// <returns>The created criterion.</returns>
@@ -2319,7 +2319,7 @@ public class SynchronisationController(
     /// <summary>
     /// Delete a criterion from a Scoping Criteria group
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="groupId">The unique identifier of the criteria group.</param>
     /// <param name="criterionId">The unique identifier of the criterion to delete.</param>
     /// <returns>No content on success.</returns>
@@ -2749,12 +2749,12 @@ public class SynchronisationController(
     #region Sync Rule Object Matching Rules (Advanced Mode)
 
     /// <summary>
-    /// List Object Matching Rules for a Sync Rule
+    /// List Object Matching Rules for a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <returns>A list of Object Matching Rules.</returns>
     /// <response code="200">Returns the list of Object Matching Rules.</response>
-    /// <response code="404">Sync Rule not found.</response>
+    /// <response code="404">Synchronisation Rule not found.</response>
     [HttpGet("sync-rules/{syncRuleId:int}/matching-rules", Name = "GetSyncRuleObjectMatchingRules")]
     [ProducesResponseType(typeof(IEnumerable<ObjectMatchingRuleDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2775,13 +2775,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Get an Object Matching Rule for a Sync Rule
+    /// Get an Object Matching Rule for a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <returns>The Object Matching Rule.</returns>
     /// <response code="200">Returns the Object Matching Rule.</response>
-    /// <response code="404">Sync Rule or Matching Rule not found.</response>
+    /// <response code="404">Synchronisation Rule or Matching Rule not found.</response>
     [HttpGet("sync-rules/{syncRuleId:int}/matching-rules/{ruleId:int}", Name = "GetSyncRuleObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -2801,14 +2801,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Create an Object Matching Rule on a Sync Rule
+    /// Create an Object Matching Rule on a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="request">The rule creation request.</param>
     /// <returns>The created Object Matching Rule.</returns>
     /// <response code="201">Object Matching Rule created successfully.</response>
     /// <response code="400">Invalid request data.</response>
-    /// <response code="404">Sync Rule or referenced entities not found.</response>
+    /// <response code="404">Synchronisation Rule or referenced entities not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/matching-rules", Name = "CreateSyncRuleObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status201Created)]
@@ -2906,15 +2906,15 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Update an Object Matching Rule on a Sync Rule
+    /// Update an Object Matching Rule on a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <param name="request">The update request.</param>
     /// <returns>The updated Object Matching Rule.</returns>
     /// <response code="200">Object Matching Rule updated successfully.</response>
     /// <response code="400">Invalid request data.</response>
-    /// <response code="404">Sync Rule or Matching Rule not found.</response>
+    /// <response code="404">Synchronisation Rule or Matching Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("sync-rules/{syncRuleId:int}/matching-rules/{ruleId:int}", Name = "UpdateSyncRuleObjectMatchingRule")]
     [ProducesResponseType(typeof(ObjectMatchingRuleDto), StatusCodes.Status200OK)]
@@ -3025,13 +3025,13 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Delete an Object Matching Rule from a Sync Rule
+    /// Delete an Object Matching Rule from a Synchronisation Rule
     /// </summary>
-    /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
+    /// <param name="syncRuleId">The unique identifier of the Synchronisation Rule.</param>
     /// <param name="ruleId">The unique identifier of the Matching Rule.</param>
     /// <returns>No content on success.</returns>
     /// <response code="204">Object Matching Rule deleted successfully.</response>
-    /// <response code="404">Sync Rule or Matching Rule not found.</response>
+    /// <response code="404">Synchronisation Rule or Matching Rule not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpDelete("sync-rules/{syncRuleId:int}/matching-rules/{ruleId:int}", Name = "DeleteSyncRuleObjectMatchingRule")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -3079,7 +3079,7 @@ public class SynchronisationController(
     /// Switch the Object Matching mode for a Connected System
     /// </summary>
     /// <remarks>
-    /// When switching to advanced mode, Matching Rules are copied from Object Types to Sync Rules. When switching to simple mode, Matching Rules are migrated from Sync Rules to Object Types.
+    /// When switching to advanced mode, Matching Rules are copied from Object Types to Synchronisation Rules. When switching to simple mode, Matching Rules are migrated from Synchronisation Rules to Object Types.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="request">The mode switch request.</param>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -99,7 +99,7 @@ public class SynchronisationController(
     /// List Object Types for a Connected System
     /// </summary>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
-    /// <returns>A list of Object Types with their attributes.</returns>
+    /// <returns>A list of Object Types with their Attributes.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/object-types", Name = "GetConnectedSystemObjectTypes")]
     [ProducesResponseType(typeof(IEnumerable<ConnectedSystemObjectTypeDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -121,7 +121,7 @@ public class SynchronisationController(
     /// <remarks>
     /// Use this endpoint to update properties of an Object Type, such as:
     /// - Selected: Whether the Object Type is managed by JIM
-    /// - RemoveContributedAttributesOnObsoletion: Whether MVO attributes are removed when CSO is obsoleted
+    /// - RemoveContributedAttributesOnObsoletion: Whether MVO Attributes are removed when CSO is obsoleted
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="objectTypeId">The unique identifier of the Object Type.</param>
@@ -179,22 +179,22 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Update an attribute
+    /// Update an Attribute
     /// </summary>
     /// <remarks>
-    /// Use this endpoint to update properties of an attribute, such as:
-    /// - Selected: Whether the attribute is managed by JIM
+    /// Use this endpoint to update properties of an Attribute, such as:
+    /// - Selected: Whether the Attribute is managed by JIM
     /// - IsExternalId: Whether this is the unique identifier for objects
     /// - IsSecondaryExternalId: Whether this is a secondary identifier (e.g., DN for LDAP)
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="objectTypeId">The unique identifier of the Object Type.</param>
-    /// <param name="attributeId">The unique identifier of the attribute.</param>
+    /// <param name="attributeId">The unique identifier of the Attribute.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated attribute details.</returns>
+    /// <returns>The updated Attribute details.</returns>
     /// <response code="200">Attribute updated successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Connected System, Object Type, or attribute not found.</response>
+    /// <response code="404">Connected System, Object Type, or Attribute not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/object-types/{objectTypeId:int}/attributes/{attributeId:int}", Name = "UpdateConnectedSystemAttribute")]
     [ProducesResponseType(typeof(ConnectedSystemAttributeDto), StatusCodes.Status200OK)]
@@ -292,17 +292,17 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Bulk update attributes for an Object Type
+    /// Bulk update Attributes for an Object Type
     /// </summary>
     /// <remarks>
-    /// Updates multiple attributes in a single operation, creating one Activity record for the entire batch rather than individual records per attribute.
+    /// Updates multiple Attributes in a single operation, creating one Activity record for the entire batch rather than individual records per Attribute.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
-    /// <param name="objectTypeId">The unique identifier of the Object Type containing the attributes.</param>
-    /// <param name="request">Dictionary of attribute updates keyed by attribute ID.</param>
-    /// <returns>Response containing the activity ID, updated count, updated attributes, and any errors.</returns>
+    /// <param name="objectTypeId">The unique identifier of the Object Type containing the Attributes.</param>
+    /// <param name="request">Dictionary of Attribute updates keyed by Attribute ID.</param>
+    /// <returns>Response containing the activity ID, updated count, updated Attributes, and any errors.</returns>
     /// <response code="200">Attributes updated successfully (may include partial success with errors).</response>
-    /// <response code="400">Invalid request or empty attributes dictionary.</response>
+    /// <response code="400">Invalid request or empty Attributes dictionary.</response>
     /// <response code="404">Connected System or Object Type not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/object-types/{objectTypeId:int}/attributes", Name = "BulkUpdateConnectedSystemAttributes")]
@@ -398,13 +398,13 @@ public class SynchronisationController(
     /// List Attribute Values for a Connected System Object
     /// </summary>
     /// <remarks>
-    /// Use this endpoint to retrieve large multi-valued attribute data (e.g. group members)
+    /// Use this endpoint to retrieve large multi-valued Attribute data (e.g. group members)
     /// with server-side search and pagination. The CSO detail endpoint caps MVA values;
     /// use this endpoint to page through all values.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="csoId">The unique identifier (GUID) of the Connected System Object.</param>
-    /// <param name="attributeName">The attribute name to retrieve values for.</param>
+    /// <param name="attributeName">The Attribute name to retrieve values for.</param>
     /// <param name="page">Page number (1-based). Default: 1.</param>
     /// <param name="pageSize">Number of values per page (1-100). Default: 50.</param>
     /// <param name="search">Optional search text to filter values.</param>
@@ -463,7 +463,7 @@ public class SynchronisationController(
     /// Get the unresolved reference count for a Connected System
     /// </summary>
     /// <remarks>
-    /// An unresolved reference occurs when a reference attribute (e.g. group 'member') contains a value that could not be matched to another Connected System Object during the last import run. A non-zero count indicates data integrity issues that should be investigated.
+    /// An unresolved reference occurs when a reference Attribute (e.g. group 'member') contains a value that could not be matched to another Connected System Object during the last import run. A non-zero count indicates data integrity issues that should be investigated.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>The count of unresolved reference Attribute Values.</returns>
@@ -482,7 +482,7 @@ public class SynchronisationController(
     /// </summary>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
-    /// <param name="partitionId">Optional partition ID to filter by.</param>
+    /// <param name="partitionId">Optional Partition ID to filter by.</param>
     /// <returns>The count of matching Connected System Objects.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/connector-space/count", Name = "GetConnectorSpaceCount")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
@@ -505,7 +505,7 @@ public class SynchronisationController(
     /// List Pending Exports for a Connected System
     /// </summary>
     /// <remarks>
-    /// Returns lightweight header objects. Use the detail endpoint to retrieve full attribute change data for a specific Pending Export.
+    /// Returns lightweight header objects. Use the detail endpoint to retrieve full Attribute change data for a specific Pending Export.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <param name="page">Page number (1-based). Default: 1.</param>
@@ -563,10 +563,10 @@ public class SynchronisationController(
     /// Get a Pending Export
     /// </summary>
     /// <remarks>
-    /// Multi-valued attribute changes are capped at 10 per attribute. Use the <c>attributeChangeSummaries</c> array to identify truncated attributes, then call the paged attribute changes endpoint to retrieve all values.
+    /// Multi-valued Attribute changes are capped at 10 per Attribute. Use the <c>attributeChangeSummaries</c> array to identify truncated Attributes, then call the paged Attribute changes endpoint to retrieve all values.
     /// </remarks>
     /// <param name="pendingExportId">The unique identifier (GUID) of the Pending Export.</param>
-    /// <returns>The Pending Export details with capped attribute changes and per-attribute summaries.</returns>
+    /// <returns>The Pending Export details with capped Attribute changes and per-attribute summaries.</returns>
     [HttpGet("pending-exports/{pendingExportId:guid}", Name = "GetPendingExport")]
     [ProducesResponseType(typeof(PendingExportDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -585,10 +585,10 @@ public class SynchronisationController(
     /// List Attribute Value changes for a Pending Export
     /// </summary>
     /// <remarks>
-    /// Use this endpoint to page through large multi-valued attribute changes (e.g. group member additions). The Pending Export detail endpoint caps multi-valued attribute changes; use this endpoint to retrieve all values for a specific attribute.
+    /// Use this endpoint to page through large multi-valued Attribute changes (e.g. group member additions). The Pending Export detail endpoint caps multi-valued Attribute changes; use this endpoint to retrieve all values for a specific Attribute.
     /// </remarks>
     /// <param name="pendingExportId">The unique identifier (GUID) of the Pending Export.</param>
-    /// <param name="attributeName">The attribute name to retrieve changes for.</param>
+    /// <param name="attributeName">The Attribute name to retrieve changes for.</param>
     /// <param name="page">Page number (1-based). Default: 1.</param>
     /// <param name="pageSize">Number of changes per page (1-100). Default: 50.</param>
     /// <param name="search">Optional search text to filter changes by value.</param>
@@ -623,10 +623,10 @@ public class SynchronisationController(
 
     #region Partitions and Containers
     /// <summary>
-    /// List partitions for a Connected System
+    /// List Partitions for a Connected System
     /// </summary>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
-    /// <returns>A list of partitions with their containers.</returns>
+    /// <returns>A list of Partitions with their Containers.</returns>
     [HttpGet("connected-systems/{connectedSystemId:int}/partitions", Name = "GetConnectedSystemPartitions")]
     [ProducesResponseType(typeof(IEnumerable<ConnectedSystemPartitionDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -646,14 +646,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Update a partition
+    /// Update a Partition
     /// </summary>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
-    /// <param name="partitionId">The unique identifier of the partition.</param>
+    /// <param name="partitionId">The unique identifier of the Partition.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated partition details.</returns>
+    /// <returns>The updated Partition details.</returns>
     /// <response code="200">Partition updated successfully.</response>
-    /// <response code="404">Connected System or partition not found.</response>
+    /// <response code="404">Connected System or Partition not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/partitions/{partitionId:int}", Name = "UpdateConnectedSystemPartition")]
     [ProducesResponseType(typeof(ConnectedSystemPartitionDto), StatusCodes.Status200OK)]
@@ -692,14 +692,14 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Update a container
+    /// Update a Container
     /// </summary>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
-    /// <param name="containerId">The unique identifier of the container.</param>
+    /// <param name="containerId">The unique identifier of the Container.</param>
     /// <param name="request">The update request with new values.</param>
-    /// <returns>The updated container details.</returns>
+    /// <returns>The updated Container details.</returns>
     /// <response code="200">Container updated successfully.</response>
-    /// <response code="404">Connected System or container not found.</response>
+    /// <response code="404">Connected System or Container not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPut("connected-systems/{connectedSystemId:int}/containers/{containerId:int}", Name = "UpdateConnectedSystemContainer")]
     [ProducesResponseType(typeof(ConnectedSystemContainerDto), StatusCodes.Status200OK)]
@@ -752,7 +752,7 @@ public class SynchronisationController(
     /// <param name="request">The Connected System creation request.</param>
     /// <returns>The created Connected System details.</returns>
     /// <response code="201">Connected System created successfully.</response>
-    /// <response code="400">Invalid request or connector definition not found.</response>
+    /// <response code="400">Invalid request or Connector Definition not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("connected-systems", Name = "CreateConnectedSystem")]
     [ProducesResponseType(typeof(ConnectedSystemDetailDto), StatusCodes.Status201Created)]
@@ -903,7 +903,7 @@ public class SynchronisationController(
     /// Import schema from a Connected System
     /// </summary>
     /// <remarks>
-    /// Connects to the external system and retrieves its Object Types and attributes. This is required before creating Sync Rules. Existing schema configuration will be replaced; Sync Rules referencing removed Object Types or attributes will need to be updated.
+    /// Connects to the external system and retrieves its Object Types and Attributes. This is required before creating Sync Rules. Existing schema configuration will be replaced; Sync Rules referencing removed Object Types or Attributes will need to be updated.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>The updated Connected System with imported schema.</returns>
@@ -960,7 +960,7 @@ public class SynchronisationController(
     /// Import hierarchy from a Connected System
     /// </summary>
     /// <remarks>
-    /// Connects to the external system and retrieves its partition and container hierarchy. Existing selections are preserved where possible using a match-and-merge approach. If previously selected items were removed, the <c>hasSelectedItemsRemoved</c> flag will be set in the response.
+    /// Connects to the external system and retrieves its Partition and Container hierarchy. Existing selections are preserved where possible using a match-and-merge approach. If previously selected items were removed, the <c>hasSelectedItemsRemoved</c> flag will be set in the response.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
     /// <returns>A result object describing what changed during the hierarchy refresh.</returns>
@@ -1067,7 +1067,7 @@ public class SynchronisationController(
     /// Clear the connector space for a Connected System
     /// </summary>
     /// <remarks>
-    /// Removes all Connected System Objects and their attributes from the connector space. Typically used before re-importing data. This is a destructive operation.
+    /// Removes all Connected System Objects and their Attributes from the connector space. Typically used before re-importing data. This is a destructive operation.
     /// </remarks>
     /// <param name="connectedSystemId">The unique identifier of the Connected System to clear.</param>
     /// <param name="deleteChangeHistory">Whether to delete change history for the cleared CSOs. Default: true (recommended for re-import scenarios).</param>
@@ -1119,9 +1119,9 @@ public class SynchronisationController(
     #region Connector Definitions
 
     /// <summary>
-    /// List connector definitions
+    /// List Connector Definitions
     /// </summary>
-    /// <returns>A list of all available connector definitions.</returns>
+    /// <returns>A list of all available Connector Definitions.</returns>
     [HttpGet("connector-definitions", Name = "GetConnectorDefinitions")]
     [ProducesResponseType(typeof(IEnumerable<ConnectorDefinitionHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -1133,10 +1133,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Get a connector definition
+    /// Get a Connector Definition
     /// </summary>
-    /// <param name="id">The unique identifier of the connector definition.</param>
-    /// <returns>The connector definition details including all settings and capabilities.</returns>
+    /// <param name="id">The unique identifier of the Connector Definition.</param>
+    /// <returns>The Connector Definition details including all settings and capabilities.</returns>
     [HttpGet("connector-definitions/{id:int}", Name = "GetConnectorDefinition")]
     [ProducesResponseType(typeof(ConnectorDefinition), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1152,10 +1152,10 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Get a connector definition by name
+    /// Get a Connector Definition by name
     /// </summary>
-    /// <param name="name">The name of the connector definition (e.g., "CSV File", "LDAP").</param>
-    /// <returns>The connector definition details including all settings and capabilities.</returns>
+    /// <param name="name">The name of the Connector Definition (e.g., "CSV File", "LDAP").</param>
+    /// <returns>The Connector Definition details including all settings and capabilities.</returns>
     [HttpGet("connector-definitions/by-name/{name}", Name = "GetConnectorDefinitionByName")]
     [ProducesResponseType(typeof(ConnectorDefinition), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1501,7 +1501,7 @@ public class SynchronisationController(
     /// Get a Sync Rule
     /// </summary>
     /// <param name="id">The unique identifier of the Sync Rule.</param>
-    /// <returns>The Sync Rule details including attribute flow configuration.</returns>
+    /// <returns>The Sync Rule details including Attribute flow configuration.</returns>
     [HttpGet("sync-rules/{id:int}", Name = "GetSyncRule")]
     [ProducesResponseType(typeof(SyncRuleHeader), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1710,10 +1710,10 @@ public class SynchronisationController(
     #region Sync Rule Mappings
 
     /// <summary>
-    /// List attribute flow mappings for a Sync Rule
+    /// List Attribute Flow Mappings for a Sync Rule
     /// </summary>
     /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
-    /// <returns>A list of attribute flow mappings.</returns>
+    /// <returns>A list of Attribute Flow Mappings.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/mappings", Name = "GetSyncRuleMappings")]
     [ProducesResponseType(typeof(IEnumerable<SyncRuleMappingDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1732,11 +1732,11 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Get an attribute flow mapping
+    /// Get an Attribute Flow Mapping
     /// </summary>
     /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="mappingId">The unique identifier of the mapping.</param>
-    /// <returns>The attribute flow mapping details.</returns>
+    /// <returns>The Attribute Flow Mapping details.</returns>
     [HttpGet("sync-rules/{syncRuleId:int}/mappings/{mappingId:int}", Name = "GetSyncRuleMapping")]
     [ProducesResponseType(typeof(SyncRuleMappingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
@@ -1757,17 +1757,17 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Create an attribute flow mapping
+    /// Create an Attribute Flow Mapping
     /// </summary>
     /// <remarks>
     /// For Import rules, specify <c>TargetMetaverseAttributeId</c> and source <c>ConnectedSystemAttributeIds</c>. For Export rules, specify <c>TargetConnectedSystemAttributeId</c> and source <c>MetaverseAttributeIds</c>.
     /// </remarks>
     /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="request">The mapping creation request.</param>
-    /// <returns>The created attribute flow mapping.</returns>
+    /// <returns>The created Attribute Flow Mapping.</returns>
     /// <response code="201">Mapping created successfully.</response>
     /// <response code="400">Invalid request or validation failed.</response>
-    /// <response code="404">Sync Rule or referenced attributes not found.</response>
+    /// <response code="404">Sync Rule or referenced Attributes not found.</response>
     /// <response code="401">User could not be identified from authentication token.</response>
     [HttpPost("sync-rules/{syncRuleId:int}/mappings", Name = "CreateSyncRuleMapping")]
     [ProducesResponseType(typeof(SyncRuleMappingDto), StatusCodes.Status201Created)]
@@ -1906,7 +1906,7 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Delete an attribute flow mapping
+    /// Delete an Attribute Flow Mapping
     /// </summary>
     /// <param name="syncRuleId">The unique identifier of the Sync Rule.</param>
     /// <param name="mappingId">The unique identifier of the mapping to delete.</param>
@@ -3127,7 +3127,7 @@ public class SynchronisationController(
     #region Expression Testing
 
     /// <summary>
-    /// Test an expression with sample attribute data
+    /// Test an expression with sample Attribute data
     /// </summary>
     /// <param name="request">The test expression request containing the expression and sample Attribute Values.</param>
     /// <returns>The result of evaluating the expression.</returns>
@@ -3269,11 +3269,11 @@ public class SynchronisationController(
     }
 
     /// <summary>
-    /// Checks if a container belongs to a Connected System, traversing the parent container chain if necessary.
+    /// Checks if a Container belongs to a Connected System, traversing the parent Container chain if necessary.
     /// </summary>
-    /// <param name="container">The container to check.</param>
+    /// <param name="container">The Container to check.</param>
     /// <param name="connectedSystemId">The Connected System ID to check against.</param>
-    /// <returns>True if the container belongs to the Connected System.</returns>
+    /// <returns>True if the Container belongs to the Connected System.</returns>
     private static bool ContainerBelongsToConnectedSystem(ConnectedSystemContainer container, int connectedSystemId)
     {
         // Check if directly connected to the system

--- a/src/JIM.Web/Controllers/Api/UserInfoController.cs
+++ b/src/JIM.Web/Controllers/Api/UserInfoController.cs
@@ -32,12 +32,10 @@ public class UserInfoController(ILogger<UserInfoController> logger, JimApplicati
     private readonly JimApplication _application = application;
 
     /// <summary>
-    /// Gets information about the currently authenticated user.
+    /// Get current user info
     /// </summary>
     /// <remarks>
-    /// Returns the user's JIM identity, assigned roles, and authorisation status.
-    /// If the user is authenticated but has no JIM identity (MetaverseObject),
-    /// <c>authorised</c> will be <c>false</c> with a message explaining how to resolve this.
+    /// If the authenticated user has no JIM identity (MetaverseObject), <c>authorised</c> will be <c>false</c> with a message explaining how to resolve this.
     /// </remarks>
     /// <returns>User identity, roles, and authorisation status.</returns>
     [HttpGet(Name = "GetUserInfo")]

--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -65,8 +65,32 @@ FROM build AS publish
 ARG VERSION_SUFFIX=
 RUN dotnet publish "JIM.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false /p:VersionSuffix="${VERSION_SUFFIX}"
 
-# Final stage - use published output
+# Generate OpenAPI document in lightweight mode (no DB or IdP required).
+# The app starts, generates the schema from controller metadata, writes the
+# JSON file, and exits. The generated file is copied into the final image.
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:c433886fdfe33c6427966a412328867b2be9a64f540a105d08943c2dc6fba39b AS openapi-gen
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENV JIM_OPENAPI_GENERATE=true \
+    JIM_OPENAPI_OUTPUT_PATH=/app/wwwroot/api/openapi/v1.json \
+    JIM_LOG_LEVEL=Warning \
+    JIM_LOG_PATH=/tmp \
+    JIM_SSO_AUTHORITY=http://localhost:8181/realms/jim \
+    JIM_SSO_CLIENT_ID=jim-web \
+    JIM_SSO_SECRET=placeholder \
+    JIM_SSO_API_SCOPE=jim-api \
+    JIM_SSO_CLAIM_TYPE=sub \
+    JIM_SSO_MV_ATTRIBUTE="Subject Identifier" \
+    JIM_SSO_INITIAL_ADMIN=placeholder \
+    JIM_DB_HOSTNAME=localhost \
+    JIM_DB_NAME=jim \
+    JIM_DB_USERNAME=jim \
+    JIM_DB_PASSWORD=placeholder
+RUN dotnet JIM.Web.dll
+
+# Final stage - use published output with pre-generated OpenAPI document
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY --from=openapi-gen /app/wwwroot/api/openapi/v1.json ./wwwroot/api/openapi/v1.json
 ENTRYPOINT ["dotnet", "JIM.Web.dll"]

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -360,7 +360,7 @@ try
             {
                 Title = "JIM API",
                 Version = "v1",
-                Description = "JIM (Junctional Identity Manager) REST API for managing identity synchronisation.",
+                Description = "Programmatic access to JIM's identity lifecycle management capabilities. Use this API to configure Connected Systems, manage Synchronisation Rules, query the Metaverse, monitor Activities, and automate deployment via scripting or CI/CD pipelines.",
                 Contact = new OpenApiContact
                 {
                     Name = "Tetron",

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -448,19 +448,42 @@ try
     var staticOpenApiPath = Path.Combine(app.Environment.WebRootPath, "api", "openapi", "v1.json");
     var hasStaticOpenApiDoc = File.Exists(staticOpenApiPath);
 
-    if (hasStaticOpenApiDoc)
+    // JIM-branded Scalar configuration: deep navy background with purple accent,
+    // matching the JIM web UI theme (navy-o6)
+    void ConfigureScalar(ScalarOptions options, string openApiRoutePattern)
     {
-        // Static file is served automatically by UseStaticFiles() at /api/openapi/v1.json
-        app.MapScalarApiReference("/api/reference", options => options
-            .WithTitle("JIM API Reference")
+        options.WithTitle("JIM API Reference")
             .WithFavicon("/images/jim-logo.png")
-            .WithOpenApiRoutePattern("/api/openapi/v1.json")
+            .ForceDarkMode()
+            .WithCustomCss("""
+                .dark-mode {
+                    --scalar-background-1: #051526;
+                    --scalar-background-2: #0d1e30;
+                    --scalar-background-3: #15293c;
+                    --scalar-background-accent: rgba(97, 75, 158, 0.12);
+                    --scalar-color-1: rgba(255, 255, 255, 0.85);
+                    --scalar-color-2: rgba(255, 255, 255, 0.55);
+                    --scalar-color-3: rgba(255, 255, 255, 0.35);
+                    --scalar-color-accent: #9585c8;
+                    --scalar-border-color: rgba(255, 255, 255, 0.08);
+                    --scalar-button-1: #614b9e;
+                    --scalar-button-1-hover: #4e3c80;
+                    --scalar-button-1-color: #ffffff;
+                }
+                """)
+            .WithOpenApiRoutePattern(openApiRoutePattern)
             .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
             .AddAuthorizationCodeFlow("OAuth2", flow =>
             {
                 flow.ClientId = clientId!;
                 flow.Pkce = Pkce.Sha256;
-            }));
+            });
+    }
+
+    if (hasStaticOpenApiDoc)
+    {
+        // Static file is served automatically by UseStaticFiles() at /api/openapi/v1.json
+        app.MapScalarApiReference("/api/reference", o => ConfigureScalar(o, "/api/openapi/v1.json"));
         app.Logger.LogInformation("Serving static OpenAPI document from {Path}", staticOpenApiPath);
     }
     else if (app.Environment.IsDevelopment())
@@ -508,16 +531,7 @@ try
             await next(context);
         });
 
-        app.MapScalarApiReference("/api/reference", options => options
-            .WithTitle("JIM API Reference")
-            .WithFavicon("/images/jim-logo.png")
-            .WithOpenApiRoutePattern("/api/openapi/{documentName}.json")
-            .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
-            .AddAuthorizationCodeFlow("OAuth2", flow =>
-            {
-                flow.ClientId = clientId!;
-                flow.Pkce = Pkce.Sha256;
-            }));
+        app.MapScalarApiReference("/api/reference", o => ConfigureScalar(o, "/api/openapi/{documentName}.json"));
         app.Logger.LogInformation("No static OpenAPI document found; using runtime generation (development only)");
     }
 

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
+using Microsoft.AspNetCore.OpenApi;
 using Scalar.AspNetCore;
 using MudBlazor;
 using MudBlazor.Services;
@@ -62,8 +63,17 @@ InitialiseLogging(new LoggerConfiguration(), true);
 
 try
 {
-    Log.Information("Starting JIM.Web");
-    await InitialiseJimApplicationAsync();
+    // Lightweight mode: generate the OpenAPI document and exit without starting the full application.
+    // Used during Docker builds and local dev via jim-openapi-generate.
+    var isOpenApiGenerateMode = Environment.GetEnvironmentVariable(Constants.Config.OpenApiGenerate)
+        ?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
+
+    Log.Information("Starting JIM.Web{Mode}", isOpenApiGenerateMode ? " (OpenAPI generation mode)" : "");
+
+    if (!isOpenApiGenerateMode)
+    {
+        await InitialiseJimApplicationAsync();
+    }
 
     var builder = WebApplication.CreateBuilder(args);
 
@@ -138,6 +148,9 @@ try
     var apiAudience = ExtractApiAudience(apiScope, clientId);
     var validIssuers = GetValidIssuers(authority);
 
+    // Skip authentication setup in OpenAPI generation mode (no IdP needed for schema generation)
+    if (!isOpenApiGenerateMode)
+    {
     // Configure triple authentication: Cookies for Blazor UI, JWT Bearer for SSO API, API Key for non-interactive API
     // Configure authentication with multiple schemes
     // Cookie is default for Blazor UI, but forwards to API Key when X-API-Key header is present
@@ -281,6 +294,7 @@ try
 
     // setup authorisation policies
     builder.Services.AddAuthorization();
+    } // end of !isOpenApiGenerateMode auth block
 
     // Add services to the container.
     builder.Services.AddRazorPages();
@@ -319,8 +333,23 @@ try
         options.SubstituteApiVersionInUrl = true;
     });
 
-    // Fetch OIDC discovery document to get IDP-agnostic authorization endpoints
-    var oidcConfig = await FetchOidcDiscoveryDocumentAsync(authority!);
+    // Fetch OIDC discovery document to get IDP-agnostic authorization endpoints.
+    // In OpenAPI generation mode, use constructed placeholder URLs to avoid requiring a live IdP.
+    // These only affect Scalar's "Try It" auth flow, not the documentation content.
+    OidcDiscoveryDocument oidcConfig;
+    if (isOpenApiGenerateMode)
+    {
+        var authorityBase = (authority ?? "https://idp.example.com/realms/jim").TrimEnd('/');
+        oidcConfig = new OidcDiscoveryDocument
+        {
+            AuthorizationEndpoint = $"{authorityBase}/protocol/openid-connect/auth",
+            TokenEndpoint = $"{authorityBase}/protocol/openid-connect/token"
+        };
+    }
+    else
+    {
+        oidcConfig = await FetchOidcDiscoveryDocumentAsync(authority!);
+    }
 
     // Setup OpenAPI with OAuth2 + API Key security schemes for API documentation
     builder.Services.AddOpenApi("v1", options =>
@@ -411,12 +440,30 @@ try
         app.UseHsts();
     }
 
-    // API documentation available at /api/reference in development.
-    // The OpenAPI document is generated once on first request and cached in memory.
-    // First load takes ~1-2 minutes due to deep DTO schema generation
-    // (see https://github.com/dotnet/aspnetcore/issues/63857).
-    if (app.Environment.IsDevelopment())
+    // API documentation: serve Scalar API reference with the OpenAPI document.
+    // Static mode: if a pre-generated file exists at wwwroot/api/openapi/v1.json (baked into
+    // Docker images during build), serve it via UseStaticFiles. Works in any environment.
+    // Dynamic fallback: in development without a static file, generate at runtime with caching.
+    // See https://github.com/dotnet/aspnetcore/issues/63857 for why runtime generation is expensive.
+    var staticOpenApiPath = Path.Combine(app.Environment.WebRootPath, "api", "openapi", "v1.json");
+    var hasStaticOpenApiDoc = File.Exists(staticOpenApiPath);
+
+    if (hasStaticOpenApiDoc)
     {
+        // Static file is served automatically by UseStaticFiles() at /api/openapi/v1.json
+        app.MapScalarApiReference("/api/reference", options => options
+            .WithOpenApiRoutePattern("/api/openapi/v1.json")
+            .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
+            .AddAuthorizationCodeFlow("OAuth2", flow =>
+            {
+                flow.ClientId = clientId!;
+                flow.Pkce = Pkce.Sha256;
+            }));
+        app.Logger.LogInformation("Serving static OpenAPI document from {Path}", staticOpenApiPath);
+    }
+    else if (app.Environment.IsDevelopment())
+    {
+        // Runtime generation with response caching (first load takes ~1-2 minutes)
         string? cachedOpenApiDoc = null;
         app.MapOpenApi("/api/openapi/{documentName}.json");
         app.Use(async (context, next) =>
@@ -430,7 +477,6 @@ try
                     return;
                 }
 
-                // Capture the response from MapOpenApi on first request
                 var originalBody = context.Response.Body;
                 using var memStream = new MemoryStream();
                 context.Response.Body = memStream;
@@ -441,20 +487,16 @@ try
                 {
                     memStream.Seek(0, SeekOrigin.Begin);
                     cachedOpenApiDoc = await new StreamReader(memStream).ReadToEndAsync();
-
-                    // Write the captured response to the original stream
                     memStream.Seek(0, SeekOrigin.Begin);
                     context.Response.Body = originalBody;
                     await memStream.CopyToAsync(originalBody);
 
-                    // Release memory from schema generation
                     GC.Collect(2, GCCollectionMode.Aggressive, true);
                     GC.WaitForPendingFinalizers();
                     GC.Collect(2, GCCollectionMode.Aggressive, true);
                 }
                 else
                 {
-                    // Error response; don't cache, pass through
                     memStream.Seek(0, SeekOrigin.Begin);
                     context.Response.Body = originalBody;
                     await memStream.CopyToAsync(originalBody);
@@ -472,6 +514,7 @@ try
                 flow.ClientId = clientId!;
                 flow.Pkce = Pkce.Sha256;
             }));
+        app.Logger.LogInformation("No static OpenAPI document found; using runtime generation (development only)");
     }
 
     app.UseHttpsRedirection();
@@ -508,6 +551,30 @@ try
         {
             options.GetLevel = (_, _, _) => Serilog.Events.LogEventLevel.Debug;
         });
+
+    // In OpenAPI generation mode, generate the document and exit without starting Kestrel
+    if (isOpenApiGenerateMode)
+    {
+        var outputPath = Environment.GetEnvironmentVariable(Constants.Config.OpenApiOutputPath)
+            ?? Path.Combine(app.Environment.WebRootPath, "api", "openapi", "v1.json");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        app.Logger.LogInformation("Generating OpenAPI document...");
+
+        var documentProvider = app.Services.GetRequiredKeyedService<IOpenApiDocumentProvider>("v1");
+        var document = await documentProvider.GetOpenApiDocumentAsync();
+
+        await using var fileStream = File.Create(outputPath);
+        await using var textWriter = new StreamWriter(fileStream);
+        var jsonWriter = new OpenApiJsonWriter(textWriter);
+        document.SerializeAs(OpenApiSpecVersion.OpenApi3_1, jsonWriter);
+        await textWriter.FlushAsync();
+
+        var fileSize = new FileInfo(outputPath).Length;
+        app.Logger.LogInformation("OpenAPI document generated at {Path} ({Size:N0} bytes)", outputPath, fileSize);
+        return 0;
+    }
 
     // Eager initialisation: warm up EF Core compiled model and database connection pool
     // before accepting requests. This prevents the first browser request from hanging while

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -452,6 +452,8 @@ try
     {
         // Static file is served automatically by UseStaticFiles() at /api/openapi/v1.json
         app.MapScalarApiReference("/api/reference", options => options
+            .WithTitle("JIM API Reference")
+            .WithFavicon("/images/jim-logo.png")
             .WithOpenApiRoutePattern("/api/openapi/v1.json")
             .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
             .AddAuthorizationCodeFlow("OAuth2", flow =>
@@ -507,6 +509,8 @@ try
         });
 
         app.MapScalarApiReference("/api/reference", options => options
+            .WithTitle("JIM API Reference")
+            .WithFavicon("/images/jim-logo.png")
             .WithOpenApiRoutePattern("/api/openapi/{documentName}.json")
             .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
             .AddAuthorizationCodeFlow("OAuth2", flow =>

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -293,6 +293,17 @@ try
             options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
         });
     builder.Services.AddEndpointsApiExplorer();
+
+    // Increase MaxDepth for the HTTP JSON options used by the OpenAPI schema generator.
+    // The default of 64 is insufficient for JIM's deep DTO graph; the schema exporter and
+    // its internal ResolveReferences expansion need headroom for recursive types.
+    // This only affects schema generation and minimal API endpoints; MVC controllers use
+    // separate JsonOptions. See: https://github.com/dotnet/aspnetcore/issues/63857
+    builder.Services.ConfigureHttpJsonOptions(options =>
+    {
+        options.SerializerOptions.MaxDepth = 256;
+    });
+
     builder.Services.Configure<RouteOptions>(ro => ro.LowercaseUrls = true);
 
     // Configure API versioning with URL path segment (e.g., /api/v1/...)
@@ -400,11 +411,61 @@ try
         app.UseHsts();
     }
 
-    // API documentation available at /api/reference in development
+    // API documentation available at /api/reference in development.
+    // The OpenAPI document is generated once on first request and cached in memory.
+    // First load takes ~1-2 minutes due to deep DTO schema generation
+    // (see https://github.com/dotnet/aspnetcore/issues/63857).
     if (app.Environment.IsDevelopment())
     {
+        string? cachedOpenApiDoc = null;
         app.MapOpenApi("/api/openapi/{documentName}.json");
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Path.StartsWithSegments("/api/openapi"))
+            {
+                if (cachedOpenApiDoc != null)
+                {
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(cachedOpenApiDoc);
+                    return;
+                }
+
+                // Capture the response from MapOpenApi on first request
+                var originalBody = context.Response.Body;
+                using var memStream = new MemoryStream();
+                context.Response.Body = memStream;
+
+                await next(context);
+
+                if (context.Response.StatusCode == 200)
+                {
+                    memStream.Seek(0, SeekOrigin.Begin);
+                    cachedOpenApiDoc = await new StreamReader(memStream).ReadToEndAsync();
+
+                    // Write the captured response to the original stream
+                    memStream.Seek(0, SeekOrigin.Begin);
+                    context.Response.Body = originalBody;
+                    await memStream.CopyToAsync(originalBody);
+
+                    // Release memory from schema generation
+                    GC.Collect(2, GCCollectionMode.Aggressive, true);
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect(2, GCCollectionMode.Aggressive, true);
+                }
+                else
+                {
+                    // Error response; don't cache, pass through
+                    memStream.Seek(0, SeekOrigin.Begin);
+                    context.Response.Body = originalBody;
+                    await memStream.CopyToAsync(originalBody);
+                }
+                return;
+            }
+            await next(context);
+        });
+
         app.MapScalarApiReference("/api/reference", options => options
+            .WithOpenApiRoutePattern("/api/openapi/{documentName}.json")
             .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
             .AddAuthorizationCodeFlow("OAuth2", flow =>
             {


### PR DESCRIPTION
## Summary

- Add interactive Scalar API reference at `/api/reference`, available in all environments including air-gapped deployments
- Implement lightweight startup mode (`JIM_OPENAPI_GENERATE=true`) that generates the OpenAPI document without requiring a database or identity provider, enabling build-time generation in Docker images and local dev via `jim-openapi-generate`
- Apply JIM navy theme branding (deep navy backgrounds, purple accent, forced dark mode) and custom favicon
- Rewrite all 174 API endpoint summaries for professional Scalar documentation: imperative mood, no trailing periods, proper capitalisation of JIM domain nouns (Connected System, Synchronisation Rule, Metaverse Object, etc.)

## Workaround

Includes `ConfigureHttpJsonOptions` with `MaxDepth=256` to work around [dotnet/aspnetcore#63857](https://github.com/dotnet/aspnetcore/issues/63857) where the `JsonSchemaExporter` exceeds the default depth limit for deep/recursive DTO schemas.

## Test plan

- [x] `dotnet build JIM.sln` passes with 0 errors, 0 warnings
- [x] All 2,523 tests pass
- [x] `jim-openapi-generate` produces valid OpenAPI doc (~539KB, 101 paths, 188 schemas) without DB/IdP
- [x] Static serving: JIM.Web serves the pre-generated doc at `/api/reference` in 9ms
- [x] Dynamic fallback: without static file, runtime generation works in dev with response caching
- [ ] Docker build: verify `jim-build-web` bakes the OpenAPI doc into the container image

🤖 Generated with [Claude Code](https://claude.com/claude-code)