### PR TITLE
ci: regenerate OpenAPI doc in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,12 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        with:
+          dotnet-version: 10.0.x
+      - name: Generate OpenAPI document
+        run: pwsh -File ./scripts/Generate-OpenApiDoc.ps1 -OutputPath "$PWD/docs/api/reference/v1.json"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: 3.x


### PR DESCRIPTION
## Summary
- The `docs` workflow was force-pushing the mkdocs site to `gh-pages` using the placeholder `docs/api/reference/v1.json` committed in the repo, which wiped the real API reference whenever a docs PR merged to main
- Add `Setup .NET` + `Generate OpenAPI document` steps to [docs.yml](.github/workflows/docs.yml) so the live OpenAPI doc is regenerated before each mkdocs deploy
- Matches the approach already used by [publish-api-reference.yml](.github/workflows/publish-api-reference.yml)

## Test plan
- [ ] Merge and confirm the next docs deploy includes the full Scalar API reference at https://tetronio.github.io/JIM/api/reference/
- [ ] Verify docs workflow run time is still acceptable (~3 min extra for the dotnet build + OpenAPI gen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)