### PR TITLE
docs: document drawer-tooltip placement exception

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -143,6 +143,7 @@ Repository and server methods that load a single entity follow a weight-based ta
 **Tooltips:**
 - ALWAYS use `Arrow="true" Placement="Placement.Top"` on all `<MudTooltip>` components
 - This ensures tooltips appear above the element with a downward-pointing arrow, consistent across the entire UI
+- **Exception:** tooltips anchored to elements inside the mini-drawer (e.g. the `DrawerUserMenu` avatar when the drawer is collapsed) should use `Placement.Right` so they emerge into the main content area rather than overlapping the drawer itself. This exception is scoped to drawer-anchored tooltips only; do not extend it to other contexts.
 
 **UI Element Sizing:**
 - ALWAYS use normal/default sizes for ALL UI elements when adding new components


### PR DESCRIPTION
## Summary

- `src/CLAUDE.md` currently mandates `Placement.Top` for all `<MudTooltip>` components.
- `DrawerUserMenu.razor` (added in [#583](https://github.com/TetronIO/JIM/issues/583)) correctly uses `Placement.Right` on the collapsed-avatar tooltip so it emerges into the main content area rather than overlapping the mini-drawer.
- This adds a named, narrowly-scoped exception to the rule so future reviewers don't flag the existing usage as a violation, and future contributors don't extend the pattern outside drawer contexts.

## Why a named exception rather than weakening the rule

The standing `Placement.Top` default is still correct for ~every other tooltip in the app. The drawer is a specific geometric constraint (a fixed-width mini-rail on the left edge) where a top-anchored tooltip would clip against or overlap the drawer itself. The exception is scoped to "tooltips anchored to elements inside the mini-drawer" only; it is not a free pass to choose placement per-component.

## Scope check

Verified while writing this:
- [src/JIM.Web/Shared/DrawerUserMenu.razor:25](src/JIM.Web/Shared/DrawerUserMenu.razor) — the one concrete case, confirmed using `Placement.Right`.
- [src/JIM.Web/Shared/MainLayout.razor](src/JIM.Web/Shared/MainLayout.razor) — the JIM logo is a plain `MudImage` with no tooltip, so the exception wording deliberately does not mention the logo.
- [src/JIM.Web/Shared/NavMenu.razor](src/JIM.Web/Shared/NavMenu.razor) — no `MudTooltip` present.

If nav items inside the mini-drawer ever gain tooltips, this exception will cover them without a further doc change.

## Test plan

- [ ] Confirm the new bullet renders cleanly in `src/CLAUDE.md` under the **Tooltips** section.
- [ ] No code changes, so no build/test needed (docs-only, per the Exceptions list in the root `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)