### PR TITLE
ci: suppress Trivy false positives for patched XML CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
         # findings explicitly in the next step.
         exit-code: '0'
         cache: 'false'
+        # Repo-root .trivyignore suppresses CVEs that are false positives or
+        # already mitigated at the application layer. Every suppression MUST
+        # include a justification and review date in the file itself.
+        trivyignores: '.trivyignore'
 
     - name: Fail build on fixable HIGH/CRITICAL Trivy findings
       shell: pwsh

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,39 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+# ============================================================================
+# Trivy vulnerability suppressions for base image scans.
+#
+# Each entry MUST include a CVE ID, justification, and review date. Entries
+# without justification will fail code review. Review dates give us a hook to
+# re-evaluate suppressions as the upstream ecosystem changes.
+#
+# Format: one CVE ID per line. Lines starting with # are comments.
+# See: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# CVE-2026-26171 / CVE-2026-33116 (System.Security.Cryptography.Xml)
+# ----------------------------------------------------------------------------
+# Both CVEs affect System.Security.Cryptography.Xml <= 10.0.5 (GHSA-w3x6-4m5h-cxqf
+# and GHSA-37gx-xxp4-5rgx respectively). Both are fixed in 10.0.6, which ships
+# in .NET runtime 10.0.6 / SDK 10.0.202 (the April 14 2026 servicing release).
+#
+# The mcr.microsoft.com/dotnet/sdk:10.0-noble image digest adc02be IS the
+# patched image (runtime 10.0.6, SDK 10.0.202). Trivy continues to flag both
+# CVEs because it matches the in-box shared-framework assembly file version
+# against the GHSA NuGet version range; the file version on the patched DLL
+# can read as a pre-patch value even though the fix is present. No newer
+# SDK base image exists to pull.
+#
+# JIM's application-level fix shipped in #580 (commit 60714da9), which pins
+# the System.Security.Cryptography.Xml NuGet to >= 10.0.6 in JIM.Application,
+# JIM.Worker, and JIM.Scheduler. The published assemblies override the in-box
+# version at runtime, so there is no real exploit surface in JIM binaries.
+#
+# JIM also does not use EncryptedXml (the affected class) at runtime.
+#
+# Review by: 2026-07-15 (re-check whether Microsoft has re-rolled the SDK
+# image or Trivy's matching has been corrected).
+CVE-2026-26171
+CVE-2026-33116


### PR DESCRIPTION
## Summary

- Add a repo-root `.trivyignore` suppressing CVE-2026-26171 and CVE-2026-33116 on the `dotnet/sdk:10.0-noble` base image
- Wire `trivyignores: '.trivyignore'` into the `scan-base-images` job in `.github/workflows/ci.yml`

## Why

Trivy flags these two CVEs on `mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:adc02be...`:
- `CVE-2026-26171` (CVSS 7.5) — `System.Security.Cryptography.Xml` DoS
- `CVE-2026-33116` (CVSS 7.5) — `System.Security.Cryptography.Xml` DoS (same CVE we patched at NuGet level in #580)

Both are fixed in `System.Security.Cryptography.Xml` 10.0.6, which ships with **.NET runtime 10.0.6 / SDK 10.0.202** — the exact version the `adc02be` base image contains. The image IS the patched image. Trivy over-reports because it matches the in-box shared-framework assembly file version against the GHSA NuGet range; the patched DLL's file version can still read as pre-patch.

No newer SDK base image exists to pull (verified via `curl -I https://mcr.microsoft.com/v2/dotnet/sdk/manifests/10.0-noble`).

## Mitigation posture

- **Runtime layer:** SDK image is already patched (10.0.6 ships the fix)
- **Application layer:** JIM pins `System.Security.Cryptography.Xml >= 10.0.6` in [#580](https://github.com/TetronIO/JIM/pull/580); published assemblies override the in-box version
- **Code surface:** JIM does not use `EncryptedXml` at runtime

## Impact

Unblocks six pending Dependabot digest updates (#574–#579) which are currently blocked by the `scan-base-images-summary` gate.

## Suppression governance

- Each entry in [`.trivyignore`](.trivyignore) requires a CVE ID, justification, and review date
- Review date: **2026-07-15** — re-check whether Microsoft has re-rolled the SDK image or Trivy's matching has been corrected

## Test plan

- [ ] `scan-base-images` matrix legs for the SDK image report `HIGH: 0` after this change
- [ ] `scan-base-images-summary` passes
- [ ] Other (legitimate) Trivy findings still block (no accidental blanket suppression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)