### PR TITLE
Revert rows-per-page select to bordered variant

### DIFF
--- a/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
@@ -89,7 +89,7 @@
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
             <MudText Typo="Typo.body2" Class="mud-text-secondary">Rows per page:</MudText>
             <MudSelect T="int" Value="@_rowsPerPage" ValueChanged="OnRowsPerPageChanged"
-                       Variant="Variant.Text" Dense="true" Margin="Margin.Dense"
+                       Variant="Variant.Outlined" Dense="true" Margin="Margin.Dense"
                        Style="width: 70px;" Class="mt-0">
                 <MudSelectItem T="int" Value="10">10</MudSelectItem>
                 <MudSelectItem T="int" Value="25">25</MudSelectItem>
@@ -417,7 +417,7 @@
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
             <MudText Typo="Typo.body2" Class="mud-text-secondary">Rows per page:</MudText>
             <MudSelect T="int" Value="@_rowsPerPage" ValueChanged="OnRowsPerPageChanged"
-                       Variant="Variant.Text" Dense="true" Margin="Margin.Dense"
+                       Variant="Variant.Outlined" Dense="true" Margin="Margin.Dense"
                        Style="width: 70px;" Class="mt-0">
                 <MudSelectItem T="int" Value="10">10</MudSelectItem>
                 <MudSelectItem T="int" Value="25">25</MudSelectItem>


### PR DESCRIPTION
## Summary
- Reverts commit 69c2a639's switch from `Variant.Outlined` to `Variant.Text` on the rows-per-page selects in the operations history pager (top and bottom).
- The Text variant still rendered an underline, and stripping the underline with CSS left the value text sitting flush against the top of the input because the underline was also reserving baseline padding.
- Bordered look restored as a stop-gap until a clean borderless approach is found.

## Test plan
- [x] `dotnet build src/JIM.Web/` clean
- [ ] Reviewer: load Operations -> History tab and confirm the rows-per-page select renders with the original outlined border, value vertically centred

🤖 Generated with [Claude Code](https://claude.com/claude-code)