### PR TITLE
Cross-page resolution and MvoChange persist follow-ups (#566)

### DIFF
--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -449,18 +449,6 @@ public interface ISyncRepository
         Guid activityId, IReadOnlyCollection<Guid> csoIds);
 
     /// <summary>
-    /// Persists only the attribute + value rows of pending MVO changes whose parent
-    /// MetaverseObjectChange record already exists in the database (i.e. from an earlier
-    /// page flush). Used by cross-page reference resolution after merging reference
-    /// attribute flows into an already-persisted Projected/Joined RPEI.
-    ///
-    /// Each change in <paramref name="mvoChanges"/> must already have its <c>Id</c> set
-    /// to the existing parent's id; the method skips the parent INSERT and writes only the
-    /// attribute and attribute-value children via COPY.
-    /// </summary>
-    Task PersistPendingMvoChangeAttributesAsync(List<MetaverseObjectChange> mvoChanges);
-
-    /// <summary>
     /// Detaches RPEIs from the EF change tracker so they are not persisted by subsequent
     /// SaveChangesAsync calls. Call after raw SQL bulk insert has persisted them.
     /// </summary>
@@ -549,11 +537,23 @@ public interface ISyncRepository
     Task CreateMetaverseObjectChangeDirectAsync(MetaverseObjectChange change);
 
     /// <summary>
-    /// Persists pending MVO change records (and their attribute and value children) via raw SQL.
+    /// Persists pending MVO change records in a single outer transaction. Handles both sets
+    /// in one round-trip so the pair is atomic and the per-flush BEGIN/COMMIT overhead is halved
+    /// when the cross-page phase produces both:
+    /// <list type="bullet">
+    ///   <item><paramref name="newChanges"/> — new parent <c>MetaverseObjectChange</c> rows plus
+    ///     their attribute and value children (written via raw SQL COPY).</item>
+    ///   <item><paramref name="attributeAppendsToExistingChanges"/> — attribute and value children
+    ///     appended to parents already persisted in an earlier page flush. Each change must have
+    ///     its <c>Id</c> set to the existing parent's id; the parent row itself is not re-inserted
+    ///     (respecting <c>IX_MetaverseObjectChanges_ActivityRunProfileExecutionItemId</c>).</item>
+    /// </list>
     /// Used by sync processors to persist changes collected during page processing, bypassing the
     /// EF change tracker which is cleared at page boundaries.
     /// </summary>
-    Task PersistPendingMvoChangesAsync(List<MetaverseObjectChange> mvoChanges);
+    Task PersistPendingMvoChangesAsync(
+        List<MetaverseObjectChange> newChanges,
+        List<MetaverseObjectChange> attributeAppendsToExistingChanges);
 
     #endregion
 

--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -2,6 +2,7 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
 using JIM.Models.Core;
 using JIM.Models.Logic;
 using JIM.Models.Staging;
@@ -431,27 +432,21 @@ public interface ISyncRepository
     Task BulkUpdateRpeiOutcomesAsync(List<ActivityRunProfileExecutionItem> rpeis, List<ActivityRunProfileExecutionItemSyncOutcome> newOutcomes);
 
     /// <summary>
-    /// Loads persisted RPEIs and their SyncOutcomes for the specified CSO ids, for use by
-    /// cross-page reference resolution to merge reference attribute flow into existing RPEIs
-    /// rather than creating duplicates. Previous implementations relied on
-    /// <c>_activity.RunProfileExecutionItems</c> as a lookup source, but per-page raw-SQL flushes
-    /// clear that collection so the lookup has to come from the database.
-    /// </summary>
-    Task<List<ActivityRunProfileExecutionItem>> GetActivityRpeisByCsoIdsForCrossPageMergeAsync(
-        Guid activityId, IReadOnlyCollection<Guid> csoIds);
-
-    /// <summary>
-    /// Returns a dictionary mapping RPEI id → existing MetaverseObjectChange id for the
-    /// supplied RPEI ids. Used by cross-page reference resolution so that the reference
-    /// attribute flows added to an already-persisted Projected/Joined RPEI can be written
-    /// as new attribute rows under the existing MvoChange parent — respecting the unique
-    /// constraint <c>IX_MetaverseObjectChanges_ActivityRunProfileExecutionItemId</c>.
+    /// Loads persisted RPEIs (with their SyncOutcomes) and the id of each RPEI's existing
+    /// MetaverseObjectChange, in a single round-trip. Used by cross-page reference resolution to
+    /// merge reference attribute flow into existing RPEIs and to route the new attribute rows
+    /// under the already-persisted MvoChange parent (respecting the unique constraint
+    /// <c>IX_MetaverseObjectChanges_ActivityRunProfileExecutionItemId</c>). Previous implementations
+    /// relied on <c>_activity.RunProfileExecutionItems</c> as a lookup source, but per-page raw-SQL
+    /// flushes clear that collection so the lookup has to come from the database.
     ///
-    /// PostgreSQL implementation uses raw Npgsql (not EF projection): measured ~3.5× faster
-    /// on Medium-scale cross-page loads (2 ms vs 7 ms for 113 RPEIs), with the gap widening
-    /// at higher scales where EF materialisation overhead dominates.
+    /// PostgreSQL implementation uses a single <c>NpgsqlBatch</c> (RPEIs joined LEFT to
+    /// <c>MetaverseObjectChanges</c> + a second statement for <c>SyncOutcomes</c>) in one network
+    /// round-trip. Replaces the previous two-call pattern (EF Include for RPEIs + a separate raw-SQL
+    /// map lookup for MvoChange ids).
     /// </summary>
-    Task<Dictionary<Guid, Guid>> GetRpeiToMvoChangeIdMapAsync(IReadOnlyCollection<Guid> rpeiIds);
+    Task<List<CrossPageMergeRpei>> GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+        Guid activityId, IReadOnlyCollection<Guid> csoIds);
 
     /// <summary>
     /// Persists only the attribute + value rows of pending MVO changes whose parent

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -3,6 +3,7 @@
 
 using JIM.Data.Repositories;
 using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
 using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Models.Exceptions;
@@ -1085,26 +1086,36 @@ public class SyncRepository : ISyncRepository
         return Task.CompletedTask;
     }
 
-    public Task<List<ActivityRunProfileExecutionItem>> GetActivityRpeisByCsoIdsForCrossPageMergeAsync(
+    public Task<List<CrossPageMergeRpei>> GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
         Guid activityId, IReadOnlyCollection<Guid> csoIds)
     {
+        if (csoIds.Count == 0)
+            return Task.FromResult(new List<CrossPageMergeRpei>());
+
         var csoIdSet = csoIds as HashSet<Guid> ?? csoIds.ToHashSet();
-        var matches = _rpeis.Values
+        var matchingRpeis = _rpeis.Values
             .Where(r => r.ActivityId == activityId
                         && r.ConnectedSystemObjectId.HasValue
                         && csoIdSet.Contains(r.ConnectedSystemObjectId.Value))
             .ToList();
-        return Task.FromResult(matches);
-    }
 
