### PR TITLE
fix(#564): pinpoint partition-configuration gaps in validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ Host fingerprinting for fair cross-environment performance comparison (#476)
 - ✨ Cross-repo sync workflow to keep metrics infrastructure aligned with span contract changes (#476)
 
+### Changed
+
+- 🖥️ Partition-configuration validation errors now pinpoint the exact gap (hierarchy not imported, no partitions selected, or selected partitions have no container selected) and name the partition involved, replacing the previous generic "no partitions or containers have been selected" message and making misconfigurations far faster to diagnose (#564)
+
 ### Fixed
 
 - 🐛 Group and other multi-valued-reference sync activities no longer produce duplicate execution items; cross-page reference resolution now merges reference attribute flow into the original Projected/Joined record instead of creating a second standalone "Attribute Flow" record for the same object. Fixes inflated activity counts and removes the confusing split-outcome rows that appeared in activity detail

--- a/src/JIM.Application/Servers/TaskingServer.cs
+++ b/src/JIM.Application/Servers/TaskingServer.cs
@@ -176,7 +176,8 @@ namespace JIM.Application.Servers
 
             // Connector supports partitions but none are selected - check the validation mode setting
             var validationMode = await Application.ServiceSettings.GetPartitionValidationModeAsync();
-            var message = $"Connected System '{connectedSystem.Name}' supports partitions but no partitions or containers have been selected. " +
+            var diagnostic = connectedSystem.BuildPartitionSelectionDiagnostic();
+            var message = $"Connected System '{connectedSystem.Name}' has incomplete partition configuration: {diagnostic}. " +
                           "Import operations will return no objects. Please configure partition and container selections on the Connected System's Partitions & Containers tab.";
 
             if (validationMode == PartitionValidationMode.Error)

--- a/src/JIM.Models/Staging/ConnectedSystemExtensions.cs
+++ b/src/JIM.Models/Staging/ConnectedSystemExtensions.cs
@@ -123,4 +123,56 @@ public static class ConnectedSystemExtensions
 
         return false;
     }
+
+    /// <summary>
+    /// Produces a diagnostic description of why <see cref="HasPartitionsOrContainersSelected"/> would return <c>false</c>,
+    /// suitable for embedding in user-facing error and warning messages.
+    /// </summary>
+    /// <remarks>
+    /// The returned string identifies which stage of partition configuration is incomplete:
+    /// the hierarchy has not been imported, partitions have been enumerated but none are selected,
+    /// or a partition is selected but no container within it is. Callers are expected to have already
+    /// determined that selection is incomplete; the return value for a valid configuration is undefined.
+    /// </remarks>
+    public static string BuildPartitionSelectionDiagnostic(this ConnectedSystem connectedSystem)
+    {
+        ArgumentNullException.ThrowIfNull(connectedSystem);
+
+        var partitions = connectedSystem.Partitions;
+        if (partitions == null || partitions.Count == 0)
+            return "the partition hierarchy has not been imported: run a partition hierarchy import before selecting partitions";
+
+        var selectedPartitions = partitions.Where(p => p.Selected).ToList();
+        if (selectedPartitions.Count == 0)
+            return $"{partitions.Count} partition(s) are available but none are selected";
+
+        var supportsContainers = connectedSystem.ConnectorDefinition?.SupportsPartitionContainers ?? false;
+        if (!supportsContainers)
+        {
+            // HasPartitionsOrContainersSelected would have returned true in this path; retain a sensible fallback.
+            return $"{selectedPartitions.Count} partition(s) are selected but validation still reports the configuration as incomplete";
+        }
+
+        var selectedNames = string.Join(", ", selectedPartitions.Select(p => $"'{p.Name}'"));
+        var totalContainers = selectedPartitions.Sum(p => p.Containers != null ? CountContainersRecursively(p.Containers) : 0);
+        if (totalContainers == 0)
+            return $"selected partition(s) {selectedNames} contain no enumerated containers: import the partition hierarchy to populate containers";
+
+        return $"{totalContainers} container(s) exist under selected partition(s) {selectedNames} but none are selected";
+    }
+
+    /// <summary>
+    /// Counts every container in the tree rooted at the supplied collection, including nested descendants.
+    /// </summary>
+    private static int CountContainersRecursively(IEnumerable<ConnectedSystemContainer> containers)
+    {
+        var count = 0;
+        foreach (var container in containers)
+        {
+            count++;
+            if (container.ChildContainers.Count > 0)
+                count += CountContainersRecursively(container.ChildContainers);
+        }
+        return count;
+    }
 }

--- a/test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs
+++ b/test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs
@@ -586,6 +586,130 @@ public class ConnectedSystemExtensionsTests
 
     #endregion
 
+    #region BuildPartitionSelectionDiagnostic Tests
+
+    [Test]
+    public void BuildPartitionSelectionDiagnostic_WhenNoPartitionsEnumerated_ReportsMissingEnumeration()
+    {
+        // Arrange - Connector supports partitions but none have been imported/enumerated yet
+        var connectedSystem = CreateConnectedSystemWithPartitionSupport(supportsPartitions: true, supportsContainers: true);
+        connectedSystem.Partitions = null;
+
+        // Act
+        var result = connectedSystem.BuildPartitionSelectionDiagnostic();
+
+        // Assert - message must indicate the hierarchy has not been imported
+        Assert.That(result, Does.Contain("hierarchy"));
+        Assert.That(result, Does.Contain("not").IgnoreCase.Or.Contain("before").IgnoreCase);
+    }
+
+    [Test]
+    public void BuildPartitionSelectionDiagnostic_WhenPartitionsEmpty_ReportsMissingEnumeration()
+    {
+        // Arrange - Partitions list exists but is empty (enumeration ran and returned nothing)
+        var connectedSystem = CreateConnectedSystemWithPartitionSupport(supportsPartitions: true, supportsContainers: true);
+        connectedSystem.Partitions = new List<ConnectedSystemPartition>();
+
+        // Act
+        var result = connectedSystem.BuildPartitionSelectionDiagnostic();
+
+        // Assert
+        Assert.That(result, Does.Contain("hierarchy"));
+    }
+
+    [Test]
+    public void BuildPartitionSelectionDiagnostic_WhenPartitionsExistButNoneSelected_ReportsAvailableCount()
+    {
+        // Arrange - Hierarchy enumerated, multiple partitions present, none selected
+        var connectedSystem = CreateConnectedSystemWithPartitionSupport(supportsPartitions: true, supportsContainers: true);
+        connectedSystem.Partitions = new List<ConnectedSystemPartition>
+        {
+            new() { Name = "DC=resurgam,DC=local", Selected = false },
+            new() { Name = "CN=Configuration,DC=resurgam,DC=local", Selected = false },
+            new() { Name = "CN=Schema,CN=Configuration,DC=resurgam,DC=local", Selected = false }
+        };
+
+        // Act
+        var result = connectedSystem.BuildPartitionSelectionDiagnostic();
+
+        // Assert - must report how many partitions were available to aid diagnosis
+        Assert.That(result, Does.Contain("3"));
+        Assert.That(result, Does.Contain("partition").IgnoreCase);
+        Assert.That(result, Does.Contain("none").IgnoreCase.Or.Contain("0 selected").IgnoreCase);
+    }
+
+    [Test]
+    public void BuildPartitionSelectionDiagnostic_WhenPartitionSelectedButContainersNull_ReportsMissingContainers()
+    {
+        // Arrange - Partition selected, containers under it have not been enumerated
+        var connectedSystem = CreateConnectedSystemWithPartitionSupport(supportsPartitions: true, supportsContainers: true);
+        connectedSystem.Partitions = new List<ConnectedSystemPartition>
+        {
+            new() { Name = "DC=resurgam,DC=local", Selected = true, Containers = null }
+        };
+
+        // Act
+        var result = connectedSystem.BuildPartitionSelectionDiagnostic();
+
+        // Assert
+        Assert.That(result, Does.Contain("container").IgnoreCase);
+        Assert.That(result, Does.Contain("DC=resurgam,DC=local"));
+    }
+
+    [Test]
+    public void BuildPartitionSelectionDiagnostic_WhenPartitionSelectedButNoContainersSelected_ReportsAvailableContainerCount()
+    {
+        // Arrange - Partition selected, containers available but none selected
+        var connectedSystem = CreateConnectedSystemWithPartitionSupport(supportsPartitions: true, supportsContainers: true);
+        var partition = new ConnectedSystemPartition
+        {
+            Name = "DC=resurgam,DC=local",
+            Selected = true,
+            Containers = new HashSet<ConnectedSystemContainer>
+            {
+                new() { Name = "OU=Corp", Selected = false },
+                new() { Name = "OU=Other", Selected = false }
+            }
+        };
+        connectedSystem.Partitions = new List<ConnectedSystemPartition> { partition };
+
+        // Act
+        var result = connectedSystem.BuildPartitionSelectionDiagnostic();
+
+        // Assert - must tell the admin containers exist and need selecting, and how many
+        Assert.That(result, Does.Contain("container").IgnoreCase);
+        Assert.That(result, Does.Contain("2"));
+        Assert.That(result, Does.Contain("DC=resurgam,DC=local"));
+    }
+
+    [Test]
+    public void BuildPartitionSelectionDiagnostic_CountsContainersRecursively()
+    {
+        // Arrange - Nested container tree (matches Samba AD "OU=Users,OU=Corp" layout)
+        var connectedSystem = CreateConnectedSystemWithPartitionSupport(supportsPartitions: true, supportsContainers: true);
+        var corp = new ConnectedSystemContainer { Name = "OU=Corp", Selected = false };
+        var users = new ConnectedSystemContainer { Name = "OU=Users", Selected = false };
+        var entitlements = new ConnectedSystemContainer { Name = "OU=Entitlements", Selected = false };
+        corp.AddChildContainer(users);
+        corp.AddChildContainer(entitlements);
+
+        var partition = new ConnectedSystemPartition
+        {
+            Name = "DC=resurgam,DC=local",
+            Selected = true,
+            Containers = new HashSet<ConnectedSystemContainer> { corp }
+        };
+        connectedSystem.Partitions = new List<ConnectedSystemPartition> { partition };
+
+        // Act
+        var result = connectedSystem.BuildPartitionSelectionDiagnostic();
+
+        // Assert - must count corp + users + entitlements = 3 containers in the tree
+        Assert.That(result, Does.Contain("3"));
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static ConnectedSystem CreateConnectedSystemWithMode(string mode)

--- a/test/JIM.Worker.Tests/Servers/TaskingServerPartitionValidationTests.cs
+++ b/test/JIM.Worker.Tests/Servers/TaskingServerPartitionValidationTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Staging;
+using JIM.Models.Tasking;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Tests for TaskingServer's partition/container selection validation, invoked from
+/// <see cref="JIM.Application.Servers.TaskingServer.CreateWorkerTaskAsync"/> when a
+/// <see cref="SynchronisationWorkerTask"/> is submitted.
+/// </summary>
+[TestFixture]
+public class TaskingServerPartitionValidationTests
+{
+    private const int ConnectedSystemId = 42;
+
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IConnectedSystemRepository> _mockConnectedSystemRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepository = null!;
+    private Mock<ITaskingRepository> _mockTaskingRepository = null!;
+    private Mock<IActivityRepository> _mockActivityRepository = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _mockRepository = new Mock<IRepository>();
+        _mockConnectedSystemRepository = new Mock<IConnectedSystemRepository>();
+        _mockServiceSettingsRepository = new Mock<IServiceSettingsRepository>();
+        _mockTaskingRepository = new Mock<ITaskingRepository>();
+        _mockActivityRepository = new Mock<IActivityRepository>();
+
+        _mockRepository.Setup(r => r.ConnectedSystems).Returns(_mockConnectedSystemRepository.Object);
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepository.Object);
+        _mockRepository.Setup(r => r.Tasking).Returns(_mockTaskingRepository.Object);
+        _mockRepository.Setup(r => r.Activity).Returns(_mockActivityRepository.Object);
+
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task CreateWorkerTaskAsync_WhenConnectedSystemNotFound_ReturnsFailed()
+    {
+        // Arrange
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, false))
+            .ReturnsAsync((ConnectedSystem?)null);
+
+        // Act
+        var result = await _application.Tasking.CreateWorkerTaskAsync(BuildSyncTask());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("Connected System not found").IgnoreCase);
+        });
+        _mockTaskingRepository.Verify(r => r.CreateWorkerTaskAsync(It.IsAny<WorkerTask>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CreateWorkerTaskAsync_WhenHierarchyNotEnumerated_ReturnsFailedWithDiagnosticMessage()
+    {
+        // Arrange — connector supports partitions, but none have been enumerated (Partitions == null)
+        var connectedSystem = BuildLdapConnectedSystem();
+        connectedSystem.Partitions = null;
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, false))
+            .ReturnsAsync(connectedSystem);
+        _mockServiceSettingsRepository.Setup(r => r.GetSettingAsync(Constants.SettingKeys.PartitionValidationMode))
+            .ReturnsAsync((ServiceSetting?)null); // defaults to Error mode
+
+        // Act
+        var result = await _application.Tasking.CreateWorkerTaskAsync(BuildSyncTask());
+
+        // Assert — error message must name the system and cite the specific incomplete-configuration reason
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("Resurgam AD"));
+            Assert.That(result.ErrorMessage, Does.Contain("hierarchy"));
+            Assert.That(result.ErrorMessage, Does.Contain("Partitions & Containers"));
+        });
+    }
+
+    [Test]
+    public async Task CreateWorkerTaskAsync_WhenPartitionsEnumeratedButNoneSelected_ReturnsFailedWithCount()
+    {
+        // Arrange
+        var connectedSystem = BuildLdapConnectedSystem();
+        connectedSystem.Partitions = new List<ConnectedSystemPartition>
+        {
+            new() { Name = "DC=resurgam,DC=local", Selected = false },
+            new() { Name = "CN=Configuration,DC=resurgam,DC=local", Selected = false }
+        };
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, false))
+            .ReturnsAsync(connectedSystem);
+        _mockServiceSettingsRepository.Setup(r => r.GetSettingAsync(Constants.SettingKeys.PartitionValidationMode))
+            .ReturnsAsync((ServiceSetting?)null);
+
+        // Act
+        var result = await _application.Tasking.CreateWorkerTaskAsync(BuildSyncTask());
+
+        // Assert — message must include the partition count to aid diagnosis
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("2"));
+            Assert.That(result.ErrorMessage, Does.Contain("none").IgnoreCase);
+        });
+    }
+
+    [Test]
+    public async Task CreateWorkerTaskAsync_WhenPartitionSelectedButNoContainerSelected_ReturnsFailedNamingThePartition()
+    {
+        // Arrange — mirrors the Samba AD scenario where the partition is selected but the nested
+        // OU=Users,OU=Corp containers were not selected (root cause suspected behind issue #564).
+        var connectedSystem = BuildLdapConnectedSystem();
+        var corp = new ConnectedSystemContainer { Name = "OU=Corp", Selected = false };
+        var users = new ConnectedSystemContainer { Name = "OU=Users", Selected = false };
+        corp.AddChildContainer(users);
+        connectedSystem.Partitions = new List<ConnectedSystemPartition>
+        {
+            new()
+            {
+                Name = "DC=resurgam,DC=local",
+                Selected = true,
+                Containers = new HashSet<ConnectedSystemContainer> { corp }
+            }
+        };
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, false))
+            .ReturnsAsync(connectedSystem);
+        _mockServiceSettingsRepository.Setup(r => r.GetSettingAsync(Constants.SettingKeys.PartitionValidationMode))
+            .ReturnsAsync((ServiceSetting?)null);
+
+        // Act
+        var result = await _application.Tasking.CreateWorkerTaskAsync(BuildSyncTask());
+
+        // Assert — error must name the selected partition and indicate containers exist but none selected
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("container").IgnoreCase);
+            Assert.That(result.ErrorMessage, Does.Contain("DC=resurgam,DC=local"));
+            Assert.That(result.ErrorMessage, Does.Contain("2")); // 2 containers in the tree (Corp + Users)
+        });
+    }
+
+    [Test]
+    public async Task CreateWorkerTaskAsync_WhenValidationModeIsWarning_DoesNotBlockButWarningSurfaces()
+    {
+        // Arrange — partition configuration is incomplete, but validation mode is Warning (permissive)
+        var connectedSystem = BuildLdapConnectedSystem();
+        connectedSystem.Partitions = null;
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, false))
+            .ReturnsAsync(connectedSystem);
+        _mockServiceSettingsRepository.Setup(r => r.GetSettingAsync(Constants.SettingKeys.PartitionValidationMode))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.PartitionValidationMode,
+                DisplayName = "Partition Validation Mode",
+                ValueType = ServiceSettingValueType.Enum,
+                Value = PartitionValidationMode.Warning.ToString()
+            });
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemRunProfilesAsync(ConnectedSystemId))
+            .ReturnsAsync(new List<ConnectedSystemRunProfile>
+            {
+                new() { Id = 100, Name = "Full Import", RunType = ConnectedSystemRunType.FullImport }
+            });
+
+        // Act
+        var result = await _application.Tasking.CreateWorkerTaskAsync(BuildSyncTask());
+
+        // Assert — task should be created despite incomplete config, with the diagnostic surfaced as a warning
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Warnings, Has.Count.GreaterThan(0));
+            Assert.That(result.Warnings[0], Does.Contain("hierarchy"));
+        });
+        _mockTaskingRepository.Verify(r => r.CreateWorkerTaskAsync(It.IsAny<WorkerTask>()), Times.Once);
+    }
+
+    [Test]
+    public async Task CreateWorkerTaskAsync_WhenPartitionSelectionIsComplete_DoesNotBlock()
+    {
+        // Arrange — fully configured: partition selected, container selected
+        var connectedSystem = BuildLdapConnectedSystem();
+        var corp = new ConnectedSystemContainer { Name = "OU=Corp", Selected = false };
+        var users = new ConnectedSystemContainer { Name = "OU=Users", Selected = true };
+        corp.AddChildContainer(users);
+        connectedSystem.Partitions = new List<ConnectedSystemPartition>
+        {
+            new()
+            {
+                Name = "DC=resurgam,DC=local",
+                Selected = true,
+                Containers = new HashSet<ConnectedSystemContainer> { corp }
+            }
+        };
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, false))
+            .ReturnsAsync(connectedSystem);
+        _mockConnectedSystemRepository.Setup(r => r.GetConnectedSystemRunProfilesAsync(ConnectedSystemId))
+            .ReturnsAsync(new List<ConnectedSystemRunProfile>
+            {
+                new() { Id = 100, Name = "Full Import", RunType = ConnectedSystemRunType.FullImport }
+            });
+
+        // Act
+        var result = await _application.Tasking.CreateWorkerTaskAsync(BuildSyncTask());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Warnings, Is.Empty);
+        });
+        _mockTaskingRepository.Verify(r => r.CreateWorkerTaskAsync(It.IsAny<WorkerTask>()), Times.Once);
+        // ServiceSettings should not even be consulted when the configuration is valid
+        _mockServiceSettingsRepository.Verify(r => r.GetSettingAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    #region Helper methods
+
+    private static SynchronisationWorkerTask BuildSyncTask()
+    {
+        return new SynchronisationWorkerTask
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = ConnectedSystemId,
+            ConnectedSystemRunProfileId = 100,
+            Status = WorkerTaskStatus.Queued,
+            InitiatedByType = ActivityInitiatorType.User,
+            InitiatedById = Guid.NewGuid(),
+            InitiatedByName = "test-user"
+        };
+    }
+
+    private static ConnectedSystem BuildLdapConnectedSystem()
+    {
+        return new ConnectedSystem
+        {
+            Id = ConnectedSystemId,
+            Name = "Resurgam AD",
+            SettingValues = new List<ConnectedSystemSettingValue>(),
+            ConnectorDefinition = new ConnectorDefinition
+            {
+                Name = "LDAP",
+                SupportsPartitions = true,
+                SupportsPartitionContainers = true
+            }
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Replaces the generic "no partitions or containers have been selected" 400 with a precise diagnostic that names the partition and the stage of partition setup that is incomplete (hierarchy not imported, no partitions selected, selected partition has no containers enumerated, or containers exist but none selected).
- Adds a reusable `ConnectedSystem.BuildPartitionSelectionDiagnostic()` helper alongside the existing `HasPartitionsOrContainersSelected()` check.
- Unit tests cover both the new helper (6 tests) and the `CreateWorkerTaskAsync` Error / Warning / Valid / NotFound branches that embed the diagnostic (6 tests).

## Context & scope
The original issue (#564) suspected that Samba AD shouldn't support partitions. Investigation showed that premise is wrong — Samba AD naming contexts **are** partitions, and the validation logic is correct. What was missing was a diagnostic precise enough to point at the *real* problem.

With this change deployed to a live Samba AD reproduction, the improved error immediately identified the actual defect: `LdapConnectorPartitions.GetPartitionContainers` returns only the direct-child containers of the partition root instead of the full subtree, so nested OUs like `OU=Users,OU=Corp` are never enumerated and therefore never selectable. **That is a separate LDAP-side bug and is being tracked in a new issue.** This PR is scoped purely to the diagnostic improvement on the validation side.

## Files changed (behaviour)
- [src/JIM.Models/Staging/ConnectedSystemExtensions.cs](src/JIM.Models/Staging/ConnectedSystemExtensions.cs): new `BuildPartitionSelectionDiagnostic()` extension method.
- [src/JIM.Application/Servers/TaskingServer.cs](src/JIM.Application/Servers/TaskingServer.cs): embeds the diagnostic in the error/warning message.
- [CHANGELOG.md](CHANGELOG.md): entry under `[Unreleased] > Changed`.
- Tests in [test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs](test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs) and [test/JIM.Worker.Tests/Servers/TaskingServerPartitionValidationTests.cs](test/JIM.Worker.Tests/Servers/TaskingServerPartitionValidationTests.cs).

## Test plan
- [x] `dotnet build JIM.sln` — 0 errors, 0 warnings
- [x] `dotnet test JIM.sln` — all tests pass
- [x] New unit tests cover each diagnostic branch plus all TaskingServer validation outcomes
- [x] Live reproduction against Samba AD confirmed the improved error text correctly identifies the configuration gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)