### PR TITLE
fix(security): patch CVE-2026-33116 + bump safe Microsoft 10.0.x packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🖥️ Page footer now links the Tetron name to tetron.io and includes a GitHub link next to the version number (#49)
 - 📦 File Connector storage uses the formal Docker named volume `jim-connector-files-volume`, mounted at `/connector-files` inside JIM Web and JIM Worker. Default deployments get working File Connector exports out of the box without any host-side permission setup. Customers integrating with external file shares bind-mount over a subdirectory of `/connector-files`. See the JIM File Connector documentation for both patterns.
 
+### Security
+
+- 🔒 Patched transitive `System.Security.Cryptography.Xml` to 10.0.6 to address CVE-2026-33116 (low-severity DoS in `EncryptedXml`); the package is pulled in via ASP.NET Core Data Protection but not used by JIM at runtime
+
 ## [0.9.1] - 2026-04-08
 
 ### Added

--- a/src/JIM.Application/JIM.Application.csproj
+++ b/src/JIM.Application/JIM.Application.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
+    <!-- Transitive override: pulled in by Microsoft.AspNetCore.DataProtection.Extensions 10.0.5,
+         which carries System.Security.Cryptography.Xml 10.0.5 (CVE-2026-33116, GHSA-37gx-xxp4-5rgx,
+         GHSA-w3x6-4m5h-cxqf). DataProtection 10.0.6 has a regression breaking round-trip MAC
+         validation, so we pin the underlying package to 10.0.6 instead of bumping DataProtection. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JIM.Connectors/JIM.Connectors.csproj
+++ b/src/JIM.Connectors/JIM.Connectors.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.5" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.6" />
     <PackageReference Include="DNParser" Version="1.3.5" />
   </ItemGroup>
 

--- a/src/JIM.Models/JIM.Models.csproj
+++ b/src/JIM.Models/JIM.Models.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
     <PackageReference Include="Serilog" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/JIM.PostgresData/JIM.PostgresData.csproj
+++ b/src/JIM.PostgresData/JIM.PostgresData.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/JIM.Scheduler/JIM.Scheduler.csproj
+++ b/src/JIM.Scheduler/JIM.Scheduler.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <!-- Transitive override: see JIM.Application.csproj for rationale (CVE-2026-33116). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/src/JIM.Scheduler/JIM.Scheduler.csproj
+++ b/src/JIM.Scheduler/JIM.Scheduler.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
     <!-- Transitive override: see JIM.Application.csproj for rationale (CVE-2026-33116). -->
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />

--- a/src/JIM.Web/JIM.Web.csproj
+++ b/src/JIM.Web/JIM.Web.csproj
@@ -15,15 +15,15 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0-preview.2" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0-preview.2" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.13.22" />
     <PackageReference Include="MudBlazor" Version="9.3.0" />
   </ItemGroup>

--- a/src/JIM.Worker/JIM.Worker.csproj
+++ b/src/JIM.Worker/JIM.Worker.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
     <!-- Transitive override: see JIM.Application.csproj for rationale (CVE-2026-33116). -->
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />

--- a/src/JIM.Worker/JIM.Worker.csproj
+++ b/src/JIM.Worker/JIM.Worker.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <!-- Transitive override: see JIM.Application.csproj for rationale (CVE-2026-33116). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/test/JIM.Web.Api.Tests/JIM.Web.Api.Tests.csproj
+++ b/test/JIM.Web.Api.Tests/JIM.Web.Api.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/test/JIM.Worker.Tests/JIM.Worker.Tests.csproj
+++ b/test/JIM.Worker.Tests/JIM.Worker.Tests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EntityFramework" Version="6.5.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="MockQueryable.EntityFrameworkCore" Version="10.0.5" />
         <PackageReference Include="MockQueryable.Moq" Version="10.0.5" />

--- a/test/JIM.Workflow.Tests/JIM.Workflow.Tests.csproj
+++ b/test/JIM.Workflow.Tests/JIM.Workflow.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="4.5.1" />


### PR DESCRIPTION
## Summary

- **Security:** Patches transitive \`System.Security.Cryptography.Xml\` to 10.0.6 to address CVE-2026-33116 (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf). Restore was failing on \`main\` because \`Directory.Build.props\` promotes NU1901 to error.
- **Patch bumps:** Microsoft 10.0.5 → 10.0.6 across EF Core, ASP.NET Core auth/OpenAPI, \`Microsoft.Extensions.Hosting\`, and \`System.DirectoryServices.Protocols\`.
- **Held back:** \`Microsoft.AspNetCore.DataProtection\` / \`.Extensions\` 10.0.6 — proven to break round-trip MAC validation in \`CredentialProtectionService\` (5 tests fail). Pinning the underlying \`System.Security.Cryptography.Xml\` directly is the minimum-impact fix and avoids the regression.

JIM does not use \`EncryptedXml\` at runtime; the advisory was triggered purely by transitive presence.

## Test plan

- [x] \`dotnet build JIM.sln\` — 0 warnings, 0 errors
- [x] \`dotnet test JIM.sln\` — 2,604 passed, 0 failed
- [x] \`CredentialProtectionService\` round-trip tests pass (verified DataProtection 10.0.6 regression repro before settling on transitive pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)