-    public Task<Dictionary<Guid, Guid>> GetRpeiToMvoChangeIdMapAsync(IReadOnlyCollection<Guid> rpeiIds)
-    {
-        var rpeiIdSet = rpeiIds as HashSet<Guid> ?? rpeiIds.ToHashSet();
-        var map = _mvoChanges.Values
+        var rpeiIds = matchingRpeis.Select(r => r.Id).ToHashSet();
+        var mvoChangeIdByRpeiId = _mvoChanges.Values
             .Where(c => c.ActivityRunProfileExecutionItemId.HasValue
-                        && rpeiIdSet.Contains(c.ActivityRunProfileExecutionItemId.Value))
+                        && rpeiIds.Contains(c.ActivityRunProfileExecutionItemId.Value))
             .ToDictionary(c => c.ActivityRunProfileExecutionItemId!.Value, c => c.Id);
-        return Task.FromResult(map);
+
+        var results = matchingRpeis
+            .Select(r => new CrossPageMergeRpei
+            {
+                Rpei = r,
+                ExistingMvoChangeId = mvoChangeIdByRpeiId.TryGetValue(r.Id, out var mvoChangeId)
+                    ? mvoChangeId
+                    : null
+            })
+            .ToList();
+
+        return Task.FromResult(results);
     }
 
     public Task PersistPendingMvoChangeAttributesAsync(List<MetaverseObjectChange> mvoChanges)

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -1118,29 +1118,22 @@ public class SyncRepository : ISyncRepository
         return Task.FromResult(results);
     }
 
-    public Task PersistPendingMvoChangeAttributesAsync(List<MetaverseObjectChange> mvoChanges)
+    private void AppendAttributeChildrenToExistingMvoChange(MetaverseObjectChange incoming)
     {
-        // In-memory model: the existing MvoChange is already in _mvoChanges (keyed by Id).
-        // Append the new AttributeChanges to the existing record and assign ids for children.
-        foreach (var incoming in mvoChanges)
+        if (!_mvoChanges.TryGetValue(incoming.Id, out var existing))
         {
-            if (!_mvoChanges.TryGetValue(incoming.Id, out var existing))
-            {
-                throw new InvalidOperationException(
-                    $"PersistPendingMvoChangeAttributesAsync: no existing MvoChange with Id {incoming.Id}");
-            }
-
-            foreach (var attrChange in incoming.AttributeChanges)
-            {
-                if (attrChange.Id == Guid.Empty)
-                    attrChange.Id = Guid.NewGuid();
-                foreach (var valueChange in attrChange.ValueChanges.Where(vc => vc.Id == Guid.Empty))
-                    valueChange.Id = Guid.NewGuid();
-                existing.AttributeChanges.Add(attrChange);
-            }
+            throw new InvalidOperationException(
+                $"PersistPendingMvoChangesAsync (append): no existing MvoChange with Id {incoming.Id}");
         }
 
-        return Task.CompletedTask;
+        foreach (var attrChange in incoming.AttributeChanges)
+        {
+            if (attrChange.Id == Guid.Empty)
+                attrChange.Id = Guid.NewGuid();
+            foreach (var valueChange in attrChange.ValueChanges.Where(vc => vc.Id == Guid.Empty))
+                valueChange.Id = Guid.NewGuid();
+            existing.AttributeChanges.Add(attrChange);
+        }
     }
 
     public void DetachRpeisFromChangeTracker(List<ActivityRunProfileExecutionItem> rpeis)
@@ -1288,9 +1281,11 @@ public class SyncRepository : ISyncRepository
         return Task.CompletedTask;
     }
 
-    public Task PersistPendingMvoChangesAsync(List<MetaverseObjectChange> mvoChanges)
+    public Task PersistPendingMvoChangesAsync(
+        List<MetaverseObjectChange> newChanges,
+        List<MetaverseObjectChange> attributeAppendsToExistingChanges)
     {
-        foreach (var change in mvoChanges)
+        foreach (var change in newChanges)
         {
             if (change.Id == Guid.Empty)
                 change.Id = Guid.NewGuid();
@@ -1314,6 +1309,9 @@ public class SyncRepository : ISyncRepository
             if (change.MetaverseObject != null && !change.MetaverseObject.Changes.Contains(change))
                 change.MetaverseObject.Changes.Add(change);
         }
+
+        foreach (var append in attributeAppendsToExistingChanges)
+            AppendAttributeChildrenToExistingMvoChange(append);
 
         return Task.CompletedTask;
     }

--- a/src/JIM.Models/Activities/DTOs/CrossPageMergeRpei.cs
+++ b/src/JIM.Models/Activities/DTOs/CrossPageMergeRpei.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Activities.DTOs;
+
+/// <summary>
+/// Pairs an already-persisted RPEI (with its SyncOutcomes) against the id of its existing
+/// <see cref="Staging.MetaverseObjectChange"/>, when one exists. Returned by cross-page
+/// reference resolution to merge new reference attribute flow into the existing RPEI/MvoChange
+/// pair rather than creating duplicates.
+/// </summary>
+public class CrossPageMergeRpei
+{
+    /// <summary>
+    /// The persisted RPEI, materialised with its <see cref="ActivityRunProfileExecutionItem.SyncOutcomes"/>
+    /// list populated.
+    /// </summary>
+    public ActivityRunProfileExecutionItem Rpei { get; set; } = null!;
+
+    /// <summary>
+    /// Id of the <see cref="Staging.MetaverseObjectChange"/> already persisted for this RPEI,
+    /// or <c>null</c> if no MvoChange has been written yet (e.g. an AttributeFlow-only RPEI from a
+    /// prior page with no scalar attribute changes on the parent).
+    /// </summary>
+    public Guid? ExistingMvoChangeId { get; set; }
+}

