### PR TITLE
fix(deps): override basic-ftp >=5.3.0 to patch GHSA-rp42-5vxx-qpwr

### DIFF
--- a/engineering/diagrams/structurizr/package-lock.json
+++ b/engineering/diagrams/structurizr/package-lock.json
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -375,7 +375,8 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/engineering/diagrams/structurizr/package.json
+++ b/engineering/diagrams/structurizr/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "puppeteer": "^24.0.0"
+  },
+  "overrides": {
+    "basic-ftp": ">=5.3.0"
   }
 }


### PR DESCRIPTION
## Summary

- Closes [Dependabot alert #11](https://github.com/TetronIO/JIM/security/dependabot/11) — `basic-ftp` DoS via unbounded memory in `Client.list()` ([GHSA-rp42-5vxx-qpwr](https://github.com/advisories/GHSA-rp42-5vxx-qpwr), High, CVSS 7.5).
- Adds an `overrides` entry in [engineering/diagrams/structurizr/package.json](engineering/diagrams/structurizr/package.json) forcing `basic-ftp >= 5.3.0`; regenerates the lockfile so the transitive bump (from 5.2.2 to 5.3.0) takes effect immediately without waiting for Puppeteer's upstream chain.

## Why this is a minimal-risk change

- `basic-ftp` is pulled in transitively via `puppeteer` → `@puppeteer/browsers` → proxy-agent chain.
- Puppeteer is used only by developer tooling ([export-diagrams.js](engineering/diagrams/structurizr/export-diagrams.js)) to export SVGs from a local Structurizr instance. It is **not** shipped in any Docker image, and JIM does not invoke `Client.list()` against any FTP server, so the vulnerable code path is unreachable.
- The override is the cleanest way to close the alert now; it can be removed once Puppeteer's transitive graph catches up.

## Verification

- `npm install --package-lock-only --ignore-scripts` in `engineering/diagrams/structurizr/` regenerates the lockfile with `basic-ftp@5.3.0`.
- `npm audit` reports **0 vulnerabilities**.
- No .NET build/test required (npm tooling only; falls under the CLAUDE.md exception for non-.NET changes).

## Test plan

- [ ] Dependabot alert #11 auto-closes on merge.
- [ ] Diagram export tooling still runs: `npm install && npm run export` in `engineering/diagrams/structurizr/` produces SVGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)