### PR TITLE
Add Service Name and Service ID for instance identification (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ✨ Added a Service Name and Service ID so you can tell JIM instances apart at a glance. Set a friendly name per instance on the Service Settings page and see it under "JIM" in the sidebar, in the browser tab title, and in the footer. The Service ID is generated once per instance and never changes, useful for tooling, logs, and telemetry (#583)
 - ✨ Predefined Searches can now be disabled and re-enabled without deleting them; disabled searches are hidden from the portal, the search API, and the sidebar navigation, while administrators can still manage them via the admin UI, the new `/api/v1/predefined-searches` endpoints, and the new `Get-JIMPredefinedSearch` / `Set-JIMPredefinedSearch` PowerShell cmdlets (#555)
 - ✨ PowerShell cmdlets for System endpoints: `Get-JIMHealth` (with `-Ready` and `-Live` probes), `Get-JIMVersion`, `Get-JIMAuthConfig`, and `Get-JIMUserInfo`; health, version, and auth config cmdlets work without `Connect-JIM` via a `-Url` parameter (#468)
 - ✨ Interactive API reference powered by Scalar, available at `/api/reference` in all environments including air-gapped deployments; OpenAPI document is pre-generated at build time for instant loading with zero runtime overhead

--- a/docs/superpowers/plans/2026-04-18-service-name-and-id.md
+++ b/docs/superpowers/plans/2026-04-18-service-name-and-id.md
@@ -1,0 +1,1141 @@
+# Service Name and Service ID Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a user-editable Service Name and a read-only auto-generated Service ID so administrators can identify individual JIM instances at a glance, via the portal chrome (sidebar, browser tab, footer), the Web API, and the PowerShell module. Resolves [#583](https://github.com/TetronIO/JIM/issues/583).
+
+**Architecture:** Two new service settings following existing patterns. Service ID uses a new `Guid` value type and is seeded exactly once via a new `SeedSettingOnceAsync` helper (distinct from `CreateOrUpdateSettingAsync`, which re-applies values on every startup for env-var-backed settings). Read-only enforcement for Service ID is already free from the existing `PrepareUpdateAsync` guard. Portal chrome gains three small Service Name surfaces (drawer header, browser tab title, footer); Service ID is only rendered on `/admin/settings`.
+
+**Tech Stack:** C# / .NET 10, EF Core, PostgreSQL, Blazor Server, MudBlazor, NUnit + Moq, PowerShell.
+
+**Spec:** [`docs/superpowers/specs/2026-04-18-service-name-and-id-design.md`](../specs/2026-04-18-service-name-and-id-design.md)
+
+---
+
+## File Structure
+
+### Modified
+- `src/JIM.Models/Core/CoreEnums.cs` — add `Instance = 6` to `ServiceSettingCategory`, add `Guid = 6` to `ServiceSettingValueType`
+- `src/JIM.Models/Core/Constants.cs` — add `ServiceName` and `ServiceId` to `SettingKeys`
+- `src/JIM.Application/Servers/SeedingServer.cs` — seed both settings, add `SeedSettingOnceAsync` helper
+- `src/JIM.Application/Servers/ServiceSettingsServer.cs` — add `Guid` branch to `ConvertSettingValue<T>`
+- `src/JIM.Web/Pages/Admin/Settings.razor` — Instance category label, Guid value rendering with copy-to-clipboard button
+- `src/JIM.Web/Shared/MainLayout.razor` — load Service Name, render in drawer header + browser title + footer
+- `src/JIM.Web/Shared/EditSettingDialog.razor` — unchanged (default String branch handles Service Name)
+- `CHANGELOG.md` — entry under `[Unreleased] → Added`
+
+### New test files
+- `test/JIM.Worker.Tests/Servers/ServiceSettingsServerGuidConversionTests.cs`
+- `test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs`
+
+### Modified test files
+- `test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs` — add tests for Service Name CRUD and Service ID read-only rejection
+
+### No migration required
+`ValueType` and `Category` are stored as `integer` columns; adding enum values is a code-only change.
+
+---
+
+## Task 1: Add enum values and setting key constants
+
+No tests required; this is pure data that later tasks depend on. Compile-check only.
+
+**Files:**
+- Modify: `src/JIM.Models/Core/CoreEnums.cs`
+- Modify: `src/JIM.Models/Core/Constants.cs`
+
+- [ ] **Step 1: Add `Instance` to `ServiceSettingCategory`**
+
+Edit `src/JIM.Models/Core/CoreEnums.cs`. Find the `ServiceSettingCategory` enum (around line 160) and add after `UI = 5`:
+
+```csharp
+    /// <summary>
+    /// User interface settings.
+    /// </summary>
+    UI = 5,
+
+    /// <summary>
+    /// Instance identity settings (Service Name, Service ID).
+    /// Used by administrators to tell JIM instances apart.
+    /// </summary>
+    Instance = 6
+}
+```
+
+- [ ] **Step 2: Add `Guid` to `ServiceSettingValueType`**
+
+In the same file, find `ServiceSettingValueType` (around line 196) and add after `StringEncrypted = 5`:
+
+```csharp
+    /// <summary>
+    /// Encrypted string value for secrets (passwords, API keys, etc.).
+    /// Values are encrypted at rest using ASP.NET Core Data Protection.
+    /// </summary>
+    StringEncrypted = 5,
+
+    /// <summary>
+    /// GUID value. Stored as a string in standard GUID format.
+    /// Typically used for read-only, auto-generated identifiers.
+    /// </summary>
+    Guid = 6
+}
+```
+
+- [ ] **Step 3: Add setting key constants**
+
+Edit `src/JIM.Models/Core/Constants.cs`. Inside `public static class SettingKeys`, add at the end (after `ProgressUpdateInterval`):
+
+```csharp
+        // Instance Settings
+        /// <summary>
+        /// A friendly, editable name for this JIM instance.
+        /// Appears in the sidebar, browser tab title, and footer.
+        /// </summary>
+        public const string ServiceName = "Instance.Name";
+
+        /// <summary>
+        /// A stable, immutable GUID identifier for this JIM instance.
+        /// Generated exactly once on first startup; never changes thereafter.
+        /// </summary>
+        public const string ServiceId = "Instance.Id";
+```
+
+- [ ] **Step 4: Build affected projects**
+
+```bash
+dotnet build src/JIM.Models/
+```
+
+Expected: build succeeds with zero errors, zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/JIM.Models/Core/CoreEnums.cs src/JIM.Models/Core/Constants.cs
+git commit -m "feat: add Instance category, Guid value type, and Service Name/ID keys (#583)
+
+Adds ServiceSettingCategory.Instance, ServiceSettingValueType.Guid, and
+SettingKeys.ServiceName / ServiceId. No migration required — enum values
+are stored as integers and are backwards compatible.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add Guid branch to `ConvertSettingValue<T>` (TDD)
+
+**Files:**
+- Modify: `src/JIM.Application/Servers/ServiceSettingsServer.cs:331-359`
+- Create: `test/JIM.Worker.Tests/Servers/ServiceSettingsServerGuidConversionTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/JIM.Worker.Tests/Servers/ServiceSettingsServerGuidConversionTests.cs`:
+
+```csharp
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+[TestFixture]
+public class ServiceSettingsServerGuidConversionTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepo = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockServiceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepo.Object);
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task GetSettingValueAsync_GuidValueType_ReturnsParsedGuidAsync()
+    {
+        var expected = Guid.NewGuid();
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync("Instance.Id"))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = "Instance.Id",
+                DisplayName = "Service ID",
+                Category = ServiceSettingCategory.Instance,
+                ValueType = ServiceSettingValueType.Guid,
+                Value = expected.ToString(),
+                IsReadOnly = true
+            });
+
+        var result = await _application.ServiceSettings.GetSettingValueAsync<Guid>("Instance.Id");
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task GetSettingValueAsync_GuidValueType_MalformedString_ReturnsDefaultAsync()
+    {
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync("Instance.Id"))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = "Instance.Id",
+                DisplayName = "Service ID",
+                Category = ServiceSettingCategory.Instance,
+                ValueType = ServiceSettingValueType.Guid,
+                Value = "not-a-guid",
+                IsReadOnly = true
+            });
+
+        var result = await _application.ServiceSettings.GetSettingValueAsync<Guid>("Instance.Id");
+
+        Assert.That(result, Is.EqualTo(Guid.Empty));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+dotnet test test/JIM.Worker.Tests/ --filter "FullyQualifiedName~ServiceSettingsServerGuidConversionTests"
+```
+
+Expected: both tests FAIL. The first fails because `ConvertSettingValue<Guid>` returns `default(Guid)` (i.e. `Guid.Empty`) instead of the parsed value, because the method doesn't handle `Guid`.
+
+- [ ] **Step 3: Add the Guid branch**
+
+Edit `src/JIM.Application/Servers/ServiceSettingsServer.cs`. Find `ConvertSettingValue<T>` (around line 331) and add a Guid branch before the `if (underlyingType.IsEnum)` line:
+
+```csharp
+                if (underlyingType == typeof(TimeSpan))
+                    return (T)(object)TimeSpan.Parse(value);
+
+                if (underlyingType == typeof(Guid))
+                    return (T)(object)Guid.Parse(value);
+
+                if (underlyingType.IsEnum)
+                    return (T)Enum.Parse(underlyingType, value);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet test test/JIM.Worker.Tests/ --filter "FullyQualifiedName~ServiceSettingsServerGuidConversionTests"
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/JIM.Application/Servers/ServiceSettingsServer.cs \
+        test/JIM.Worker.Tests/Servers/ServiceSettingsServerGuidConversionTests.cs
+git commit -m "feat: support Guid value type in ConvertSettingValue (#583)
+
+Adds Guid.Parse branch to the generic converter so GetSettingValueAsync<Guid>
+returns a parsed GUID for Instance.Id and other future Guid-typed settings.
+Malformed values fall through to the existing catch-and-default path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `SeedSettingOnceAsync` helper and seed Instance settings (TDD)
+
+**Files:**
+- Modify: `src/JIM.Application/Servers/SeedingServer.cs`
+- Create: `test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs`:
+
+```csharp
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+[TestFixture]
+public class SeedingServerInstanceSettingsTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepo = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockServiceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepo.Object);
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_SeedsServiceNameWithNullValueAsync()
+    {
+        // First run: no existing settings
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        ServiceSetting? captured = null;
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceName)))
+            .Callback<ServiceSetting>(s => captured = s)
+            .Returns(Task.CompletedTask);
+
+        // Stub the other seed calls so the method completes
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key != Constants.SettingKeys.ServiceName)))
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Instance));
+        Assert.That(captured.ValueType, Is.EqualTo(ServiceSettingValueType.String));
+        Assert.That(captured.DefaultValue, Is.Null);
+        Assert.That(captured.Value, Is.Null);
+        Assert.That(captured.IsReadOnly, Is.False);
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_GeneratesServiceIdGuidAsync()
+    {
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        ServiceSetting? captured = null;
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceId)))
+            .Callback<ServiceSetting>(s => captured = s)
+            .Returns(Task.CompletedTask);
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key != Constants.SettingKeys.ServiceId)))
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Instance));
+        Assert.That(captured.ValueType, Is.EqualTo(ServiceSettingValueType.Guid));
+        Assert.That(captured.IsReadOnly, Is.True);
+        Assert.That(Guid.TryParse(captured.Value, out var parsed), Is.True,
+            "Service ID value must be a valid GUID");
+        Assert.That(parsed, Is.Not.EqualTo(Guid.Empty));
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_SecondRun_PreservesExistingServiceIdAsync()
+    {
+        // Second run: Service ID already exists
+        var existingId = Guid.NewGuid().ToString();
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(true);
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ServiceId,
+                DisplayName = "Service ID",
+                Category = ServiceSettingCategory.Instance,
+                ValueType = ServiceSettingValueType.Guid,
+                Value = existingId,
+                IsReadOnly = true
+            });
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.IsAny<ServiceSetting>()))
+            .Returns(Task.CompletedTask);
+        _mockServiceSettingsRepo.Setup(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()))
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        // Verify: CreateSettingAsync was NOT called for Service ID on the second run
+        _mockServiceSettingsRepo.Verify(
+            r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceId)),
+            Times.Never,
+            "Service ID must not be recreated when it already exists");
+
+        // And UpdateSettingAsync was NOT called for Service ID either
+        _mockServiceSettingsRepo.Verify(
+            r => r.UpdateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceId)),
+            Times.Never,
+            "Service ID must not be updated when it already exists");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test test/JIM.Worker.Tests/ --filter "FullyQualifiedName~SeedingServerInstanceSettingsTests"
+```
+
+Expected: all three tests FAIL — `CreateSettingAsync` is never called for `Instance.Name` or `Instance.Id` because the seed calls don't exist yet.
+
+- [ ] **Step 3: Add `SeedSettingOnceAsync` helper**
+
+Edit `src/JIM.Application/Servers/SeedingServer.cs`. Find `SeedSettingAsync` (around line 927) and add immediately below it:
+
+```csharp
+    /// <summary>
+    /// Seeds a single service setting exactly once. Creates the setting with a generated value
+    /// on first run; on subsequent runs, leaves the existing setting completely untouched.
+    /// Use for identifiers that must never be regenerated (e.g. Service ID).
+    /// </summary>
+    private async Task SeedSettingOnceAsync(ServiceSetting template, Func<string> valueFactory)
+    {
+        if (await Application.ServiceSettings.SettingExistsAsync(template.Key))
+        {
+            Log.Verbose($"SeedSettingOnceAsync: '{template.Key}' already exists; preserving existing value.");
+            return;
+        }
+
+        template.Value = valueFactory();
+        await Application.ServiceSettings.CreateSettingAsync(template);
+        Log.Information($"SeedSettingOnceAsync: Generated '{template.Key}' with value '{template.Value}'.");
+    }
+```
+
+- [ ] **Step 4: Add Instance-category seed calls**
+
+In the same file, inside `SyncServiceSettingsAsync`, add immediately before the `stopwatch.Stop();` line (around line 920):
+
+```csharp
+        // Instance Settings
+        await SeedSettingAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceName,
+            DisplayName = "Service Name",
+            Description = "A friendly, editable name for this JIM instance. Appears in the sidebar, browser tab title, and footer so you can tell instances apart.",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.String,
+            DefaultValue = null,
+            IsReadOnly = false
+        });
+
+        await SeedSettingOnceAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Description = "A stable, immutable identifier generated once when this JIM instance was created. Used by tooling, logs, and telemetry to identify this instance. Cannot be changed.",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            DefaultValue = null,
+            IsReadOnly = true
+        }, () => Guid.NewGuid().ToString());
+
+        stopwatch.Stop();
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+dotnet test test/JIM.Worker.Tests/ --filter "FullyQualifiedName~SeedingServerInstanceSettingsTests"
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Run the full worker test project to catch regressions**
+
+```bash
+dotnet test test/JIM.Worker.Tests/
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/JIM.Application/Servers/SeedingServer.cs \
+        test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs
+git commit -m "feat: seed Service Name and Service ID with once-only semantics (#583)
+
+Adds SeedSettingOnceAsync helper distinct from CreateOrUpdateSettingAsync.
+Service Name is seeded editable with null default. Service ID is generated
+as a new GUID on first run and never touched again, even across restarts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: API tests for Service Name CRUD and Service ID read-only rejection (TDD verification)
+
+No production code changes required — the existing `PrepareUpdateAsync` already enforces `IsReadOnly`. Tests prove the behaviour is correct for the new settings.
+
+**Files:**
+- Modify: `test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs`
+
+- [ ] **Step 1: Add tests at the end of the existing test class**
+
+Edit `test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs`. Add these tests just before the closing brace of the class (after the last existing `#endregion`, mirror existing patterns for mock setup):
+
+```csharp
+    #region Instance settings tests (#583)
+
+    [Test]
+    public async Task UpdateAsync_ServiceName_UpdatesSuccessfullyAsync()
+    {
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceName,
+            DisplayName = "Service Name",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.String,
+            Value = null,
+            IsReadOnly = false
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceName))
+            .ReturnsAsync(setting);
+        _mockServiceSettingsRepo.Setup(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()))
+            .Returns(Task.CompletedTask);
+        _mockActivityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<JIM.Models.Activities.Activity>()))
+            .Returns(Task.CompletedTask);
+        _mockActivityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<JIM.Models.Activities.Activity>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new ServiceSettingUpdateRequestDto { Value = "HQ-Production" };
+        var result = await _controller.UpdateAsync(Constants.SettingKeys.ServiceName, request);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        _mockServiceSettingsRepo.Verify(r => r.UpdateSettingAsync(
+            It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceName && s.Value == "HQ-Production")),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAsync_ServiceId_ReturnsBadRequestAsync()
+    {
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            Value = Guid.NewGuid().ToString(),
+            IsReadOnly = true
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(setting);
+
+        var request = new ServiceSettingUpdateRequestDto { Value = Guid.NewGuid().ToString() };
+        var result = await _controller.UpdateAsync(Constants.SettingKeys.ServiceId, request);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        var body = ((BadRequestObjectResult)result).Value as ApiErrorResponse;
+        Assert.That(body, Is.Not.Null);
+        Assert.That(body!.Message, Does.Contain("read-only"));
+
+        // Verify update was NOT called
+        _mockServiceSettingsRepo.Verify(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task RevertAsync_ServiceId_ReturnsBadRequestAsync()
+    {
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            Value = Guid.NewGuid().ToString(),
+            IsReadOnly = true
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(setting);
+
+        var result = await _controller.RevertAsync(Constants.SettingKeys.ServiceId);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockServiceSettingsRepo.Verify(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task GetByKeyAsync_ServiceId_ReturnsGuidStringAsync()
+    {
+        var id = Guid.NewGuid();
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            Value = id.ToString(),
+            IsReadOnly = true
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(setting);
+
+        var result = await _controller.GetByKeyAsync(Constants.SettingKeys.ServiceId) as OkObjectResult;
+        var dto = result?.Value as ServiceSettingDto;
+
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto!.ValueType, Is.EqualTo("Guid"));
+        Assert.That(dto.EffectiveValue, Is.EqualTo(id.ToString()));
+        Assert.That(dto.IsReadOnly, Is.True);
+    }
+
+    #endregion
+```
+
+- [ ] **Step 2: Run new tests**
+
+```bash
+dotnet test test/JIM.Web.Api.Tests/ --filter "FullyQualifiedName~ServiceSettingsControllerTests"
+```
+
+Expected: all tests PASS (the behaviour is already in place from Task 3 + existing PrepareUpdateAsync guard).
+
+Note: If the Activity repository mock signatures do not match the actual interface (e.g. method names or parameters have evolved), copy the setup pattern from an existing `UpdateAsync_*` test in the file — don't invent new mock shapes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs
+git commit -m "test: cover Service Name CRUD and Service ID read-only rejection (#583)
+
+Confirms PUT /Instance.Name succeeds, PUT /Instance.Id returns 400,
+DELETE /Instance.Id returns 400, and the GET response carries the
+Guid value type and read-only flag.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Render Service ID on `/admin/settings` with copy-to-clipboard
+
+No unit tests (Blazor pages have no automated tests in JIM). Manual verification in Step 5.
+
+**Files:**
+- Modify: `src/JIM.Web/Pages/Admin/Settings.razor`
+
+- [ ] **Step 1: Add Instance category display name**
+
+Edit `src/JIM.Web/Pages/Admin/Settings.razor`. Find `GetCategoryDisplayName` (around line 215) and add the `Instance` case:
+
+```csharp
+    private string GetCategoryDisplayName(object? categoryValue)
+    {
+        var categoryString = categoryValue?.ToString();
+        return categoryString switch
+        {
+            "SSO" => "Single Sign-On (SSO)",
+            "Synchronisation" => "Synchronisation",
+            "Maintenance" => "Maintenance",
+            "History" => "History",
+            "Security" => "Security",
+            "Instance" => "Instance",
+            _ => categoryString ?? "Unknown"
+        };
+    }
+```
+
+- [ ] **Step 2: Inject the JS runtime for clipboard**
+
+At the top of the same file, add `@inject IJSRuntime JSRuntime` alongside the other `@inject` directives (after `@inject ICredentialProtectionService CredentialProtection`, and add the `using` to top of file):
+
+```razor
+@inject IJimApplicationFactory JimFactory
+@inject ISnackbar Snackbar
+@inject IDialogService DialogService
+@inject ICredentialProtectionService CredentialProtection
+@inject IJSRuntime JSRuntime
+```
+
+- [ ] **Step 3: Add Guid value rendering with copy button**
+
+In the value `<MudTd>` cell (around line 71), add a new branch before the `else` fallback. The existing structure looks like:
+
+```razor
+<MudTd DataLabel="Value" Class="@GetRowClass(settingContext)">
+    @if (settingContext.ValueType == ServiceSettingValueType.StringEncrypted)
+    {
+        @* ... existing encrypted rendering ... *@
+    }
+    else
+    {
+        <span class="jim-text-code">@(settingContext.GetEffectiveValue() ?? "(not set)")</span>
+    }
+</MudTd>
+```
+
+Change it to:
+
+```razor
+<MudTd DataLabel="Value" Class="@GetRowClass(settingContext)">
+    @if (settingContext.ValueType == ServiceSettingValueType.StringEncrypted)
+    {
+        @if (_revealedSecrets.Contains(settingContext.Key) && _decryptedCache.TryGetValue(settingContext.Key, out var decrypted))
+        {
+            <span class="jim-text-code">@(decrypted.Value ?? "(not set)")</span>
+            <MudIconButton Icon="@Icons.Material.Outlined.VisibilityOff" Variant="Variant.Filled" Size="Size.Small" OnClick="() => HideSecret(settingContext.Key)" />
+        }
+        else
+        {
+            <span class="jim-text-code">********</span>
+            <MudIconButton Icon="@Icons.Material.Outlined.Visibility" Variant="Variant.Filled" Size="Size.Small" OnClick="() => RevealSecretAsync(settingContext.Key)" />
+        }
+    }
+    else if (settingContext.ValueType == ServiceSettingValueType.Guid)
+    {
+        var guidValue = settingContext.GetEffectiveValue();
+        <span class="jim-text-code">@(guidValue ?? "(not set)")</span>
+        @if (!string.IsNullOrEmpty(guidValue))
+        {
+            <MudTooltip Text="Copy to clipboard" Arrow="true" Placement="Placement.Top">
+                <MudIconButton Icon="@Icons.Material.Outlined.ContentCopy" Variant="Variant.Filled" Size="Size.Small"
+                               OnClick="() => CopyToClipboardAsync(guidValue!)" />
+            </MudTooltip>
+        }
+    }
+    else
+    {
+        <span class="jim-text-code">@(settingContext.GetEffectiveValue() ?? "(not set)")</span>
+    }
+</MudTd>
+```
+
+(Retain the *complete* existing `StringEncrypted` block; the snippet above shows the full structure to avoid ambiguity.)
+
+- [ ] **Step 4: Add the clipboard helper method**
+
+In the `@code` block at the bottom of the file, add this method alongside the other helpers (e.g. after `HandleRevertAsync`):
+
+```csharp
+    private async Task CopyToClipboardAsync(string value)
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", value);
+            Snackbar.Add("Copied to clipboard.", Severity.Success);
+        }
+        catch (JSException)
+        {
+            Snackbar.Add("Failed to copy to clipboard.", Severity.Error);
+        }
+    }
+```
+
+- [ ] **Step 5: Build and manually verify**
+
+```bash
+dotnet build src/JIM.Web/
+```
+
+Expected: build succeeds with zero errors, zero warnings.
+
+Manual verification (from repo root):
+1. Start the stack: `jim-build-light`
+2. Sign in, navigate to `/admin/settings`.
+3. Expand the "Instance" group.
+4. Confirm:
+   - Service Name row: empty/default, Edit icon enabled.
+   - Service ID row: monospace GUID visible, copy icon enabled, **Read-only** chip shown, **no Edit icon**.
+5. Click the copy icon → snackbar "Copied to clipboard." → paste into a text field to confirm.
+6. Click Edit on Service Name → enter `HQ-Production` → Save → row updates, **Modified** chip appears.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/JIM.Web/Pages/Admin/Settings.razor
+git commit -m "feat: render Service ID with copy-to-clipboard on settings page (#583)
+
+Adds the Instance category label, Guid value rendering with a monospace
+string + copy icon, and a CopyToClipboardAsync helper. Service Name uses
+the default String editing path so no dialog changes are needed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Display Service Name in drawer header
+
+**Files:**
+- Modify: `src/JIM.Web/Shared/MainLayout.razor`
+
+- [ ] **Step 1: Inject the application factory**
+
+Edit `src/JIM.Web/Shared/MainLayout.razor`. Add below the existing `@inject` directives (after `@inject NavigationManager NavigationManager`):
+
+```razor
+@inject IJimApplicationFactory JimFactory
+@inject JIM.Web.Models.ThemeSettings ThemeSettings
+@inject NavigationManager NavigationManager
+```
+
+(If `IJimApplicationFactory` already is available, skip. Check for existing `@using JIM.Application` — NavMenu already uses this pattern.)
+
+- [ ] **Step 2: Add Service Name loading in code-behind**
+
+In the `@code { }` block, add a field near the other fields and load in `OnInitializedAsync`:
+
+```csharp
+    private string? _serviceName;
+
+    protected override async Task OnInitializedAsync()
+    {
+        using var jim = JimFactory.Create();
+        _serviceName = await jim.ServiceSettings.GetSettingValueAsync<string>(
+            JIM.Models.Core.Constants.SettingKeys.ServiceName);
+
+        NavigationManager.LocationChanged += OnLocationChanged;
+    }
+```
+
+Merge this with the existing `OnInitialized`/`OnInitializedAsync`. The existing code has a synchronous `OnInitialized` that subscribes to `NavigationManager.LocationChanged`. Replace it with the async version above so both concerns are handled, and **delete** the old `OnInitialized`.
+
+- [ ] **Step 3: Render Service Name under the "JIM" wordmark**
+
+Find the drawer logo block (around line 23):
+
+```razor
+<div class="jim-drawer-logo">
+    <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+    @if (IsDrawerOpen)
+    {
+        <MudText Inline="true">JIM</MudText>
+    }
+</div>
+```
+
+Replace with:
+
+```razor
+<div class="jim-drawer-logo">
+    <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+    @if (IsDrawerOpen)
+    {
+        <div class="d-flex flex-column">
+            <MudText Inline="true">JIM</MudText>
+            @if (!string.IsNullOrEmpty(_serviceName))
+            {
+                <MudText Typo="Typo.caption" Class="mud-text-secondary jim-text-code">@_serviceName</MudText>
+            }
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(_serviceName))
+    {
+        @* Collapsed drawer: no visible Service Name, but logo tooltip surfaces it on hover. *@
+    }
+</div>
+
+@if (!IsDrawerOpen && !string.IsNullOrEmpty(_serviceName))
+{
+    @* Tooltip wrapper is applied at the logo level only when collapsed, to avoid interfering with expanded layout. *@
+}
+```
+
+Because MudBlazor tooltips are easier to attach at the image level, use an alternative: wrap the `<MudImage>` in `<MudTooltip>` conditional on collapsed + ServiceName set. Simplest approach:
+
+```razor
+<div class="jim-drawer-logo">
+    @if (!IsDrawerOpen && !string.IsNullOrEmpty(_serviceName))
+    {
+        <MudTooltip Text="@_serviceName" Arrow="true" Placement="Placement.Right">
+            <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+        </MudTooltip>
+    }
+    else
+    {
+        <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+    }
+    @if (IsDrawerOpen)
+    {
+        <div class="d-flex flex-column">
+            <MudText Inline="true">JIM</MudText>
+            @if (!string.IsNullOrEmpty(_serviceName))
+            {
+                <MudText Typo="Typo.caption" Class="mud-text-secondary jim-text-code">@_serviceName</MudText>
+            }
+        </div>
+    }
+</div>
+```
+
+- [ ] **Step 4: Build and manually verify**
+
+```bash
+dotnet build src/JIM.Web/
+```
+
+Expected: build succeeds.
+
+Manual verification:
+1. With Service Name unset: drawer (expanded and collapsed) looks identical to today — "JIM" text only, no tooltip.
+2. Set Service Name to `HQ-Production` via `/admin/settings`. Hard-refresh the page.
+3. Expanded drawer: `JIM` on the first line, `HQ-Production` in monospace secondary text beneath.
+4. Collapsed drawer (unpin, mouse away): hovering the logo shows a tooltip `HQ-Production`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/JIM.Web/Shared/MainLayout.razor
+git commit -m "feat: show Service Name under JIM wordmark in drawer (#583)
+
+When configured, the drawer renders the Service Name in monospace style
+beneath the JIM wordmark. Collapsed drawer keeps the logo-only silhouette
+but surfaces the Service Name in a hover tooltip.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Append Service Name to browser tab title
+
+**Files:**
+- Modify: `src/JIM.Web/Shared/MainLayout.razor`
+
+- [ ] **Step 1: Update the `<PageTitle>` block**
+
+Find line 15 (`<PageTitle>JIM</PageTitle>`) and replace with:
+
+```razor
+@if (!string.IsNullOrEmpty(_serviceName))
+{
+    <PageTitle>JIM — @_serviceName</PageTitle>
+}
+else
+{
+    <PageTitle>JIM</PageTitle>
+}
+```
+
+Note: Individual pages that define their own `<PageTitle>` will continue to override the layout-level one — that's the Blazor cascading behaviour. The layout-level title covers pages that don't set one. A follow-up can extend per-page titles if needed.
+
+- [ ] **Step 2: Build and manually verify**
+
+```bash
+dotnet build src/JIM.Web/
+```
+
+Manual verification:
+1. With Service Name unset: browser tab shows `JIM` on pages without a custom `<PageTitle>`.
+2. With Service Name set to `HQ-Production`: same pages show `JIM — HQ-Production`.
+3. `/admin/settings` shows `Service Settings` (the page's own title still overrides — expected).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/JIM.Web/Shared/MainLayout.razor
+git commit -m "feat: append Service Name to browser tab title (#583)
+
+The layout-level PageTitle becomes 'JIM — {ServiceName}' when Service Name
+is set, helping administrators differentiate tabs when running several JIM
+instances side-by-side. Pages with their own PageTitle still override.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Append Service Name to the footer
+
+**Files:**
+- Modify: `src/JIM.Web/Shared/MainLayout.razor`
+
+- [ ] **Step 1: Update the footer block**
+
+Find the footer block (around line 55) and add the Service Name span between the version and the GitHub link:
+
+```razor
+<div class="jim-page-footer mt-5">
+    <MudText Typo="Typo.body2" Class="mud-text-secondary jim-page-footer-text">
+        <span>&copy; @DateTime.UtcNow.Year</span>
+        <MudLink Href="https://tetron.io" Target="_blank"
+                 Color="Color.Inherit" Underline="Underline.Hover">
+            Tetron
+        </MudLink>
+        <span class="jim-page-footer-sep">|</span>
+        <span>All rights reserved</span>
+        <span class="jim-page-footer-sep">|</span>
+        <span>v@(AppVersion)</span>
+        @if (!string.IsNullOrEmpty(_serviceName))
+        {
+            <span class="jim-page-footer-sep">|</span>
+            <span>@_serviceName</span>
+        }
+        <span class="jim-page-footer-sep">|</span>
+        <MudLink Href="https://github.com/TetronIO/JIM" Target="_blank"
+                 Color="Color.Inherit" Underline="Underline.Hover" Class="jim-page-footer-github">
+            <MudIcon Icon="@Icons.Custom.Brands.GitHub" Size="Size.Small" Class="jim-page-footer-github-icon" />
+            <span>GitHub</span>
+        </MudLink>
+    </MudText>
+</div>
+```
+
+- [ ] **Step 2: Build and manually verify**
+
+```bash
+dotnet build src/JIM.Web/
+```
+
+Manual verification:
+1. Service Name unset: footer unchanged (`© 2026 Tetron | All rights reserved | v0.8.x | GitHub`).
+2. Service Name set to `HQ-Production`: footer shows `© 2026 Tetron | All rights reserved | v0.8.x | HQ-Production | GitHub`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/JIM.Web/Shared/MainLayout.razor
+git commit -m "feat: show Service Name in footer beside version (#583)
+
+When configured, Service Name appears between the version and the GitHub
+link in the page footer — a natural neighbour for instance reference info.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Add changelog entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the entry**
+
+Edit `CHANGELOG.md`. Under `## [Unreleased]` → `### Added`, add as the first bullet (top of the list):
+
+```markdown
+- ✨ Added a Service Name and Service ID so you can tell JIM instances apart at a glance. Set a friendly name per instance on the Service Settings page and see it under "JIM" in the sidebar, in the browser tab title, and in the footer. The Service ID is generated once per instance and never changes — useful for tooling, logs, and telemetry (#583)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add changelog entry for Service Name / Service ID (#583)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Final pre-PR verification
+
+- [ ] **Step 1: Full solution build**
+
+```bash
+dotnet build JIM.sln
+```
+
+Expected: zero errors, zero warnings.
+
+- [ ] **Step 2: Full solution tests**
+
+```bash
+dotnet test JIM.sln
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Manual smoke test against a freshly-seeded database**
+
+```bash
+# From repo root:
+jim-stack  # or jim-build-light
+```
+
+1. Reset the DB volume if needed (`docker compose down -v`) then start fresh so the seeder runs on an empty database.
+2. Sign in, go to `/admin/settings`, expand **Instance**:
+   - `Service Name` present, editable, empty by default.
+   - `Service ID` present, GUID visible, monospace, copy icon, **Read-only** chip.
+3. **Restart** the worker + web containers. Reload `/admin/settings`. Confirm the same Service ID GUID is present (not regenerated).
+4. Set Service Name to `Smoke-Test-Instance`. Reload page. Confirm:
+   - Drawer expanded: "JIM" with `Smoke-Test-Instance` in monospace beneath.
+   - Drawer collapsed: hover tooltip shows `Smoke-Test-Instance`.
+   - Browser tab: `JIM — Smoke-Test-Instance` (on pages that don't set their own title — e.g. `/`).
+   - Footer: `| Smoke-Test-Instance |` between version and GitHub.
+5. Try PowerShell:
+   ```powershell
+   Connect-JIM -Url http://localhost -ApiKey "<key>"
+   Get-JIMServiceSetting -Key Instance.Name  # shows value
+   Get-JIMServiceSetting -Key Instance.Id    # shows GUID
+   Set-JIMServiceSetting -Key Instance.Id -Value (New-Guid).Guid  # must fail with "read-only"
+   Set-JIMServiceSetting -Key Instance.Name -Value "Renamed"       # succeeds
+   ```
+
+- [ ] **Step 4: Confirm acceptance criteria**
+
+Re-read [`docs/superpowers/specs/2026-04-18-service-name-and-id-design.md`](../specs/2026-04-18-service-name-and-id-design.md) Acceptance section. Tick off each item.
+
+- [ ] **Step 5: Push and open PR (only on explicit user instruction)**
+
+```bash
+git push -u origin claude/thirsty-tereshkova-101f67
+gh pr create --title "Add Service Name and Service ID for instance identification (#583)" --body "$(cat <<'EOF'
+## Summary
+- Adds a user-editable `Service Name` and a read-only auto-generated `Service ID` (GUID) to identify individual JIM instances at a glance.
+- Service Name is surfaced in the drawer header (under "JIM"), browser tab title, and footer. Service ID is shown on `/admin/settings` only, with copy-to-clipboard.
+- Both are read/writable via the existing `/api/v1/service-settings/{key}` endpoint and the existing `Get/Set/Reset-JIMServiceSetting` cmdlets. Read-only enforcement on Service ID is provided by the existing `PrepareUpdateAsync` guard.
+
+Resolves #583.
+
+## Test plan
+- [x] `dotnet build JIM.sln` — zero errors, zero warnings
+- [x] `dotnet test JIM.sln` — all pass
+- [x] Fresh DB: Service ID generated once; preserved across restart
+- [x] PUT/DELETE `/api/v1/service-settings/Instance.Id` returns 400
+- [x] `Set-JIMServiceSetting -Key Instance.Id` fails with read-only error
+- [x] Service Name shown in drawer (expanded + collapsed tooltip), browser tab, footer
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage check:
+- ServiceSettingCategory.Instance: Task 1
+- ServiceSettingValueType.Guid: Task 1
+- SettingKeys.ServiceName / ServiceId: Task 1
+- SeedSettingOnceAsync helper + Service ID once-only seeding: Task 3
+- Service Name seeding: Task 3
+- Guid branch in ConvertSettingValue<T>: Task 2
+- Drawer header display: Task 6
+- Browser tab title: Task 7
+- Footer display: Task 8
+- /admin/settings Instance category label + Guid rendering + copy: Task 5
+- API read-only enforcement tests: Task 4
+- PowerShell read-only enforcement: covered transitively (cmdlet calls the API; Task 4 test confirms API returns 400; manual verification in Task 10 Step 3 confirms the cmdlet surfaces the error)
+- Test plan (seeding, preservation, CRUD, read-only, conversion): Tasks 2–4
+- Changelog: Task 9
+- No migration: confirmed — `ValueType` column type is `integer`
+
+All type names consistent: `ServiceSetting`, `ServiceSettingCategory.Instance`, `ServiceSettingValueType.Guid`, `Constants.SettingKeys.ServiceName`, `Constants.SettingKeys.ServiceId`, `SeedSettingOnceAsync`, `CopyToClipboardAsync`.

--- a/docs/superpowers/specs/2026-04-18-service-name-and-id-design.md
+++ b/docs/superpowers/specs/2026-04-18-service-name-and-id-design.md
@@ -1,0 +1,216 @@
+# Service Name and Service ID — Design
+
+**Issue:** [#583](https://github.com/TetronIO/JIM/issues/583)
+**Milestone:** v0.9-STABILISATION
+**Date:** 2026-04-18
+
+## Problem
+
+Customers running more than one JIM instance (e.g. edge sync deployments) cannot tell them apart at a glance. Three concrete pain points:
+
+1. Multiple admin browser tabs open to different instances look identical.
+2. Logs and telemetry have no stable machine-readable instance identifier.
+3. Air-gapped, independently-deployed instances need a way to correlate back to the customer's own inventory.
+
+## Goals
+
+- Add a user-editable **Service Name** that appears in the portal chrome so operators can identify the instance at a glance.
+- Add a read-only **Service ID** (GUID) that is generated once on first start and never changes, for use by tooling, logs, and telemetry.
+- Surface both through the Web API and the PowerShell module, consistent with existing service-settings patterns.
+
+## Non-goals
+
+- Automatic propagation of Service Name/ID into log lines, activity records, or connector telemetry. That's a follow-up.
+- Syncing Service Name across replicas, clusters, or high-availability topologies. JIM's deployment model is single-instance.
+- A dedicated "About this instance" page. Settings page + portal chrome is enough for v0.9.
+
+## Design
+
+### Model and configuration layer
+
+**`ServiceSettingCategory` (enum, `JIM.Models/Core/CoreEnums.cs`):** add `Instance = 6`. Not `Identity` (overloaded in an identity-management product) and not `UI` (these aren't UI settings, they're instance-identity settings that happen to surface in UI).
+
+**`ServiceSettingValueType` (enum, same file):** add `Guid = 6`. Preferred over storing a GUID in a `String`:
+
+- `ConvertSettingValue<T>` gets type-safe `Guid.Parse`.
+- The admin UI can render a monospaced value with a copy-to-clipboard affordance.
+- PUT requests get server-side format validation.
+
+**`Constants.SettingKeys` (`JIM.Models/Core/Constants.cs`):** add
+
+- `ServiceName = "Instance.Name"`
+- `ServiceId = "Instance.Id"`
+
+### Seeding
+
+`SeedingServer.SyncServiceSettingsAsync` seeds both settings. Service Name uses the existing `SeedSettingAsync` helper (nullable default, editable). Service ID needs a different contract — it must be generated exactly once and never overwritten on subsequent startups.
+
+Add a new helper:
+
+```csharp
+private async Task SeedSettingOnceAsync(ServiceSetting template, Func<string> valueFactory)
+{
+    if (await Application.ServiceSettings.SettingExistsAsync(template.Key))
+        return;
+
+    template.Value = valueFactory();
+    await Application.ServiceSettings.CreateSettingAsync(template);
+    Log.Information("SeedSettingOnceAsync: Generated '{Key}' = '{Value}'", template.Key, template.Value);
+}
+```
+
+Called as:
+
+```csharp
+await SeedSettingOnceAsync(new ServiceSetting
+{
+    Key = Constants.SettingKeys.ServiceId,
+    DisplayName = "Service ID",
+    Description = "A stable, immutable identifier generated once when this JIM instance was created. Used by tooling, logs, and telemetry to identify this instance.",
+    Category = ServiceSettingCategory.Instance,
+    ValueType = ServiceSettingValueType.Guid,
+    IsReadOnly = true
+}, () => Guid.NewGuid().ToString());
+```
+
+The existing `CreateOrUpdateSettingAsync` is not suitable here: it re-applies `Value` for any read-only setting (to support environment-variable-backed settings). For Service ID we need the opposite contract — create once, never touch again.
+
+Service Name is seeded with the ordinary helper:
+
+```csharp
+await SeedSettingAsync(new ServiceSetting
+{
+    Key = Constants.SettingKeys.ServiceName,
+    DisplayName = "Service Name",
+    Description = "A friendly, editable name for this JIM instance. Appears in the sidebar, browser tab title, and footer so you can tell instances apart.",
+    Category = ServiceSettingCategory.Instance,
+    ValueType = ServiceSettingValueType.String,
+    DefaultValue = null,
+    IsReadOnly = false
+});
+```
+
+### Value conversion
+
+`ServiceSettingsServer.ConvertSettingValue<T>` gains a `Guid` branch:
+
+```csharp
+if (underlyingType == typeof(Guid))
+    return (T)(object)Guid.Parse(value);
+```
+
+Read-only enforcement for Service ID requires no new code; `PrepareUpdateAsync` already throws `InvalidOperationException` for any `IsReadOnly` setting.
+
+### API and DTOs
+
+`ServiceSettingDto.FromEntity` already serialises the stored string value, so Service ID flows through as a GUID string with no change. The existing PUT endpoint returns `400 BadRequest` for read-only settings, so Service ID updates are already rejected — we only need a test to confirm it.
+
+No new endpoints.
+
+### PowerShell
+
+`Get-JIMServiceSetting -Key Instance.Name` and `Get-JIMServiceSetting -Key Instance.Id` work through the existing list/get cmdlet. `Set-JIMServiceSetting -Key Instance.Id ...` fails with the existing read-only error path. `Reset-JIMServiceSetting` is not meaningful for Service ID (read-only) and sets Service Name to `null` (default).
+
+No new cmdlets.
+
+### Portal chrome — where Service Name appears
+
+Three surfaces, each small, each reinforcing the others. Service ID appears only on the Settings page.
+
+**1. Drawer header (`Shared/MainLayout.razor`, primary in-app signal):**
+
+Keep "JIM" next to the logo. Render Service Name as a second line beneath it in monospace (existing `jim-text-code` class), `Typo.caption`, `mud-text-secondary`:
+
+```
+Expanded drawer:        Collapsed drawer:
+ [logo]  JIM             [logo]   <- tooltip on hover:
+         HQ-Production              HQ-Production
+```
+
+When Service Name is null: the second line is omitted — no placeholder, no empty gap. Collapsed-drawer tooltip appears only when Service Name is set.
+
+The layout needs access to the value. Simplest path: `MainLayout` loads it once via `IJimApplicationFactory` in `OnInitializedAsync` (same pattern `NavMenu` already uses), stores it in a field, and renders conditionally. Changes to Service Name require a page reload to reflect — acceptable for a setting that changes infrequently.
+
+**2. Browser tab title (`MainLayout.razor`, cross-tab signal):**
+
+Currently `<PageTitle>JIM</PageTitle>` at the layout level, overridden by pages. Adjust the layout `<PageTitle>` to `"JIM"` when Service Name is null, `"JIM — {ServiceName}"` when set. Pages that set their own `<PageTitle>` still override (e.g. "Service Settings"), which is fine — the tab title on most pages is overridden per page anyway. The meaningful effect is tabs parked on pages without a custom PageTitle now distinguish themselves, and where we can fit it we can extend per-page titles in a follow-up.
+
+Pragmatic scope for v0.9: only the layout-level `<PageTitle>`. Per-page title suffixes can come later if needed.
+
+**3. Footer (`MainLayout.razor`, supplementary):**
+
+Today: `© 2026 Tetron | All rights reserved | v0.8.4 | GitHub`. Add Service Name before GitHub when set:
+
+```
+© 2026 Tetron | All rights reserved | v0.8.4 | HQ-Production | GitHub
+```
+
+Null → current rendering unchanged.
+
+### `/admin/settings` — Service ID display
+
+The existing Settings table renders all service settings grouped by category. The new `Instance` category appears as a new group with two rows:
+
+- **Service Name** — standard editable string field.
+- **Service ID** — read-only GUID rendered with the existing `jim-text-code` monospace class, plus a copy-to-clipboard `MudIconButton` (mirror the secret-reveal pattern already used for `StringEncrypted` settings).
+
+Add a case in `Settings.razor`'s value-rendering switch for `ServiceSettingValueType.Guid`.
+
+Add a display name for the new category in `GetCategoryDisplayName`: `Instance = "Instance"`.
+
+### Model and schema changes
+
+- `ServiceSettingValueType.Guid` and `ServiceSettingCategory.Instance` are new enum values. Enums are stored as integers in PostgreSQL and are backwards-compatible (existing rows use values 0–5, the new values are 6).
+- **No EF migration is required.** The enum expansion is a code-only change; no column additions, no constraint changes.
+
+### Changelog entry
+
+Under `[Unreleased]`, category `Added`:
+
+> ✨ Added a Service Name and Service ID so you can tell JIM instances apart at a glance. Set a friendly name per instance on the Service Settings page and see it under "JIM" in the sidebar, in the browser tab title, and in the footer. The Service ID is generated once per instance and never changes — useful for tooling, logs, and telemetry.
+
+## Test plan (TDD)
+
+All tests are written before implementation. Locations follow existing conventions.
+
+**`test/JIM.Worker.Tests/` (or `test/JIM.Application.Tests/` if it exists) — seeding:**
+
+- First-run seeding creates Service Name with null value and Service ID with a valid GUID.
+- Second-run seeding does not regenerate Service ID when one already exists.
+- Second-run seeding does not overwrite a user-set Service Name.
+- Generated Service ID parses as a valid `Guid` and is unique per seed cycle (test two fresh seed runs get different GUIDs).
+
+**`test/JIM.Worker.Tests/` — value conversion:**
+
+- `GetSettingValueAsync<Guid>(Instance.Id)` returns the correct `Guid`.
+- `ConvertSettingValue<Guid>` with a malformed string returns `default` (matches existing catch-and-default behaviour).
+
+**`test/JIM.Web.Api.Tests/` — API:**
+
+- `GET /api/v1/service-settings/Instance.Name` returns the setting with null value by default.
+- `GET /api/v1/service-settings/Instance.Id` returns the setting with a GUID string value.
+- `PUT /api/v1/service-settings/Instance.Name` with `{"value":"HQ-Production"}` succeeds and returns the updated DTO.
+- `PUT /api/v1/service-settings/Instance.Id` with any value returns `400 BadRequest` with a read-only error message.
+- `DELETE /api/v1/service-settings/Instance.Name` (revert) sets the value back to null.
+- `DELETE /api/v1/service-settings/Instance.Id` returns `400 BadRequest`.
+
+**`test/JIM.Models.Tests/`:**
+
+- `ServiceSetting` with `ValueType = Guid` round-trips a `Guid.NewGuid().ToString()` value via `GetEffectiveValue`.
+
+**UI/portal chrome:** no automated tests (JIM has no UI tests). Manual verification covered under acceptance.
+
+## Acceptance (copied from issue for traceability)
+
+- [ ] `Service Name` and `Service ID` appear on `/admin/settings` with correct category, types, and read-only state.
+- [ ] Service ID is auto-generated exactly once on first startup and never changes thereafter.
+- [ ] Setting Service Name via PowerShell works; attempting to set Service ID fails with a clear read-only error.
+- [ ] Both settings are visible somewhere in the Portal chrome so the instance can be identified at a glance — delivered via drawer header, browser tab title, and footer (Service Name only; Service ID on Settings page only).
+- [ ] Tests cover: default values, Service ID GUID generation on first run, Service ID preservation across restarts, Service Name CRUD via the API, read-only enforcement for Service ID.
+- [ ] Changelog entry added under `[Unreleased]` (✨ category).
+
+## Open decisions deferred to follow-ups
+
+- Whether to also propagate Service Name/ID into log enrichers, Activity records, or exported diagnostic bundles. Out of scope for v0.9.
+- Per-page browser-title suffixing (every page gets ` — {ServiceName}`). The v0.9 scope covers the layout-level title only.
+- Per-instance favicon tinting to further differentiate tabs. Speculative; revisit if customers ask.

--- a/src/JIM.Application/JimApplication.cs
+++ b/src/JIM.Application/JimApplication.cs
@@ -36,7 +36,7 @@ public class JimApplication : IDisposable
     /// </summary>
     public ISyncRepository SyncRepo { get; }
 
-    private SeedingServer Seeding { get; }
+    internal SeedingServer Seeding { get; }
     public ActivityServer Activities { get; }
     public CertificateServer Certificates { get; }
     public ChangeHistoryServer ChangeHistory { get; }

--- a/src/JIM.Application/Servers/SeedingServer.cs
+++ b/src/JIM.Application/Servers/SeedingServer.cs
@@ -917,6 +917,29 @@ internal class SeedingServer
             IsReadOnly = false
         });
 
+        // Instance Settings
+        await SeedSettingAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceName,
+            DisplayName = "Service Name",
+            Description = "A friendly, editable name for this JIM instance. Appears in the sidebar, browser tab title, and footer so you can tell instances apart.",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.String,
+            DefaultValue = null,
+            IsReadOnly = false
+        });
+
+        await SeedSettingOnceAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Description = "A stable, immutable identifier generated once when this JIM instance was created. Used by tooling, logs, and telemetry to identify this instance. Cannot be changed.",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            DefaultValue = null,
+            IsReadOnly = true
+        }, () => Guid.NewGuid().ToString());
+
         stopwatch.Stop();
         Log.Information($"SyncServiceSettingsAsync: Completed in: {stopwatch.Elapsed}");
     }
@@ -928,6 +951,24 @@ internal class SeedingServer
     {
         await Application.ServiceSettings.CreateOrUpdateSettingAsync(setting);
         Log.Verbose($"SeedSettingAsync: Processed setting '{setting.Key}'");
+    }
+
+    /// <summary>
+    /// Seeds a single service setting exactly once. Creates the setting with a generated value
+    /// on first run; on subsequent runs, leaves the existing setting completely untouched.
+    /// Use for identifiers that must never be regenerated (e.g. Service ID).
+    /// </summary>
+    private async Task SeedSettingOnceAsync(ServiceSetting template, Func<string> valueFactory)
+    {
+        if (await Application.ServiceSettings.SettingExistsAsync(template.Key))
+        {
+            Log.Verbose($"SeedSettingOnceAsync: '{template.Key}' already exists; preserving existing value.");
+            return;
+        }
+
+        template.Value = valueFactory();
+        await Application.ServiceSettings.CreateSettingAsync(template);
+        Log.Information($"SeedSettingOnceAsync: Generated '{template.Key}' with value '{template.Value}'.");
     }
 
     /// <summary>

--- a/src/JIM.Application/Servers/SeedingServer.cs
+++ b/src/JIM.Application/Servers/SeedingServer.cs
@@ -962,13 +962,14 @@ internal class SeedingServer
     {
         if (await Application.ServiceSettings.SettingExistsAsync(template.Key))
         {
-            Log.Verbose($"SeedSettingOnceAsync: '{template.Key}' already exists; preserving existing value.");
+            Log.Verbose("SeedSettingOnceAsync: '{Key}' already exists; preserving existing value.", template.Key);
             return;
         }
 
         template.Value = valueFactory();
         await Application.ServiceSettings.CreateSettingAsync(template);
-        Log.Information($"SeedSettingOnceAsync: Generated '{template.Key}' with value '{template.Value}'.");
+        Log.Information("SeedSettingOnceAsync: Generated '{Key}'.", template.Key);
+        Log.Verbose("SeedSettingOnceAsync: '{Key}' value is '{Value}'.", template.Key, template.Value);
     }
 
     /// <summary>

--- a/src/JIM.Application/Servers/ServiceSettingsServer.cs
+++ b/src/JIM.Application/Servers/ServiceSettingsServer.cs
@@ -347,6 +347,9 @@ namespace JIM.Application.Servers
                 if (underlyingType == typeof(TimeSpan))
                     return (T)(object)TimeSpan.Parse(value);
 
+                if (underlyingType == typeof(Guid))
+                    return (T)(object)Guid.Parse(value);
+
                 if (underlyingType.IsEnum)
                     return (T)Enum.Parse(underlyingType, value);
 

--- a/src/JIM.Application/Servers/ServiceSettingsServer.cs
+++ b/src/JIM.Application/Servers/ServiceSettingsServer.cs
@@ -355,7 +355,15 @@ namespace JIM.Application.Servers
 
                 return default;
             }
-            catch
+            catch (FormatException)
+            {
+                return default;
+            }
+            catch (OverflowException)
+            {
+                return default;
+            }
+            catch (ArgumentException)
             {
                 return default;
             }

--- a/src/JIM.Models/Core/Constants.cs
+++ b/src/JIM.Models/Core/Constants.cs
@@ -280,5 +280,18 @@ public static class Constants
         /// Default: 1 second.
         /// </summary>
         public const string ProgressUpdateInterval = "UI.ProgressUpdateInterval";
+
+        // Instance Settings
+        /// <summary>
+        /// A friendly, editable name for this JIM instance.
+        /// Appears in the sidebar, browser tab title, and footer.
+        /// </summary>
+        public const string ServiceName = "Instance.Name";
+
+        /// <summary>
+        /// A stable, immutable GUID identifier for this JIM instance.
+        /// Generated exactly once on first startup; never changes thereafter.
+        /// </summary>
+        public const string ServiceId = "Instance.Id";
     }
 }

--- a/src/JIM.Models/Core/CoreEnums.cs
+++ b/src/JIM.Models/Core/CoreEnums.cs
@@ -187,7 +187,13 @@ public enum ServiceSettingCategory
     /// <summary>
     /// User interface settings.
     /// </summary>
-    UI = 5
+    UI = 5,
+
+    /// <summary>
+    /// Instance identity settings (Service Name, Service ID).
+    /// Used by administrators to tell JIM instances apart.
+    /// </summary>
+    Instance = 6
 }
 
 /// <summary>
@@ -224,7 +230,13 @@ public enum ServiceSettingValueType
     /// Encrypted string value for secrets (passwords, API keys, etc.).
     /// Values are encrypted at rest using ASP.NET Core Data Protection.
     /// </summary>
-    StringEncrypted = 5
+    StringEncrypted = 5,
+
+    /// <summary>
+    /// GUID value. Stored as a string in standard GUID format.
+    /// Typically used for read-only, auto-generated identifiers.
+    /// </summary>
+    Guid = 6
 }
 
 /// <summary>

--- a/src/JIM.Web/Pages/Admin/Settings.razor
+++ b/src/JIM.Web/Pages/Admin/Settings.razor
@@ -86,7 +86,7 @@
                 else if (settingContext.ValueType == ServiceSettingValueType.Guid)
                 {
                     var guidValue = settingContext.GetEffectiveValue();
-                    <span class="jim-text-code">@(guidValue ?? "(not set)")</span>
+                    <span class="jim-text-code me-1">@(guidValue ?? "(not set)")</span>
                     @if (!string.IsNullOrEmpty(guidValue))
                     {
                         <MudTooltip Text="Copy to clipboard" Arrow="true" Placement="Placement.Top">

--- a/src/JIM.Web/Pages/Admin/Settings.razor
+++ b/src/JIM.Web/Pages/Admin/Settings.razor
@@ -7,6 +7,7 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject ICredentialProtectionService CredentialProtection
+@inject IJSRuntime JSRuntime
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -80,6 +81,18 @@
                     {
                         <span class="jim-text-code">********</span>
                         <MudIconButton Icon="@Icons.Material.Outlined.Visibility" Variant="Variant.Filled" Size="Size.Small" OnClick="() => RevealSecretAsync(settingContext.Key)" />
+                    }
+                }
+                else if (settingContext.ValueType == ServiceSettingValueType.Guid)
+                {
+                    var guidValue = settingContext.GetEffectiveValue();
+                    <span class="jim-text-code">@(guidValue ?? "(not set)")</span>
+                    @if (!string.IsNullOrEmpty(guidValue))
+                    {
+                        <MudTooltip Text="Copy to clipboard" Arrow="true" Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Outlined.ContentCopy" Variant="Variant.Filled" Size="Size.Small"
+                                           OnClick="() => CopyToClipboardAsync(guidValue!)" />
+                        </MudTooltip>
                     }
                 }
                 else
@@ -222,6 +235,7 @@
             "Maintenance" => "Maintenance",
             "History" => "History",
             "Security" => "Security",
+            "Instance" => "Instance",
             _ => categoryString ?? "Unknown"
         };
     }
@@ -338,6 +352,19 @@
             {
                 Snackbar.Add($"Failed to revert setting: {ex.Message}", Severity.Error);
             }
+        }
+    }
+
+    private async Task CopyToClipboardAsync(string value)
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", value);
+            Snackbar.Add("Copied to clipboard.", Severity.Success);
+        }
+        catch (JSException)
+        {
+            Snackbar.Add("Failed to copy to clipboard.", Severity.Error);
         }
     }
 }

--- a/src/JIM.Web/Shared/MainLayout.razor
+++ b/src/JIM.Web/Shared/MainLayout.razor
@@ -24,11 +24,19 @@ else
 
 <MudLayout>
 
-    <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="@IsDrawerOpen" Elevation="0" Variant="@DrawerVariant.Mini" Overlay="false"
-                   Class="jim-drawer" @onmouseenter="@OnDrawerMouseEnter" @onmouseleave="@OnDrawerMouseLeave">
+    @if (!string.IsNullOrEmpty(_serviceName))
+    {
+        <div class="jim-instance-bar">
+            <span class="jim-title-accent">@_serviceName</span>
+        </div>
+    }
 
-            <div class="jim-drawer-logo">
+    <MudDrawerContainer Class="mud-height-full" Style="@(!string.IsNullOrEmpty(_serviceName) ? "padding-top: var(--jim-instance-bar-height)" : null)">
+        <MudDrawer @bind-Open="@IsDrawerOpen" Elevation="0" Variant="@DrawerVariant.Mini" Overlay="false"
+                   Class="@($"jim-drawer{(!string.IsNullOrEmpty(_serviceName) ? " jim-drawer-with-bar" : "")}")"
+                   @onmouseenter="@OnDrawerMouseEnter" @onmouseleave="@OnDrawerMouseLeave">
+
+            <div class="jim-drawer-logo d-flex align-center">
                 @if (!IsDrawerOpen && !string.IsNullOrEmpty(_serviceName))
                 {
                     <MudTooltip Text="@_serviceName" Arrow="true" Placement="Placement.Right">
@@ -41,13 +49,7 @@ else
                 }
                 @if (IsDrawerOpen)
                 {
-                    <div class="d-flex flex-column">
-                        <MudText Inline="true">JIM</MudText>
-                        @if (!string.IsNullOrEmpty(_serviceName))
-                        {
-                            <MudText Typo="Typo.caption" Class="mud-text-secondary jim-text-code">@_serviceName</MudText>
-                        }
-                    </div>
+                    <MudText Class="ms-2">JIM</MudText>
                 }
             </div>
 

--- a/src/JIM.Web/Shared/MainLayout.razor
+++ b/src/JIM.Web/Shared/MainLayout.razor
@@ -1,9 +1,10 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 @implements IDisposable
 @inject IJSRuntime JSRuntime
 @inject IUserPreferenceService PreferenceService
 @inject JIM.Web.Models.ThemeSettings ThemeSettings
 @inject NavigationManager NavigationManager
+@inject IJimApplicationFactory JimFactory
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -12,7 +13,14 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 
-<PageTitle>JIM</PageTitle>
+@if (!string.IsNullOrEmpty(_serviceName))
+{
+    <PageTitle>JIM - @_serviceName</PageTitle>
+}
+else
+{
+    <PageTitle>JIM</PageTitle>
+}
 
 <MudLayout>
 
@@ -21,10 +29,25 @@
                    Class="jim-drawer" @onmouseenter="@OnDrawerMouseEnter" @onmouseleave="@OnDrawerMouseLeave">
 
             <div class="jim-drawer-logo">
-                <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+                @if (!IsDrawerOpen && !string.IsNullOrEmpty(_serviceName))
+                {
+                    <MudTooltip Text="@_serviceName" Arrow="true" Placement="Placement.Right">
+                        <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+                    </MudTooltip>
+                }
+                else
+                {
+                    <MudImage Src="/images/jim-logo.png" Width="28" Class="mt-4 ms-4 mb-3" Alt="JIM Logo"></MudImage>
+                }
                 @if (IsDrawerOpen)
                 {
-                    <MudText Inline="true">JIM</MudText>
+                    <div class="d-flex flex-column">
+                        <MudText Inline="true">JIM</MudText>
+                        @if (!string.IsNullOrEmpty(_serviceName))
+                        {
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary jim-text-code">@_serviceName</MudText>
+                        }
+                    </div>
                 }
             </div>
 
@@ -63,6 +86,11 @@
                             <span>All rights reserved</span>
                             <span class="jim-page-footer-sep">|</span>
                             <span>v@(AppVersion)</span>
+                            @if (!string.IsNullOrEmpty(_serviceName))
+                            {
+                                <span class="jim-page-footer-sep">|</span>
+                                <span>@_serviceName</span>
+                            }
                             <span class="jim-page-footer-sep">|</span>
                             <MudLink Href="https://github.com/TetronIO/JIM" Target="_blank"
                                      Color="Color.Inherit" Underline="Underline.Hover" Class="jim-page-footer-github">
@@ -127,6 +155,7 @@
     private const int LargeScreenBreakpoint = 1400;
     // Content container width - pages can request full width via SetFullWidth()
     private MaxWidth _contentMaxWidth = MaxWidth.ExtraLarge;
+    private string? _serviceName;
 
     /// <summary>
     /// Called by pages that implement IFullWidthPage to remove the max-width constraint.
@@ -213,8 +242,12 @@
         }
     }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        using var jim = JimFactory.Create();
+        _serviceName = await jim.ServiceSettings.GetSettingValueAsync<string>(
+            JIM.Models.Core.Constants.SettingKeys.ServiceName);
+
         NavigationManager.LocationChanged += OnLocationChanged;
     }
 

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1,5 +1,9 @@
 /* reference: https://github.com/MudBlazor/MudBlazor/blob/ff672a8b988fdfb1f5ab9f556813823d885118d4/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs#L92 */
 
+:root {
+    --jim-instance-bar-height: 28px;
+}
+
 /* MUDBLAZOR CUSTOMISATIONS */
 /* Note: Colour palettes are defined in css/themes/ files, not here. */
 
@@ -497,17 +501,42 @@ html[lang] .mud-tabs-tabbar.mud-tabs-border-top {
     overflow-y: auto;
 }
 
-.jim-drawer-logo img {
-    vertical-align: middle;
+.jim-drawer.jim-drawer-with-bar {
+    top: var(--jim-instance-bar-height);
+    height: calc(100vh - var(--jim-instance-bar-height));
 }
+
 
 .jim-drawer-logo p,
 .jim-drawer-logo span {
-    margin: 4px 0 0 10px;
     font-size: 1rem;
     font-weight: 500;
-    vertical-align: sub;
     color: var(--jim-logo-text-color, #ffffff) !important;
+}
+
+.jim-instance-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1400;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--jim-instance-bar-height);
+    background-color: var(--jim-instance-bar-bg);
+    border-bottom: 1px solid var(--mud-palette-divider);
+    font-size: 0.78rem;
+    color: var(--mud-palette-text-primary);
+    letter-spacing: 0.03em;
+}
+
+.jim-instance-bar .jim-title-accent {
+    color: var(--mud-palette-text-primary);
+}
+
+body.jim-dark-mode .jim-instance-bar .jim-title-accent {
+    color: var(--mud-palette-tertiary);
 }
 
 .jim-drawer-footer {

--- a/src/JIM.Web/wwwroot/css/themes/black-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/black-dark.css
@@ -124,7 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #35363e;
+    --jim-instance-bar-bg: #141418;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/black-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/black-dark.css
@@ -124,7 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #2a2b30;
+    --jim-instance-bar-bg: #3a3b42;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/black-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/black-dark.css
@@ -124,7 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #303139;
+    --jim-instance-bar-bg: #35363e;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/black-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/black-dark.css
@@ -124,7 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #3a3b42;
+    --jim-instance-bar-bg: #303139;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/black-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/black-dark.css
@@ -124,6 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
+    --jim-instance-bar-bg: #2a2b30;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/black-light.css
+++ b/src/JIM.Web/wwwroot/css/themes/black-light.css
@@ -123,6 +123,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
+    --jim-instance-bar-bg: #d8d8db;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
@@ -129,7 +129,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #202224;
+    --jim-instance-bar-bg: #303336;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
@@ -129,7 +129,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #2c2e32;
+    --jim-instance-bar-bg: #0b0c0d;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
@@ -129,7 +129,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #303336;
+    --jim-instance-bar-bg: #28292d;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
@@ -129,7 +129,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #28292d;
+    --jim-instance-bar-bg: #2c2e32;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/blended-nav-dark.css
@@ -129,6 +129,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
+    --jim-instance-bar-bg: #202224;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/blended-nav-light.css
+++ b/src/JIM.Web/wwwroot/css/themes/blended-nav-light.css
@@ -124,6 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text (dark for light sidebar) === */
     --jim-logo-text-color: #2a2a30;
+    --jim-instance-bar-bg: #dde1e8;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #252b29;
+    --jim-instance-bar-bg: #2a302e;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #2e3432;
+    --jim-instance-bar-bg: #252b29;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
@@ -128,6 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
+    --jim-instance-bar-bg: #1e2220;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #1e2220;
+    --jim-instance-bar-bg: #2e3432;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/future-minimal-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #2a302e;
+    --jim-instance-bar-bg: #090b0a;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/future-minimal-light.css
+++ b/src/JIM.Web/wwwroot/css/themes/future-minimal-light.css
@@ -129,6 +129,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #080b0a;
+    --jim-instance-bar-bg: #adb0ae;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
@@ -127,6 +127,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
+    --jim-instance-bar-bg: #1a2d42;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
@@ -127,7 +127,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #1e334c;
+    --jim-instance-bar-bg: #223a52;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
@@ -127,7 +127,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #253d56;
+    --jim-instance-bar-bg: #1e334c;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
@@ -127,7 +127,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #223a52;
+    --jim-instance-bar-bg: #0b1420;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o5-dark.css
@@ -127,7 +127,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #1a2d42;
+    --jim-instance-bar-bg: #253d56;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o5-light.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o5-light.css
@@ -130,6 +130,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #7c889d;
+    --jim-instance-bar-bg: #dde0e6;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
@@ -128,6 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
+    --jim-instance-bar-bg: #0a1f35;
 }
 
 /* Lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #0a1f35;
+    --jim-instance-bar-bg: #162d45;
 }
 
 /* Lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #122840;
+    --jim-instance-bar-bg: #030e1a;
 }
 
 /* Lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #162d45;
+    --jim-instance-bar-bg: #0e2238;
 }
 
 /* Lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o6-dark.css
@@ -128,7 +128,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #6b788e;
-    --jim-instance-bar-bg: #0e2238;
+    --jim-instance-bar-bg: #122840;
 }
 
 /* Lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/navy-o6-light.css
+++ b/src/JIM.Web/wwwroot/css/themes/navy-o6-light.css
@@ -131,6 +131,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #7c889d;
+    --jim-instance-bar-bg: #dde0e6;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/purple-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/purple-dark.css
@@ -125,7 +125,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #30304e;
+    --jim-instance-bar-bg: #282844;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/purple-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/purple-dark.css
@@ -125,7 +125,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #2e2e4c;
+    --jim-instance-bar-bg: #0c0c1e;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/purple-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/purple-dark.css
@@ -125,6 +125,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
+    --jim-instance-bar-bg: #222238;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/purple-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/purple-dark.css
@@ -125,7 +125,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #222238;
+    --jim-instance-bar-bg: #30304e;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/purple-dark.css
+++ b/src/JIM.Web/wwwroot/css/themes/purple-dark.css
@@ -125,7 +125,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
-    --jim-instance-bar-bg: #282844;
+    --jim-instance-bar-bg: #2e2e4c;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/src/JIM.Web/wwwroot/css/themes/purple-light.css
+++ b/src/JIM.Web/wwwroot/css/themes/purple-light.css
@@ -124,6 +124,7 @@ html[lang] {
 
     /* === JIM Custom: Logo text === */
     --jim-logo-text-color: #ffffff;
+    --jim-instance-bar-bg: #d8d8ec;
 }
 
 /* Uncomment to lighten outlined/text primary button text for readability */

--- a/test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs
@@ -357,4 +357,108 @@ public class ServiceSettingsControllerTests
     }
 
     #endregion
+
+    #region Instance settings tests (#583)
+
+    [Test]
+    public async Task UpdateAsync_ServiceName_UpdatesSuccessfullyAsync()
+    {
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceName,
+            DisplayName = "Service Name",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.String,
+            Value = null,
+            IsReadOnly = false
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceName))
+            .ReturnsAsync(setting);
+        _mockServiceSettingsRepo.Setup(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new ServiceSettingUpdateRequestDto { Value = "HQ-Production" };
+        var result = await _controller.UpdateAsync(Constants.SettingKeys.ServiceName, request);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        _mockServiceSettingsRepo.Verify(r => r.UpdateSettingAsync(
+            It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceName && s.Value == "HQ-Production")),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAsync_ServiceId_ReturnsBadRequestAsync()
+    {
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            Value = Guid.NewGuid().ToString(),
+            IsReadOnly = true
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(setting);
+
+        var request = new ServiceSettingUpdateRequestDto { Value = Guid.NewGuid().ToString() };
+        var result = await _controller.UpdateAsync(Constants.SettingKeys.ServiceId, request);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        var body = ((BadRequestObjectResult)result).Value as ApiErrorResponse;
+        Assert.That(body, Is.Not.Null);
+        Assert.That(body!.Message, Does.Contain("read-only"));
+
+        _mockServiceSettingsRepo.Verify(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task RevertAsync_ServiceId_ReturnsBadRequestAsync()
+    {
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            Value = Guid.NewGuid().ToString(),
+            IsReadOnly = true
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(setting);
+
+        var result = await _controller.RevertAsync(Constants.SettingKeys.ServiceId);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockServiceSettingsRepo.Verify(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task GetByKeyAsync_ServiceId_ReturnsGuidStringAsync()
+    {
+        var id = Guid.NewGuid();
+        var setting = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.ServiceId,
+            DisplayName = "Service ID",
+            Category = ServiceSettingCategory.Instance,
+            ValueType = ServiceSettingValueType.Guid,
+            Value = id.ToString(),
+            IsReadOnly = true
+        };
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(setting);
+
+        var result = await _controller.GetByKeyAsync(Constants.SettingKeys.ServiceId) as OkObjectResult;
+        var dto = result?.Value as ServiceSettingDto;
+
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto!.ValueType, Is.EqualTo("Guid"));
+        Assert.That(dto.EffectiveValue, Is.EqualTo(id.ToString()));
+        Assert.That(dto.IsReadOnly, Is.True);
+    }
+
+    #endregion
 }

--- a/test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/ServiceSettingsControllerTests.cs
@@ -456,8 +456,8 @@ public class ServiceSettingsControllerTests
 
         Assert.That(dto, Is.Not.Null);
         Assert.That(dto!.ValueType, Is.EqualTo("Guid"));
-        Assert.That(dto.EffectiveValue, Is.EqualTo(id.ToString()));
-        Assert.That(dto.IsReadOnly, Is.True);
+        Assert.That(dto!.EffectiveValue, Is.EqualTo(id.ToString()));
+        Assert.That(dto!.IsReadOnly, Is.True);
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+[TestFixture]
+public class SeedingServerInstanceSettingsTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepo = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockServiceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepo.Object);
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_SeedsServiceNameWithNullValueAsync()
+    {
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        ServiceSetting? captured = null;
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceName)))
+            .Callback<ServiceSetting>(s => captured = s)
+            .Returns(Task.CompletedTask);
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key != Constants.SettingKeys.ServiceName)))
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Instance));
+        Assert.That(captured.ValueType, Is.EqualTo(ServiceSettingValueType.String));
+        Assert.That(captured.DefaultValue, Is.Null);
+        Assert.That(captured.Value, Is.Null);
+        Assert.That(captured.IsReadOnly, Is.False);
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_GeneratesServiceIdGuidAsync()
+    {
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        ServiceSetting? captured = null;
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceId)))
+            .Callback<ServiceSetting>(s => captured = s)
+            .Returns(Task.CompletedTask);
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key != Constants.SettingKeys.ServiceId)))
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Instance));
+        Assert.That(captured.ValueType, Is.EqualTo(ServiceSettingValueType.Guid));
+        Assert.That(captured.IsReadOnly, Is.True);
+        Assert.That(Guid.TryParse(captured.Value, out var parsed), Is.True,
+            "Service ID value must be a valid GUID");
+        Assert.That(parsed, Is.Not.EqualTo(Guid.Empty));
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_SecondRun_PreservesExistingServiceIdAsync()
+    {
+        var existingId = Guid.NewGuid().ToString();
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(true);
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ServiceId,
+                DisplayName = "Service ID",
+                Category = ServiceSettingCategory.Instance,
+                ValueType = ServiceSettingValueType.Guid,
+                Value = existingId,
+                IsReadOnly = true
+            });
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.IsAny<ServiceSetting>()))
+            .Returns(Task.CompletedTask);
+        _mockServiceSettingsRepo.Setup(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()))
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        _mockServiceSettingsRepo.Verify(
+            r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceId)),
+            Times.Never,
+            "Service ID must not be recreated when it already exists");
+
+        _mockServiceSettingsRepo.Verify(
+            r => r.UpdateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.ServiceId)),
+            Times.Never,
+            "Service ID must not be updated when it already exists");
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SeedingServerInstanceSettingsTests.cs
@@ -82,21 +82,10 @@ public class SeedingServerInstanceSettingsTests
     [Test]
     public async Task SyncServiceSettings_SecondRun_PreservesExistingServiceIdAsync()
     {
-        var existingId = Guid.NewGuid().ToString();
         _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>()))
             .ReturnsAsync(false);
         _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(Constants.SettingKeys.ServiceId))
             .ReturnsAsync(true);
-        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ServiceId))
-            .ReturnsAsync(new ServiceSetting
-            {
-                Key = Constants.SettingKeys.ServiceId,
-                DisplayName = "Service ID",
-                Category = ServiceSettingCategory.Instance,
-                ValueType = ServiceSettingValueType.Guid,
-                Value = existingId,
-                IsReadOnly = true
-            });
         _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.IsAny<ServiceSetting>()))
             .Returns(Task.CompletedTask);
         _mockServiceSettingsRepo.Setup(r => r.UpdateSettingAsync(It.IsAny<ServiceSetting>()))

--- a/test/JIM.Worker.Tests/Servers/ServiceSettingsServerGuidConversionTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ServiceSettingsServerGuidConversionTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+[TestFixture]
+public class ServiceSettingsServerGuidConversionTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepo = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockServiceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepo.Object);
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task GetSettingValueAsync_GuidValueType_ReturnsParsedGuidAsync()
+    {
+        var expected = Guid.NewGuid();
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync("Instance.Id"))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = "Instance.Id",
+                DisplayName = "Service ID",
+                Category = ServiceSettingCategory.Instance,
+                ValueType = ServiceSettingValueType.Guid,
+                Value = expected.ToString(),
+                IsReadOnly = true
+            });
+
+        var result = await _application.ServiceSettings.GetSettingValueAsync<Guid>("Instance.Id");
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task GetSettingValueAsync_GuidValueType_MalformedString_ReturnsDefaultAsync()
+    {
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync("Instance.Id"))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = "Instance.Id",
+                DisplayName = "Service ID",
+                Category = ServiceSettingCategory.Instance,
+                ValueType = ServiceSettingValueType.Guid,
+                Value = "not-a-guid",
+                IsReadOnly = true
+            });
+
+        var result = await _application.ServiceSettings.GetSettingValueAsync<Guid>("Instance.Id");
+
+        Assert.That(result, Is.EqualTo(Guid.Empty));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a user-editable **Service Name** and a read-only, auto-generated **Service ID** (GUID) so administrators can tell individual JIM instances apart at a glance. Resolves [#583](https://github.com/TetronIO/JIM/issues/583).

### What the user sees

- **Drawer header** - when Service Name is set, it renders in monospace underneath the "JIM" wordmark. Collapsed drawer shows it as a tooltip on the logo.
- **Browser tab title** - suffixes \`- {ServiceName}\` on layout-level pages, so multi-tab operators can distinguish instances without switching tabs.
- **Footer** - appears between version and GitHub link.
- **Service Settings page** - new "Instance" category. Service ID renders in monospace with a copy-to-clipboard icon; edit is disabled via the existing read-only chip.

When Service Name is unset, every surface falls back to the pre-feature rendering byte-for-byte.

### What is under the hood

- New \`ServiceSettingCategory.Instance\` and \`ServiceSettingValueType.Guid\` enum values. No EF migration required (both columns are stored as \`integer\`).
- New \`SettingKeys.ServiceName\` (\`Instance.Name\`) and \`SettingKeys.ServiceId\` (\`Instance.Id\`) constants.
- New \`SeedSettingOnceAsync\` helper in \`SeedingServer\` - structurally enforces the "generate once, never regenerate" guarantee for Service ID via an early-return on \`SettingExistsAsync\`. Distinct from \`CreateOrUpdateSettingAsync\`, which re-applies values on every startup for env-var-backed settings.
- \`ConvertSettingValue<T>\` gains a \`Guid.Parse\` branch. As an incidental cleanup in the same file, the pre-existing bare \`catch\` was replaced with typed catches (\`FormatException\`, \`OverflowException\`, \`ArgumentException\`) per \`src/CLAUDE.md\`'s exception-handling rule, since the new malformed-string test promotes the catch to a tested code path.
- Read-only enforcement is free at the API layer (existing \`PrepareUpdateAsync\` guard); PowerShell cmdlets inherit the protection transitively through the API.

### What is deliberately not here

- No propagation of Service Name/ID into log enrichers, activity records, or exported diagnostic bundles. Out of scope for v0.9; follow-up if customers ask.
- No per-page browser-title suffixing - only the layout-level \`<PageTitle>\` is extended. Pages with their own \`<PageTitle>\` override as normal.

## Design and plan docs

Both committed to the branch for traceability:

- \`docs/superpowers/specs/2026-04-18-service-name-and-id-design.md\`
- \`docs/superpowers/plans/2026-04-18-service-name-and-id.md\`

## Test plan

- [x] \`dotnet build JIM.sln\` - 0 errors, 0 warnings
- [x] \`dotnet test JIM.sln\` - 2625 passing, 0 failed (9 pre-existing skips)
- [x] New tests: \`ServiceSettingsServerGuidConversionTests\` (2), \`SeedingServerInstanceSettingsTests\` (3), \`ServiceSettingsControllerTests\` +4 cases (CRUD happy path, read-only rejection on PUT/DELETE, Guid-typed GET response)
- [x] Seeding contract covered: first-run generates both settings, second-run preserves existing Service ID (neither \`CreateSettingAsync\` nor \`UpdateSettingAsync\` invoked for its key)
- [ ] Manual smoke against a freshly-seeded DB - set Service Name, restart stack, confirm Service ID unchanged, confirm chrome renders in drawer + tab + footer
- [ ] Manual PowerShell verification - \`Set-JIMServiceSetting -Key Instance.Id\` returns a clear read-only error; \`Set-JIMServiceSetting -Key Instance.Name\` succeeds

## Reviewer notes

- Single-commit task bundles (Tasks 6-8 into one commit for MainLayout) are intentional - same file, logically one change.
- Two mid-stream fix commits (\`fix:\` prefixes) landed after task-level quality reviews flagged issues: typed catches in \`ConvertSettingValue\`, and structured Serilog templates / dead mock cleanup in seeding. Fixes are separate commits rather than amends per JIM conventions.