--- a/src/JIM.PostgresData/Repositories/SyncRepository.MvoChangeOperations.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.MvoChangeOperations.cs
@@ -11,14 +11,16 @@ namespace JIM.PostgresData.Repositories;
 public partial class SyncRepository
 {
     /// <inheritdoc />
-    public async Task PersistPendingMvoChangesAsync(List<MetaverseObjectChange> mvoChanges)
+    public async Task PersistPendingMvoChangesAsync(
+        List<MetaverseObjectChange> newChanges,
+        List<MetaverseObjectChange> attributeAppendsToExistingChanges)
     {
-        if (mvoChanges.Count == 0)
+        if (newChanges.Count == 0 && attributeAppendsToExistingChanges.Count == 0)
             return;
 
-        // Pre-generate IDs for all entities in the graph so FK relationships are known
-        // before we build the COPY binary import statements.
-        foreach (var change in mvoChanges)
+        // Pre-generate IDs for new-change graph entities so FK relationships are known
+        // before building the COPY binary import statements.
+        foreach (var change in newChanges)
         {
             if (change.Id == Guid.Empty)
                 change.Id = Guid.NewGuid();
@@ -36,57 +38,14 @@ public partial class SyncRepository
             }
         }
 
-        // Increase command timeout for large change record persistence.
-        var previousTimeout = _context.Database.GetCommandTimeout();
-        _context.Database.SetCommandTimeout(PostgresDataRepository.BulkOperationCommandTimeoutSeconds);
-
-        // Use an EF transaction for atomicity — COPY binary imports on the underlying
-        // NpgsqlConnection participate in the active transaction automatically.
-        await using var transaction = await _context.Database.BeginTransactionAsync();
-
-        // Step 1: INSERT parent MetaverseObjectChange rows
-        await BulkInsertMvoChangesRawAsync(mvoChanges);
-
-        // Step 2: INSERT MetaverseObjectChangeAttribute rows
-        var allAttrChanges = mvoChanges
-            .SelectMany(c => c.AttributeChanges.Select(ac =>
-                (ChangeId: c.Id, AttributeId: ac.Attribute?.Id, AttrChange: ac)))
-            .ToList();
-
-        if (allAttrChanges.Count > 0)
-            await BulkInsertMvoChangeAttributesRawAsync(allAttrChanges);
-
-        // Step 3: INSERT MetaverseObjectChangeAttributeValue rows
-        var allValueChanges = mvoChanges
-            .SelectMany(c => c.AttributeChanges
-                .SelectMany(ac => ac.ValueChanges.Select(vc => (AttrChangeId: ac.Id, Value: vc))))
-            .ToList();
-
-        if (allValueChanges.Count > 0)
-            await BulkInsertMvoChangeAttributeValuesRawAsync(allValueChanges);
-
-        await transaction.CommitAsync();
-        _context.Database.SetCommandTimeout(previousTimeout);
-
-        Log.Debug("PersistPendingMvoChangesAsync: Persisted {ChangeCount} MVO changes with {AttrCount} attribute changes and {ValueCount} value changes",
-            mvoChanges.Count, allAttrChanges.Count, allValueChanges.Count);
-    }
-
-    /// <inheritdoc />
-    public async Task PersistPendingMvoChangeAttributesAsync(List<MetaverseObjectChange> mvoChanges)
-    {
-        if (mvoChanges.Count == 0)
-            return;
-
-        // Each change's Id is assumed to already be set to the existing parent MvoChange id.
-        // We ONLY pre-generate ids for the attribute + value children, because the parent
-        // rows already exist in the database (written on an earlier page flush) and must
-        // not be re-inserted under the unique (ActivityRunProfileExecutionItemId) constraint.
-        foreach (var change in mvoChanges)
+        // For appends, the parent id must already be set (it's the existing MvoChange row).
+        // Only the attribute/value children need id generation — writing a new parent here
+        // would violate IX_MetaverseObjectChanges_ActivityRunProfileExecutionItemId.
+        foreach (var change in attributeAppendsToExistingChanges)
         {
             if (change.Id == Guid.Empty)
                 throw new InvalidOperationException(
-                    "PersistPendingMvoChangeAttributesAsync requires each MvoChange to already have its existing parent Id set.");
+                    "PersistPendingMvoChangesAsync (append): each MvoChange must already have its existing parent Id set.");
 
             foreach (var attrChange in change.AttributeChanges)
             {
@@ -101,10 +60,18 @@ public partial class SyncRepository
         var previousTimeout = _context.Database.GetCommandTimeout();
         _context.Database.SetCommandTimeout(PostgresDataRepository.BulkOperationCommandTimeoutSeconds);
 
+        // One outer transaction for both the new-parent inserts and the append-only
+        // attribute/value writes. Halves the per-flush BEGIN/COMMIT overhead when the
+        // cross-page phase produces both, and makes the pair atomic: either the new page
+        // of changes AND its cross-page appends land together, or neither does.
         await using var transaction = await _context.Database.BeginTransactionAsync();
 
-        // Skip parent INSERT. Write only attribute + value children under the existing parent Ids.
-        var allAttrChanges = mvoChanges
+        if (newChanges.Count > 0)
+            await BulkInsertMvoChangesRawAsync(newChanges);
+
+        // Attribute rows from BOTH sets write to the same table in one COPY call.
+        var allAttrChanges = newChanges
+            .Concat(attributeAppendsToExistingChanges)
             .SelectMany(c => c.AttributeChanges.Select(ac =>
                 (ChangeId: c.Id, AttributeId: ac.Attribute?.Id, AttrChange: ac)))
             .ToList();
@@ -112,7 +79,8 @@ public partial class SyncRepository
         if (allAttrChanges.Count > 0)
             await BulkInsertMvoChangeAttributesRawAsync(allAttrChanges);
 
-        var allValueChanges = mvoChanges
+        var allValueChanges = newChanges
+            .Concat(attributeAppendsToExistingChanges)
             .SelectMany(c => c.AttributeChanges
                 .SelectMany(ac => ac.ValueChanges.Select(vc => (AttrChangeId: ac.Id, Value: vc))))
             .ToList();
@@ -123,8 +91,8 @@ public partial class SyncRepository
         await transaction.CommitAsync();
         _context.Database.SetCommandTimeout(previousTimeout);
 
-        Log.Debug("PersistPendingMvoChangeAttributesAsync: Appended {AttrCount} attribute changes and {ValueCount} value changes to {ChangeCount} existing MVO changes",
-            allAttrChanges.Count, allValueChanges.Count, mvoChanges.Count);
+        Log.Debug("PersistPendingMvoChangesAsync: Persisted {NewCount} new MVO changes and appended children to {AppendCount} existing; {AttrCount} attribute changes, {ValueCount} value changes",
+            newChanges.Count, attributeAppendsToExistingChanges.Count, allAttrChanges.Count, allValueChanges.Count);
     }
 
     /// <summary>

--- a/src/JIM.PostgresData/Repositories/SyncRepository.RpeiOperations.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.RpeiOperations.cs
@@ -2,6 +2,8 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
+using JIM.Models.Enums;
 using JIM.Models.Staging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -282,16 +284,19 @@ public partial class SyncRepository
     }
 
     /// <remarks>
-    /// Scale note: this EF materialisation approach is confirmed fast for the current
-    /// supported ceiling (Scale100K) — observed baseline is ~26 ms for 103 cross-page
-    /// CSOs on the Medium template, and the cost scales roughly linearly with the
-    /// cross-page CSO count. Above Scale100K the Include(SyncOutcomes) materialisation
-    /// becomes the dominant cost and this method should be rewritten as a raw-SQL
-    /// projection into a purpose-built DTO (carry only Id, ConnectedSystemObjectId,
-    /// AttributeFlowCount, ObjectChangeType, OutcomeSummary, plus a flat outcomes bag).
-    /// Tracked as a follow-up in GitHub issue #565.
+    /// Replaces the earlier two-call pattern (EF-projected RPEIs + Include(SyncOutcomes),
+    /// followed by a separate raw-SQL RPEI→MvoChange-id map lookup) with a single
+    /// <see cref="NpgsqlBatch"/> that ships two statements in one network round-trip:
+    /// <list type="number">
+    ///   <item>RPEI scalars LEFT JOINed to <c>MetaverseObjectChanges</c> (one row per RPEI).</item>
+    ///   <item>Matching <c>ActivityRunProfileExecutionItemSyncOutcomes</c> stitched onto the RPEIs in memory.</item>
+    /// </list>
+    /// Measured sibling comparison (<c>GetRpeiToMvoChangeIdMapAsync</c>) showed raw Npgsql ~3.5×
+    /// faster than EF projection on the same workload; the gap widens with row count because
+    /// EF materialisation scales harder than the query itself. Carries only the columns the
+    /// worker actually reads and mutates — no navigation properties, no change tracking.
     /// </remarks>
