### PR TITLE
feat: jim-connector-files-volume named Docker volume for File Connector storage

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -172,27 +172,7 @@ else
     print_warning "Build had warnings or errors. Run 'dotnet build JIM.sln' to see details."
 fi
 
-# 9. Create connector-files directory with symlink to test data
-print_step "Setting up connector-files directory..."
-mkdir -p connector-files
-
-# Create symlink to test/test-data directory (dynamic - new files appear automatically).
-# NOTE: the directory was renamed from test/Data to test/test-data in commit 90bc8b19
-# (Dec 2025). The old name survived silently on macOS hosts because HFS+/APFS is
-# case-insensitive by default, so "test/Data" still resolved to "test/test-data".
-# On case-sensitive filesystems (Linux) the check fails, so use the real name.
-if [ ! -L connector-files/test-data ]; then
-    if [ -d "test/test-data" ]; then
-        ln -s "$(pwd)/test/test-data" connector-files/test-data
-        print_success "Symlink created: connector-files/test-data -> test/test-data"
-    else
-        print_warning "test/test-data directory not found, skipping symlink"
-    fi
-else
-    print_success "Symlink already exists: connector-files/test-data"
-fi
-
-# 10. Configure Git commit signing
+# 9. Configure Git commit signing
 # Delegates to .devcontainer/configure-signing.sh which handles Codespaces
 # (via gh-gpgsign) and local devcontainers (via forwarded SSH agent) and
 # prints a prominent warning if neither is available. Returns non-zero if
@@ -237,7 +217,7 @@ else
     print_warning "Failed to set core.hooksPath; pre-commit checks will not run"
 fi
 
-# 11. Create useful shell aliases
+# 10. Create useful shell aliases
 print_step "Creating shell aliases..."
 
 # Add source line to .zshrc if not already present
@@ -265,7 +245,7 @@ if ! grep -q "source.*jim-aliases.sh" ~/.bashrc; then
     echo "fi" >> ~/.bashrc
 fi
 
-# 12. Install Claude Code CLI
+# 11. Install Claude Code CLI
 print_step "Installing Claude Code CLI..."
 if command -v npm >/dev/null 2>&1; then
     if npm install -g @anthropic-ai/claude-code --silent 2>/dev/null; then
@@ -277,7 +257,7 @@ else
     print_warning "npm not found - skipping Claude Code CLI install"
 fi
 
-# 13. Check gh CLI authentication
+# 12. Check gh CLI authentication
 # The gh CLI is used for PR/issue operations and other GitHub API calls.
 # It is NOT involved in git push/pull (SSH remote handles that) or commit
 # signing (SSH agent forward handles that), so a missing gh token is not
@@ -305,7 +285,7 @@ else
 "
 fi
 
-# 14. Display useful information
+# 13. Display useful information
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo -e "${GREEN}✓ JIM Development Environment Ready!${NC}"

--- a/.gitignore
+++ b/.gitignore
@@ -453,9 +453,6 @@ env
 !.claude/commands/
 !.claude/skills/
 
