### PR TITLE
docs: correct LDAP connector entries and highlight auxiliary class support

### DIFF
--- a/docs/concepts/connected-systems.md
+++ b/docs/concepts/connected-systems.md
@@ -102,10 +102,13 @@ The connector adapts its behaviour to the target directory type (for example, us
 - SSL/TLS and StartTLS support
 - Partition and container discovery
 - Container creation during provisioning
-- Schema discovery for available object types and attributes
+- Schema discovery for **both structural and auxiliary object classes**, so objects whose primary class is auxiliary are first-class citizens
 - Parallel imports for large directories
 - Delta import via the accesslog overlay (OpenLDAP and compatible directories)
 - Active Directory-specific features (`userAccountControl`, FILETIME dates, etc.)
+
+!!! tip "Auxiliary classes are fully supported"
+    Some traditional ILM solutions only discover **structural** object classes, which forces customers whose directories rely on **auxiliary** classes as primary classes to build and maintain their own connectors at significant cost. JIM handles this out of the box: enable **Include Auxiliary Classes** on the LDAP connector and auxiliary classes, along with any attributes they contribute, are brought into schema discovery alongside structural classes.
 
 ## Planned Connectors
 

--- a/docs/concepts/connected-systems.md
+++ b/docs/concepts/connected-systems.md
@@ -86,24 +86,26 @@ The File Connector imports from and exports to **CSV and delimited text files**.
 - Auto-confirm export (changes are written directly to the output file)
 - Suitable for integrating with systems that produce flat-file extracts (HR exports, batch feeds, etc.)
 
-### JIM LDAP Connector (Active Directory)
+### JIM LDAP Connector
 
-The LDAP Connector supports **Active Directory** and **Samba AD** directories. It provides:
+The LDAP Connector is a single, unified connector for **LDAP-compliant directories**. Supported directory servers include:
 
-- Full import and export (create, update, delete)
+- **Microsoft Active Directory**
+- **Samba AD**
+- **OpenLDAP**
+- **389 Directory Server** and other RFC 4512-compliant directories
+
+The connector adapts its behaviour to the target directory type (for example, using Active Directory-specific features where available, or RFC-standard behaviour for generic directories). Key capabilities:
+
+- Full and delta import
+- Full export (create, update, delete)
 - SSL/TLS and StartTLS support
+- Partition and container discovery
 - Container creation during provisioning
 - Schema discovery for available object types and attributes
-- Active Directory-specific features (userAccountControl, FILETIME dates, etc.)
-
-### JIM LDAP Connector (OpenLDAP / RFC 4512)
-
-The OpenLDAP Connector supports **OpenLDAP**, **389 Directory Server**, and other **RFC 4512-compliant** directories. It includes:
-
 - Parallel imports for large directories
-- Delta import via the accesslog overlay
-- Partition-scoped imports
-- Full export support (create, update, delete)
+- Delta import via the accesslog overlay (OpenLDAP and compatible directories)
+- Active Directory-specific features (`userAccountControl`, FILETIME dates, etc.)
 
 ## Planned Connectors
 


### PR DESCRIPTION
## Summary

Follow-up fixes to `docs/concepts/connected-systems.md` after the recent Partitions cleanup.

- Collapsed the two fabricated LDAP connector entries (`JIM LDAP Connector (Active Directory)` and `JIM LDAP Connector (OpenLDAP / RFC 4512)`) into a single `JIM LDAP Connector` section. There is only one `LdapConnector` class in `src/JIM.Connectors/LDAP/`; it adapts its behaviour to the target directory type and supports Active Directory, Samba AD, OpenLDAP, 389 Directory Server, and other RFC 4512-compliant directories.
- Strengthened the schema-discovery bullet to call out support for **both structural and auxiliary object classes**.
- Added a concise `!!! tip` callout highlighting full auxiliary-class support as a differentiator, using the CLAUDE.md-approved generic phrasing ("traditional ILM solutions") rather than naming any third-party product. The callout points readers at the exact opt-in setting name (`Include Auxiliary Classes`) so it is actionable.

This is a docs-only change, so no `dotnet build` or `dotnet test` is required (per the Exceptions list in `CLAUDE.md`).

## Test plan

- [ ] Review rendered `concepts/connected-systems/` page locally or in a docs preview to confirm the single LDAP connector section reads cleanly and the tip admonition renders as expected
- [ ] Confirm no references to separate AD/OpenLDAP connectors remain on the page
- [ ] Confirm no third-party ILM product names were introduced

https://claude.ai/code/session_01MLqDUc9LMR3ENHKqNQYw69