-    public async Task<List<ActivityRunProfileExecutionItem>> GetActivityRpeisByCsoIdsForCrossPageMergeAsync(
+    public async Task<List<CrossPageMergeRpei>> GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
         Guid activityId, IReadOnlyCollection<Guid> csoIds)
     {
         if (csoIds.Count == 0)
@@ -299,60 +304,110 @@ public partial class SyncRepository
 
         var csoIdArray = csoIds as Guid[] ?? csoIds.ToArray();
 
-        // AsNoTracking: the worker mutates the returned RPEIs (AttributeFlowCount, OutcomeSummary,
-        // new child outcomes) but persists those changes via raw SQL (BulkUpdateRpeiFieldsRawAsync
-        // and BulkInsertSyncOutcomesRawAsync), not via EF. Change tracking would be pure overhead.
-        return await _context.ActivityRunProfileExecutionItems
-            .AsNoTracking()
-            .Include(r => r.SyncOutcomes)
-            .Where(r => r.ActivityId == activityId
-                        && r.ConnectedSystemObjectId.HasValue
-                        && csoIdArray.Contains(r.ConnectedSystemObjectId.Value))
-            .ToListAsync();
-    }
-
-    /// <remarks>
-    /// Raw Npgsql SELECT rather than EF projection — measured ~3.5× faster on the Medium-scale
-    /// cross-page load (2 ms vs 7 ms for 113 RPEIs). Chosen during the initial integration run
-    /// of <c>feature/sync-integrity-and-diagnostics</c>; the EF projection sibling was removed
-    /// once the delta was confirmed. Keep this as raw-SQL — the gap widens at higher scales
-    /// where EF materialisation overhead grows faster than the query itself.
-    /// </remarks>
-    public async Task<Dictionary<Guid, Guid>> GetRpeiToMvoChangeIdMapAsync(IReadOnlyCollection<Guid> rpeiIds)
-    {
-        if (rpeiIds.Count == 0)
-            return [];
-
-        var rpeiIdArray = rpeiIds as Guid[] ?? rpeiIds.ToArray();
-
         var npgsqlConn = (NpgsqlConnection)_context.Database.GetDbConnection();
         if (npgsqlConn.State != System.Data.ConnectionState.Open)
             await npgsqlConn.OpenAsync();
 
         var npgsqlTx = (NpgsqlTransaction?)_context.Database.CurrentTransaction?.GetDbTransaction();
 
-        await using var cmd = new NpgsqlCommand(
-            """
-            SELECT "ActivityRunProfileExecutionItemId", "Id"
-            FROM "MetaverseObjectChanges"
-            WHERE "ActivityRunProfileExecutionItemId" = ANY(@rpeiIds)
-            """,
-            npgsqlConn,
-            npgsqlTx);
-        cmd.Parameters.Add(new NpgsqlParameter("rpeiIds", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Uuid)
-        {
-            Value = rpeiIdArray
-        });
+        // Ship both statements in one round-trip. Statement 1 = RPEI scalars LEFT JOIN
+        // MvoChange.Id (one row per RPEI). Statement 2 = the SyncOutcomes for those RPEIs
+        // (stitched in memory below). Both filter by the same (ActivityId, CsoIds) predicate
+        // so we can parameterise them independently.
+        await using var batch = new NpgsqlBatch(npgsqlConn, npgsqlTx);
 
-        var map = new Dictionary<Guid, Guid>(capacity: rpeiIdArray.Length);
-        await using var reader = await cmd.ExecuteReaderAsync();
+        var rpeiCommand = new NpgsqlBatchCommand(
+            """
+            SELECT rpei."Id", rpei."ActivityId", rpei."ObjectChangeType", rpei."NoChangeReason",
+                   rpei."ConnectedSystemObjectId", rpei."ExternalIdSnapshot", rpei."DisplayNameSnapshot",
+                   rpei."ObjectTypeSnapshot", rpei."ErrorType", rpei."ErrorMessage", rpei."ErrorStackTrace",
+                   rpei."AttributeFlowCount", rpei."OutcomeSummary",
+                   mvoc."Id" AS "MvoChangeId"
+            FROM "ActivityRunProfileExecutionItems" rpei
+            LEFT JOIN "MetaverseObjectChanges" mvoc
+                ON mvoc."ActivityRunProfileExecutionItemId" = rpei."Id"
+            WHERE rpei."ActivityId" = @activityId
+              AND rpei."ConnectedSystemObjectId" = ANY(@csoIds)
+            """);
+        rpeiCommand.Parameters.Add(new NpgsqlParameter("activityId", NpgsqlTypes.NpgsqlDbType.Uuid) { Value = activityId });
+        rpeiCommand.Parameters.Add(new NpgsqlParameter("csoIds", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Uuid) { Value = csoIdArray });
+        batch.BatchCommands.Add(rpeiCommand);
+
+        var outcomesCommand = new NpgsqlBatchCommand(
+            """
+            SELECT so."Id", so."ActivityRunProfileExecutionItemId", so."ParentSyncOutcomeId",
+                   so."OutcomeType", so."TargetEntityId", so."TargetEntityDescription",
+                   so."DetailCount", so."DetailMessage", so."Ordinal", so."ConnectedSystemObjectChangeId"
+            FROM "ActivityRunProfileExecutionItemSyncOutcomes" so
+            INNER JOIN "ActivityRunProfileExecutionItems" rpei
+                ON rpei."Id" = so."ActivityRunProfileExecutionItemId"
+            WHERE rpei."ActivityId" = @activityId
+              AND rpei."ConnectedSystemObjectId" = ANY(@csoIds)
+            """);
+        outcomesCommand.Parameters.Add(new NpgsqlParameter("activityId", NpgsqlTypes.NpgsqlDbType.Uuid) { Value = activityId });
+        outcomesCommand.Parameters.Add(new NpgsqlParameter("csoIds", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Uuid) { Value = csoIdArray });
+        batch.BatchCommands.Add(outcomesCommand);
+
+        var resultsByRpeiId = new Dictionary<Guid, CrossPageMergeRpei>();
+        var results = new List<CrossPageMergeRpei>();
+
+        await using var reader = await batch.ExecuteReaderAsync();
+
+        // Result set 1 — RPEI row per RPEI (LEFT JOIN guarantees one row per RPEI since the
+        // MvoChange→RPEI FK is unique).
         while (await reader.ReadAsync())
         {
-            // Column 0 is nullable in the schema but the WHERE clause guarantees non-null here.
-            map[reader.GetGuid(0)] = reader.GetGuid(1);
+            var rpei = new ActivityRunProfileExecutionItem
+            {
+                Id = reader.GetGuid(0),
+                ActivityId = reader.GetGuid(1),
+                ObjectChangeType = (ObjectChangeType)reader.GetInt32(2),
+                NoChangeReason = reader.IsDBNull(3) ? null : (NoChangeReason)reader.GetInt32(3),
+                ConnectedSystemObjectId = reader.IsDBNull(4) ? null : reader.GetGuid(4),
+                ExternalIdSnapshot = reader.IsDBNull(5) ? null : reader.GetString(5),
+                DisplayNameSnapshot = reader.IsDBNull(6) ? null : reader.GetString(6),
+                ObjectTypeSnapshot = reader.IsDBNull(7) ? null : reader.GetString(7),
+                ErrorType = reader.IsDBNull(8) ? null : (ActivityRunProfileExecutionItemErrorType)reader.GetInt32(8),
+                ErrorMessage = reader.IsDBNull(9) ? null : reader.GetString(9),
+                ErrorStackTrace = reader.IsDBNull(10) ? null : reader.GetString(10),
+                AttributeFlowCount = reader.IsDBNull(11) ? null : reader.GetInt32(11),
+                OutcomeSummary = reader.IsDBNull(12) ? null : reader.GetString(12)
+            };
+            var existingMvoChangeId = reader.IsDBNull(13) ? (Guid?)null : reader.GetGuid(13);
+
+            var entry = new CrossPageMergeRpei
+            {
+                Rpei = rpei,
+                ExistingMvoChangeId = existingMvoChangeId
+            };
+            results.Add(entry);
+            resultsByRpeiId[rpei.Id] = entry;
         }
 
-        return map;
+        // Result set 2 — SyncOutcome rows, attached to their parent RPEI.
+        await reader.NextResultAsync();
+        while (await reader.ReadAsync())
+        {
+            var rpeiId = reader.GetGuid(1);
+            if (!resultsByRpeiId.TryGetValue(rpeiId, out var entry))
+                continue;
+
+            entry.Rpei.SyncOutcomes.Add(new ActivityRunProfileExecutionItemSyncOutcome
+            {
+                Id = reader.GetGuid(0),
+                ActivityRunProfileExecutionItemId = rpeiId,
+                ParentSyncOutcomeId = reader.IsDBNull(2) ? null : reader.GetGuid(2),
+                OutcomeType = (ActivityRunProfileExecutionItemSyncOutcomeType)reader.GetInt32(3),
+                TargetEntityId = reader.IsDBNull(4) ? null : reader.GetGuid(4),
+                TargetEntityDescription = reader.IsDBNull(5) ? null : reader.GetString(5),
+                DetailCount = reader.IsDBNull(6) ? null : reader.GetInt32(6),
+                DetailMessage = reader.IsDBNull(7) ? null : reader.GetString(7),
+                Ordinal = reader.GetInt32(8),
+                ConnectedSystemObjectChangeId = reader.IsDBNull(9) ? null : reader.GetGuid(9)
+            });
+        }
+
+        return results;
     }
 
     public async Task BulkUpdateRpeiOutcomesAsync(

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -1230,10 +1230,10 @@ public abstract class SyncTaskProcessorBase
                 // Prefer the AttributeFlow child as parent (MVO is fully formed after attribute flow),
                 // fall back to root outcome, fall back to creating outcomes at root level.
                 var rootOutcome = originatingRpei.SyncOutcomes.FirstOrDefault(o =>
-                    o.ParentSyncOutcome == null && o.ParentSyncOutcomeId == null);
+                    !o.ParentSyncOutcomeId.HasValue);
                 var attributeFlowChild = originatingRpei.SyncOutcomes.FirstOrDefault(o =>
                     o.OutcomeType == ActivityRunProfileExecutionItemSyncOutcomeType.AttributeFlow
-                    && o.ParentSyncOutcome != null);
+                    && o.ParentSyncOutcomeId.HasValue);
                 var exportParent = attributeFlowChild ?? rootOutcome;
 
                 // Track Provisioned outcomes by CS ID so we can nest Pending Exports under them