-# Local connector files directory (contains symlinks to test data)
-connector-files/
-
 # Integration test artifacts
 test/integration/results/
 test/integration/test-data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 🖥️ Page footer now links the Tetron name to tetron.io and includes a GitHub link next to the version number (#49)
+- 📦 File Connector storage migrated to a formal Docker named volume `jim-connector-files-volume`, mounted at `/connector-files` inside JIM Web and JIM Worker. Default deployments get working File Connector exports out of the box without any host-side permission setup. Customers integrating with external file shares bind-mount over a subdirectory of `/connector-files` — see the [JIM File Connector documentation](docs/connectors/jim-file-connector.md) for both patterns.
+- 🔄 File Connector File Path settings now use the new container path `/connector-files/...` (previously `/var/connector-files/...`). Existing connected systems must be updated to the new path.
 
 ## [0.9.1] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 🖥️ Page footer now links the Tetron name to tetron.io and includes a GitHub link next to the version number (#49)
-- 📦 File Connector storage migrated to a formal Docker named volume `jim-connector-files-volume`, mounted at `/connector-files` inside JIM Web and JIM Worker. Default deployments get working File Connector exports out of the box without any host-side permission setup. Customers integrating with external file shares bind-mount over a subdirectory of `/connector-files` — see the [JIM File Connector documentation](docs/connectors/jim-file-connector.md) for both patterns.
-- 🔄 File Connector File Path settings now use the new container path `/connector-files/...` (previously `/var/connector-files/...`). Existing connected systems must be updated to the new path.
+- 📦 File Connector storage uses the formal Docker named volume `jim-connector-files-volume`, mounted at `/connector-files` inside JIM Web and JIM Worker. Default deployments get working File Connector exports out of the box without any host-side permission setup. Customers integrating with external file shares bind-mount over a subdirectory of `/connector-files` — see the [JIM File Connector documentation](docs/connectors/jim-file-connector.md) for both patterns.
 
 ## [0.9.1] - 2026-04-08
 

--- a/docker-compose.integration-tests.yml
+++ b/docker-compose.integration-tests.yml
@@ -56,7 +56,7 @@ services:
       - samba-primary-data:/usr/local/samba/var
       - samba-primary-private:/usr/local/samba/private
       - samba-primary-etc:/usr/local/samba/etc
-      - test-csv-data:/connector-files
+      - jim-connector-files-volume:/connector-files
     hostname: dc1
     networks:
       - jim-network
@@ -260,7 +260,7 @@ services:
     # No ports exposed - internal to Docker network only for testing
     volumes:
       - openldap-primary-data:/bitnami/openldap
-      - test-csv-data:/connector-files
+      - jim-connector-files-volume:/connector-files
     networks:
       - jim-network
     profiles:
@@ -327,9 +327,11 @@ volumes:
     name: jim-integration-samba-target-private
   samba-target-etc:
     name: jim-integration-samba-target-etc
-  # Other volumes
-  test-csv-data:
-    name: jim-integration-csv-data
+  # Shared File Connector volume — must match the name declared in docker-compose.yml
+  # so jim.worker, jim.web, and the test directory containers all share the same storage.
+  jim-connector-files-volume:
+    name: jim-connector-files-volume
+    external: true
   openldap-primary-data:
     name: jim-integration-openldap-primary-data
   sqlserver-data:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,9 +13,6 @@ services:
       - LDAPTLS_REQCERT=never
     ports:
       - "5200:80"
-    volumes:
-      # Map repo test data to connector-files/test-data for development
-      - ./test/test-data:/var/connector-files/test-data
     depends_on:
       jim.keycloak:
         condition: service_healthy
@@ -26,7 +23,6 @@ services:
       # OpenLDAP TLS configuration for LDAPS connections
       - LDAPTLS_REQCERT=never
     volumes:
-      - ./test/test-data:/var/connector-files/test-data
       # Expose worker logs for metrics streaming (integration tests)
       - ./test/integration/results/logs/worker:/var/log/jim
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - jim-logs-volume:/var/log/jim
       - jim-keys-volume:/data/keys
+      - jim-connector-files-volume:/connector-files
     read_only: true
     tmpfs:
       - /tmp
@@ -52,6 +53,7 @@ services:
     volumes:
       - jim-logs-volume:/var/log/jim
       - jim-keys-volume:/data/keys
+      - jim-connector-files-volume:/connector-files
     read_only: true
     tmpfs:
       - /tmp
@@ -173,3 +175,10 @@ volumes:
     name: jim-logs-volume
   jim-keys-volume:
     name: jim-keys-volume
+  # File Connector storage: imports and exports for the JIM File Connector.
+  # Mounted on jim.web (for the file browser dialog) and jim.worker (read/write).
+  # Customers integrating with fixed external file locations bind-mount over
+  # subdirectories of this volume (e.g. a network share at /connector-files/hr-input).
+  # See docs/connectors/jim-file-connector.md for configuration patterns.
+  jim-connector-files-volume:
+    name: jim-connector-files-volume

--- a/docs/administration/deployment.md
+++ b/docs/administration/deployment.md
@@ -262,28 +262,23 @@ Ensure your JIM server is resolvable by name in your network:
 
 The OIDC redirect URIs configured in your identity provider must match the JIM server's accessible URL.
 
-### Step 6: Configure File Connector Volumes (Optional)
+### Step 6: File Connector storage (optional)
 
-If you plan to use the File Connector to import/export CSV files, configure a volume mount:
+The File Connector ships pre-configured to read and write at `/connector-files` inside the container, backed by a Docker-managed volume named `jim-connector-files-volume`. **No setup is required for the default case** — start the stack and the volume is created automatically with correct ownership.
 
-1. Create a directory on the host:
+To put files in or pull them out:
 
-    ```bash
-    mkdir -p /opt/jim/connector-files
-    ```
+```bash
+# Push an import file into the volume
+docker cp ./Users.csv jim.worker:/connector-files/Users.csv
 
-2. Add a volume mount to `docker-compose.yml` for the `jim.worker` service:
+# Pull an exported file out
+docker cp jim.worker:/connector-files/Exports.csv ./Exports.csv
+```
 
-    ```yaml
-    jim.worker:
-      volumes:
-        - jim-logs-volume:/var/log/jim
-        - /opt/jim/connector-files:/var/connector-files
-    ```
+Then configure the File Connector's **File Path** setting as `/connector-files/Users.csv`.
 
-3. Place CSV files in `/opt/jim/connector-files/` on the host
-
-4. In JIM, configure the File Connector with the container path: `/var/connector-files/yourfile.csv`
+If you need to integrate with an external system that writes to a fixed network location (e.g. an SMB or NFS share), bind-mount that path over a subdirectory of `/connector-files`. See the [JIM File Connector documentation](../connectors/jim-file-connector.md#file-access) for the full pattern, including the UID 1654 ownership requirement for bind-mounted host paths.
 
 ### Step 7: Start Services
 

--- a/docs/connectors/jim-file-connector.md
+++ b/docs/connectors/jim-file-connector.md
@@ -22,7 +22,7 @@ The JIM File Connector enables bi-directional synchronisation of identity data w
 
 | Setting | Description | Default | Example |
 |---------|-------------|---------|---------|
-| File Path | Path to the CSV file inside the container. Used for import, export, or both depending on mode. | *(required)* | `/var/connector-files/Users.csv` |
+| File Path | Path to the CSV file inside the container. Used for import, export, or both depending on mode. | *(required)* | `/connector-files/Users.csv` |
 | Mode | Operational mode: Import Only, Export Only, or Bidirectional. | `Import Only` | `Bidirectional` |
 | Object Type Column | Column in the file that contains the object type. Use when the file contains multiple object types. | *(optional)* | `Type` |
 | Object Type | Fixed object type name. Use when the file contains a single type of object. | *(optional)* | `User` |
@@ -34,29 +34,85 @@ The JIM File Connector enables bi-directional synchronisation of identity data w
 !!! note "Object type configuration"
     You must specify either **Object Type Column** or **Object Type** (but not both). If the file contains multiple object types in different rows, use Object Type Column to point to the column that identifies each row's type. If every row represents the same type, use Object Type to set a fixed value.
 
-## Docker Volume Setup
+## File access
 
-The File Connector reads from and writes to the local filesystem inside the JIM container. To make files accessible, mount a host directory as a Docker volume mapped to `/var/connector-files/` (or any path of your choosing).
+JIM ships with a formal Docker volume — `jim-connector-files-volume` — mounted inside both the JIM Web and JIM Worker containers at `/connector-files`. The File Connector reads from and writes to paths under this directory. **You will configure all File Connector File Path settings as `/connector-files/<some-path>`.**
 
-=== "Docker Compose"
+There are two patterns for getting files into and out of `/connector-files`. Most deployments use both at the same time, depending on the integration.
 
-    ```yaml
-    services:
-      jim-worker:
-        volumes:
-          - ./connector-files:/var/connector-files
-    ```
+### 1. Default: write to the named volume
 
-=== "Docker Run"
+This is the simplest pattern and the recommended starting point. The volume is created and managed by Docker; ownership is set automatically so the JIM container's runtime user can read and write to it without any host-side permission tweaking.
 
-    ```bash
-    docker run -v /path/to/files:/var/connector-files jim-worker
-    ```
+You don't need to configure anything in your `docker-compose.yml` — the volume is part of the bundled JIM compose files. To put a file in the volume, copy it via the worker container:
 
-Once the volume is mounted, configure the **File Path** setting in JIM to reference the file inside the container, e.g. `/var/connector-files/Users.csv`.
+```bash
+docker cp ./Users.csv jim.worker:/connector-files/Users.csv
+```
 
-!!! warning "File permissions"
-    Ensure the JIM container process has read access to import files and write access to the directory for export files. On Linux hosts, check that the file ownership and permissions allow the container's user to access the mounted volume.
+To read an exported file out:
+
+```bash
+docker cp jim.worker:/connector-files/Exports.csv ./Exports.csv
+```
+
+When to use this pattern:
+
+- **Exports** — JIM writes the file; a downstream process or human pulls it out via `docker cp`, an SFTP sidecar, or similar.
+- **Manual imports** — admin pushes a file in once, JIM imports it.
+- **Sidecar-orchestrated drops** — a helper service (cron job, file-transfer container) runs alongside JIM, drops a file into the volume, and JIM picks it up on the next scheduled import.
+
+### 2. Integration: bind-mount over a subdirectory
+
+Use this pattern when an external system writes files to a fixed location you cannot change — typically a network share (SMB/CIFS or NFS) the customer's HR system writes to nightly.
+
+You bind-mount the host path over a *subdirectory* of `/connector-files`. JIM still sees a unified `/connector-files` filesystem; only the specific subdirectory's contents come from the host.
+
+```yaml
+# docker-compose.override.yml or your production overlay
+services:
+  jim.worker:
+    volumes:
+      # Mount your network share (already mounted on the host) at a subdirectory
+      - /mnt/hr-extracts:/connector-files/hr-input
+  jim.web:
+    volumes:
+      - /mnt/hr-extracts:/connector-files/hr-input
+```
+
+Then configure the File Connector with `File Path = /connector-files/hr-input/employees.csv`.
+
+!!! warning "Permissions on bind-mounted paths"
+    The JIM container runs as a non-root user (UID 1654, named `app`). The default named volume is owned by this user, so writes work out of the box. Bind-mounted host paths preserve host UID/GID — so if your HR system writes files owned by a different UID, the JIM worker may not have read access (for imports) or write access (for exports). Either:
+
+    - Make the host directory readable/writable by UID 1654 (`chown 1654:1654 /mnt/hr-extracts`), or
+    - Adjust your network share's mount options (`uid=1654,gid=1654` for CIFS, or apply NFS UID-mapping) so files appear to be owned by UID 1654 inside the container.
+
+    Permission errors during sync show up as RPEIs on the failing import or export Activity, with a clear "Access to the path … is denied" message.
+
+### Mounting both at once
+
+The patterns combine naturally. A typical deployment looks like this:
+
+```yaml
+services:
+  jim.worker:
+    volumes:
+      # Default volume is already wired up — JIM uses it for exports and ad-hoc imports.
+      # No line needed here; comes from the base docker-compose.yml.
+
+      # Pull HR extracts directly from the network share they're written to.
+      - /mnt/hr-extracts:/connector-files/hr-input
+
+      # Push payroll exports to a different network share that the payroll team picks up.
+      - /mnt/payroll-drop:/connector-files/payroll-output
+```
+
+JIM's File Connector configurations would then point at:
+
+- `/connector-files/Users.csv` — admin-pushed file in the named volume
+- `/connector-files/hr-input/employees.csv` — read from the HR share
+- `/connector-files/payroll-output/payroll.csv` — written to the payroll share
 
 ## Schema Discovery
 
@@ -73,11 +129,20 @@ In **Export Only** mode where no file exists yet, schema discovery creates a min
 
 ### File not found
 
-The error `File not found: '/var/connector-files/Users.csv'` indicates that the file is not accessible at the specified path inside the container.
+The error `File not found: '/connector-files/Users.csv'` indicates the file is not accessible at the specified path inside the container.
 
-- Verify the Docker volume mount is correctly configured.
-- Check that the file exists on the host at the expected location.
-- Ensure the path in the File Path setting matches the container-side mount point exactly (paths are case-sensitive on Linux).
+- For named-volume files: confirm the file is in the volume — `docker exec jim.worker ls /connector-files`.
+- For bind-mounted paths: verify the host path exists and is mounted in `docker-compose.yml` (`docker compose config | grep connector-files`).
+- Paths are case-sensitive on Linux. Make sure the File Path in JIM matches the actual filename exactly.
+
+### Access denied (permission error)
+
+The error `Access to the path '/connector-files/...' is denied` typically occurs with bind-mounted host directories.
+
+- The JIM worker runs as UID 1654. If host files are owned by a different UID, the worker can't read or write them.
+- Fix the ownership: `chown -R 1654:1654 /mnt/your-mount-point` on the host.
+- For CIFS/SMB mounts, add `uid=1654,gid=1654` to the mount options.
+- For NFS, use UID mapping or ensure the file owner UID matches.
 
 ### Column count mismatch
 

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -1044,106 +1044,62 @@ docker compose exec jim.web dotnet ef database update
 
 ## File Connector Setup
 
-The JIM File Connector imports identity data from CSV files. Because JIM runs in Docker containers, files must be accessible via Docker volumes.
+The JIM File Connector imports and exports identity data via CSV files. JIM ships with a Docker-managed named volume — `jim-connector-files-volume` — mounted at `/connector-files` inside both the JIM Web and JIM Worker containers. The connector reads and writes paths under that directory. The customer-facing reference is in [docs/connectors/jim-file-connector.md](../docs/connectors/jim-file-connector.md); this section is the developer-flavour view.
 
-> **📝 Quick Start for Development**: Test data files from `test/Data/` are automatically available via symlink at `/var/connector-files/test-data/` in the devcontainer. See [FILE_CONNECTOR_TEST_DATA.md](FILE_CONNECTOR_TEST_DATA.md) for details.
+### Why a named volume
 
-### Understanding Docker Volumes
+The worker container runs as the non-root `app` user (UID 1654). Bind-mounting a host directory into the container preserves the host UID, which usually doesn't match — so JIM can't write to it without explicit `chown` or mount-option intervention. Docker-managed named volumes inherit ownership from the container's mount point at first mount, so `app` always has read/write access. For dev and for the default customer deployment we use the named volume; for integration with external systems that write to fixed host paths, customers bind-mount over a subdirectory of `/connector-files`.
 
-Docker volumes bridge your host filesystem to the container. The File Connector expects files at a **container path** (e.g., `/var/connector-files/Users.csv`), which maps to a **host path** on your machine.
+This is the same model dev and production use — there is no special dev override.
 
-### Volume Configuration by Environment
+### Getting files into the volume during dev
 
-| Environment | Host Path | Container Path |
-|-------------|-----------|----------------|
-| **Windows** | `c:/temp/jim-connector-files/` | `/var/connector-files/` |
-| **Linux** | `~/temp/jim-connector-files/` | `/var/connector-files/` |
-| **macOS** | `~/temp/jim-connector-files/` | `/var/connector-files/` |
-| **Codespaces** | `/tmp/jim-connector-files/` | `/var/connector-files/` |
+Use `docker cp` against the worker container:
 
-These mappings are already pre-configured in the respective `docker-compose.override.*.yml` files - no additional Docker volume commands are required. The `jim-stack` alias automatically uses the correct override file for your environment.
+```bash
+docker cp ./Users.csv jim.worker:/connector-files/Users.csv
+```
 
-### Setup Steps
+The integration test harness uses the helper `Copy-CsvToConnectorFiles` in `test/integration/utils/Test-Helpers.ps1` to push test CSVs to `/connector-files/test-data/` — see `Generate-TestCSV.ps1` for the seeding pattern.
 
-1. **Create the host directory** (if it doesn't exist):
-   ```bash
-   # For Codespaces:
-   mkdir -p /tmp/jim-connector-files
+### Getting files out of the volume
 
-   # For Linux/macOS:
-   mkdir -p ~/temp/jim-connector-files
+```bash
+docker cp jim.worker:/connector-files/Exports.csv ./Exports.csv
+```
 
-   # For Windows (PowerShell):
-   New-Item -ItemType Directory -Force -Path "c:\temp\jim-connector-files"
-   ```
+For ongoing/automated extraction, customers run a sidecar service or scheduled job that mounts the same volume and ships files elsewhere (SFTP, blob storage, etc.).
 
-2. **Place your CSV file in the host directory**:
-   ```bash
-   # Example: copy a file to the connector files directory
-   cp /path/to/your/Users.csv /tmp/jim-connector-files/
-   ```
+### Configuring the File Connector in JIM
 
-3. **Restart the Docker stack** (if already running) to pick up the volume mount:
-   ```bash
-   jim-stack-down && jim-stack
-   ```
+When creating a Connected System with the File Connector, set the **File Path** to a path under `/connector-files`, e.g. `/connector-files/Users.csv`. The UI's file browser starts at `/connector-files` and shows what's currently in the volume.
 
-4. **In the JIM UI**, enter the **container path** for "Import File Path":
-   ```
-   /var/connector-files/Users.csv
-   ```
+### Network Share Access (Bind-mount over a subdirectory)
 
-### File Connector Settings
+When integrating with an external system that writes files to a fixed location (commonly an SMB or NFS share already mounted on the host), bind-mount that path over a subdirectory of `/connector-files`:
 
-When creating a Connected System with the File Connector:
+```yaml
+# In your production overlay or docker-compose.override.yml
+services:
+  jim.worker:
+    volumes:
+      - /mnt/hr-extracts:/connector-files/hr-input
+  jim.web:
+    volumes:
+      - /mnt/hr-extracts:/connector-files/hr-input
+```
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| **Import File Path** | Container path to the CSV file to import | `/var/connector-files/Users.csv` |
-| **Object Type Column** | Column containing object type (optional) | `Type` |
-| **Object Type** | Fixed object type if file contains single type (optional) | `User` |
-| **Delimiter** | CSV delimiter character | `,` (default) |
-| **Culture** | Culture for parsing (optional) | `en-gb` |
+JIM still sees `/connector-files` as a single filesystem; only the `hr-input` subdirectory comes from the host. The File Connector setting becomes `/connector-files/hr-input/employees.csv`.
 
-### Schema Discovery
-
-When you retrieve the schema, the File Connector:
-1. Opens the CSV file at the "Import File Path"
-2. Reads column headers as attribute names
-3. Inspects up to 50 rows to detect data types (Text, Number, Boolean, Guid, DateTime)
-4. Detects multi-valued attributes (duplicate column names)
-
-### Run Profile Configuration
-
-When creating a Run Profile for the File Connector:
-- The connector reads the file specified in "Import File Path" during import operations
+For bind-mounted host paths, ensure the host files are readable/writable by UID 1654 — either `chown 1654:1654 /mnt/hr-extracts` or set mount options like `uid=1654,gid=1654` for CIFS/NFS.
 
 ### Troubleshooting
 
-**"File path not provided, the path couldn't be accessed, or the file doesn't exist"**
-- Verify the file exists in your host directory
-- Check the Docker stack is running with volume mounts: `docker compose ps`
-- Ensure you're using the container path (`/var/connector-files/...`), not the host path
-- Restart the stack if you added files after starting: `jim-stack-down && jim-stack`
+**File not found** — confirm the file is in the volume: `docker exec jim.worker ls /connector-files`. For bind-mounted subdirs, verify the host path is mounted: `docker compose config | grep connector-files`.
 
-**File not found during import**
-- The Run Profile's File Path must also use the container path
-- Verify the file exists and has read permissions
+**Access denied during export** — the JIM worker (UID 1654) doesn't have write access to a bind-mounted host path. Either `chown -R 1654:1654 /your/host/path` or set the mount UID. The default named volume doesn't have this problem.
 
-### Network Share Access (Advanced)
-
-For accessing network shares (e.g., Windows file shares), you can mount them into the host directory:
-
-```bash
-# Linux example - mount CIFS/SMB share
-sudo mkdir -p /mnt/jim_share
-sudo mount -t cifs //server/share /mnt/jim_share -o username=user,password=pass
-
-# Then symlink or copy to the connector files directory
-ln -s /mnt/jim_share/Users.csv /tmp/jim-connector-files/Users.csv
-```
-
-For production deployments, consider using Docker volume drivers or bind mounts to network storage.
+**Permission errors surface as RPEIs** — `Access to the path … is denied` will appear on the Activity for the failing import or export, not be silently swallowed.
 
 ## PowerShell Module Development
 

--- a/engineering/RELEASE_PROCESS.md
+++ b/engineering/RELEASE_PROCESS.md
@@ -291,26 +291,23 @@ Ensure your JIM server is resolvable by name in your network:
 
 The OIDC redirect URIs configured in your identity provider must match the JIM server's accessible URL.
 
-#### Step 7: Configure File Connector Volumes (If Using File Connector)
+#### Step 7: File Connector storage (if using the File Connector)
 
-If you plan to use the File Connector to import/export CSV files, configure a volume mount:
+The File Connector ships pre-configured to read and write at `/connector-files` inside the container, backed by the Docker-managed `jim-connector-files-volume`. **Default deployments need no setup** — start the stack and the volume is created automatically with correct ownership.
 
-1. Create a directory on the host for connector files:
-   ```bash
-   mkdir -p /opt/jim/connector-files
-   ```
+To put CSV files in or pull them out:
 
-2. Add a volume mount to `docker-compose.yml` for the `jim.worker` service:
-   ```yaml
-   jim.worker:
-     volumes:
-       - jim-logs-volume:/var/log/jim
-       - /opt/jim/connector-files:/var/connector-files
-   ```
+```bash
+# Push a file in
+docker cp /path/to/Users.csv jim.worker:/connector-files/Users.csv
 
-3. Place CSV files in `/opt/jim/connector-files/` on the host
+# Pull an exported file out
+docker cp jim.worker:/connector-files/Exports.csv /path/to/Exports.csv
+```
 
-4. In JIM, configure the File Connector with the container path: `/var/connector-files/yourfile.csv`
+Configure the File Connector's File Path setting as `/connector-files/Users.csv`.
+
+For integrating with external systems that write to fixed network locations (SMB/NFS), bind-mount the host path over a subdirectory of `/connector-files` — see [docs/connectors/jim-file-connector.md](../docs/connectors/jim-file-connector.md#file-access) for the full pattern, including the UID 1654 ownership requirement for bind-mounted host paths.
 
 #### Step 8: Start Services
 

--- a/engineering/plans/476-integration-test-metrics-jim-side.md
+++ b/engineering/plans/476-integration-test-metrics-jim-side.md
@@ -173,8 +173,6 @@ volumes:
   - ./test/integration/results/logs/worker:/var/log/jim    # Expose worker logs for metrics streaming
 ```
 
-(Note: the previous `./test/test-data:/var/connector-files/test-data` bind-mount was removed when File Connector storage migrated to the named `jim-connector-files-volume` — see `docs/connectors/jim-file-connector.md`.)
-
 This is the correct file because:
 - `docker-compose.override.yml` is already dev-only (contains Keycloak, debug ports, test-data mounts)
 - The integration test runner already uses `-f docker-compose.yml -f docker-compose.override.yml`

--- a/engineering/plans/476-integration-test-metrics-jim-side.md
+++ b/engineering/plans/476-integration-test-metrics-jim-side.md
@@ -167,12 +167,13 @@ Add a bind mount so the worker log file is readable from the host filesystem.
 
 **File**: `docker-compose.override.yml` (dev/devcontainer only; never touches `docker-compose.yml` or `docker-compose.production.yml`)
 
-Add to `jim.worker` service volumes (line ~29, alongside the existing `test-data` mount):
+Add to `jim.worker` service volumes (line ~29):
 ```yaml
 volumes:
-  - ./test/test-data:/var/connector-files/test-data
   - ./test/integration/results/logs/worker:/var/log/jim    # Expose worker logs for metrics streaming
 ```
+
+(Note: the previous `./test/test-data:/var/connector-files/test-data` bind-mount was removed when File Connector storage migrated to the named `jim-connector-files-volume` — see `docs/connectors/jim-file-connector.md`.)
 
 This is the correct file because:
 - `docker-compose.override.yml` is already dev-only (contains Keycloak, debug ports, test-data mounts)

--- a/src/JIM.Application/Servers/FileSystemServer.cs
+++ b/src/JIM.Application/Servers/FileSystemServer.cs
@@ -16,7 +16,7 @@ public class FileSystemServer
     /// <summary>
     /// The root directories that users are allowed to browse.
     /// </summary>
-    private static readonly string[] AllowedRoots = { "/var/connector-files" };
+    private static readonly string[] AllowedRoots = { "/connector-files" };
 
     internal FileSystemServer(JimApplication application)
     {
@@ -38,8 +38,8 @@ public class FileSystemServer
             {
                 return new FileSystemListResult
                 {
-                    Path = "/var/connector-files",
-                    Error = "No accessible directories found. Ensure /var/connector-files is mounted.",
+                    Path = "/connector-files",
+                    Error = "No accessible directories found. Ensure /connector-files is mounted.",
                     Entries = new List<FileSystemEntry>()
                 };
             }

--- a/src/JIM.Connectors/File/FileConnector.cs
+++ b/src/JIM.Connectors/File/FileConnector.cs
@@ -57,7 +57,7 @@ public class FileConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         return new List<ConnectorSetting>
         {
             // Primary settings
-            new() { Name = SettingFilePath, Required = true, Description = "Path to the CSV file. Used for import, export, or both depending on mode. e.g. /var/connector-files/Users.csv", Category = ConnectedSystemSettingCategory.General, Type = ConnectedSystemSettingType.File },
+            new() { Name = SettingFilePath, Required = true, Description = "Path to the CSV file. Used for import, export, or both depending on mode. e.g. /connector-files/Users.csv", Category = ConnectedSystemSettingCategory.General, Type = ConnectedSystemSettingType.File },
             new()
             {
                 Name = SettingMode,

--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -36,9 +36,14 @@ RUN apt-get update \
     # See: https://github.com/dotnet/runtime/issues/123676
     && ln -sf /usr/lib/$(uname -m)-linux-gnu/libldap.so.2 /usr/lib/$(uname -m)-linux-gnu/libldap-2.5.so.0
 
-# Create data directories writable by non-root user before switching
-RUN mkdir -p /data/keys /var/log/jim \
-    && chown -R app:app /data/keys /var/log/jim
+# Create data directories writable by non-root user before switching.
+# /connector-files is the formal File Connector mount point; JIM.Web needs
+# read access so the file browser dialog (FileBrowserDialog.razor) can list
+# files for admins configuring connectors. Creating it here with app:app
+# ownership ensures Docker inherits the correct ownership when the
+# jim-connector-files-volume is mounted on first container start.
+RUN mkdir -p /data/keys /var/log/jim /connector-files \
+    && chown -R app:app /data/keys /var/log/jim /connector-files
 
 # Run as non-root for security (built-in 'app' user, UID 1654)
 USER app

--- a/src/JIM.Web/Pages/Admin/CertificateList.razor
+++ b/src/JIM.Web/Pages/Admin/CertificateList.razor
@@ -179,7 +179,7 @@
             HelperText="A friendly name for this certificate" />
         <MudTextField T="string" @bind-Value="_filePath" Label="File Path" Required="true"
             RequiredError="A file path is required" Variant="Variant.Outlined" Class="mt-5"
-            HelperText="Full path to the certificate file (e.g., /var/connector-files/certs/root-ca.pem)" />
+            HelperText="Full path to the certificate file (e.g., /connector-files/certs/root-ca.pem)" />
         <MudTextField T="string" @bind-Value="_filePathNotes" Label="Notes" Lines="3" Variant="Variant.Outlined"
             Class="mt-5" HelperText="Optional notes about this certificate" />
     </DialogContent>

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemRunProfilesTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemRunProfilesTab.razor
@@ -146,7 +146,7 @@
                 {
                     <MudTextField T="string" @bind-Value="_newRunProfile.FilePath" Label="File Path" Variant="Variant.Outlined"
                                   Class="mt-3"
-                                  HelperText="File-based connectors need the in-container path specifying, i.e. /var/connector-files/test-data/Users.csv" />
+                                  HelperText="File-based connectors need the in-container path specifying, i.e. /connector-files/Users.csv" />
                 }
 
                 @if (IsImportRunType(_newRunProfile.RunType) && ConnectedSystem.ConnectorDefinition.SupportsPartitions && ConnectedSystem.Partitions != null)
@@ -200,7 +200,7 @@
                 {
                     <MudTextField T="string" @bind-Value="_editRunProfile.FilePath" Label="File Path" Variant="Variant.Outlined"
                                   Class="mt-3"
-                                  HelperText="File-based connectors need the in-container path specifying, i.e. /var/connector-files/test-data/Users.csv" />
+                                  HelperText="File-based connectors need the in-container path specifying, i.e. /connector-files/Users.csv" />
                 }
 
                 @if (IsImportRunType(_editRunProfile.RunType) && ConnectedSystem.ConnectorDefinition.SupportsPartitions && ConnectedSystem.Partitions != null)

--- a/src/JIM.Web/Shared/FileBrowserDialog.razor
+++ b/src/JIM.Web/Shared/FileBrowserDialog.razor
@@ -138,8 +138,8 @@
     {
         _breadcrumbs = new List<BreadcrumbItem>();
 
-        // The allowed root is /var/connector-files - show paths relative to that
-        const string rootPath = "/var/connector-files";
+        // The allowed root is /connector-files - show paths relative to that
+        const string rootPath = "/connector-files";
         const string rootDisplayName = "connector-files";
 
         if (result.IsRoot)

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -33,9 +33,12 @@ RUN apt-get update \
     # See: https://github.com/dotnet/runtime/issues/123676
     && ln -sf /usr/lib/$(uname -m)-linux-gnu/libldap.so.2 /usr/lib/$(uname -m)-linux-gnu/libldap-2.5.so.0
 
-# Create data directories writable by non-root user before switching
-RUN mkdir -p /data/keys /var/log/jim \
-    && chown -R app:app /data/keys /var/log/jim
+# Create data directories writable by non-root user before switching.
+# /connector-files is the formal File Connector mount point; creating it here
+# with app:app ownership ensures Docker inherits the correct ownership when
+# the jim-connector-files-volume is mounted on first container start.
+RUN mkdir -p /data/keys /var/log/jim /connector-files \
+    && chown -R app:app /data/keys /var/log/jim /connector-files
 
 # Run as non-root for security (built-in 'app' user, UID 1654)
 USER app

--- a/test/integration/Generate-TestCSV.ps1
+++ b/test/integration/Generate-TestCSV.ps1
@@ -210,41 +210,36 @@ $crossDomainHeaders = @(
 # Write header row only (file connector will append exports)
 $crossDomainHeaders -join "," | Set-Content -Path $crossDomainCsvPath -Encoding UTF8
 
-# Grant world write permission so the JIM worker container (running as non-root 'app' user, UID 1654)
-# can write to this file when performing exports. Host files owned by the devcontainer 'vscode' user
-# (UID 1000) with default 0644 permissions are otherwise read-only to the container user.
-# Production deployments use customer-managed volumes and do not hit this issue.
-if (-not $IsWindows) {
-    chmod 666 $crossDomainCsvPath
-}
-
 Write-Host "  ✓ Created $crossDomainCsvPath (empty export target)" -ForegroundColor Green
 
-# Copy to Docker volume (if running in container environment)
-Write-TestStep "Step 5" "Copying files to Docker volume"
+# Copy to the jim-connector-files-volume named Docker volume via jim.worker.
+# jim.worker is always running during integration tests and has the volume mounted
+# at /connector-files. Docker-managed volume ownership eliminates the UID mismatch
+# between the host user and the container's non-root 'app' user (UID 1654).
+Write-TestStep "Step 5" "Copying files to jim-connector-files-volume"
 
 try {
-    # Check if samba-ad-primary container exists and is running
-    $containerRunning = docker ps --filter "name=samba-ad-primary" --filter "status=running" --format "{{.Names}}" 2>$null
+    $containerRunning = docker ps --filter "name=jim.worker" --filter "status=running" --format "{{.Names}}" 2>$null
 
-    if ($containerRunning -eq "samba-ad-primary") {
-        Write-Host "  Copying CSV files to container volume..." -ForegroundColor Gray
+    if ($containerRunning -eq "jim.worker") {
+        Write-Host "  Ensuring /connector-files/test-data subdirectory exists..." -ForegroundColor Gray
+        docker exec jim.worker mkdir -p /connector-files/test-data 2>$null
 
-        # Copy files into the shared volume via container
-        docker cp $csvPath samba-ad-primary:/connector-files/hr-users.csv
-        docker cp $deptCsvPath samba-ad-primary:/connector-files/departments.csv
-        docker cp $trainingCsvPath samba-ad-primary:/connector-files/training-records.csv
-        docker cp $crossDomainCsvPath samba-ad-primary:/connector-files/cross-domain-users.csv
+        Write-Host "  Copying CSV files to volume via jim.worker..." -ForegroundColor Gray
+        docker cp $csvPath jim.worker:/connector-files/test-data/hr-users.csv
+        docker cp $deptCsvPath jim.worker:/connector-files/test-data/departments.csv
+        docker cp $trainingCsvPath jim.worker:/connector-files/test-data/training-records.csv
+        docker cp $crossDomainCsvPath jim.worker:/connector-files/test-data/cross-domain-users.csv
 
-        Write-Host "  ✓ Files copied to /connector-files in container" -ForegroundColor Green
+        Write-Host "  ✓ Files copied to /connector-files/test-data in jim-connector-files-volume" -ForegroundColor Green
     }
     else {
-        Write-Host "  ⚠ Container not running, files only in local directory" -ForegroundColor Yellow
-        Write-Host "    Start containers and re-run to copy to volume" -ForegroundColor Yellow
+        Write-Host "  ⚠ jim.worker not running, files only in local directory" -ForegroundColor Yellow
+        Write-Host "    Start JIM stack and re-run to copy to the volume" -ForegroundColor Yellow
     }
 }
 catch {
-    Write-Host "  ⚠ Could not copy to container: $_" -ForegroundColor Yellow
+    Write-Host "  ⚠ Could not copy to jim.worker: $_" -ForegroundColor Yellow
 }
 
 # Summary

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -242,7 +242,7 @@ This scenario tests the complete Identity Lifecycle Management (ILM) pattern:
 ### What Gets Tested
 
 1. **Setup** - Automatically configures JIM with:
-   - CSV Connected System (HR source at `/connector-files/hr-users.csv`)
+   - CSV Connected System (HR source at `/connector-files/test-data/hr-users.csv`)
    - LDAP Connected System (Samba AD at `samba-ad-primary:389`)
    - Sync Rules (employeeId, firstName, lastName, email, department, etc.)
    - Object Matching Rules (for CSO auto-join on provisioning)

--- a/test/integration/Setup-Scenario1.ps1
+++ b/test/integration/Setup-Scenario1.ps1
@@ -32,7 +32,7 @@
     This script requires the JIM PowerShell module and assumes:
     - JIM is running and accessible
     - Samba AD container is running on jim-network
-    - CSV files exist at /var/connector-files/test-data/hr-users.csv
+    - CSV files exist at /connector-files/test-data/hr-users.csv
 #>
 
 param(
@@ -204,7 +204,7 @@ try {
 
     $settingValues = @{}
     if ($filePathSetting) {
-        $settingValues[$filePathSetting.id] = @{ stringValue = "/var/connector-files/test-data/hr-users.csv" }
+        $settingValues[$filePathSetting.id] = @{ stringValue = "/connector-files/test-data/hr-users.csv" }
     }
     if ($delimiterSetting) {
         $settingValues[$delimiterSetting.id] = @{ stringValue = "," }
@@ -341,7 +341,7 @@ try {
     # Configure Training CSV settings
     $trainingSettingValues = @{}
     if ($filePathSetting) {
-        $trainingSettingValues[$filePathSetting.id] = @{ stringValue = "/var/connector-files/test-data/training-records.csv" }
+        $trainingSettingValues[$filePathSetting.id] = @{ stringValue = "/connector-files/test-data/training-records.csv" }
     }
     if ($delimiterSetting) {
         $trainingSettingValues[$delimiterSetting.id] = @{ stringValue = "," }
@@ -382,7 +382,7 @@ try {
     # Configure Cross-Domain CSV settings
     $crossDomainSettingValues = @{}
     if ($filePathSetting) {
-        $crossDomainSettingValues[$filePathSetting.id] = @{ stringValue = "/var/connector-files/test-data/cross-domain-users.csv" }
+        $crossDomainSettingValues[$filePathSetting.id] = @{ stringValue = "/connector-files/test-data/cross-domain-users.csv" }
     }
     if ($delimiterSetting) {
         $crossDomainSettingValues[$delimiterSetting.id] = @{ stringValue = "," }
@@ -1412,7 +1412,7 @@ try {
     $ldapProfiles = Get-JIMRunProfile -ConnectedSystemId $ldapSystem.id
 
     # CSV Run Profiles
-    $csvFilePath = "/var/connector-files/test-data/hr-users.csv"
+    $csvFilePath = "/connector-files/test-data/hr-users.csv"
 
     # Full Import (CSV)
     $csvImportProfile = $csvProfiles | Where-Object { $_.name -eq "Full Import" }
@@ -1531,7 +1531,7 @@ try {
 
     # Training Run Profiles
     $trainingProfiles = Get-JIMRunProfile -ConnectedSystemId $trainingSystem.id
-    $trainingFilePath = "/var/connector-files/test-data/training-records.csv"
+    $trainingFilePath = "/connector-files/test-data/training-records.csv"
 
     # Full Import (Training)
     $trainingImportProfile = $trainingProfiles | Where-Object { $_.name -eq "Full Import" }
@@ -1578,7 +1578,7 @@ try {
 
     # Cross-Domain Run Profiles
     $crossDomainProfiles = Get-JIMRunProfile -ConnectedSystemId $crossDomainSystem.id
-    $crossDomainFilePath = "/var/connector-files/test-data/cross-domain-users.csv"
+    $crossDomainFilePath = "/connector-files/test-data/cross-domain-users.csv"
 
     # Full Import (Cross-Domain) - for confirming exports
     $crossDomainImportProfile = $crossDomainProfiles | Where-Object { $_.name -eq "Full Import" }

--- a/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
+++ b/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
@@ -639,7 +639,7 @@ try {
         Write-Host "  ✓ Changed $moverSamAccountName title to 'Senior Developer'" -ForegroundColor Green
 
         # Copy updated CSV
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Trigger sync sequence with progress output
         Write-Host "Triggering sync sequence:" -ForegroundColor Gray
@@ -703,7 +703,7 @@ try {
         Write-Host "  ✓ Changed $moverSamAccountName display name to '$newDisplayName'" -ForegroundColor Green
 
         # Copy updated CSV
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Trigger sync sequence with progress output
         Write-Host "Triggering sync sequence:" -ForegroundColor Gray
@@ -785,7 +785,7 @@ try {
         Write-Host "  ✓ Changed $moverSamAccountName department to Finance (triggers OU move)" -ForegroundColor Green
 
         # Copy updated CSV
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Trigger sync sequence with progress output
         Write-Host "Triggering sync sequence:" -ForegroundColor Gray
@@ -876,7 +876,7 @@ try {
         Write-Host "  ✓ Changed $disableSamAccountName status to 'Archived'" -ForegroundColor Green
 
         # Copy updated CSV
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Trigger sync sequence with progress output
         Write-Host "Triggering sync sequence:" -ForegroundColor Gray
@@ -950,7 +950,7 @@ try {
         Write-Host "  ✓ Changed $enableSamAccountName status to 'Active'" -ForegroundColor Green
 
         # Copy updated CSV
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Trigger sync sequence with progress output
         Write-Host "Triggering sync sequence:" -ForegroundColor Gray
@@ -1011,7 +1011,7 @@ try {
         Write-Host "  ✓ Removed $userToRemove from CSV" -ForegroundColor Green
 
         # Copy updated CSV
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Trigger sync sequence with progress output
         Write-Host "Triggering sync sequence:" -ForegroundColor Gray
@@ -1090,7 +1090,7 @@ try {
         }
         $csv = @($csv) + $newUser
         $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Initial sync - uses Delta Sync for efficiency (baseline already established)
         Write-Host "  Initial sync (provisioning new user):" -ForegroundColor Gray
@@ -1116,7 +1116,7 @@ try {
             Write-Host "  Removing user (simulating quit)..." -ForegroundColor Gray
             $csvContent = Get-Content $csvPath | Where-Object { $_ -notmatch "test.reconnect" }
             $csvContent | Set-Content $csvPath
-            docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+            Copy-CsvToConnectorFiles -SourcePath $csvPath
 
             # Only need CSV import/sync for removal - no LDAP export needed
             Write-Host "    [1/2] CSV Full Import..." -ForegroundColor DarkGray
@@ -1142,7 +1142,7 @@ try {
             $csv = Import-Csv $csvPath
             $csv = @($csv) + $newUser
             $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-            docker cp $csvPath "$($DirectoryConfig.ContainerName):/connector-files/hr-users.csv"
+            Copy-CsvToConnectorFiles -SourcePath $csvPath
 
             Invoke-SyncSequence -Config $config -ShowProgress -ValidateActivityStatus | Out-Null
             Write-Host "  ✓ Restore sync completed" -ForegroundColor Green

--- a/test/integration/scenarios/Invoke-Scenario4-DeletionRules.ps1
+++ b/test/integration/scenarios/Invoke-Scenario4-DeletionRules.ps1
@@ -196,7 +196,7 @@ function Invoke-ProvisionUser {
     }
     $csv = @($csv) + $newUser
     $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+    Copy-CsvToConnectorFiles -SourcePath $csvPath
     Write-Host "  Added $SamAccountName to CSV" -ForegroundColor Gray
 
     # Import + Sync + Export + Confirm
@@ -264,7 +264,7 @@ function Invoke-RemoveUserFromSource {
     $csv = Import-Csv $csvPath
     $csv = @($csv | Where-Object { $_.samAccountName -ne $SamAccountName })
     $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+    Copy-CsvToConnectorFiles -SourcePath $csvPath
     Write-Host "  Removed $SamAccountName from CSV" -ForegroundColor Gray
 
     if ($FullCycle) {
@@ -339,7 +339,7 @@ function Invoke-ProvisionTrainingData {
     }
     $csv = @($csv) + $newRecord
     $csv | Export-Csv -Path $trainingCsvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+    Copy-CsvToConnectorFiles -SourcePath $trainingCsvPath
     Write-Host "  Added training record for $SamAccountName to Training CSV" -ForegroundColor Gray
 
     # Training Import + Sync (joins Training CSO to existing MVO)
@@ -394,7 +394,7 @@ function Invoke-RemoveTrainingData {
     $csv = Import-Csv $trainingCsvPath
     $csv = @($csv | Where-Object { $_.employeeId -ne $EmployeeId })
     $csv | Export-Csv -Path $trainingCsvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+    Copy-CsvToConnectorFiles -SourcePath $trainingCsvPath
     Write-Host "  Removed training record for $EmployeeId from Training CSV" -ForegroundColor Gray
 
     # Training Import + Sync (obsoletes Training CSO, triggers recall if configured)
@@ -585,8 +585,8 @@ try {
     # Copy to container volume
     $csvPath = "$testDataPath/hr-users.csv"
     $trainingCsvPath = "$testDataPath/training-records.csv"
-        # No docker cp needed — test-data is bind-mounted into JIM containers
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+    Copy-CsvToConnectorFiles -SourcePath $csvPath
+    Copy-CsvToConnectorFiles -SourcePath $trainingCsvPath
     Write-Host "  CSVs initialised (HR + Training, 1 baseline user each)" -ForegroundColor Green
 
     # Clean up test-specific directory users from previous test runs

--- a/test/integration/scenarios/Invoke-Scenario5-MatchingRules.ps1
+++ b/test/integration/scenarios/Invoke-Scenario5-MatchingRules.ps1
@@ -111,7 +111,7 @@ try {
 
     # Copy to container volume
     $csvPath = "$testDataPath/hr-users.csv"
-    # No docker cp needed — test-data is bind-mounted into JIM containers
+    Copy-CsvToConnectorFiles -SourcePath $csvPath
     Write-Host "  ✓ Dedicated CSV initialised (1 baseline user for schema discovery)" -ForegroundColor Green
 
     # Clean up test-specific directory users from previous test runs
@@ -244,7 +244,7 @@ try {
         Write-Host "  Added test.projection to CSV with HrId=$($testUser.HrId), EmployeeId=$($testUser.EmployeeId)" -ForegroundColor Gray
 
         # Copy updated CSV to container
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Run import and sync
         Write-Host "  Running import and sync..." -ForegroundColor Gray
@@ -310,7 +310,7 @@ try {
         }
         $csv = @($csv) + $joinUser
         $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Import from HR to create MVO
         Write-Host "  Creating MVO via HR import..." -ForegroundColor Gray
@@ -434,7 +434,7 @@ try {
         # Add both users to CSV at once
         $csv = @($csv) + $dupUser1 + $dupUser2
         $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         Write-Host "  Added 2 users with SAME hrId=$($testUser1.HrId) to CSV..." -ForegroundColor Gray
 
@@ -485,7 +485,7 @@ try {
 
         # Clean up Test 3 data - reload the baseline CSV to avoid interfering with subsequent tests
         Copy-Item -Path "$scenarioDataPath/scenario5-hr-users.csv" -Destination "$testDataPath/hr-users.csv" -Force
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
         Write-Host "  ✓ Reset CSV to baseline for subsequent tests" -ForegroundColor Gray
     }
 
@@ -585,7 +585,7 @@ try {
                 }
                 $csv = @($csv) + $multiRule1
                 $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-                # No docker cp needed — test-data is bind-mounted into JIM containers
+                Copy-CsvToConnectorFiles -SourcePath $csvPath
 
                 # Import first user to create MVO
                 Write-Host "  Creating MVO with EmployeeId=$($testUser1.EmployeeId), Email=$($testUser1.Email)..." -ForegroundColor Gray
@@ -610,7 +610,7 @@ try {
                     Write-Host "  Removing first user from CSV..." -ForegroundColor Gray
                     $csvContent = Get-Content $csvPath | Where-Object { $_ -notmatch "test.multirule.first" }
                     $csvContent | Set-Content $csvPath
-                    # No docker cp needed — test-data is bind-mounted into JIM containers
+                    Copy-CsvToConnectorFiles -SourcePath $csvPath
 
                     # Import to process deletion
                     $delImportResult = Start-JIMRunProfile -ConnectedSystemId $config.CSVSystemId -RunProfileId $config.CSVImportProfileId -Wait -PassThru
@@ -649,7 +649,7 @@ try {
                     }
                     $csv = @($csv) + $multiRule2
                     $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-                    # No docker cp needed — test-data is bind-mounted into JIM containers
+                    Copy-CsvToConnectorFiles -SourcePath $csvPath
 
                     # Import second user
                     Write-Host "  Importing second user with different EmployeeId=$($testUser2.EmployeeId), same Email=$($testUser2.Email)..." -ForegroundColor Gray
@@ -736,7 +736,7 @@ try {
         }
         $csv = @($csv) + $conflictUser1
         $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Import and sync first user to create MVO
         Write-Host "  Creating MVO with first user (HrId=$($testUser1.HrId), EmployeeId=$($testUser1.EmployeeId))..." -ForegroundColor Gray
@@ -773,7 +773,7 @@ try {
         }
         $csv = @($csv) + $conflictUser2
         $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
 
         # Import second user (this will create a separate CSO)
         Write-Host "  Importing second user with DIFFERENT HrId=$($testUser2.HrId), SAME EmployeeId=$($testUser2.EmployeeId)..." -ForegroundColor Gray
@@ -817,7 +817,7 @@ try {
 
         # Clean up Test 5 data - reset CSV to baseline and run import to obsolete leftover CSOs
         Copy-Item -Path "$scenarioDataPath/scenario5-hr-users.csv" -Destination "$testDataPath/hr-users.csv" -Force
-        # No docker cp needed — test-data is bind-mounted into JIM containers
+        Copy-CsvToConnectorFiles -SourcePath $csvPath
         $cleanupImport = Start-JIMRunProfile -ConnectedSystemId $config.CSVSystemId -RunProfileId $config.CSVImportProfileId -Wait -PassThru
         $cleanupSync = Start-JIMRunProfile -ConnectedSystemId $config.CSVSystemId -RunProfileId $config.CSVSyncProfileId -Wait -PassThru
         Write-Host "  ✓ Reset CSV to baseline and ran cleanup import/sync for subsequent tests" -ForegroundColor Gray
@@ -895,7 +895,7 @@ try {
                 }
                 $csv = @($csv) + $caseUser1
                 $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-                # No docker cp needed — test-data is bind-mounted into JIM containers
+                Copy-CsvToConnectorFiles -SourcePath $csvPath
 
                 # Import and sync first user to create MVO
                 Write-Host "  Creating MVO with UPPERCASE EmployeeId='$($testUser1.EmployeeId)'..." -ForegroundColor Gray
@@ -952,7 +952,7 @@ try {
                     }
                     $csv = @($csv) + $caseUser2
                     $csv | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
-                    # No docker cp needed — test-data is bind-mounted into JIM containers
+                    Copy-CsvToConnectorFiles -SourcePath $csvPath
 
                     # Import and sync second user - should join to existing MVO via case-insensitive match
                     Write-Host "  Importing second user with lowercase EmployeeId='$($testUser2.EmployeeId)'..." -ForegroundColor Gray
@@ -995,7 +995,7 @@ try {
                 # Clean up Test 6 data
                 $csvContent = Get-Content $csvPath | Where-Object { $_ -notmatch "test.casesens" }
                 $csvContent | Set-Content $csvPath
-                # No docker cp needed — test-data is bind-mounted into JIM containers
+                Copy-CsvToConnectorFiles -SourcePath $csvPath
                 Write-Host "  ✓ Cleaned up case sensitivity test data" -ForegroundColor Gray
             }
         }

--- a/test/integration/scenarios/Invoke-Scenario6-SchedulerService.ps1
+++ b/test/integration/scenarios/Invoke-Scenario6-SchedulerService.ps1
@@ -701,8 +701,8 @@ if ($Step -eq "Parallel" -or $Step -eq "All") {
                     $hrCsv | Export-Csv -Path $hrCsvPath -NoTypeInformation -Encoding UTF8
                     Write-Host "    HR CSV: Changed $($hrUser.samAccountName) title from '$oldTitle' to 'Scheduler Test - Parallel Flow'" -ForegroundColor DarkGray
 
-                    # No docker cp needed — test-data directory is bind-mounted into JIM containers
-                    Write-Host "    HR CSV: Updated on host (bind-mounted into containers)" -ForegroundColor DarkGray
+                    Copy-CsvToConnectorFiles -SourcePath $hrCsvPath
+                    Write-Host "    HR CSV: Copied to jim-connector-files-volume" -ForegroundColor DarkGray
                 }
             }
 
@@ -716,8 +716,8 @@ if ($Step -eq "Parallel" -or $Step -eq "All") {
                     $trainingCsv | Export-Csv -Path $trainingCsvPath -NoTypeInformation -Encoding UTF8
                     Write-Host "    Training CSV: Changed $($trainingUser.samAccountName) training status from '$oldStatus' to 'Pass'" -ForegroundColor DarkGray
 
-                    # No docker cp needed — test-data directory is bind-mounted into JIM containers
-                    Write-Host "    Training CSV: Updated on host (bind-mounted into containers)" -ForegroundColor DarkGray
+                    Copy-CsvToConnectorFiles -SourcePath $trainingCsvPath
+                    Write-Host "    Training CSV: Copied to jim-connector-files-volume" -ForegroundColor DarkGray
                 }
             }
 

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -718,6 +718,52 @@ function Get-RandomSubset {
 
 # Progress bar functions for visual feedback during long operations
 
+function Copy-CsvToConnectorFiles {
+    <#
+    .SYNOPSIS
+        Copy a CSV file from the host to /connector-files/test-data in the jim-connector-files-volume.
+
+    .DESCRIPTION
+        Uses `docker cp` via the jim.worker container to push a host file into the named
+        Docker volume at /connector-files/test-data/<filename>. The destination filename
+        defaults to the source file's basename, or can be overridden.
+
+        This is the integration-test equivalent of the customer "drop a file into the
+        File Connector volume" step. It mirrors the pattern used in Generate-TestCSV.ps1.
+
+    .PARAMETER SourcePath
+        The host path to the CSV file to copy.
+
+    .PARAMETER DestinationName
+        Optional override for the target filename. Defaults to the basename of SourcePath.
+
+    .EXAMPLE
+        Copy-CsvToConnectorFiles -SourcePath "$testDataPath/hr-users.csv"
+
+        Copies to jim.worker:/connector-files/test-data/hr-users.csv
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$SourcePath,
+
+        [Parameter(Mandatory=$false)]
+        [string]$DestinationName
+    )
+
+    if (-not (Test-Path $SourcePath)) {
+        throw "Source file not found: $SourcePath"
+    }
+
+    if (-not $DestinationName) {
+        $DestinationName = [System.IO.Path]::GetFileName($SourcePath)
+    }
+
+    $result = docker cp $SourcePath "jim.worker:/connector-files/test-data/$DestinationName" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to copy $SourcePath to jim.worker:/connector-files/test-data/${DestinationName}: $result"
+    }
+}
+
 function Write-ProgressBar {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Summary

Replaces the dev-only `/var/connector-files` host bind-mount with a formal Docker named volume `jim-connector-files-volume`, mounted at `/connector-files` inside `jim.web` and `jim.worker`. Default deployments now get working File Connector exports out of the box without any host-side `chown`. The integration test harness uses the same pattern as customers — no dev override.

## Why

- **Default permission footgun.** The worker runs as non-root `app` (UID 1654). Bind-mounted host directories preserve host UID, so customers following the previous deployment docs would hit "Access to the path … is denied" on every export. Docker-managed volumes inherit container-mount-point ownership at first mount, so writes just work.
- **Dev/customer divergence.** The previous setup relied on `docker-compose.override.yml` mounting `./test/test-data` into the container — a pattern customers couldn't replicate. Now there is a single file-access pattern, exercised in dev exactly as customers will.
- **Convention alignment.** Matches the existing `jim-keys-volume` / `jim-logs-volume` / `jim-db-volume` named-volume pattern.

## What changed

Seven phased commits on this branch:

1. `feat(docker)`: Dockerfiles create `/connector-files` owned by `app:app` so the volume inherits ownership on first mount.
2. `feat(docker)`: `jim-connector-files-volume` declared in `docker-compose.yml`, mounted on `jim.web` + `jim.worker`. `docker-compose.override.yml` bind-mount removed. `docker-compose.integration-tests.yml` references the same shared volume (`external: true`).
3. `refactor`: Source-code path constants and help text updated from `/var/connector-files` to `/connector-files` (FileSystemServer, FileBrowserDialog, FileConnector, two HelperText strings).
4. `test`: New `Copy-CsvToConnectorFiles` helper in Test-Helpers.ps1; Generate-TestCSV.ps1 + 5 scenario scripts now `docker cp` through `jim.worker` instead of relying on the bind-mount. Setup-Scenario1.ps1 path values updated.
5. `chore`: Removed the `.devcontainer/setup.sh` step that created `connector-files/test-data` symlinks; removed `connector-files/` from `.gitignore`.
6. `docs`: Rewrote File Connector docs (`docs/connectors/jim-file-connector.md`, `docs/administration/deployment.md`, `engineering/DEVELOPER_GUIDE.md`, `engineering/RELEASE_PROCESS.md`) with two explicit patterns — named-volume default and bind-mount-over-subdirectory for SMB/NFS integration. CHANGELOG updated.
7. `docs`: Dropped legacy/migration framing per pre-release status.

## Customer-facing patterns documented

1. **Named volume (default)** — zero setup; `docker cp` files in/out of `jim.worker:/connector-files/`.
2. **Bind-mount over a subdirectory** — for integrating with external systems writing to fixed network paths (SMB/NFS). Includes UID 1654 ownership requirement guidance.

## Test plan

- [x] `dotnet build JIM.sln` — 0 warnings, 0 errors
- [x] `dotnet test JIM.sln` — 1565 + 34 + others all passing
- [x] Container start: jim.worker comes up healthy with `/connector-files` mounted, owned by `app:app` (UID 1654)
- [x] Worker write test: `docker exec jim.worker sh -c 'echo test > /connector-files/x.txt'` succeeds
- [x] `docker cp` host→volume→host roundtrip works
- [ ] Full integration test (Scenario 1 OpenLDAP) — deferred to PR review pipeline since local port 5200 was in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)