### PR TITLE
feat: publish API reference to GitHub Pages on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,54 @@ jobs:
           path: sbom-${{ matrix.image }}.spdx.json
           retention-days: 5
 
-  # Job 3: Publish PowerShell module to PSGallery
+  # Job 3: Publish the documentation site with the latest OpenAPI document.
+  # Extracts the pre-generated OpenAPI JSON from the released jim-web Docker image,
+  # drops it into the docs/ tree, builds the MkDocs site, and deploys to GitHub Pages.
+  # This ensures the public API reference at https://tetronio.github.io/JIM/api/reference/
+  # always matches the latest stable release.
+  publish-docs:
+    name: Publish Documentation Site
+    runs-on: ubuntu-latest
+    needs: [validate, build-containers]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - name: Set image prefix
+        id: prefix
+        run: echo "IMAGE_PREFIX=$(echo 'ghcr.io/${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract OpenAPI document from jim-web image
+        run: |
+          IMAGE="${{ steps.prefix.outputs.IMAGE_PREFIX }}/jim-web:${{ steps.version.outputs.VERSION }}"
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker create "$IMAGE")
+          docker cp "${CONTAINER_ID}:/app/wwwroot/api/openapi/v1.json" docs/api/reference/v1.json
+          docker rm "$CONTAINER_ID"
+          echo "Extracted OpenAPI document: $(wc -c < docs/api/reference/v1.json) bytes"
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: 3.x
+
+      - name: Install MkDocs
+        run: pip install "mkdocs>=1.6,<2" "mkdocs-material>=9.7,<10" "mkdocs-glightbox>=0.4,<1"
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force
+
+  # Job 4: Publish PowerShell module to PSGallery
   # Depends on build-containers to ensure nothing publishes if Docker builds fail
   publish-powershell:
     name: Publish PowerShell Module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ✨ Interactive API reference powered by Scalar, available at `/api/reference` in all environments including air-gapped deployments; OpenAPI document is pre-generated at build time for instant loading with zero runtime overhead
+- ✨ Public API reference published to the JIM documentation site at [tetronio.github.io/JIM/api/reference/](https://tetronio.github.io/JIM/api/reference/); automatically updated on every release to match the published JIM version
 - ✨ Clear Connected System activity now tracks and displays removal statistics, showing how many pending exports and connected system objects were removed (#74)
 
 ### Performance

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,6 +8,14 @@ JIM provides a comprehensive REST API for programmatic access to all identity ma
 
 The API is served from the same application as the web UI; there is no separate service to deploy.
 
+!!! tip "Interactive API Reference"
+
+    For a complete, searchable endpoint reference with request/response schemas and an interactive "Try It" feature, see the **[Interactive API Reference](reference/)** (generated from the latest release).
+
+    The same reference is also available on every JIM instance at `/api/reference` — ideal for air-gapped environments.
+
+    The pages below focus on setup, authentication, and end-to-end examples; use the interactive reference for detailed endpoint specifications.
+
 ## Quick Start
 
 **Base URL:**

--- a/docs/api/reference/index.html
+++ b/docs/api/reference/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>JIM API Reference</title>
+    <link rel="icon" type="image/png" href="../../assets/images/jim-logo.png">
+    <style>
+        body { margin: 0; padding: 0; }
+        .dark-mode {
+            --scalar-background-1: #051526;
+            --scalar-background-2: #0d1e30;
+            --scalar-background-3: #15293c;
+            --scalar-background-accent: rgba(97, 75, 158, 0.12);
+            --scalar-color-1: rgba(255, 255, 255, 0.85);
+            --scalar-color-2: rgba(255, 255, 255, 0.55);
+            --scalar-color-3: rgba(255, 255, 255, 0.35);
+            --scalar-color-accent: #9585c8;
+            --scalar-border-color: rgba(255, 255, 255, 0.08);
+            --scalar-button-1: #614b9e;
+            --scalar-button-1-hover: #4e3c80;
+            --scalar-button-1-color: #ffffff;
+        }
+    </style>
+</head>
+<body>
+    <script
+        id="api-reference"
+        data-url="./v1.json"
+        data-configuration='{"theme":"default","forceDarkMode":true,"metaData":{"title":"JIM API Reference"}}'>
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>

--- a/docs/api/reference/v1.json
+++ b/docs/api/reference/v1.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "JIM API",
+    "version": "v1",
+    "description": "The full JIM API Reference is published here when a new JIM release is created. This placeholder will be replaced on the next release."
+  },
+  "paths": {}
+}


### PR DESCRIPTION
## Summary

- Publish the interactive Scalar API reference at [tetronio.github.io/JIM/api/reference/](https://tetronio.github.io/JIM/api/reference/)
- Reuses the OpenAPI document already baked into the jim-web Docker image (no additional generation step needed)
- Updates on every release; the public reference always matches the latest stable version

## How it works

1. During release, the jim-web Docker image is built with `wwwroot/api/openapi/v1.json` baked in via the existing `openapi-gen` build stage.
2. A new `publish-docs` job runs after `build-containers` succeeds, pulls the released image, and extracts the JSON to `docs/api/reference/v1.json`.
3. MkDocs builds the full documentation site with the extracted JSON and deploys via `mkdocs gh-deploy --force`.

## Changes

- `docs/api/reference/index.html` - Standalone Scalar page with the JIM navy theme
- `docs/api/reference/v1.json` - Placeholder; replaced by the release workflow
- `docs/api/index.md` - Callout pointing users to the interactive reference
- `.github/workflows/release.yml` - New `publish-docs` job
- `CHANGELOG.md` - Added entry under Unreleased

## Test plan

- [x] Verified MkDocs copies HTML + JSON files correctly to `site/api/reference/`
- [x] Verified placeholder page loads at `/api/reference/` and JSON at `/api/reference/v1.json`
- [ ] Verify on next release that the OpenAPI JSON is extracted and deployed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)