@@ -1614,7 +1614,7 @@ public abstract class SyncTaskProcessorBase
                                 {
                                     var attrFlowChild = existingChangeEntry.Rpei.SyncOutcomes.FirstOrDefault(o =>
                                         o.OutcomeType == ActivityRunProfileExecutionItemSyncOutcomeType.AttributeFlow
-                                        && o.ParentSyncOutcome != null);
+                                        && o.ParentSyncOutcomeId.HasValue);
                                     if (attrFlowChild != null)
                                         attrFlowChild.DetailCount = existingChangeEntry.Rpei.AttributeFlowCount;
                                 }

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -1699,27 +1699,21 @@ public abstract class SyncTaskProcessorBase
         // each per-page FlushRpeisAsync, so the lookup has to come from the database — reading
         // from the in-memory collection would produce an empty lookup and cause cross-page
         // resolution to create duplicate AttributeFlow RPEIs instead of merging into existing ones.
+        // Single-round-trip fetch: RPEIs + SyncOutcomes + RPEI→MvoChange ids via NpgsqlBatch.
+        // The MvoChange ids let cross-page attribute flows be persisted as children of the
+        // already-existing parent MvoChange (enforced by the unique-per-RPEI index on
+        // MetaverseObjectChanges).
         var unresolvedCsoIds = _unresolvedCrossPageReferences.Select(x => x.CsoId).ToHashSet();
         var rpeiLoadStopwatch = System.Diagnostics.Stopwatch.StartNew();
-        var existingRpeis = await _syncRepo.GetActivityRpeisByCsoIdsForCrossPageMergeAsync(
+        var crossPageMergeRpeis = await _syncRepo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
             _activity.Id, unresolvedCsoIds);
         rpeiLoadStopwatch.Stop();
-        var existingRpeisByCsoId = existingRpeis.ToDictionary(r => r.ConnectedSystemObjectId!.Value);
+        var existingRpeisByCsoId = crossPageMergeRpeis.ToDictionary(x => x.Rpei.ConnectedSystemObjectId!.Value);
+        var mvoChangeIdCount = crossPageMergeRpeis.Count(x => x.ExistingMvoChangeId.HasValue);
         Log.Information(
-            "ResolveCrossPageReferences: Loaded {RpeiCount} existing RPEIs for {CsoCount} cross-page CSOs from database in {ElapsedMs} ms (lookup hit rate {HitRate:P0})",
-            existingRpeis.Count, unresolvedCsoIds.Count, rpeiLoadStopwatch.ElapsedMilliseconds,
-            unresolvedCsoIds.Count > 0 ? (double)existingRpeis.Count / unresolvedCsoIds.Count : 1.0);
-
-        // Build RPEI-id → existing MvoChange-id map so cross-page attribute flows can be
-        // persisted as children of the already-existing parent MvoChange (enforced by the
-        // unique-per-RPEI index on MetaverseObjectChanges).
-        var rpeiIdsToLookUp = existingRpeis.Select(r => r.Id).ToList();
-        var mvoChangeIdLookupStopwatch = System.Diagnostics.Stopwatch.StartNew();
-        var rpeiIdToMvoChangeId = await _syncRepo.GetRpeiToMvoChangeIdMapAsync(rpeiIdsToLookUp);
-        mvoChangeIdLookupStopwatch.Stop();
-        Log.Information(
-            "ResolveCrossPageReferences: Loaded {MapCount} existing MvoChange ids for {RpeiCount} RPEIs in {ElapsedMs} ms",
-            rpeiIdToMvoChangeId.Count, rpeiIdsToLookUp.Count, mvoChangeIdLookupStopwatch.ElapsedMilliseconds);
+            "ResolveCrossPageReferences: Loaded {RpeiCount} existing RPEIs ({MvoChangeCount} with MvoChange ids) for {CsoCount} cross-page CSOs from database in {ElapsedMs} ms (lookup hit rate {HitRate:P0})",
+            crossPageMergeRpeis.Count, mvoChangeIdCount, unresolvedCsoIds.Count, rpeiLoadStopwatch.ElapsedMilliseconds,
+            unresolvedCsoIds.Count > 0 ? (double)crossPageMergeRpeis.Count / unresolvedCsoIds.Count : 1.0);
 
         // Clear the change tracker to prevent performance degradation.
         // After processing all pages, the change tracker accumulates thousands of tracked entities
