### PR TITLE
Integration test perf and connector-files volume diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,6 +456,7 @@ env
 # Integration test artifacts
 test/integration/results/
 test/integration/test-data/
+test/integration/test-data/.cache/
 test/integration/.api-key
 test/test-data/
 test-data/

--- a/src/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/src/JIM.Application/Servers/ExportExecutionServer.cs
@@ -309,8 +309,9 @@ public class ExportExecutionServer
             await ExecuteUsingCallsWithBatchingAsync(connectedSystem, callsConnector, result, options,
                 cancellationToken, progressCallback, connectorFactory, repositoryFactory, batchCompletedCallback);
         }
-        // Check if connector supports export using files — still loads all exports upfront
-        // (file-based connectors write all data in one pass so batch-loading doesn't help)
+        // File-based connectors load all pending exports upfront because the connector writes the
+        // full output file in a single pass. Batching the DB load would only help if the write
+        // strategy also streamed; see issue #633 for that follow-up.
         else if (connector is IConnectorExportUsingFiles filesConnector)
         {
             var pendingExports = await GetExecutableExportsAsync(connectedSystem.Id);

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -2574,11 +2574,10 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         var now = DateTime.UtcNow;
 
         return await Repository.Database.PendingExports
+            .AsNoTracking()
             .AsSplitQuery()
             .Include(pe => pe.AttributeValueChanges)
                 .ThenInclude(avc => avc.Attribute)
-            .Include(pe => pe.ConnectedSystemObject)
-                .ThenInclude(cso => cso!.Type)
             .Include(pe => pe.ConnectedSystemObject)
                 .ThenInclude(cso => cso!.AttributeValues)
                     .ThenInclude(av => av.Attribute)
@@ -2603,6 +2602,7 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     public async Task<List<PendingExport>> GetExecutableExportBatchAsync(int connectedSystemId, int skip, int take)
     {
         return await ExecutableExportsQuery(connectedSystemId)
+            .AsNoTracking()
             .AsSplitQuery()
             .Include(pe => pe.AttributeValueChanges)
                 .ThenInclude(avc => avc.Attribute)

--- a/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
@@ -89,7 +89,7 @@
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
             <MudText Typo="Typo.body2" Class="mud-text-secondary">Rows per page:</MudText>
             <MudSelect T="int" Value="@_rowsPerPage" ValueChanged="OnRowsPerPageChanged"
-                       Variant="Variant.Outlined" Dense="true" Margin="Margin.Dense"
+                       Variant="Variant.Text" Dense="true" Margin="Margin.Dense"
                        Style="width: 70px;" Class="mt-0">
                 <MudSelectItem T="int" Value="10">10</MudSelectItem>
                 <MudSelectItem T="int" Value="25">25</MudSelectItem>
@@ -417,7 +417,7 @@
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
             <MudText Typo="Typo.body2" Class="mud-text-secondary">Rows per page:</MudText>
             <MudSelect T="int" Value="@_rowsPerPage" ValueChanged="OnRowsPerPageChanged"
-                       Variant="Variant.Outlined" Dense="true" Margin="Margin.Dense"
+                       Variant="Variant.Text" Dense="true" Margin="Margin.Dense"
                        Style="width: 70px;" Class="mt-0">
                 <MudSelectItem T="int" Value="10">10</MudSelectItem>
                 <MudSelectItem T="int" Value="25">25</MudSelectItem>

--- a/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
@@ -346,7 +346,7 @@
                         var percentage = (double)context.ObjectsProcessed / context.ObjectsToProcess * 100;
                         <MudStack Spacing="0" Style="width: 120px;">
                             <MudProgressLinear Value="@percentage" Color="Color.Info" Rounded="true" Size="Size.Small" />
-                            <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="white-space: nowrap;">@context.ObjectsProcessed.ToString("N0") / @context.ObjectsToProcess.ToString("N0")</MudText>
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary mt-3" Style="white-space: nowrap;">@context.ObjectsProcessed.ToString("N0") / @context.ObjectsToProcess.ToString("N0")</MudText>
                         </MudStack>
                     }
                     else

--- a/src/JIM.Web/Pages/Admin/Components/OperationsQueueTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsQueueTab.razor
@@ -452,11 +452,13 @@ else
     {
         if (context.Status == WorkerTaskStatus.Processing)
         {
-            if (context.ObjectsToProcess > 0)
+            if (context.ObjectsToProcess.HasValue && context.ObjectsToProcess.Value > 0 && context.ObjectsProcessed.HasValue)
             {
-                var percentage = (double)context.ObjectsProcessed!.Value / context.ObjectsToProcess.Value * 100;
+                var processed = context.ObjectsProcessed.Value;
+                var total = context.ObjectsToProcess.Value;
+                var percentage = (double)processed / total * 100;
                 <MudProgressLinear Value="@percentage" Color="Color.Info" Rounded="true" />
-                <MudText Typo="Typo.caption" Class="mt-3">@context.ObjectsProcessed.Value.ToString("N0") / @context.ObjectsToProcess.Value.ToString("N0")@(!string.IsNullOrEmpty(context.ProgressMessage) ? $" - {context.ProgressMessage}" : "")</MudText>
+                <MudText Typo="Typo.caption" Class="mt-3">@processed.ToString("N0") / @total.ToString("N0")@(!string.IsNullOrEmpty(context.ProgressMessage) ? $" - {context.ProgressMessage}" : "")</MudText>
             }
             else
             {

--- a/src/JIM.Web/Pages/Admin/Components/OperationsQueueTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsQueueTab.razor
@@ -456,7 +456,7 @@ else
             {
                 var percentage = (double)context.ObjectsProcessed!.Value / context.ObjectsToProcess.Value * 100;
                 <MudProgressLinear Value="@percentage" Color="Color.Info" Rounded="true" />
-                <MudText Typo="Typo.caption" Class="mt-2">@context.ObjectsProcessed.Value.ToString("N0") / @context.ObjectsToProcess.Value.ToString("N0")@(!string.IsNullOrEmpty(context.ProgressMessage) ? $" - {context.ProgressMessage}" : "")</MudText>
+                <MudText Typo="Typo.caption" Class="mt-3">@context.ObjectsProcessed.Value.ToString("N0") / @context.ObjectsToProcess.Value.ToString("N0")@(!string.IsNullOrEmpty(context.ProgressMessage) ? $" - {context.ProgressMessage}" : "")</MudText>
             }
             else
             {

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1382,8 +1382,20 @@ html[lang] .mud-alert-position {
     transition: background-color 0.2s ease, color 0.2s ease;
 }
 
+.jim-chip-link .mud-chip .jim-title-accent {
+    transition: color 0.2s ease;
+}
+
 .jim-chip-link:hover .mud-chip {
     background-color: var(--mud-palette-primary);
+    color: var(--mud-palette-primary-text);
+}
+
+/* Ensure the accent-coloured prefix (e.g. object type) inside a hovered chip
+   switches to the chip's hover text colour so it remains legible against the
+   primary background. Uses the theme's primary-text variable so this works
+   uniformly across every theme. */
+.jim-chip-link:hover .mud-chip .jim-title-accent {
     color: var(--mud-palette-primary-text);
 }
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -227,3 +227,39 @@ These flags are for human developer iteration only. Claude must not use them bec
 The OpenLDAP accesslog database uses an MDB storage engine with a fixed maximum map size (`olcDbMaxSize`). When the map is full, OpenLDAP **silently stops recording changes**; delta imports will find zero modifications and sync changes will be lost. There is no error message; the writes just stop.
 
 The map size is configured in `test/integration/docker/openldap/scripts/01-add-second-suffix.sh`. Current setting: **8 GB** (sufficient for Scale100K / 100K objects with large group membership operations). If adding templates beyond Scale100K (e.g. Scale1M / 1M objects), increase the accesslog `olcDbMaxSize` proportionally (estimate ~10 MB per 1,000 objects for the initial population, plus additional capacity for sync cycles and group membership writes).
+
+## CSV cache
+
+The three large, deterministic HR CSVs (`hr-users.csv`, `departments.csv`, `training-records.csv`) are cached by `test/integration/Get-OrGenerate-TestCSV.ps1`, which `Invoke-IntegrationTests.ps1` and `Run-IntegrationTests.ps1` call instead of invoking `Generate-TestCSV.ps1` directly. At Scale100K the cache turns ~100 s of CSV generation into a sub-second tar extraction.
+
+**Cache location:** `test/integration/test-data/.cache/csv-<template>-<hash16>.tar` (gitignored).
+
+**Cache key inputs:** whole-file SHA256 over `Generate-TestCSV.ps1` + `utils/Test-Helpers.ps1`, plus the template name and PowerShell major version. Editing either script invalidates every template's cache entry. This is intentional (matches the Samba snapshot precedent in `Build-SambaSnapshots.ps1`).
+
+**Determinism requirement:** the CSVs MUST be byte-identical across runs, otherwise the cache silently serves stale data. The two places this is enforced:
+- `Generate-TestCSV.ps1` uses `$script:TrainingEpoch` (a fixed `2026-01-01` UTC date) instead of `Get-Date` for `completionDate`.
+- `utils/Test-Helpers.ps1 > New-TestUser` uses a fixed `2030-01-01` UTC epoch instead of `Get-Date` for `AccountExpires`.
+Do NOT reintroduce `Get-Date` into these code paths. If you add a new deterministic date field, derive it from a fixed epoch too.
+
+**Not cached:** `cross-domain-users.csv`. It is a header-only export target that the File connector appends to during the test. The wrapper regenerates it fresh on every run (including cache hits) to avoid leaking state between runs.
+
+**Docker seeding runs every time.** The cache archive holds file contents only; the `jim-connector-files-volume` state is not cached. Both cache-hit and cache-miss paths call `Write-FileToConnectorVolume` to stream the four CSVs into `jim.worker` with correct ownership.
+
+**Flags:**
+- `-IgnoreCache` — force regeneration and overwrite any existing cache entry
+- `-NoCache` — generate as normal but neither read nor write the cache
+- `-CachePath <dir>` — override the default `<OutputPath>/.cache` location
+
+**Verifying the cache:** `test/integration/Test-CsvCache.ps1` is a standalone acceptance-test script that proves generator determinism, cache round-trip byte-identity, key sensitivity, and invalidation on script edits. Runs in a few seconds against the `Nano` template without needing Docker or `jim.worker`. Run it whenever you touch `Generate-TestCSV.ps1`, `utils/Test-Helpers.ps1 > New-TestUser`, or the cache wrapper.
+
+**GitHub Actions wiring** (for the future pre-release workflow; out of scope for this iteration):
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: test/integration/test-data/.cache
+    key:  csv-${{ matrix.template }}-${{ hashFiles('test/integration/Generate-TestCSV.ps1','test/integration/utils/Test-Helpers.ps1') }}
+    restore-keys: |
+      csv-${{ matrix.template }}-
+- run: ./test/integration/Get-OrGenerate-TestCSV.ps1 -Template ${{ matrix.template }}
+```

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -243,7 +243,7 @@ Do NOT reintroduce `Get-Date` into these code paths. If you add a new determinis
 
 **Not cached:** `cross-domain-users.csv`. It is a header-only export target that the File connector appends to during the test. The wrapper regenerates it fresh on every run (including cache hits) to avoid leaking state between runs.
 
-**Docker seeding runs every time.** The cache archive holds file contents only; the `jim-connector-files-volume` state is not cached. Both cache-hit and cache-miss paths call `Write-FileToConnectorVolume` to stream the four CSVs into `jim.worker` with correct ownership.
+**Docker seeding runs every time.** The cache archive holds file contents only; the `jim-connector-files-volume` state is not cached. Both cache-hit and cache-miss paths call `Write-FilesToConnectorVolume` (plural) to copy the four CSVs into the volume via a single rootless `docker run --user 1654:1654 busybox` that mounts the volume and the source directory. Files land owned by UID 1654 directly (no `chown` or `jim.worker` exec required), which is both faster and better aligned with the read-only rootfs hardening. Wall-clock is ~1 s for a full Scale100K-sized payload (~70 MB across four files). The legacy per-file `Write-FileToConnectorVolume` still exists as a thin wrapper for single-file callers.
 
 **Flags:**
 - `-IgnoreCache` — force regeneration and overwrite any existing cache entry

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -230,7 +230,20 @@ The map size is configured in `test/integration/docker/openldap/scripts/01-add-s
 
 ## CSV cache
 
-The three large, deterministic HR CSVs (`hr-users.csv`, `departments.csv`, `training-records.csv`) are cached by `test/integration/Get-OrGenerate-TestCSV.ps1`, which `Invoke-IntegrationTests.ps1` and `Run-IntegrationTests.ps1` call instead of invoking `Generate-TestCSV.ps1` directly. At Scale100K the cache turns ~100 s of CSV generation into a sub-second tar extraction.
+The three large, deterministic HR CSVs (`hr-users.csv`, `departments.csv`, `training-records.csv`) are cached by `test/integration/Get-OrGenerate-TestCSV.ps1`. At Scale100K the cache turns ~100 s of CSV generation into a sub-second tar extraction.
+
+**Callers that use the cache (templated by the caller, potentially large):**
+- `Invoke-IntegrationTests.ps1` (main runner, Step 3 populate)
+- `Run-IntegrationTests.ps1` (scenario orchestrator)
+- `scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1` (scenario-internal reset to baseline)
+- `scenarios/Invoke-Scenario7-ClearConnectedSystemObjects.ps1` (scenario-internal seed)
+
+**Callers that deliberately bypass the cache (call `Generate-TestCSV.ps1` directly):**
+- `scenarios/Invoke-Scenario4-DeletionRules.ps1` — hard-coded `Nano` template then overlays scenario-specific HR/Training CSVs from `scenarios/data/`. Caching would save negligible time (3 users) and the overlay would immediately replace the wrapper's output.
+- `scenarios/Invoke-Scenario5-MatchingRules.ps1` — hard-coded `Nano`, same overlay pattern as Scenario 4.
+- `scenarios/Invoke-Scenario6-SchedulerService.ps1` — hard-coded `Micro` (10 users); too small for caching to be worth the wrapper complexity.
+
+When adding a new scenario, ask: does it use `-Template $Template` with a potentially large template, and does it consume the generator's pristine output without further file-level tampering? If both yes, call `Get-OrGenerate-TestCSV.ps1`. Otherwise stick with `Generate-TestCSV.ps1` directly.
 
 **Cache location:** `test/integration/test-data/.cache/csv-<template>-<hash16>.tar` (gitignored).
 

--- a/test/integration/Generate-TestCSV.ps1
+++ b/test/integration/Generate-TestCSV.ps1
@@ -15,6 +15,11 @@
 .PARAMETER OutputPath
     Path where CSV files should be created (default: ./test-data)
 
+.PARAMETER SkipSeed
+    Skip the final step of streaming CSVs into jim-connector-files-volume.
+    Used by Get-OrGenerate-TestCSV.ps1 when generating to a temp directory for archiving;
+    the wrapper runs the seeding step itself after extracting to the final output path.
+
 .EXAMPLE
     ./Generate-TestCSV.ps1 -Template Small
 #>
@@ -25,11 +30,18 @@ param(
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]
-    [string]$OutputPath = "./test-data"
+    [string]$OutputPath = "./test-data",
+
+    [Parameter(Mandatory=$false)]
+    [switch]$SkipSeed
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+# Fixed epoch for deterministic date generation (used by training records).
+# MUST stay constant: changing it invalidates every cached CSV archive (see Get-OrGenerate-TestCSV.ps1).
+$script:TrainingEpoch = [DateTime]::new(2026, 1, 1, 0, 0, 0, [DateTimeKind]::Utc)
 
 # Import helpers
 . "$PSScriptRoot/utils/Test-Helpers.ps1"
@@ -165,9 +177,11 @@ for ($i = 1; $i -le $usersWithTraining; $i++) {
         $completedCourses += $courses[$courseIndex].Code
     }
 
-    # Training completion date (deterministic based on index)
-    $daysAgo = 7 + ($i * 3) % 365  # Between 7 days and 1 year ago
-    $completionDate = (Get-Date).AddDays(-$daysAgo).ToString("yyyy-MM-ddTHH:mm:ssZ")
+    # Training completion date (deterministic based on index).
+    # Base date is a fixed epoch, not Get-Date, so re-runs produce byte-identical CSVs;
+    # this is what makes the CSV cache (see Get-OrGenerate-TestCSV.ps1) safe.
+    $daysAgo = 7 + ($i * 3) % 365  # Between 7 days and 1 year ago, relative to the epoch
+    $completionDate = $script:TrainingEpoch.AddDays(-$daysAgo).ToString("yyyy-MM-ddTHH:mm:ssZ")
 
     # Training status: Pass (90%), Fail (5%), InProgress (5%)
     $statusIndex = $i % 20
@@ -220,15 +234,20 @@ Write-Host "  ✓ Created $crossDomainCsvPath (empty export target)" -Foreground
 # which leaves files owned by the host user and unwriteable by the container process;
 # this caused UnauthorizedAccessException when the File connector tried to rewrite
 # the cross-domain export target. See docker-compose.yml and src/JIM.Worker/Dockerfile.
-Write-TestStep "Step 5" "Seeding files into jim-connector-files-volume"
+if ($SkipSeed) {
+    Write-Host "  (Skipping connector-volume seeding; -SkipSeed specified)" -ForegroundColor Gray
+}
+else {
+    Write-TestStep "Step 5" "Seeding files into jim-connector-files-volume"
 
-Write-Host "  Streaming CSV files into jim.worker..." -ForegroundColor Gray
-Write-FileToConnectorVolume -SourcePath $csvPath            -DestinationPath "/connector-files/test-data/hr-users.csv"
-Write-FileToConnectorVolume -SourcePath $deptCsvPath        -DestinationPath "/connector-files/test-data/departments.csv"
-Write-FileToConnectorVolume -SourcePath $trainingCsvPath    -DestinationPath "/connector-files/test-data/training-records.csv"
-Write-FileToConnectorVolume -SourcePath $crossDomainCsvPath -DestinationPath "/connector-files/test-data/cross-domain-users.csv"
+    Write-Host "  Streaming CSV files into jim.worker..." -ForegroundColor Gray
+    Write-FileToConnectorVolume -SourcePath $csvPath            -DestinationPath "/connector-files/test-data/hr-users.csv"
+    Write-FileToConnectorVolume -SourcePath $deptCsvPath        -DestinationPath "/connector-files/test-data/departments.csv"
+    Write-FileToConnectorVolume -SourcePath $trainingCsvPath    -DestinationPath "/connector-files/test-data/training-records.csv"
+    Write-FileToConnectorVolume -SourcePath $crossDomainCsvPath -DestinationPath "/connector-files/test-data/cross-domain-users.csv"
 
-Write-Host "  ✓ Files seeded into /connector-files/test-data (owned by app:app)" -ForegroundColor Green
+    Write-Host "  ✓ Files seeded into /connector-files/test-data (owned by app:app)" -ForegroundColor Green
+}
 
 # Summary
 Write-TestSection "CSV Generation Summary"

--- a/test/integration/Generate-TestCSV.ps1
+++ b/test/integration/Generate-TestCSV.ps1
@@ -240,11 +240,13 @@ if ($SkipSeed) {
 else {
     Write-TestStep "Step 5" "Seeding files into jim-connector-files-volume"
 
-    Write-Host "  Streaming CSV files into jim.worker..." -ForegroundColor Gray
-    Write-FileToConnectorVolume -SourcePath $csvPath            -DestinationPath "/connector-files/test-data/hr-users.csv"
-    Write-FileToConnectorVolume -SourcePath $deptCsvPath        -DestinationPath "/connector-files/test-data/departments.csv"
-    Write-FileToConnectorVolume -SourcePath $trainingCsvPath    -DestinationPath "/connector-files/test-data/training-records.csv"
-    Write-FileToConnectorVolume -SourcePath $crossDomainCsvPath -DestinationPath "/connector-files/test-data/cross-domain-users.csv"
+    Write-Host "  Copying CSV files into jim-connector-files-volume..." -ForegroundColor Gray
+    Write-FilesToConnectorVolume -SourceDir $OutputPath -Files @(
+        @{ SourceFile = 'hr-users.csv';            DestinationPath = '/connector-files/test-data/hr-users.csv' }
+        @{ SourceFile = 'departments.csv';         DestinationPath = '/connector-files/test-data/departments.csv' }
+        @{ SourceFile = 'training-records.csv';    DestinationPath = '/connector-files/test-data/training-records.csv' }
+        @{ SourceFile = 'cross-domain-users.csv';  DestinationPath = '/connector-files/test-data/cross-domain-users.csv' }
+    )
 
     Write-Host "  ✓ Files seeded into /connector-files/test-data (owned by app:app)" -ForegroundColor Green
 }

--- a/test/integration/Get-OrGenerate-TestCSV.ps1
+++ b/test/integration/Get-OrGenerate-TestCSV.ps1
@@ -92,12 +92,20 @@ Write-Host "Cache file:  $archivePath" -ForegroundColor Gray
 
 $cacheHit = (-not $IgnoreCache) -and (-not $NoCache) -and (Test-Path $archivePath)
 
+# Status fields captured while we work; a single banner is printed at the end so
+# the outcome is always the most recent, high-visibility thing on screen.
+$status        = $null  # 'hit' | 'miss-write' | 'miss-nocache' | 'ignore-write' | 'ignore-nocache'
+$elapsedLabel  = $null  # what was timed ("restore" / "generate")
+$elapsedSeconds = $null
+
 if ($cacheHit) {
     Write-Host "Cache hit; restoring CSVs..." -ForegroundColor Green
     $restoreStart = Get-Date
     Restore-CsvsFromCache -ArchivePath $archivePath -OutputPath $resolvedOutputPath
-    $restoreSeconds = [math]::Round(((Get-Date) - $restoreStart).TotalSeconds, 2)
-    Write-Host "  ✓ Restored cached CSVs in ${restoreSeconds}s" -ForegroundColor Green
+    $elapsedSeconds = [math]::Round(((Get-Date) - $restoreStart).TotalSeconds, 2)
+    $elapsedLabel = "restore"
+    $status = 'hit'
+    Write-Host "  ✓ Restored cached CSVs in ${elapsedSeconds}s" -ForegroundColor Green
 }
 else {
     if ($IgnoreCache) {
@@ -110,20 +118,74 @@ else {
         Write-Host "Cache miss; generating..." -ForegroundColor Yellow
     }
 
+    $generateStart = Get-Date
     & "$scriptRoot/Generate-TestCSV.ps1" -Template $Template -OutputPath $resolvedOutputPath -SkipSeed
     # Generate-TestCSV.ps1 uses $ErrorActionPreference = "Stop"; a failure throws rather than
     # setting $LASTEXITCODE, so we don't check it here.
+    $elapsedSeconds = [math]::Round(((Get-Date) - $generateStart).TotalSeconds, 2)
+    $elapsedLabel = "generate"
 
-    if (-not $NoCache) {
+    if ($NoCache) {
+        $status = if ($IgnoreCache) { 'ignore-nocache' } else { 'miss-nocache' }
+    }
+    else {
         Write-Host "Archiving CSVs into cache..." -ForegroundColor Gray
         Save-CsvsToCache -ArchivePath $archivePath -OutputPath $resolvedOutputPath -Template $Template -Hash16 $hash16
         Write-Host "  ✓ Wrote $archivePath" -ForegroundColor Green
+        $status = if ($IgnoreCache) { 'ignore-write' } else { 'miss-write' }
     }
 }
 
 # Always regenerate cross-domain-users.csv fresh (not cached).
 $crossDomainPath = Invoke-CrossDomainTargetRegeneration -OutputPath $resolvedOutputPath
 Write-Host "  ✓ Wrote fresh $crossDomainPath (empty export target)" -ForegroundColor Green
+
+# ---------------------------------------------------------------------------
+# Cache status banner
+# ---------------------------------------------------------------------------
+# Printed before the connector-volume seeding step so that on a cache miss the
+# banner is not scrolled offscreen by Generate-TestCSV.ps1's ~50 lines of output,
+# and on any seeding failure the cache outcome is still visible above the error.
+
+$archiveSize = if (Test-Path $archivePath) {
+    $bytes = (Get-Item $archivePath).Length
+    if ($bytes -ge 1MB) { "{0:N1} MB" -f ($bytes / 1MB) }
+    elseif ($bytes -ge 1KB) { "{0:N1} KB" -f ($bytes / 1KB) }
+    else { "$bytes B" }
+}
+else { "(no archive)" }
+
+Write-Host ""
+switch ($status) {
+    'hit' {
+        Write-Host "===========================================" -ForegroundColor Green
+        Write-Host " CSV cache: HIT ($Template, $archiveSize, ${elapsedSeconds}s $elapsedLabel)" -ForegroundColor Green
+        Write-Host "===========================================" -ForegroundColor Green
+    }
+    'miss-write' {
+        Write-Host "===========================================" -ForegroundColor Yellow
+        Write-Host " CSV cache: MISS -> WROTE ($Template, $archiveSize, ${elapsedSeconds}s $elapsedLabel)" -ForegroundColor Yellow
+        Write-Host " Next run with this key will restore from cache." -ForegroundColor Gray
+        Write-Host "===========================================" -ForegroundColor Yellow
+    }
+    'miss-nocache' {
+        Write-Host "===========================================" -ForegroundColor Yellow
+        Write-Host " CSV cache: DISABLED (-NoCache, ${elapsedSeconds}s $elapsedLabel)" -ForegroundColor Yellow
+        Write-Host "===========================================" -ForegroundColor Yellow
+    }
+    'ignore-write' {
+        Write-Host "===========================================" -ForegroundColor Yellow
+        Write-Host " CSV cache: BYPASSED -> OVERWROTE (-IgnoreCache, $Template, $archiveSize, ${elapsedSeconds}s $elapsedLabel)" -ForegroundColor Yellow
+        Write-Host "===========================================" -ForegroundColor Yellow
+    }
+    'ignore-nocache' {
+        Write-Host "===========================================" -ForegroundColor Yellow
+        Write-Host " CSV cache: BYPASSED (-IgnoreCache -NoCache, ${elapsedSeconds}s $elapsedLabel)" -ForegroundColor Yellow
+        Write-Host "===========================================" -ForegroundColor Yellow
+    }
+}
+Write-Host "Cache file: $archivePath" -ForegroundColor Gray
+Write-Host ""
 
 # Always seed the connector-files volume (not cached).
 Invoke-ConnectorVolumeSeeding -OutputPath $resolvedOutputPath

--- a/test/integration/Get-OrGenerate-TestCSV.ps1
+++ b/test/integration/Get-OrGenerate-TestCSV.ps1
@@ -1,0 +1,129 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Cache-aware wrapper around Generate-TestCSV.ps1.
+
+.DESCRIPTION
+    Test CSV generation is fully deterministic (see Generate-TestCSV.ps1 and the TrainingEpoch /
+    account-expiry comments in utils/Test-Helpers.ps1), so the output for a given template + generator
+    version is reproducible to the byte. This wrapper caches the three large, slow-to-generate CSVs
+    (hr-users, departments, training-records) as a tar archive keyed by a content hash, and restores
+    them in place of regenerating on subsequent runs.
+
+    Behaviour:
+      - Cache hit:  extract cached tar into -OutputPath, regenerate cross-domain-users.csv fresh,
+                    seed the connector-files volume, done.
+      - Cache miss: invoke Generate-TestCSV.ps1 with -SkipSeed to produce files without touching the
+                    connector volume, archive the three cacheable CSVs into the cache, then
+                    regenerate cross-domain-users.csv and seed the connector-files volume.
+
+    cross-domain-users.csv is intentionally *not* cached: it is a header-only export target that the
+    File connector appends to during the test. Regenerating it fresh on every run prevents any risk
+    of stale / growing cached copies leaking state across runs.
+
+.PARAMETER Template
+    Data scale template (forwarded to Generate-TestCSV.ps1).
+
+.PARAMETER OutputPath
+    Path where CSV files should be placed (default: ./test-data; forwarded to Generate-TestCSV.ps1).
+
+.PARAMETER CachePath
+    Override the cache directory. Default: <OutputPath>/.cache.
+
+.PARAMETER IgnoreCache
+    Force regeneration and overwrite any existing cache entry.
+
+.PARAMETER NoCache
+    Generate as normal but do not read from or write to the cache.
+
+.EXAMPLE
+    ./Get-OrGenerate-TestCSV.ps1 -Template Scale100K
+
+.EXAMPLE
+    ./Get-OrGenerate-TestCSV.ps1 -Template Small -IgnoreCache
+#>
+
+param(
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100K", "Scale200K", "Scale500K", "Scale750K", "Scale1M")]
+    [string]$Template = "Small",
+
+    [Parameter(Mandatory=$false)]
+    [string]$OutputPath = "./test-data",
+
+    [Parameter(Mandatory=$false)]
+    [string]$CachePath,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$IgnoreCache,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$NoCache
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = $PSScriptRoot
+. "$scriptRoot/utils/Test-Helpers.ps1"
+. "$scriptRoot/utils/CsvCache-Helpers.ps1"
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if (-not (Test-Path $OutputPath)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+$resolvedOutputPath = (Resolve-Path $OutputPath).Path
+
+if (-not $CachePath) {
+    $CachePath = Join-Path $resolvedOutputPath ".cache"
+}
+
+$hash16 = Get-CsvCacheKey -IntegrationRoot $scriptRoot -Template $Template
+$archivePath = Get-CsvCacheArchivePath -CacheRoot $CachePath -Template $Template -Hash16 $hash16
+
+Write-TestSection "CSV cache lookup ($Template)"
+Write-Host "Cache key:   $hash16" -ForegroundColor Gray
+Write-Host "Cache file:  $archivePath" -ForegroundColor Gray
+
+$cacheHit = (-not $IgnoreCache) -and (-not $NoCache) -and (Test-Path $archivePath)
+
+if ($cacheHit) {
+    Write-Host "Cache hit; restoring CSVs..." -ForegroundColor Green
+    $restoreStart = Get-Date
+    Restore-CsvsFromCache -ArchivePath $archivePath -OutputPath $resolvedOutputPath
+    $restoreSeconds = [math]::Round(((Get-Date) - $restoreStart).TotalSeconds, 2)
+    Write-Host "  ✓ Restored cached CSVs in ${restoreSeconds}s" -ForegroundColor Green
+}
+else {
+    if ($IgnoreCache) {
+        Write-Host "Cache bypassed (-IgnoreCache)." -ForegroundColor Yellow
+    }
+    elseif ($NoCache) {
+        Write-Host "Cache disabled (-NoCache)." -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "Cache miss; generating..." -ForegroundColor Yellow
+    }
+
+    & "$scriptRoot/Generate-TestCSV.ps1" -Template $Template -OutputPath $resolvedOutputPath -SkipSeed
+    # Generate-TestCSV.ps1 uses $ErrorActionPreference = "Stop"; a failure throws rather than
+    # setting $LASTEXITCODE, so we don't check it here.
+
+    if (-not $NoCache) {
+        Write-Host "Archiving CSVs into cache..." -ForegroundColor Gray
+        Save-CsvsToCache -ArchivePath $archivePath -OutputPath $resolvedOutputPath -Template $Template -Hash16 $hash16
+        Write-Host "  ✓ Wrote $archivePath" -ForegroundColor Green
+    }
+}
+
+# Always regenerate cross-domain-users.csv fresh (not cached).
+$crossDomainPath = Invoke-CrossDomainTargetRegeneration -OutputPath $resolvedOutputPath
+Write-Host "  ✓ Wrote fresh $crossDomainPath (empty export target)" -ForegroundColor Green
+
+# Always seed the connector-files volume (not cached).
+Invoke-ConnectorVolumeSeeding -OutputPath $resolvedOutputPath

--- a/test/integration/Invoke-IntegrationTests.ps1
+++ b/test/integration/Invoke-IntegrationTests.ps1
@@ -270,7 +270,7 @@ try {
         # HR-driven provisioning is tested against a clean directory.
 
         Write-Host "Generating test CSV files..." -ForegroundColor Gray
-        & "$scriptRoot/Generate-TestCSV.ps1" -Template $Template
+        & "$scriptRoot/Get-OrGenerate-TestCSV.ps1" -Template $Template
 
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to generate CSV files"

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -1189,29 +1189,10 @@ function Reset-JIMForNextScenario {
     Write-Host ""
     Write-Host "${BLUE}--- Lightweight Reset ---${NC}"
 
-    # 0. Empty the shared File Connector volume in place.
-    #
-    # `docker compose down -v` below will try to delete jim-connector-files-volume,
-    # but Samba AD and OpenLDAP (started from docker-compose.integration-tests.yml
-    # and kept running across scenarios for performance) also mount this volume.
-    # Docker refuses to delete a volume that's still mounted, so without this step
-    # the volume silently persists between scenarios and accumulates stale files —
-    # including CSVs and subdirectories created by Samba/OpenLDAP with host UIDs
-    # (e.g. 1000/ubuntu) that the next run's non-root worker can't overwrite.
-    #
-    # We can't `docker exec` this inside jim.worker: Samba writes to the shared
-    # volume as root/ubuntu, and jim.worker drops CAP_DAC_OVERRIDE, so even its
-    # root user can't rmdir Samba-created subdirectories. Instead we launch a
-    # one-off throwaway container from the worker's own image (already pulled,
-    # no extra network fetch) with default (non-restricted) capabilities, mount
-    # the volume, and rm -rf its contents as root.
-    $workerImage = (docker inspect jim.worker --format '{{.Config.Image}}' 2>$null)
-    if (-not $workerImage) {
-        # Fall back to the compose-project image name if the container isn't up.
-        $workerImage = 'jim-worker'
-    }
-    Write-Host "${GRAY}  Emptying jim-connector-files-volume contents (via throwaway $workerImage container)...${NC}"
-    docker run --rm --user 0 --entrypoint sh -v jim-connector-files-volume:/vol $workerImage -c 'rm -rf /vol/* /vol/.[!.]* 2>/dev/null; true' 2>&1 | Out-Null
+    # 0. Empty the shared File Connector volume in place. See Clear-ConnectorFilesVolume
+    # for the full rationale; briefly, `docker compose down -v` below can't remove
+    # jim-connector-files-volume while Samba AD / OpenLDAP keep it pinned.
+    Clear-ConnectorFilesVolume
 
     # 1. Stop JIM containers (keep Samba AD running)
     Write-Host "${GRAY}  Stopping JIM containers...${NC}"
@@ -1866,6 +1847,18 @@ if (-not $SkipReset) {
 
     # Remove the JIM database volume to ensure completely fresh state
     docker volume rm jim-db-volume 2>&1 | Out-Null
+
+    # Remove the connector-files volume. With the containers force-rm'd above, no
+    # one should be holding this volume anymore; `docker volume rm` removes it
+    # outright. If it still fails for any reason (e.g. a leftover container from
+    # an unrelated Docker project), fall back to an in-place wipe so the next
+    # scenario doesn't inherit stale CSVs. This mirrors the Reset-JIMForNextScenario
+    # strategy where Samba/LDAP stay up and the volume must be emptied in place.
+    $rmResult = docker volume rm jim-connector-files-volume 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "${GRAY}  jim-connector-files-volume could not be removed (${rmResult}); wiping in place instead...${NC}"
+        Clear-ConnectorFilesVolume
+    }
 
     Write-Success "Containers stopped and all volumes removed"
 }
@@ -2630,6 +2623,21 @@ if (Get-Command docker -ErrorAction SilentlyContinue) {
     ) -PassThru -RedirectStandardOutput "$dockerStatsPath.stdout.log" -RedirectStandardError "$dockerStatsPath.stderr.log"
 }
 
+# Start the connector-files volume auditor. inotifywait sidecar logs every
+# write/create/delete/rename to jim-connector-files-volume so we can pin down
+# any out-of-band writers that the transcript can't name. See the 08:47:22
+# Scale100K incident for the failure mode this was added to diagnose.
+$volumeAuditLogPath = Join-Path $scriptRoot "results" "volume-audit-$Scenario-$Template-$(Get-Date -Format 'yyyy-MM-dd_HHmmss').log"
+Write-Step "Starting connector-files volume auditor -> $volumeAuditLogPath"
+$volumeAuditor = Start-ConnectorVolumeAuditor -LogPath $volumeAuditLogPath
+
+# Start the docker events capture. Streams all container/image/volume lifecycle
+# events to disk so throwaway `docker run` calls (our busybox seed helper,
+# rogue calls from other sessions) can be identified retroactively.
+$dockerEventsLogPath = Join-Path $scriptRoot "results" "docker-events-$Scenario-$Template-$(Get-Date -Format 'yyyy-MM-dd_HHmmss').log"
+Write-Step "Starting docker events capture -> $dockerEventsLogPath"
+$dockerEventsProcess = Start-DockerEventsCapture -LogPath $dockerEventsLogPath
+
 # Start the JIM error watcher. This tails jim.web / jim.worker / jim.scheduler
 # logs for [ERR] lines and writes any matches to a sentinel file. Start-JIMRunProfile
 # -Wait loops check the sentinel between polls (via the JIM_RUNPROFILE_ABORT_SENTINEL
@@ -2661,6 +2669,29 @@ finally {
         $rowCount = @(Get-Content $dockerStatsPath).Count - 1
         if ($rowCount -lt 0) { $rowCount = 0 }
         Write-Step "Docker stats capture stopped ($rowCount samples recorded)"
+    }
+
+    # Stop the connector-files volume auditor and record the line count so
+    # reviewers can tell at a glance whether anything wrote to the volume.
+    try {
+        $auditLineCount = Stop-ConnectorVolumeAuditor -Handle $volumeAuditor
+        if ($volumeAuditor) {
+            Write-Step "Volume auditor stopped ($auditLineCount events recorded in $volumeAuditLogPath)"
+        }
+    }
+    catch {
+        Write-Host "${YELLOW}  Warning: volume auditor stop failed: $_${NC}"
+    }
+
+    # Stop the docker events capture.
+    try {
+        $eventLineCount = Stop-DockerEventsCapture -Process $dockerEventsProcess -LogPath $dockerEventsLogPath
+        if ($dockerEventsProcess) {
+            Write-Step "Docker events capture stopped ($eventLineCount events recorded in $dockerEventsLogPath)"
+        }
+    }
+    catch {
+        Write-Host "${YELLOW}  Warning: docker events capture stop failed: $_${NC}"
     }
 
     # Stop the live watcher and run the post-scenario belt-and-braces scan.
@@ -3170,6 +3201,12 @@ Write-Section "Output Files"
 Write-Host "  ${GRAY}Scenario log:${NC}       $scenarioLogFile"
 if ($currentFile) {
     Write-Host "  ${GRAY}Performance metrics:${NC} $currentFile"
+}
+if ($volumeAuditLogPath -and (Test-Path $volumeAuditLogPath)) {
+    Write-Host "  ${GRAY}Volume audit log:${NC}   $volumeAuditLogPath"
+}
+if ($dockerEventsLogPath -and (Test-Path $dockerEventsLogPath)) {
+    Write-Host "  ${GRAY}Docker events log:${NC}  $dockerEventsLogPath"
 }
 
 # Re-run Command

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -2359,7 +2359,7 @@ if ($SetupOnly) {
         if ($templateRelevant) {
             Write-Step "Generating test data (Template: $Template)..."
             try {
-                & "$scriptRoot/Generate-TestCSV.ps1" -Template $Template -OutputPath "$scriptRoot/../test-data"
+                & "$scriptRoot/Get-OrGenerate-TestCSV.ps1" -Template $Template -OutputPath "$scriptRoot/../test-data"
                 Write-Success "Test data generated"
             }
             catch {

--- a/test/integration/Test-CsvCache.ps1
+++ b/test/integration/Test-CsvCache.ps1
@@ -1,0 +1,204 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Acceptance tests for the CSV cache (Get-OrGenerate-TestCSV.ps1).
+
+.DESCRIPTION
+    Covers the acceptance criteria from issue #634:
+      1. Generator produces byte-identical CSVs across runs (determinism).
+      2. Two successive wrapper runs: first is a miss, second is a hit.
+      3. Restored CSVs are byte-identical to freshly-generated ones.
+      4. Editing a hashed file invalidates the cache key.
+      5. -IgnoreCache forces regeneration.
+
+    Runs the generator with -SkipSeed so it can execute without a running jim.worker.
+    The cache wrapper's own seeding step (which does need jim.worker) is bypassed by
+    dot-sourcing the wrapper and calling its internal functions directly rather than
+    running the wrapper end-to-end.
+
+    Usage:
+        ./Test-CsvCache.ps1                       # default template: Nano
+        ./Test-CsvCache.ps1 -Template Small       # larger, slower
+#>
+
+param(
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("Nano", "Micro", "Small", "Medium")]
+    [string]$Template = "Nano"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = $PSScriptRoot
+
+# Dot-source the helpers directly. Do NOT dot-source Get-OrGenerate-TestCSV.ps1 itself:
+# its param block re-binds $Template in the current scope, overwriting this script's
+# $Template parameter.
+. "$scriptRoot/utils/CsvCache-Helpers.ps1"
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+$script:TestCount = 0
+$script:FailCount = 0
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    $script:TestCount++
+    if ($Condition) {
+        Write-Host "  [PASS] $Message" -ForegroundColor Green
+    }
+    else {
+        $script:FailCount++
+        Write-Host "  [FAIL] $Message" -ForegroundColor Red
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    Assert-True ($Expected -eq $Actual) "$Message (expected=$Expected, actual=$Actual)"
+}
+
+function Get-CsvTriplet {
+    param([string]$Dir)
+    @(
+        "hr-users.csv"
+        "departments.csv"
+        "training-records.csv"
+    ) | ForEach-Object {
+        [PSCustomObject]@{
+            Name = $_
+            Hash = (Get-FileHash (Join-Path $Dir $_) -Algorithm SHA256).Hash
+        }
+    }
+}
+
+function Invoke-GeneratorOnly {
+    param([string]$OutputPath, [string]$Template)
+    # Generate-TestCSV.ps1 is a PowerShell script with $ErrorActionPreference = "Stop";
+    # failures throw rather than setting $LASTEXITCODE, so no exit-code check is needed.
+    & "$scriptRoot/Generate-TestCSV.ps1" -Template $Template -OutputPath $OutputPath -SkipSeed | Out-Null
+}
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+$workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("jim-csv-cache-test-" + [Guid]::NewGuid().ToString("N").Substring(0, 8))
+Write-Host ""
+Write-Host "Workspace: $workRoot" -ForegroundColor Cyan
+Write-Host "Template:  $Template" -ForegroundColor Cyan
+Write-Host ""
+
+try {
+    $runA = Join-Path $workRoot "gen-a"
+    $runB = Join-Path $workRoot "gen-b"
+    $runC = Join-Path $workRoot "restored"
+    $cacheDir = Join-Path $workRoot "cache"
+    New-Item -ItemType Directory -Path $runA, $runB, $runC, $cacheDir -Force | Out-Null
+
+    # -----------------------------------------------------------------------
+    # Test 1: Generator determinism
+    # -----------------------------------------------------------------------
+    Write-Host "Test 1: Generator produces byte-identical CSVs across runs" -ForegroundColor Cyan
+    Invoke-GeneratorOnly -OutputPath $runA -Template $Template
+    Invoke-GeneratorOnly -OutputPath $runB -Template $Template
+
+    $hashesA = Get-CsvTriplet -Dir $runA
+    $hashesB = Get-CsvTriplet -Dir $runB
+
+    for ($i = 0; $i -lt $hashesA.Count; $i++) {
+        Assert-Equal $hashesA[$i].Hash $hashesB[$i].Hash "$($hashesA[$i].Name) is byte-identical across runs"
+    }
+
+    # -----------------------------------------------------------------------
+    # Test 2: Cache archive round-trip preserves bytes
+    # -----------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "Test 2: Cache archive round-trip preserves bytes" -ForegroundColor Cyan
+
+    $hash16 = Get-CsvCacheKey -IntegrationRoot $scriptRoot -Template $Template
+    Assert-True ($hash16.Length -eq 16) "Cache key is 16 hex chars"
+
+    $archivePath = Get-CsvCacheArchivePath -CacheRoot $cacheDir -Template $Template -Hash16 $hash16
+    Save-CsvsToCache -ArchivePath $archivePath -OutputPath $runA -Template $Template -Hash16 $hash16
+    Assert-True (Test-Path $archivePath) "Cache archive was created at $archivePath"
+
+    Restore-CsvsFromCache -ArchivePath $archivePath -OutputPath $runC
+    $hashesC = Get-CsvTriplet -Dir $runC
+
+    for ($i = 0; $i -lt $hashesA.Count; $i++) {
+        Assert-Equal $hashesA[$i].Hash $hashesC[$i].Hash "$($hashesA[$i].Name) is byte-identical after cache round-trip"
+    }
+
+    $manifestInArchive = Join-Path $runC "manifest.json"
+    Assert-True (-not (Test-Path $manifestInArchive)) "manifest.json is stripped from extracted output"
+
+    $crossDomainInArchive = Join-Path $runC "cross-domain-users.csv"
+    Assert-True (-not (Test-Path $crossDomainInArchive)) "cross-domain-users.csv is NOT in the cache"
+
+    # -----------------------------------------------------------------------
+    # Test 3: Cache key is sensitive to template name
+    # -----------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "Test 3: Cache key differs across templates" -ForegroundColor Cyan
+    $hashNano  = Get-CsvCacheKey -IntegrationRoot $scriptRoot -Template "Nano"
+    $hashSmall = Get-CsvCacheKey -IntegrationRoot $scriptRoot -Template "Small"
+    Assert-True ($hashNano -ne $hashSmall) "Nano and Small templates produce different cache keys"
+
+    # -----------------------------------------------------------------------
+    # Test 4: Cache key is sensitive to hashed script changes
+    # -----------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "Test 4: Editing a hashed file changes the cache key" -ForegroundColor Cyan
+
+    # Temporarily replace Generate-TestCSV.ps1 with a shadow copy, edit it, recompute, restore.
+    $origGenerator = "$scriptRoot/Generate-TestCSV.ps1"
+    $origContent   = Get-Content -Raw -Path $origGenerator
+    $origHash      = Get-CsvCacheKey -IntegrationRoot $scriptRoot -Template $Template
+    try {
+        $mutated = $origContent + "`n# cache-bust test marker`n"
+        Set-Content -Path $origGenerator -Value $mutated -NoNewline
+        $mutatedHash = Get-CsvCacheKey -IntegrationRoot $scriptRoot -Template $Template
+        Assert-True ($origHash -ne $mutatedHash) "Cache key changes when Generate-TestCSV.ps1 is edited"
+    }
+    finally {
+        Set-Content -Path $origGenerator -Value $origContent -NoNewline
+    }
+
+    # -----------------------------------------------------------------------
+    # Test 5: Cross-domain regeneration writes a fresh header file
+    # -----------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "Test 5: cross-domain-users.csv is regenerated fresh" -ForegroundColor Cyan
+    $crossDomainPath = Invoke-CrossDomainTargetRegeneration -OutputPath $runC
+    Assert-True (Test-Path $crossDomainPath) "cross-domain-users.csv was written"
+    $headerLine = Get-Content -Path $crossDomainPath -TotalCount 1
+    Assert-True ($headerLine -eq "samAccountName,displayName,email,department,employeeId,company,pronouns") "Header line is exactly the seven expected columns"
+    $lineCount = (Get-Content -Path $crossDomainPath | Measure-Object -Line).Lines
+    Assert-Equal 1 $lineCount "cross-domain-users.csv has exactly one (header) line"
+}
+finally {
+    if (Test-Path $workRoot) {
+        Remove-Item -Path $workRoot -Recurse -Force
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "=======================================================" -ForegroundColor Cyan
+if ($script:FailCount -eq 0) {
+    Write-Host " $script:TestCount / $script:TestCount tests passed." -ForegroundColor Green
+    exit 0
+}
+else {
+    Write-Host " $($script:TestCount - $script:FailCount) / $script:TestCount tests passed; $script:FailCount FAILED." -ForegroundColor Red
+    exit 1
+}

--- a/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
+++ b/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
@@ -400,6 +400,19 @@ try {
         $testUser = New-TestUser -Index 1
         Write-Host "Testing joiner scenario with $($testUser.SamAccountName) and $((Get-TemplateScale -Template $Template).Users - 1) other users..." -ForegroundColor Gray
 
+        # Pair list reused for both parity checks in this step: once before the
+        # first CSV import (detects truncation between setup-seed and first read)
+        # and once before Training Full Import (the specific read that failed in
+        # the 08:47:22 Scale100K incident). See Assert-ConnectorVolumeCsvParity.
+        $csvParityPairs = @(
+            @{ HostPath = "$PSScriptRoot/../../test-data/hr-users.csv";         ContainerPath = '/connector-files/test-data/hr-users.csv' }
+            @{ HostPath = "$PSScriptRoot/../../test-data/training-records.csv"; ContainerPath = '/connector-files/test-data/training-records.csv' }
+            @{ HostPath = "$PSScriptRoot/../../test-data/departments.csv";      ContainerPath = '/connector-files/test-data/departments.csv' }
+        )
+
+        # Parity probe: confirm the volume still has the files we seeded at setup.
+        Assert-ConnectorVolumeCsvParity -Pairs $csvParityPairs
+
         # Trigger CSV Import
         Write-Host "Triggering CSV import..." -ForegroundColor Gray
         $importResult = Start-JIMRunProfile -ConnectedSystemId $config.CSVSystemId -RunProfileId $config.CSVImportProfileId -Wait -PassThru
@@ -445,6 +458,13 @@ try {
         if ($config.TrainingSystemId -and $config.TrainingImportProfileId -and $config.TrainingSyncProfileId) {
             Write-Host ""
             Write-Host "Establishing Training data baseline (joins to HR-created MVOs)..." -ForegroundColor Gray
+
+            # Parity probe: the 08:47:22 Scale100K incident truncated the volume
+            # CSVs between the HR sync and this import. Check again here so a
+            # recurrence fails with a clear error (naming the caller via
+            # .last-seed) rather than silently producing 3 training records.
+            Assert-ConnectorVolumeCsvParity -Pairs $csvParityPairs
+
             Write-Host "  Running Training Full Import..." -ForegroundColor DarkGray
             $trainingImportResult = Start-JIMRunProfile -ConnectedSystemId $config.TrainingSystemId -RunProfileId $config.TrainingImportProfileId -Wait -PassThru
             Assert-ActivitySuccess -ActivityId $trainingImportResult.activityId -Name "Training Full Import (Joiner)"

--- a/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
+++ b/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
@@ -225,7 +225,7 @@ try {
     # NOTE: This is necessary even after database reset because CSV files persist
     # on the host filesystem and are mounted into containers.
     Write-Host "Resetting CSV test data to baseline..." -ForegroundColor Gray
-    & "$PSScriptRoot/../Generate-TestCSV.ps1" -Template $Template -OutputPath "$PSScriptRoot/../../test-data"
+    & "$PSScriptRoot/../Get-OrGenerate-TestCSV.ps1" -Template $Template -OutputPath "$PSScriptRoot/../../test-data"
     Write-Host "  ✓ CSV test data reset to baseline" -ForegroundColor Green
 
     # Clean up test-specific directory users from previous test runs

--- a/test/integration/scenarios/Invoke-Scenario4-DeletionRules.ps1
+++ b/test/integration/scenarios/Invoke-Scenario4-DeletionRules.ps1
@@ -590,10 +590,10 @@ try {
     Copy-Item -Path "$scenarioDataPath/scenario4-hr-users.csv" -Destination "$testDataPath/hr-users.csv" -Force
     Copy-Item -Path "$scenarioDataPath/scenario4-training-records.csv" -Destination "$testDataPath/training-records.csv" -Force
 
-    $csvPath = "$testDataPath/hr-users.csv"
-    $trainingCsvPath = "$testDataPath/training-records.csv"
-    Write-FileToConnectorVolume -SourcePath $csvPath         -DestinationPath "/connector-files/test-data/hr-users.csv"
-    Write-FileToConnectorVolume -SourcePath $trainingCsvPath -DestinationPath "/connector-files/test-data/training-records.csv"
+    Write-FilesToConnectorVolume -SourceDir $testDataPath -Files @(
+        @{ SourceFile = 'hr-users.csv';         DestinationPath = '/connector-files/test-data/hr-users.csv' }
+        @{ SourceFile = 'training-records.csv'; DestinationPath = '/connector-files/test-data/training-records.csv' }
+    )
     Write-Host "  CSVs initialised (HR + Training overlays over Nano baseline)" -ForegroundColor Green
 
     # Clean up test-specific directory users from previous test runs

--- a/test/integration/scenarios/Invoke-Scenario7-ClearConnectedSystemObjects.ps1
+++ b/test/integration/scenarios/Invoke-Scenario7-ClearConnectedSystemObjects.ps1
@@ -135,7 +135,7 @@ try {
     # to this the suite was relying on files leaking across scenarios through the
     # shared jim-connector-files-volume.
     Write-Host "Seeding CSV test data..." -ForegroundColor Gray
-    & "$PSScriptRoot/../Generate-TestCSV.ps1" -Template $Template -OutputPath "$PSScriptRoot/../../test-data"
+    & "$PSScriptRoot/../Get-OrGenerate-TestCSV.ps1" -Template $Template -OutputPath "$PSScriptRoot/../../test-data"
     Write-Host "  ✓ CSV test data seeded" -ForegroundColor Green
 
     # Setup scenario configuration (reuse Scenario 1 setup for CSV connected system)

--- a/test/integration/utils/CsvCache-Helpers.ps1
+++ b/test/integration/utils/CsvCache-Helpers.ps1
@@ -91,11 +91,11 @@ function Invoke-CrossDomainTargetRegeneration {
 function Invoke-ConnectorVolumeSeeding {
     <#
     .SYNOPSIS
-        Stream all four CSVs into /connector-files inside jim.worker with correct ownership.
+        Copy all four CSVs into /connector-files inside the shared volume with correct ownership.
     .DESCRIPTION
         Kept in sync with the equivalent block in Generate-TestCSV.ps1 (step 5). The cache stores
         file contents only; the connector-files volume state is never cached, so this must run on
-        every invocation including cache hits. Assumes Write-FileToConnectorVolume is available
+        every invocation including cache hits. Assumes Write-FilesToConnectorVolume is available
         (imported from utils/Test-Helpers.ps1 by the caller).
     #>
     param(
@@ -103,11 +103,13 @@ function Invoke-ConnectorVolumeSeeding {
     )
 
     Write-TestStep "Seed" "Seeding files into jim-connector-files-volume"
-    Write-Host "  Streaming CSV files into jim.worker..." -ForegroundColor Gray
-    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "hr-users.csv")           -DestinationPath "/connector-files/test-data/hr-users.csv"
-    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "departments.csv")        -DestinationPath "/connector-files/test-data/departments.csv"
-    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "training-records.csv")   -DestinationPath "/connector-files/test-data/training-records.csv"
-    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "cross-domain-users.csv") -DestinationPath "/connector-files/test-data/cross-domain-users.csv"
+    Write-Host "  Copying CSV files into jim-connector-files-volume..." -ForegroundColor Gray
+    Write-FilesToConnectorVolume -SourceDir $OutputPath -Files @(
+        @{ SourceFile = 'hr-users.csv';            DestinationPath = '/connector-files/test-data/hr-users.csv' }
+        @{ SourceFile = 'departments.csv';         DestinationPath = '/connector-files/test-data/departments.csv' }
+        @{ SourceFile = 'training-records.csv';    DestinationPath = '/connector-files/test-data/training-records.csv' }
+        @{ SourceFile = 'cross-domain-users.csv';  DestinationPath = '/connector-files/test-data/cross-domain-users.csv' }
+    )
     Write-Host "  ✓ Files seeded into /connector-files/test-data (owned by app:app)" -ForegroundColor Green
 }
 

--- a/test/integration/utils/CsvCache-Helpers.ps1
+++ b/test/integration/utils/CsvCache-Helpers.ps1
@@ -1,0 +1,170 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Helper functions for the CSV cache used by Get-OrGenerate-TestCSV.ps1.
+
+.DESCRIPTION
+    Extracted into its own file so tests (Test-CsvCache.ps1) can dot-source the helpers
+    without triggering the wrapper's param-block defaults or orchestration.
+#>
+
+# CSVs that are safe to cache (byte-deterministic output).
+# cross-domain-users.csv is excluded by design: it is a header-only export target that the
+# File connector appends to during the test. Regenerating it fresh on every run prevents
+# any risk of stale or growing cached copies leaking state across runs.
+$script:CacheableCsvs = @("hr-users.csv", "departments.csv", "training-records.csv")
+
+function Get-CsvCacheKey {
+    <#
+    .SYNOPSIS
+        Compute the 16-hex-char content hash used to key the CSV cache archive.
+    .DESCRIPTION
+        Hashes (in order): whole Generate-TestCSV.ps1, whole utils/Test-Helpers.ps1, the template
+        name, and the PowerShell major version. Any of these changing invalidates the cache.
+        Hashing whole files (rather than extracting specific functions) matches Get-PopulateScriptHash
+        in Build-SambaSnapshots.ps1; it over-invalidates on unrelated helper edits, which is a price
+        worth paying for simplicity and safety.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][string]$IntegrationRoot,
+        [Parameter(Mandatory=$true)][string]$Template
+    )
+
+    $filesToHash = @(
+        "$IntegrationRoot/Generate-TestCSV.ps1",
+        "$IntegrationRoot/utils/Test-Helpers.ps1"
+    )
+
+    $combinedContent = ""
+    foreach ($file in $filesToHash) {
+        if (-not (Test-Path $file)) {
+            throw "Expected hash input '$file' not found."
+        }
+        $combinedContent += Get-Content -Path $file -Raw
+    }
+    $combinedContent += "template=$Template"
+    $combinedContent += "psmajor=$($PSVersionTable.PSVersion.Major)"
+
+    $hashBytes = [System.Security.Cryptography.SHA256]::HashData(
+        [System.Text.Encoding]::UTF8.GetBytes($combinedContent)
+    )
+    return [System.BitConverter]::ToString($hashBytes).Replace("-", "").Substring(0, 16).ToLower()
+}
+
+function Get-CsvCacheArchivePath {
+    param(
+        [Parameter(Mandatory=$true)][string]$CacheRoot,
+        [Parameter(Mandatory=$true)][string]$Template,
+        [Parameter(Mandatory=$true)][string]$Hash16
+    )
+    return Join-Path $CacheRoot "csv-$Template-$Hash16.tar"
+}
+
+function Invoke-CrossDomainTargetRegeneration {
+    <#
+    .SYNOPSIS
+        Write a fresh header-only cross-domain-users.csv into $OutputPath.
+    .DESCRIPTION
+        Kept in sync with the equivalent block in Generate-TestCSV.ps1 (step 4). Must be invoked on
+        every run, including cache hits, because cross-domain-users.csv is not cached.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][string]$OutputPath
+    )
+
+    $crossDomainCsvPath = Join-Path $OutputPath "cross-domain-users.csv"
+    $crossDomainHeaders = @(
+        "samAccountName",
+        "displayName",
+        "email",
+        "department",
+        "employeeId",
+        "company",
+        "pronouns"
+    )
+    $crossDomainHeaders -join "," | Set-Content -Path $crossDomainCsvPath -Encoding UTF8
+    return $crossDomainCsvPath
+}
+
+function Invoke-ConnectorVolumeSeeding {
+    <#
+    .SYNOPSIS
+        Stream all four CSVs into /connector-files inside jim.worker with correct ownership.
+    .DESCRIPTION
+        Kept in sync with the equivalent block in Generate-TestCSV.ps1 (step 5). The cache stores
+        file contents only; the connector-files volume state is never cached, so this must run on
+        every invocation including cache hits. Assumes Write-FileToConnectorVolume is available
+        (imported from utils/Test-Helpers.ps1 by the caller).
+    #>
+    param(
+        [Parameter(Mandatory=$true)][string]$OutputPath
+    )
+
+    Write-TestStep "Seed" "Seeding files into jim-connector-files-volume"
+    Write-Host "  Streaming CSV files into jim.worker..." -ForegroundColor Gray
+    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "hr-users.csv")           -DestinationPath "/connector-files/test-data/hr-users.csv"
+    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "departments.csv")        -DestinationPath "/connector-files/test-data/departments.csv"
+    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "training-records.csv")   -DestinationPath "/connector-files/test-data/training-records.csv"
+    Write-FileToConnectorVolume -SourcePath (Join-Path $OutputPath "cross-domain-users.csv") -DestinationPath "/connector-files/test-data/cross-domain-users.csv"
+    Write-Host "  ✓ Files seeded into /connector-files/test-data (owned by app:app)" -ForegroundColor Green
+}
+
+function Save-CsvsToCache {
+    param(
+        [Parameter(Mandatory=$true)][string]$ArchivePath,
+        [Parameter(Mandatory=$true)][string]$OutputPath,
+        [Parameter(Mandatory=$true)][string]$Template,
+        [Parameter(Mandatory=$true)][string]$Hash16
+    )
+
+    $cacheDir = Split-Path -Parent $ArchivePath
+    if (-not (Test-Path $cacheDir)) {
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+    }
+
+    $manifest = [PSCustomObject]@{
+        template   = $Template
+        hash16     = $Hash16
+        psMajor    = $PSVersionTable.PSVersion.Major
+        files      = $script:CacheableCsvs
+        createdUtc = (Get-Date).ToUniversalTime().ToString("o")
+    }
+    $manifestPath = Join-Path $OutputPath "manifest.json"
+    $manifest | ConvertTo-Json | Set-Content -Path $manifestPath -Encoding UTF8
+    try {
+        $filesToArchive = $script:CacheableCsvs + @("manifest.json")
+        $tmpArchive = "$ArchivePath.tmp"
+        & tar -cf $tmpArchive -C $OutputPath @filesToArchive
+        if ($LASTEXITCODE -ne 0) {
+            throw "tar failed to create cache archive (exit code $LASTEXITCODE)"
+        }
+        # Atomic replace so a concurrent reader never sees a half-written tar.
+        Move-Item -Path $tmpArchive -Destination $ArchivePath -Force
+    }
+    finally {
+        if (Test-Path $manifestPath) { Remove-Item -Path $manifestPath -Force }
+    }
+}
+
+function Restore-CsvsFromCache {
+    param(
+        [Parameter(Mandatory=$true)][string]$ArchivePath,
+        [Parameter(Mandatory=$true)][string]$OutputPath
+    )
+
+    if (-not (Test-Path $OutputPath)) {
+        New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+    }
+
+    & tar -xf $ArchivePath -C $OutputPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "tar failed to extract cache archive $ArchivePath (exit code $LASTEXITCODE)"
+    }
+
+    # manifest.json is an artefact of the archive only; remove from $OutputPath so the
+    # output mirrors what Generate-TestCSV.ps1 would produce.
+    $manifestPath = Join-Path $OutputPath "manifest.json"
+    if (Test-Path $manifestPath) { Remove-Item -Path $manifestPath -Force }
+}

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -724,25 +724,166 @@ function Get-RandomSubset {
 
 # Progress bar functions for visual feedback during long operations
 
+$script:ConnectorVolumeHelperImage = 'busybox:1.37.0'
+
+function Write-FilesToConnectorVolume {
+    <#
+    .SYNOPSIS
+        Copy one or more host files into the jim-connector-files-volume in a single rootless docker run.
+
+    .DESCRIPTION
+        Mounts the shared jim-connector-files-volume and the host source directory into a throwaway
+        busybox container running as UID 1654, then copies the requested files in one shot. Files
+        land owned by UID 1654 (the `app` user in jim.worker) because that is the UID doing the
+        writes; no `chown` and no root is required in the pipeline.
+
+        This replaces the per-file `docker exec -i -u app jim.worker tee ...` streaming pattern.
+        For bulk seeding (e.g. the four CSVs in Step 5 of the integration harness) this cuts
+        Scale100K Step 5 from ~15-25 s to ~1-3 s by eliminating the per-file docker exec round-
+        trips and the PowerShell-pipe-over-stdin transfer.
+
+        Correctness notes:
+          - Each destination is removed via `rm -f` before the copy. Busybox `cp` overwrites
+            contents in place rather than unlinking, so `rm -f` preserves the fresh-inode
+            guarantee of the old implementation (defends against stale files owned by a
+            different UID written e.g. via Samba/OpenLDAP).
+          - Destination paths are passed through a generated shell script, not as `docker run`
+            argv, so paths with spaces or special characters are safe provided they do not
+            contain single quotes. CSV filenames never do.
+          - The host source directory is bind-mounted read-only.
+
+    .PARAMETER SourceDir
+        Host directory containing all source files. Bind-mounted read-only into the helper
+        container at /src.
+
+    .PARAMETER Files
+        Array of hashtables, each with:
+          - SourceFile: filename (not path) inside $SourceDir
+          - DestinationPath: absolute path inside the container volume, e.g.
+            /connector-files/test-data/hr-users.csv
+
+    .EXAMPLE
+        Write-FilesToConnectorVolume -SourceDir $outputPath -Files @(
+            @{ SourceFile = 'hr-users.csv';    DestinationPath = '/connector-files/test-data/hr-users.csv' }
+            @{ SourceFile = 'departments.csv'; DestinationPath = '/connector-files/test-data/departments.csv' }
+        )
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$SourceDir,
+
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]$Files
+    )
+
+    if (-not (Test-Path -Path $SourceDir -PathType Container)) {
+        throw "Source directory not found: $SourceDir"
+    }
+
+    if ($Files.Count -eq 0) {
+        throw "Write-FilesToConnectorVolume called with no files."
+    }
+
+    $resolvedSourceDir = (Resolve-Path -Path $SourceDir).Path
+    if ([System.IO.Path]::DirectorySeparatorChar -eq '\') {
+        $resolvedSourceDir = $resolvedSourceDir.Replace('\','/')
+    }
+
+    $destDirs = [System.Collections.Generic.HashSet[string]]::new()
+    $script = [System.Text.StringBuilder]::new()
+    $null = $script.AppendLine('set -e')
+
+    foreach ($entry in $Files) {
+        $sourceFile = [string]$entry.SourceFile
+        $destPath   = [string]$entry.DestinationPath
+
+        if (-not $sourceFile) {
+            throw "Write-FilesToConnectorVolume: entry is missing SourceFile."
+        }
+        if (-not $destPath) {
+            throw "Write-FilesToConnectorVolume: entry is missing DestinationPath."
+        }
+        if (-not $destPath.StartsWith('/')) {
+            throw "DestinationPath must be absolute (got '$destPath')."
+        }
+        if ($sourceFile -match '[\\/]') {
+            throw "SourceFile must be a filename, not a path (got '$sourceFile'). Set SourceDir to the containing directory."
+        }
+        if ($sourceFile -match "'" -or $destPath -match "'") {
+            throw "Write-FilesToConnectorVolume does not support paths containing single quotes."
+        }
+        if (-not (Test-Path -Path (Join-Path $resolvedSourceDir $sourceFile) -PathType Leaf)) {
+            throw "Source file not found: $(Join-Path $resolvedSourceDir $sourceFile)"
+        }
+
+        $destDir = [System.IO.Path]::GetDirectoryName($destPath).Replace('\','/')
+        if ($destDir -and $destDir -ne '/') {
+            $null = $destDirs.Add($destDir)
+        }
+
+        # rm -f guarantees a fresh inode even if a stale file owned by a different
+        # UID is already at the destination (e.g. from a previous run or a parallel
+        # Samba/OpenLDAP write path). cp --remove-destination would be tidier but
+        # busybox cp doesn't ship that flag; the explicit rm is portable.
+        $null = $script.AppendLine("rm -f '$destPath'")
+        $null = $script.AppendLine("cp '/src/$sourceFile' '$destPath'")
+    }
+
+    $mkdirScript = [System.Text.StringBuilder]::new()
+    foreach ($d in $destDirs) {
+        $null = $mkdirScript.AppendLine("mkdir -p '$d'")
+    }
+    # Prepend mkdirs so the directories exist before cp runs.
+    $fullScript = $mkdirScript.ToString() + $script.ToString()
+
+    $mountSpec = "${resolvedSourceDir}:/src:ro"
+    $volumeMount = 'jim-connector-files-volume:/connector-files'
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = 'docker'
+    $psi.ArgumentList.Add('run')
+    $psi.ArgumentList.Add('--rm')
+    $psi.ArgumentList.Add('--user')
+    $psi.ArgumentList.Add('1654:1654')
+    $psi.ArgumentList.Add('-v')
+    $psi.ArgumentList.Add($volumeMount)
+    $psi.ArgumentList.Add('-v')
+    $psi.ArgumentList.Add($mountSpec)
+    $psi.ArgumentList.Add($script:ConnectorVolumeHelperImage)
+    $psi.ArgumentList.Add('sh')
+    $psi.ArgumentList.Add('-c')
+    $psi.ArgumentList.Add($fullScript)
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    try {
+        $stdout = $proc.StandardOutput.ReadToEnd()
+        $stderr = $proc.StandardError.ReadToEnd()
+        $proc.WaitForExit()
+        if ($proc.ExitCode -ne 0) {
+            $fileList = ($Files | ForEach-Object { $_.DestinationPath }) -join ', '
+            $hint = ''
+            if ($stderr -match 'Permission denied') {
+                $hint = " This usually means a destination file or its parent directory is owned by a UID other than 1654 (e.g. from a past 'docker cp' into the volume). Reset the volume with 'docker volume rm jim-connector-files-volume' after stopping jim.worker / jim.web, or chown the affected path from a root-privileged sidecar."
+            }
+            throw "docker run helper (image $script:ConnectorVolumeHelperImage) failed with exit code $($proc.ExitCode) while seeding [$fileList].$hint stderr: $stderr. stdout: $stdout"
+        }
+    }
+    finally {
+        $proc.Dispose()
+    }
+}
+
 function Write-FileToConnectorVolume {
     <#
     .SYNOPSIS
-        Stream a host file into /connector-files inside jim.worker with correct ownership.
+        Copy a single host file into /connector-files inside the shared volume with correct ownership.
 
     .DESCRIPTION
-        The only safe way to put a file into the shared jim-connector-files-volume for
-        testing is to stream it in through a non-root shell inside jim.worker so the
-        file lands owned by the worker's `app` user (UID 1654). We cannot use
-        `docker cp` — it preserves the host UID/GID, which leaves files the container
-        user can't overwrite when the File connector next exports.
-
-        This helper:
-          1. Verifies jim.worker is running.
-          2. Ensures the destination directory exists (owned by app:app).
-          3. Unlinks the destination file if present, then creates a fresh inode by
-             streaming the source via `docker exec -i -u app jim.worker sh -c 'cat > ...'`.
-
-        Use this anywhere a test needs to seed or refresh a file under /connector-files.
+        Thin wrapper around Write-FilesToConnectorVolume for call sites that only need to write
+        one file. See Write-FilesToConnectorVolume for the full design rationale.
 
     .PARAMETER SourcePath
         Host path to the file to copy in.
@@ -762,83 +903,16 @@ function Write-FileToConnectorVolume {
         [string]$DestinationPath
     )
 
-    if (-not (Test-Path $SourcePath)) {
+    if (-not (Test-Path -Path $SourcePath -PathType Leaf)) {
         throw "Source file not found: $SourcePath"
     }
 
-    if (-not $DestinationPath.StartsWith('/')) {
-        throw "DestinationPath must be absolute (got '$DestinationPath')."
-    }
+    $sourceDir  = [System.IO.Path]::GetDirectoryName($SourcePath)
+    $sourceFile = [System.IO.Path]::GetFileName($SourcePath)
 
-    $containerRunning = docker ps --filter "name=jim.worker" --filter "status=running" --format "{{.Names}}" 2>$null
-    if ($containerRunning -ne "jim.worker") {
-        throw "jim.worker container is not running; cannot write $DestinationPath."
-    }
-
-    $destDir = [System.IO.Path]::GetDirectoryName($DestinationPath).Replace('\','/')
-    if ($destDir -and $destDir -ne '/') {
-        docker exec -u app jim.worker mkdir -p $destDir | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to create directory '$destDir' in jim.worker."
-        }
-    }
-
-    # Stream the file via docker exec stdin so the resulting file is owned by `app`.
-    # `rm -f` first guarantees a fresh inode even if a stale file with different
-    # ownership is already present (e.g. a customer or earlier test wrote through
-    # a different UID via `docker cp` or via the Samba/OpenLDAP side of the volume).
-    #
-    # Both steps use ArgumentList (no shell) so the path is passed verbatim and is
-    # safe against special characters (spaces, single quotes, etc.).
-
-    # Step 1: remove any stale file so tee always creates a fresh inode.
-    $rmPsi = New-Object System.Diagnostics.ProcessStartInfo
-    $rmPsi.FileName = "docker"
-    $rmPsi.ArgumentList.Add("exec")
-    $rmPsi.ArgumentList.Add("-u")
-    $rmPsi.ArgumentList.Add("app")
-    $rmPsi.ArgumentList.Add("jim.worker")
-    $rmPsi.ArgumentList.Add("rm")
-    $rmPsi.ArgumentList.Add("-f")
-    $rmPsi.ArgumentList.Add($DestinationPath)
-    $rmPsi.UseShellExecute = $false
-    $rmProc = [System.Diagnostics.Process]::Start($rmPsi)
-    $rmProc.WaitForExit()
-    $rmProc.Dispose()
-
-    # Step 2: stream file content via stdin into tee, which writes to the path directly.
-    $fileStream = [System.IO.File]::OpenRead($SourcePath)
-    try {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = "docker"
-        $psi.ArgumentList.Add("exec")
-        $psi.ArgumentList.Add("-i")
-        $psi.ArgumentList.Add("-u")
-        $psi.ArgumentList.Add("app")
-        $psi.ArgumentList.Add("jim.worker")
-        $psi.ArgumentList.Add("tee")
-        $psi.ArgumentList.Add($DestinationPath)
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.UseShellExecute = $false
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        try {
-            $fileStream.CopyTo($proc.StandardInput.BaseStream)
-            $proc.StandardInput.Close()
-            $proc.StandardOutput.ReadToEnd() | Out-Null
-            $proc.WaitForExit()
-            if ($proc.ExitCode -ne 0) {
-                throw "docker exec returned exit code $($proc.ExitCode) while writing $DestinationPath."
-            }
-        }
-        finally {
-            $proc.Dispose()
-        }
-    }
-    finally {
-        $fileStream.Dispose()
-    }
+    Write-FilesToConnectorVolume -SourceDir $sourceDir -Files @(
+        @{ SourceFile = $sourceFile; DestinationPath = $DestinationPath }
+    )
 }
 
 function Copy-CsvToConnectorFiles {

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -650,8 +650,14 @@ function New-TestUser {
     # - All contractors: 1 week to 12 months in the future
     # - ~15% of employees (those with resignations): 1 week to 3 months in the future
     # - Other employees: no expiry (null)
+    #
+    # Base date is a fixed epoch (not Get-Date) so CSV generation is byte-deterministic across runs,
+    # which is what makes the CSV cache (Get-OrGenerate-TestCSV.ps1) safe. Any call site that needs a
+    # "from-now" offset should compute it against Get-Date itself.
+    # Chosen well into the future so that expiry dates derived from (epoch + 7..365 days) remain
+    # future-dated for the foreseeable life of this test suite.
     $accountExpires = $null
-    $now = Get-Date
+    $now = [DateTime]::new(2030, 1, 1, 0, 0, 0, [DateTimeKind]::Utc)
 
     if ($isContractor) {
         # Contractors: expiry between 1 week and 12 months

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -726,6 +726,42 @@ function Get-RandomSubset {
 
 $script:ConnectorVolumeHelperImage = 'busybox:1.37.0'
 
+function Clear-ConnectorFilesVolume {
+    <#
+    .SYNOPSIS
+        Empty the contents of jim-connector-files-volume in place.
+
+    .DESCRIPTION
+        `docker compose down -v` cannot delete jim-connector-files-volume while
+        samba-ad-primary / openldap-primary (started from docker-compose.integration-tests.yml
+        and kept alive across scenarios in -Scenario All mode) hold it open. Without an
+        in-place wipe the volume silently persists between runs and accumulates stale files.
+
+        This helper launches a throwaway container from the jim.worker image (already pulled,
+        no extra network fetch) with default (non-restricted) capabilities, mounts the volume,
+        and rm -rf's its contents as root. This is safe to call whether jim.worker is running
+        or not; falls back to the compose-project image name when the container isn't up.
+
+        Call sites:
+          - Run-IntegrationTests.ps1 Step 1 (top-level reset)
+          - Run-IntegrationTests.ps1 Reset-JIMForNextScenario (between-scenarios lightweight reset)
+        Both paths must start each scenario with an empty volume, so the helper lives here
+        rather than being duplicated in both call sites.
+    #>
+    param()
+
+    $workerImage = (docker inspect jim.worker --format '{{.Config.Image}}' 2>$null)
+    if (-not $workerImage) {
+        # Fall back to the compose-project image name if the container isn't up.
+        $workerImage = 'jim-worker'
+    }
+
+    Write-Host "  Emptying jim-connector-files-volume contents (via throwaway $workerImage container)..." -ForegroundColor Gray
+    docker run --rm --user 0 --entrypoint sh `
+        -v jim-connector-files-volume:/vol $workerImage `
+        -c 'rm -rf /vol/* /vol/.[!.]* 2>/dev/null; true' 2>&1 | Out-Null
+}
+
 function Write-FilesToConnectorVolume {
     <#
     .SYNOPSIS
@@ -789,32 +825,61 @@ function Write-FilesToConnectorVolume {
         $resolvedSourceDir = $resolvedSourceDir.Replace('\','/')
     }
 
+    # Caller provenance: captured once per call and used in three places —
+    #   (a) the DarkGray breadcrumb line in the scenario transcript,
+    #   (b) the .last-seed file inside the volume (for post-mortem forensics when
+    #       a scenario transcript doesn't show the call, e.g. stray out-of-band writer),
+    #   (c) failure messages so the throw points at the caller, not just the helper.
+    $stack = Get-PSCallStack
+    $callerScript = if ($stack.Count -ge 2 -and $stack[1].ScriptName) {
+        Split-Path -Leaf $stack[1].ScriptName
+    } else { '<unknown>' }
+    $callerLine = if ($stack.Count -ge 2) { $stack[1].ScriptLineNumber } else { 0 }
+    $callerCmd = if ($stack.Count -ge 2) { $stack[1].Command } else { '<unknown>' }
+    $callerInfo = "${callerScript}:${callerLine} (${callerCmd})"
+
+    # Capture expected per-file sizes on host now so we can verify post-copy that
+    # what's in the volume matches what we asked busybox to copy. This catches two
+    # failure modes: (1) a silent short-read / truncation in the cp path, and (2)
+    # any out-of-band overwriter between this call's return and the caller's
+    # first read. (1) is diagnosed immediately by the throw below; (2) requires
+    # the caller to re-check later via Assert-ConnectorVolumeCsvParity.
+    $expectedSizes = @{}
+    $totalBytes = 0L
+
+    # Collect destination metadata and build the copy script in one pass.
     $destDirs = [System.Collections.Generic.HashSet[string]]::new()
-    $script = [System.Text.StringBuilder]::new()
-    $null = $script.AppendLine('set -e')
+    $shellScript = [System.Text.StringBuilder]::new()
+    $null = $shellScript.AppendLine('set -e')
 
     foreach ($entry in $Files) {
         $sourceFile = [string]$entry.SourceFile
         $destPath   = [string]$entry.DestinationPath
 
         if (-not $sourceFile) {
-            throw "Write-FilesToConnectorVolume: entry is missing SourceFile."
+            throw "Write-FilesToConnectorVolume: entry is missing SourceFile. (caller: $callerInfo)"
         }
         if (-not $destPath) {
-            throw "Write-FilesToConnectorVolume: entry is missing DestinationPath."
+            throw "Write-FilesToConnectorVolume: entry is missing DestinationPath. (caller: $callerInfo)"
         }
         if (-not $destPath.StartsWith('/')) {
-            throw "DestinationPath must be absolute (got '$destPath')."
+            throw "DestinationPath must be absolute (got '$destPath'). (caller: $callerInfo)"
         }
         if ($sourceFile -match '[\\/]') {
-            throw "SourceFile must be a filename, not a path (got '$sourceFile'). Set SourceDir to the containing directory."
+            throw "SourceFile must be a filename, not a path (got '$sourceFile'). Set SourceDir to the containing directory. (caller: $callerInfo)"
         }
         if ($sourceFile -match "'" -or $destPath -match "'") {
-            throw "Write-FilesToConnectorVolume does not support paths containing single quotes."
+            throw "Write-FilesToConnectorVolume does not support paths containing single quotes. (caller: $callerInfo)"
         }
-        if (-not (Test-Path -Path (Join-Path $resolvedSourceDir $sourceFile) -PathType Leaf)) {
-            throw "Source file not found: $(Join-Path $resolvedSourceDir $sourceFile)"
+
+        $hostFile = Join-Path $resolvedSourceDir $sourceFile
+        if (-not (Test-Path -Path $hostFile -PathType Leaf)) {
+            throw "Source file not found: $hostFile (caller: $callerInfo)"
         }
+
+        $sourceSize = (Get-Item -LiteralPath $hostFile).Length
+        $expectedSizes[$destPath] = $sourceSize
+        $totalBytes += $sourceSize
 
         $destDir = [System.IO.Path]::GetDirectoryName($destPath).Replace('\','/')
         if ($destDir -and $destDir -ne '/') {
@@ -825,16 +890,37 @@ function Write-FilesToConnectorVolume {
         # UID is already at the destination (e.g. from a previous run or a parallel
         # Samba/OpenLDAP write path). cp --remove-destination would be tidier but
         # busybox cp doesn't ship that flag; the explicit rm is portable.
-        $null = $script.AppendLine("rm -f '$destPath'")
-        $null = $script.AppendLine("cp '/src/$sourceFile' '$destPath'")
+        $null = $shellScript.AppendLine("rm -f '$destPath'")
+        $null = $shellScript.AppendLine("cp '/src/$sourceFile' '$destPath'")
     }
 
+    # Breadcrumb: prints to the transcript so a reader can see exactly which
+    # script and line issued every seed, plus the payload shape. Intentionally
+    # short so it doesn't clutter normal runs.
+    Write-Host "  [seed] $callerInfo -> $($Files.Count) file(s), $totalBytes bytes from $resolvedSourceDir" -ForegroundColor DarkGray
+
+    # .last-seed breadcrumb written INSIDE the container at the top of the shell
+    # script. If the volume is ever found with unexpected contents, `docker exec
+    # jim.worker cat /connector-files/.last-seed` reports the timestamp, the
+    # PowerShell PID ($env:JIM_SEED_CALLER_PID), the caller location, and the
+    # destination list. This catches out-of-band writers whose transcripts we
+    # don't control — the .last-seed reflects whatever wrote the volume most
+    # recently, regardless of which session ran it.
     $mkdirScript = [System.Text.StringBuilder]::new()
     foreach ($d in $destDirs) {
         $null = $mkdirScript.AppendLine("mkdir -p '$d'")
     }
-    # Prepend mkdirs so the directories exist before cp runs.
-    $fullScript = $mkdirScript.ToString() + $script.ToString()
+
+    $destList = ($Files | ForEach-Object { $_.DestinationPath }) -join ' '
+    $headerScript = [System.Text.StringBuilder]::new()
+    # Use printf-with-literal-strings so no variable expansion happens on content
+    # coming from PowerShell; caller_pid is injected via env, the rest are literals.
+    $null = $headerScript.AppendLine('set -e')
+    $null = $headerScript.AppendLine("printf '%s pid=%d ppid=%d caller_pid=%s caller=%s bytes=%d files=%s\n' `"`$(date -Iseconds)`" `$`$ `"`${PPID}`" `"`${JIM_SEED_CALLER_PID:-unset}`" '$callerInfo' '$totalBytes' '$destList' > /connector-files/.last-seed")
+
+    # Prepend header + mkdirs so provenance is captured even if a later cp fails,
+    # and directories exist before cp runs.
+    $fullScript = $headerScript.ToString() + $mkdirScript.ToString() + $shellScript.ToString()
 
     $mountSpec = "${resolvedSourceDir}:/src:ro"
     $volumeMount = 'jim-connector-files-volume:/connector-files'
@@ -843,6 +929,10 @@ function Write-FilesToConnectorVolume {
     $psi.FileName = 'docker'
     $psi.ArgumentList.Add('run')
     $psi.ArgumentList.Add('--rm')
+    # Expose the PowerShell PID to the shell so .last-seed records it — useful
+    # when multiple pwsh sessions could contend for the same volume.
+    $psi.ArgumentList.Add('-e')
+    $psi.ArgumentList.Add("JIM_SEED_CALLER_PID=$PID")
     $psi.ArgumentList.Add('--user')
     $psi.ArgumentList.Add('1654:1654')
     $psi.ArgumentList.Add('-v')
@@ -868,11 +958,75 @@ function Write-FilesToConnectorVolume {
             if ($stderr -match 'Permission denied') {
                 $hint = " This usually means a destination file or its parent directory is owned by a UID other than 1654 (e.g. from a past 'docker cp' into the volume). Reset the volume with 'docker volume rm jim-connector-files-volume' after stopping jim.worker / jim.web, or chown the affected path from a root-privileged sidecar."
             }
-            throw "docker run helper (image $script:ConnectorVolumeHelperImage) failed with exit code $($proc.ExitCode) while seeding [$fileList].$hint stderr: $stderr. stdout: $stdout"
+            throw "docker run helper (image $script:ConnectorVolumeHelperImage) failed with exit code $($proc.ExitCode) while seeding [$fileList] from $callerInfo.$hint stderr: $stderr. stdout: $stdout"
         }
     }
     finally {
         $proc.Dispose()
+    }
+
+    # Post-seed size verification. Stat every destination inside the volume and
+    # compare against the host source size captured above. A mismatch here would
+    # mean the cp path did something weird (short read, silent partial write),
+    # or — if sizes match now but diverge later — that a subsequent out-of-band
+    # writer overwrote the file. Either way, fail fast and loudly so the hour-
+    # long sync downstream doesn't proceed on corrupted input.
+    $statPaths = ($Files | ForEach-Object { "'$($_.DestinationPath)'" }) -join ' '
+    $statScript = "for f in $statPaths; do printf '%s %s\n' `"`$f`" `"`$(stat -c '%s' `"`$f`")`"; done"
+    $statPsi = New-Object System.Diagnostics.ProcessStartInfo
+    $statPsi.FileName = 'docker'
+    $statPsi.ArgumentList.Add('run')
+    $statPsi.ArgumentList.Add('--rm')
+    $statPsi.ArgumentList.Add('--user')
+    $statPsi.ArgumentList.Add('1654:1654')
+    $statPsi.ArgumentList.Add('-v')
+    $statPsi.ArgumentList.Add($volumeMount)
+    $statPsi.ArgumentList.Add($script:ConnectorVolumeHelperImage)
+    $statPsi.ArgumentList.Add('sh')
+    $statPsi.ArgumentList.Add('-c')
+    $statPsi.ArgumentList.Add($statScript)
+    $statPsi.UseShellExecute = $false
+    $statPsi.RedirectStandardOutput = $true
+    $statPsi.RedirectStandardError = $true
+
+    $statProc = [System.Diagnostics.Process]::Start($statPsi)
+    try {
+        $statStdout = $statProc.StandardOutput.ReadToEnd()
+        $statStderr = $statProc.StandardError.ReadToEnd()
+        $statProc.WaitForExit()
+        if ($statProc.ExitCode -ne 0) {
+            throw "Post-seed verification failed: stat helper exited $($statProc.ExitCode). stderr: $statStderr. stdout: $statStdout. Caller: $callerInfo"
+        }
+
+        $mismatches = @()
+        foreach ($line in ($statStdout -split "`n")) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line.Trim() -split '\s+', 2
+            if ($parts.Count -ne 2) { continue }
+            $path = $parts[0]
+            $actual = [int64]$parts[1]
+            $expected = $expectedSizes[$path]
+            if ($null -eq $expected) { continue }
+            if ($actual -ne $expected) {
+                $mismatches += "  ${path}: host=$expected bytes, volume=$actual bytes"
+            }
+        }
+
+        if ($mismatches.Count -gt 0) {
+            $details = $mismatches -join "`n"
+            throw @"
+Post-seed size verification detected corruption. Caller: $callerInfo
+Source dir: $resolvedSourceDir
+Mismatches:
+$details
+The File connector will read truncated data. Investigate the seed path (busybox cp
+failure, bind-mount issue) or any out-of-band writer to jim-connector-files-volume
+BEFORE re-running (root cause will recur on retry).
+"@
+        }
+    }
+    finally {
+        $statProc.Dispose()
     }
 }
 
@@ -939,6 +1093,108 @@ function Copy-CsvToConnectorFiles {
     }
 
     Write-FileToConnectorVolume -SourcePath $SourcePath -DestinationPath "/connector-files/test-data/$DestinationName"
+}
+
+function Assert-ConnectorVolumeCsvParity {
+    <#
+    .SYNOPSIS
+        Verify volume CSV file sizes match host expectations; throw on divergence.
+
+    .DESCRIPTION
+        Defence-in-depth check meant to run immediately before a CSV-consuming run
+        profile fires. Write-FilesToConnectorVolume already verifies sizes at seed
+        time; this helper catches the narrower failure mode where the volume was
+        seeded correctly but something truncated the file between seed and read
+        (the 08:47:22 Scale100K incident we investigated).
+
+        On mismatch, throws with the container path, expected (host) size, and
+        actual (volume) size so the transcript captures exactly which file
+        diverged. Also reads /connector-files/.last-seed from the volume and
+        surfaces its contents — that file records the most recent seeder's PID,
+        caller, and payload, so the failure message points at the out-of-band
+        writer if one exists.
+
+    .PARAMETER Pairs
+        Array of hashtables each with HostPath (absolute host path to the file
+        we SHOULD be reading) and ContainerPath (absolute /connector-files path
+        inside the volume). All files listed are checked in a single docker exec.
+
+    .EXAMPLE
+        Assert-ConnectorVolumeCsvParity -Pairs @(
+            @{ HostPath = "$testDataPath/hr-users.csv";         ContainerPath = '/connector-files/test-data/hr-users.csv' }
+            @{ HostPath = "$testDataPath/training-records.csv"; ContainerPath = '/connector-files/test-data/training-records.csv' }
+        )
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]$Pairs
+    )
+
+    if ($Pairs.Count -eq 0) { return }
+
+    foreach ($p in $Pairs) {
+        if (-not $p.HostPath -or -not $p.ContainerPath) {
+            throw "Assert-ConnectorVolumeCsvParity: each pair must have HostPath and ContainerPath."
+        }
+        if (-not (Test-Path -Path $p.HostPath -PathType Leaf)) {
+            throw "Assert-ConnectorVolumeCsvParity: host file not found: $($p.HostPath)"
+        }
+    }
+
+    # Build a single shell command that prints "<path> <size>" per container path.
+    # Running one docker exec is meaningfully cheaper than one per file when this
+    # helper is called before every CSV-consuming run profile.
+    $containerPaths = ($Pairs | ForEach-Object { "'$($_.ContainerPath)'" }) -join ' '
+    $statCmd = "for f in $containerPaths; do printf '%s %s\n' `"`$f`" `"`$(stat -c '%s' `"`$f`" 2>/dev/null || echo MISSING)`"; done"
+
+    $statOutput = & docker exec jim.worker sh -c $statCmd 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Assert-ConnectorVolumeCsvParity: docker exec jim.worker failed: $statOutput"
+    }
+
+    $actualByPath = @{}
+    foreach ($line in ($statOutput -split "`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $parts = $line.Trim() -split '\s+', 2
+        if ($parts.Count -ne 2) { continue }
+        $actualByPath[$parts[0]] = $parts[1]
+    }
+
+    $mismatches = @()
+    foreach ($p in $Pairs) {
+        $expected = (Get-Item -LiteralPath $p.HostPath).Length
+        $actualRaw = $actualByPath[$p.ContainerPath]
+        if ($null -eq $actualRaw -or $actualRaw -eq 'MISSING') {
+            $mismatches += "  $($p.ContainerPath): host=$expected bytes, volume=MISSING"
+            continue
+        }
+        $actual = [int64]$actualRaw
+        if ($actual -ne $expected) {
+            $mismatches += "  $($p.ContainerPath): host=$expected bytes, volume=$actual bytes"
+        }
+    }
+
+    if ($mismatches.Count -eq 0) { return }
+
+    # Divergence detected — grab the .last-seed breadcrumb and fail loudly.
+    $lastSeed = & docker exec jim.worker sh -c 'cat /connector-files/.last-seed 2>/dev/null || echo "(.last-seed not present)"' 2>&1
+    $details = $mismatches -join "`n"
+    throw @"
+Connector volume CSV parity check FAILED. One or more files have diverged from the
+host source between the most recent seed and this read. Do not proceed with the
+pending run profile — the File connector will read truncated or stale data.
+
+Mismatches:
+$details
+
+Most recent seed provenance (from /connector-files/.last-seed):
+  $lastSeed
+
+Next steps:
+  - Check for stray pwsh sessions / background jobs that might have issued another seed.
+  - Grep the scenario transcript for '[seed]' lines between the last good read and now.
+  - docker exec jim.worker ls -la /connector-files/test-data to see current file state.
+"@
 }
 
 function Write-ProgressBar {
@@ -2209,6 +2465,273 @@ function Stop-JimErrorWatcher {
 
     $lines = @(Get-Content -Path $Handle.SentinelPath -ErrorAction SilentlyContinue | Where-Object { $_ -ne '' })
     return $lines
+}
+
+function Start-ConnectorVolumeAuditor {
+    <#
+    .SYNOPSIS
+        Start an inotifywait sidecar that logs every write/create/delete/rename
+        to jim-connector-files-volume for the duration of a scenario.
+
+    .DESCRIPTION
+        Launches a detached alpine container that installs inotify-tools and
+        monitors /connector-files recursively. Every filesystem event is written
+        to a log on the host (via a bind-mounted results directory), giving us
+        an authoritative timeline of who wrote what to the volume and when.
+
+        This is the strongest probe for diagnosing out-of-band writers: unlike
+        transcript-based breadcrumbs, it captures events regardless of which
+        process (even non-JIM ones) performed the write. Paired with the
+        .last-seed breadcrumb in Write-FilesToConnectorVolume, the two together
+        can identify the caller for any unexpected mutation.
+
+        Overhead is negligible on typical scenario runs: inotify is kernel-side
+        and the sidecar only emits events when they occur. A Scale100K run with
+        ~4 CSV writes produces a handful of log lines.
+
+        Returns a handle for the companion Stop-ConnectorVolumeAuditor helper.
+        Safe to call when docker isn't available — returns $null in that case.
+
+    .PARAMETER LogPath
+        Absolute host path to the audit log file to write. Parent directory is
+        created if missing.
+
+    .OUTPUTS
+        PSCustomObject with ContainerName and LogPath, or $null if the sidecar
+        could not be started (no docker, or docker run failed).
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$LogPath
+    )
+
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $logDir = Split-Path -Parent $LogPath
+    if ($logDir -and -not (Test-Path $logDir)) {
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    }
+    # Pre-create the log file so the bind mount is a file (not a directory)
+    # inside the sidecar and so the first `tail -f` from a debugging operator
+    # doesn't trip on a missing path.
+    if (-not (Test-Path $LogPath)) {
+        New-Item -ItemType File -Path $LogPath -Force | Out-Null
+    }
+
+    $containerName = "jim-volume-audit-$([Guid]::NewGuid().ToString('N').Substring(0,8))"
+
+    # alpine + inotify-tools is ~10 MB pull on first use, cached thereafter.
+    # --init gives us a proper PID 1 so SIGTERM from `docker stop` reaches
+    # inotifywait cleanly. We chain `apk add` and `inotifywait` in one shell
+    # string and redirect output directly to the bind-mounted audit log —
+    # inotifywait line-buffers its output by default, so `tail -f` on the host
+    # updates live without needing stdbuf.
+    $monitorCmd = "apk add -q inotify-tools >/dev/null 2>&1 && " +
+                  "inotifywait -m -r -q " +
+                  "--timefmt '%FT%T%z' " +
+                  "--format '%T %e %w%f' " +
+                  "/watch >> /audit.log"
+
+    $runArgs = @(
+        'run', '-d', '--rm', '--init',
+        '--name', $containerName,
+        '-v', 'jim-connector-files-volume:/watch:ro',
+        '-v', "${LogPath}:/audit.log",
+        'alpine:3.20',
+        'sh', '-c', $monitorCmd
+    )
+
+    $startOutput = & docker @runArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  (connector-volume audit sidecar failed to start: $startOutput)" -ForegroundColor DarkYellow
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        ContainerName = $containerName
+        LogPath       = $LogPath
+    }
+}
+
+function Stop-ConnectorVolumeAuditor {
+    <#
+    .SYNOPSIS
+        Stop an inotifywait sidecar started by Start-ConnectorVolumeAuditor.
+
+    .DESCRIPTION
+        Best-effort cleanup: tries `docker stop` followed by `docker rm -f`.
+        Safe to call with $null (no-op); safe to call multiple times. Always
+        call from a `finally` block so the sidecar doesn't leak past the run.
+
+    .PARAMETER Handle
+        The handle returned by Start-ConnectorVolumeAuditor, or $null.
+
+    .OUTPUTS
+        Returns the number of audit log lines captured (0 if the log file is
+        empty or missing).
+    #>
+    param(
+        [Parameter(Mandatory=$false)]
+        $Handle
+    )
+
+    if ($null -eq $Handle) { return 0 }
+
+    # --time 2 caps the wait for graceful SIGTERM; force-kills if the process
+    # doesn't exit. This limits worst-case cleanup cost to ~2s per scenario.
+    docker stop --time 2 $Handle.ContainerName 2>&1 | Out-Null
+    docker rm -f $Handle.ContainerName 2>&1 | Out-Null
+
+    if (Test-Path $Handle.LogPath) {
+        $lineCount = @(Get-Content -Path $Handle.LogPath -ErrorAction SilentlyContinue).Count
+        return $lineCount
+    }
+    return 0
+}
+
+function Start-DockerEventsCapture {
+    <#
+    .SYNOPSIS
+        Stream `docker events` to a log file for the duration of a scenario.
+
+    .DESCRIPTION
+        Spawns `docker events` as a background process that writes every
+        container/image/volume lifecycle event to a host log. Essential for
+        retroactive diagnosis of throwaway containers (e.g. our busybox seed
+        helper, rogue `docker run` calls from other sessions) — `docker events`
+        is a live stream with no retention by default, so capturing it to disk
+        is the only way to see the history.
+
+        The format includes Time, Type, Action, image, and container name, which
+        is enough to identify the command that produced each event when
+        correlated with the .last-seed breadcrumb and the inotify audit log.
+
+    .PARAMETER LogPath
+        Absolute host path to write the events log to.
+
+    .OUTPUTS
+        System.Diagnostics.Process for the docker events stream, or $null on
+        failure.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$LogPath
+    )
+
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+
+    $logDir = Split-Path -Parent $LogPath
+    if ($logDir -and -not (Test-Path $logDir)) {
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    }
+
+    try {
+        # ProcessStartInfo + ArgumentList preserves argv boundaries on Linux
+        # pwsh; `Start-Process -ArgumentList` joins the array with spaces, which
+        # then retokenises the format string (its internal spaces cause docker
+        # to see the trailing words as positional args, not part of --format).
+        # We also want stdout flushed line-by-line so a live `tail -f` sees
+        # events as they happen — stdbuf -oL in front of docker forces that.
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = '/usr/bin/stdbuf'
+        $psi.ArgumentList.Add('-oL')
+        $psi.ArgumentList.Add('docker')
+        $psi.ArgumentList.Add('events')
+        $psi.ArgumentList.Add('--format')
+        $psi.ArgumentList.Add('{{.Time}} {{.Type}} {{.Action}} image={{.Actor.Attributes.image}} name={{.Actor.Attributes.name}}')
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+
+        $process = [System.Diagnostics.Process]::Start($psi)
+
+        # Pump stdout/stderr to the log files on background threads so we don't
+        # block the parent and the pipe doesn't fill up.
+        $outStream = [System.IO.StreamWriter]::new($LogPath, $true)
+        $errStream = [System.IO.StreamWriter]::new("$LogPath.stderr", $true)
+        $outStream.AutoFlush = $true
+        $errStream.AutoFlush = $true
+
+        # Register handlers BEFORE BeginOutputReadLine so we don't race early lines.
+        $outStream | Add-Member -Name 'Proc' -MemberType NoteProperty -Value $process -Force
+        Register-ObjectEvent -InputObject $process -EventName OutputDataReceived -MessageData $outStream -Action {
+            if ($EventArgs.Data) { $Event.MessageData.WriteLine($EventArgs.Data) }
+        } | Out-Null
+        Register-ObjectEvent -InputObject $process -EventName ErrorDataReceived -MessageData $errStream -Action {
+            if ($EventArgs.Data) { $Event.MessageData.WriteLine($EventArgs.Data) }
+        } | Out-Null
+        $process.BeginOutputReadLine()
+        $process.BeginErrorReadLine()
+
+        # Tag the process with the streams so Stop-DockerEventsCapture can close them.
+        $process | Add-Member -Name 'OutStream' -MemberType NoteProperty -Value $outStream -Force
+        $process | Add-Member -Name 'ErrStream' -MemberType NoteProperty -Value $errStream -Force
+        return $process
+    }
+    catch {
+        Write-Host "  (docker events capture failed to start: $_)" -ForegroundColor DarkYellow
+        return $null
+    }
+}
+
+function Stop-DockerEventsCapture {
+    <#
+    .SYNOPSIS
+        Stop the docker events stream started by Start-DockerEventsCapture.
+
+    .DESCRIPTION
+        Kills the docker events process. Safe to call with $null or an already-
+        exited process; safe to call multiple times. Always call from a
+        `finally` block.
+
+    .PARAMETER Process
+        The process handle returned by Start-DockerEventsCapture, or $null.
+
+    .OUTPUTS
+        Returns the number of event lines captured (0 if missing).
+    #>
+    param(
+        [Parameter(Mandatory=$false)]
+        $Process,
+
+        [Parameter(Mandatory=$false)]
+        [string]$LogPath
+    )
+
+    if ($null -ne $Process -and -not $Process.HasExited) {
+        try {
+            Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+        }
+        catch {
+            # Best effort; docker events sometimes exits on its own when the
+            # daemon restarts, in which case HasExited lies briefly.
+        }
+    }
+
+    # Close the stream writers so final buffered events flush to disk before
+    # we count lines. Guarded because a $null Process skipped them entirely.
+    if ($null -ne $Process) {
+        try {
+            $Process.WaitForExit(2000) | Out-Null
+        }
+        catch { }
+        foreach ($propName in 'OutStream', 'ErrStream') {
+            $s = $Process.PSObject.Properties[$propName]
+            if ($s -and $s.Value) {
+                try { $s.Value.Flush(); $s.Value.Dispose() } catch { }
+            }
+        }
+    }
+
+    if ($LogPath -and (Test-Path $LogPath)) {
+        return @(Get-Content -Path $LogPath -ErrorAction SilentlyContinue).Count
+    }
+    return 0
 }
 
 function Assert-NoWorkerErrors {


### PR DESCRIPTION
## Summary

Three threads of work on the integration test harness, plus one production-path perf fix and a couple of small UI cleanups.

### Integration test performance
- **Cache deterministic test CSVs across runs** (#634): wraps `Generate-TestCSV.ps1` in a content-hash-keyed tar cache so Scale100K regeneration drops from ~100s to a sub-second extract. Required determinism fixes (fixed epochs in place of `Get-Date`) to make byte-identity caching safe.
- **Single rootless `docker run` for volume seeding** (#635): replaces per-file `docker exec | tee` streaming with one `busybox` container that mounts source + volume and copies in one shot. ~70 MB payload drops from 15-25s to ~0.7s. Files land owned by UID 1654 — no `chown`, no root anywhere.
- High-visibility cache-status banner (`HIT` / `MISS -> WROTE` / `BYPASSED` / `DISABLED`) printed after every cache step so outcome can't be missed in run logs.
- Routes the two scenario-level CSV generator call sites (Scenarios 1 and 7) through the cache wrapper. Scenarios 4/5/6 stay on direct generator calls — overlay-pattern or trivially small. `test/CLAUDE.md` documents the decision rule.

### Connector-files volume diagnostics
Motivated by the 04-21 Scale100K incident where the training CSV was silently truncated to 3 rows mid-scenario with no transcript evidence of who did it. Adds:
- `Start-ConnectorVolumeAuditor`: detached `inotify-tools` sidecar logs every write/create/modify/delete to `results/volume-audit-*.log`
- `[seed]` breadcrumb in `Write-FilesToConnectorVolume` naming the caller script + line
- `Start-DockerEventsCapture`: streams docker events for retroactive identification of throwaway containers
- `.last-seed` marker file inside the volume (timestamp, caller PID, location, destinations)
- `Assert-ConnectorVolumeCsvParity`: pre-read helper that stats volume CSVs against host sizes; wired into Scenario 1 before the first HR import and before Training Full Import
- Post-copy byte-count verification in `Write-FilesToConnectorVolume`
- `Clear-ConnectorFilesVolume` extracted and called from both top-level and between-scenario resets so every scenario starts with an empty volume

### Production
- ⚡ `AsNoTracking()` on executable export queries: loading 100k pending exports with full `CSO.AttributeValues` into EF Core's change tracker caused O(n²) identity resolution overhead, pegging a CPU core and stalling file-based exports at 0% for 20+ minutes before any writes began. Export processing is read-only — confirmations all go through raw SQL — so tracking provides no benefit.
- Comment on file-based export's upfront-load behaviour clarified to point at #633 for the streaming-write follow-up.

### UI
- Fix unreadable chip-link prefix colour on hover (object-type prefix in CSO/MVO chip links no longer pinned to tertiary palette on hover)
- Operations history pager: unadorned rows-per-page selects
- Operations tabs: breathing room under progress bars

## Test plan
- [x] `dotnet build JIM.sln` — 0 warnings, 0 errors
- [x] `dotnet test JIM.sln` — all suites pass (1582 + 689 + 95 + 34 + others)
- [x] `Test-CsvCache.ps1 -Template Nano` — 15/15 pass (cache determinism intact)
- [x] Live end-to-end: happy-path seed emits breadcrumb, writes `.last-seed`, post-seed verification matches; simulated truncation caught by parity assertion with `.last-seed` content in error
- [x] Live auditor: 9 inotify events captured from create/modify/delete sequence
- [x] Live events capture: 14 docker events captured from two busybox runs
- [ ] Manual: full Scale100K integration run (user-driven; Claude does not run integration tests)