@@ -1837,11 +1831,10 @@ public abstract class SyncTaskProcessorBase
                     // attribute additions are written as children of that row rather than a new one.
                     ActivityRunProfileExecutionItem rpei;
                     Guid? existingMvoChangeId = null;
-                    if (existingRpeisByCsoId.TryGetValue(csoId, out var existingRpei))
+                    if (existingRpeisByCsoId.TryGetValue(csoId, out var existingMergeRpei))
                     {
-                        rpei = existingRpei;
-                        rpeiIdToMvoChangeId.TryGetValue(rpei.Id, out var mvoChangeId);
-                        existingMvoChangeId = mvoChangeId == Guid.Empty ? null : mvoChangeId;
+                        rpei = existingMergeRpei.Rpei;
+                        existingMvoChangeId = existingMergeRpei.ExistingMvoChangeId;
                         rpei.AttributeFlowCount = (rpei.AttributeFlowCount ?? 0) + additionsCount + removalsCount;
 
                         // Update outcome tree: add or update the AttributeFlow child node

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -1690,6 +1690,17 @@ public abstract class SyncTaskProcessorBase
         Log.Information("ResolveCrossPageReferences: Resolving cross-page references for {Count} CSOs",
             totalCrossPagesToResolve);
 
+        // Memory snapshot at phase entry — cross-page resolution reloads CSO graphs with deep
+        // includes, rebuilds outcome trees, and re-evaluates exports, so its memory footprint
+        // is distinctive from the main sync loop. The matching snapshot at phase exit lets us
+        // size the headroom it takes at a glance; combined with docker stats externally this
+        // short-circuits future memory investigations into this phase.
+        var managedBytesAtStart = GC.GetTotalMemory(forceFullCollection: false);
+        var workingSetBytesAtStart = Environment.WorkingSet;
+        Log.Information("ResolveCrossPageReferences: Memory at phase entry — Managed: {ManagedMb:F1} MB, WorkingSet: {WorkingSetMb:F1} MB",
+            managedBytesAtStart / (1024.0 * 1024.0),
+            workingSetBytesAtStart / (1024.0 * 1024.0));
+
         await _syncRepo.UpdateActivityMessageAsync(_activity,
             $"Resolving cross-page references (0 / {totalCrossPagesToResolve})");
 
@@ -2079,6 +2090,15 @@ public abstract class SyncTaskProcessorBase
 
         Log.Information("ResolveCrossPageReferences: Completed cross-page reference resolution for {Count} CSOs",
             totalCrossPagesToResolve);
+
+        // Memory snapshot at phase exit, with deltas against the entry snapshot.
+        var managedBytesAtEnd = GC.GetTotalMemory(forceFullCollection: false);
+        var workingSetBytesAtEnd = Environment.WorkingSet;
+        Log.Information("ResolveCrossPageReferences: Memory at phase exit — Managed: {ManagedMb:F1} MB (Δ {ManagedDeltaMb:+0.0;-0.0;0.0} MB), WorkingSet: {WorkingSetMb:F1} MB (Δ {WorkingSetDeltaMb:+0.0;-0.0;0.0} MB)",
+            managedBytesAtEnd / (1024.0 * 1024.0),
+            (managedBytesAtEnd - managedBytesAtStart) / (1024.0 * 1024.0),
+            workingSetBytesAtEnd / (1024.0 * 1024.0),
+            (workingSetBytesAtEnd - workingSetBytesAtStart) / (1024.0 * 1024.0));
 
         _unresolvedCrossPageReferences.Clear();
 

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -2520,24 +2520,21 @@ public abstract class SyncTaskProcessorBase
     }
 
     /// <summary>
-    /// Persists pending MVO change records via raw SQL bulk insert.
+    /// Persists pending MVO change records via raw SQL bulk insert in a single outer transaction.
     /// Must be called after CreatePendingMvoChangeObjectsAsync and before ClearChangeTracker.
     /// Handles both initial-page inserts (full parent + child rows) and cross-page-merge
-    /// appends (child rows only under already-persisted parents).
+    /// appends (child rows only under already-persisted parents) atomically.
     /// </summary>
     protected async Task FlushPendingMvoChangesAsync()
     {
-        if (_pendingMvoChangesToPersist.Count > 0)
-        {
-            await _syncRepo.PersistPendingMvoChangesAsync(_pendingMvoChangesToPersist);
-            _pendingMvoChangesToPersist.Clear();
-        }
+        if (_pendingMvoChangesToPersist.Count == 0 && _pendingMvoChangeAttributesToPersist.Count == 0)
+            return;
 
-        if (_pendingMvoChangeAttributesToPersist.Count > 0)
-        {
-            await _syncRepo.PersistPendingMvoChangeAttributesAsync(_pendingMvoChangeAttributesToPersist);
-            _pendingMvoChangeAttributesToPersist.Clear();
-        }
+        await _syncRepo.PersistPendingMvoChangesAsync(
+            _pendingMvoChangesToPersist,
+            _pendingMvoChangeAttributesToPersist);
+        _pendingMvoChangesToPersist.Clear();
+        _pendingMvoChangeAttributesToPersist.Clear();
     }
 
     /// <summary>

--- a/test/JIM.InMemoryData.Tests/SyncRepositoryActivityRpeiTests.cs
+++ b/test/JIM.InMemoryData.Tests/SyncRepositoryActivityRpeiTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
 
 namespace JIM.InMemoryData.Tests;
 
@@ -141,5 +143,140 @@ public class SyncRepositoryActivityRpeiTests
     {
         var rpei = new ActivityRunProfileExecutionItem { Id = Guid.NewGuid() };
         await _repo.PersistRpeiCsoChangesAsync(new List<ActivityRunProfileExecutionItem> { rpei });
+    }
+
+    [Test]
+    public async Task GetRpeisWithMvoChangeIdsForCrossPageMergeAsync_EmptyCsoIds_ReturnsEmptyAsync()
+    {
+        var result = await _repo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+            Guid.NewGuid(), Array.Empty<Guid>());
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetRpeisWithMvoChangeIdsForCrossPageMergeAsync_RpeiWithoutMvoChange_HasNullExistingMvoChangeIdAsync()
+    {
+        var activityId = Guid.NewGuid();
+        var csoId = Guid.NewGuid();
+        var rpei = new ActivityRunProfileExecutionItem
+        {
+            Id = Guid.NewGuid(),
+            ActivityId = activityId,
+            ObjectChangeType = ObjectChangeType.Projected,
+            ConnectedSystemObjectId = csoId
+        };
+        await _repo.BulkInsertRpeisAsync(new List<ActivityRunProfileExecutionItem> { rpei });
+
+        var result = await _repo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+            activityId, new[] { csoId });
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Rpei.Id, Is.EqualTo(rpei.Id));
+        Assert.That(result[0].Rpei.ConnectedSystemObjectId, Is.EqualTo(csoId));
+        Assert.That(result[0].ExistingMvoChangeId, Is.Null);
+    }
+
+    [Test]
+    public async Task GetRpeisWithMvoChangeIdsForCrossPageMergeAsync_RpeiWithMvoChange_MapsExistingMvoChangeIdAsync()
+    {
+        var activityId = Guid.NewGuid();
+        var csoId = Guid.NewGuid();
+        var rpei = new ActivityRunProfileExecutionItem
+        {
+            Id = Guid.NewGuid(),
+            ActivityId = activityId,
+            ObjectChangeType = ObjectChangeType.Projected,
+            ConnectedSystemObjectId = csoId
+        };
+        await _repo.BulkInsertRpeisAsync(new List<ActivityRunProfileExecutionItem> { rpei });
+
+        var mvoChange = new MetaverseObjectChange
+        {
+            Id = Guid.NewGuid(),
+            ActivityRunProfileExecutionItemId = rpei.Id,
+            ChangeType = ObjectChangeType.Projected,
+            ChangeTime = DateTime.UtcNow
+        };
+        await _repo.CreateMetaverseObjectChangeDirectAsync(mvoChange);
+
+        var result = await _repo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+            activityId, new[] { csoId });
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].ExistingMvoChangeId, Is.EqualTo(mvoChange.Id));
+    }
+
+    [Test]
+    public async Task GetRpeisWithMvoChangeIdsForCrossPageMergeAsync_IncludesSyncOutcomesAsync()
+    {
+        var activityId = Guid.NewGuid();
+        var csoId = Guid.NewGuid();
+        var rpei = new ActivityRunProfileExecutionItem
+        {
+            Id = Guid.NewGuid(),
+            ActivityId = activityId,
+            ObjectChangeType = ObjectChangeType.Projected,
+            ConnectedSystemObjectId = csoId
+        };
+        var rootOutcome = new ActivityRunProfileExecutionItemSyncOutcome
+        {
+            Id = Guid.NewGuid(),
+            ActivityRunProfileExecutionItemId = rpei.Id,
+            OutcomeType = ActivityRunProfileExecutionItemSyncOutcomeType.Projected,
+            Ordinal = 0
+        };
+        var childOutcome = new ActivityRunProfileExecutionItemSyncOutcome
+        {
+            Id = Guid.NewGuid(),
+            ActivityRunProfileExecutionItemId = rpei.Id,
+            ParentSyncOutcomeId = rootOutcome.Id,
+            OutcomeType = ActivityRunProfileExecutionItemSyncOutcomeType.AttributeFlow,
+            Ordinal = 0,
+            DetailCount = 3
+        };
+        rpei.SyncOutcomes.Add(rootOutcome);
+        rpei.SyncOutcomes.Add(childOutcome);
+        await _repo.BulkInsertRpeisAsync(new List<ActivityRunProfileExecutionItem> { rpei });
+
+        var result = await _repo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+            activityId, new[] { csoId });
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Rpei.SyncOutcomes, Has.Count.EqualTo(2));
+        Assert.That(result[0].Rpei.SyncOutcomes.Any(o => !o.ParentSyncOutcomeId.HasValue), Is.True,
+            "Root outcome should be present.");
+        Assert.That(result[0].Rpei.SyncOutcomes.Any(o => o.ParentSyncOutcomeId == rootOutcome.Id), Is.True,
+            "Child outcome should be present and linked to the root.");
+    }
+
+    [Test]
+    public async Task GetRpeisWithMvoChangeIdsForCrossPageMergeAsync_FiltersOutDifferentActivityAsync()
+    {
+        var targetActivityId = Guid.NewGuid();
+        var otherActivityId = Guid.NewGuid();
+        var csoId = Guid.NewGuid();
+
+        var targetRpei = new ActivityRunProfileExecutionItem
+        {
+            Id = Guid.NewGuid(),
+            ActivityId = targetActivityId,
+            ObjectChangeType = ObjectChangeType.Projected,
+            ConnectedSystemObjectId = csoId
+        };
+        var otherRpei = new ActivityRunProfileExecutionItem
+        {
+            Id = Guid.NewGuid(),
+            ActivityId = otherActivityId,
+            ObjectChangeType = ObjectChangeType.Projected,
+            ConnectedSystemObjectId = csoId
+        };
+        await _repo.BulkInsertRpeisAsync(new List<ActivityRunProfileExecutionItem> { targetRpei, otherRpei });
+
+        var result = await _repo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+            targetActivityId, new[] { csoId });
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Rpei.Id, Is.EqualTo(targetRpei.Id));
     }
 }

--- a/test/JIM.InMemoryData.Tests/SyncRepositoryMvoTests.cs
+++ b/test/JIM.InMemoryData.Tests/SyncRepositoryMvoTests.cs
@@ -3,6 +3,7 @@
 
 using JIM.Models.Activities;
 using JIM.Models.Core;
+using JIM.Models.Enums;
 using JIM.Models.Exceptions;
 using JIM.Models.Logic;
 using JIM.Models.Staging;
@@ -236,6 +237,96 @@ public class SyncRepositoryMvoTests
         var rule = CreateMatchingRule(1, 10, 5);
         var result = await _repo.FindMatchingMetaverseObjectAsync(cso, new List<ObjectMatchingRule> { rule });
         Assert.That(result, Is.Null);
+    }
+
+    #endregion
+
+    #region PersistPendingMvoChangesAsync (combined new + append)
+
+    [Test]
+    public async Task PersistPendingMvoChangesAsync_BothListsEmpty_NoOpAsync()
+    {
+        await _repo.PersistPendingMvoChangesAsync(
+            new List<MetaverseObjectChange>(),
+            new List<MetaverseObjectChange>());
+
+        Assert.That(_repo.MetaverseObjectChanges, Is.Empty);
+    }
+
+    [Test]
+    public async Task PersistPendingMvoChangesAsync_OnlyNewChanges_InsertsParentsAndChildrenAsync()
+    {
+        var change = BuildNewMvoChange(Guid.NewGuid());
+
+        await _repo.PersistPendingMvoChangesAsync(
+            new List<MetaverseObjectChange> { change },
+            new List<MetaverseObjectChange>());
+
+        Assert.That(change.Id, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(_repo.MetaverseObjectChanges, Has.Count.EqualTo(1));
+        Assert.That(_repo.MetaverseObjectChanges.ContainsKey(change.Id), Is.True);
+    }
+
+    [Test]
+    public async Task PersistPendingMvoChangesAsync_OnlyAppends_AddsAttributeChildrenToExistingParentAsync()
+    {
+        var parent = BuildNewMvoChange(Guid.NewGuid());
+        parent.Id = Guid.NewGuid();
+        await _repo.CreateMetaverseObjectChangeDirectAsync(parent);
+        Assume.That(parent.AttributeChanges, Is.Empty, "Parent starts with no attribute children.");
+
+        var append = new MetaverseObjectChange { Id = parent.Id };
+        append.AttributeChanges.Add(new MetaverseObjectChangeAttribute
+        {
+            AttributeName = "DisplayName",
+            AttributeType = AttributeDataType.Text
+        });
+
+        await _repo.PersistPendingMvoChangesAsync(
+            new List<MetaverseObjectChange>(),
+            new List<MetaverseObjectChange> { append });
+
+        Assert.That(_repo.MetaverseObjectChanges[parent.Id].AttributeChanges, Has.Count.EqualTo(1));
+        Assert.That(_repo.MetaverseObjectChanges[parent.Id].AttributeChanges[0].AttributeName, Is.EqualTo("DisplayName"));
+    }
+
+    [Test]
+    public async Task PersistPendingMvoChangesAsync_BothLists_PersistsAtomicallyAsync()
+    {
+        // Existing parent (from a prior page) receives an attribute append.
+        var existingParent = BuildNewMvoChange(Guid.NewGuid());
+        existingParent.Id = Guid.NewGuid();
+        await _repo.CreateMetaverseObjectChangeDirectAsync(existingParent);
+
+        var append = new MetaverseObjectChange { Id = existingParent.Id };
+        append.AttributeChanges.Add(new MetaverseObjectChangeAttribute
+        {
+            AttributeName = "Manager",
+            AttributeType = AttributeDataType.Reference
+        });
+
+        // New parent for an RPEI persisted this round.
+        var newParent = BuildNewMvoChange(Guid.NewGuid());
+
+        await _repo.PersistPendingMvoChangesAsync(
+            new List<MetaverseObjectChange> { newParent },
+            new List<MetaverseObjectChange> { append });
+
+        Assert.That(_repo.MetaverseObjectChanges, Has.Count.EqualTo(2));
+        Assert.That(_repo.MetaverseObjectChanges[existingParent.Id].AttributeChanges, Has.Count.EqualTo(1));
+        Assert.That(_repo.MetaverseObjectChanges[newParent.Id], Is.Not.Null);
+    }
+
+    private static MetaverseObjectChange BuildNewMvoChange(Guid rpeiId)
+    {
+        return new MetaverseObjectChange
+        {
+            ActivityRunProfileExecutionItemId = rpeiId,
+            ChangeTime = DateTime.UtcNow,
+            ChangeType = ObjectChangeType.Projected,
+            ChangeInitiatorType = MetaverseObjectChangeInitiatorType.SynchronisationRule,
+            InitiatedByType = ActivityInitiatorType.System
+        };
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/FullSyncTests.cs
@@ -3068,8 +3068,10 @@ public class FullSyncTests
 
         // Assert against the persisted RPEI store (simulating the production DB), not the
         // activity's in-memory collection — which is cleared by per-page raw-SQL flushes.
-        var persistedRpeis = await SyncRepo.GetActivityRpeisByCsoIdsForCrossPageMergeAsync(
-            activity.Id, new[] { csoA.Id, csoB.Id });
+        var persistedRpeis = (await SyncRepo.GetRpeisWithMvoChangeIdsForCrossPageMergeAsync(
+            activity.Id, new[] { csoA.Id, csoB.Id }))
+            .Select(x => x.Rpei)
+            .ToList();
 
         var csoAPersistedRpeis = persistedRpeis.Where(r => r.ConnectedSystemObjectId == csoA.Id).ToList();
         Assert.That(csoAPersistedRpeis, Has.Count.EqualTo(1),


### PR DESCRIPTION
## Summary

Tactical follow-ups from the `feature/sync-integrity-and-diagnostics` retro, tracked in #566. Four of the seven items — the ones that are actionable code changes independent of a future driver — landed on this branch. Items #4 (premature abstraction, no current caller) and #6 (long-term thinking item needing a PRD) were skipped; #1 is superseded by #2.

- **#2 — Combine cross-page RPEI lookups into one `NpgsqlBatch` round-trip.** Collapses the two separate DB fetches at the start of `ResolveCrossPageReferencesAsync` (EF-projected RPEIs + `Include(SyncOutcomes)`, then a raw-SQL RPEI→MvoChange id map) into a single `NpgsqlBatch` that ships two statements in one network round-trip and returns a purpose-built `CrossPageMergeRpei` DTO. Replaces the earlier EF materialisation with raw Npgsql, matching the worker hot-path convention. Estimated ~200–500 ms shaved at Scale100K.
- **#3 — Wrap dual MvoChange persist in a single outer transaction.** Collapses `PersistPendingMvoChangesAsync` (new parents + children) and `PersistPendingMvoChangeAttributesAsync` (attribute-only appends to existing parents) into one repository method that opens ONE transaction and runs the attribute/value COPYs for both input sets. Halves `BEGIN`/`COMMIT` round-trips per flush when the cross-page phase produces both; makes the pair atomic.
- **#7 — FK over navigation for remaining `ParentSyncOutcome` checks.** Swaps the two residual `o.ParentSyncOutcome != null` / `== null` sites in `SyncTaskProcessorBase` to `ParentSyncOutcomeId.HasValue`. FK scalars are always populated from row data; navigation checks silently go wrong under a future `AsNoTracking()` without `ThenInclude`. Defensive, no behaviour change on current load paths.
- **#5 — Memory snapshots around `ResolveCrossPageReferencesAsync`.** Adds `GC.GetTotalMemory` + `Environment.WorkingSet` snapshots at phase entry and exit (exit includes deltas against entry). Combined with `docker stats` externally, lets log readers size the cross-page phase's footprint at a glance.

## Test plan

- [x] Unit tests added for new combined cross-page lookup (5 tests) and combined MvoChange persist (4 tests) in `JIM.InMemoryData.Tests`
- [x] Full-solution `dotnet build JIM.sln` — zero warnings, zero errors
- [x] Full-solution `dotnet test JIM.sln` — all tests pass (1565 worker + 685 API + 91 InMemoryData + 183 Models + 42 Utilities + 34 workflow)
- [x] Cross-page workflow tests (`FullSyncTests` cross-page scenarios) pass
- [x] Small integration test run (passed by reviewer during incremental eval)
- [ ] Full integration regression (`Run-IntegrationTests.ps1 -Scenario All -Template Medium`) — recommend running before merge

## Notes

- Scope intentionally does not touch schema or external contracts.
- Each commit is independently reviewable; see individual commit messages for per-item detail.

Closes #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)