### PR TITLE
fix(ci): authenticate to GHCR in release publish-docs job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,13 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract OpenAPI document from jim-web image
         run: |
           IMAGE="${{ steps.prefix.outputs.IMAGE_PREFIX }}/jim-web:${{ steps.version.outputs.VERSION }}"


### PR DESCRIPTION
## Summary
- The `publish-docs` job in `release.yml` pulls the freshly-pushed `jim-web` image to extract the baked-in OpenAPI document, but was missing a `docker/login-action` step. Because the image is private, the pull returned `unauthorized` and the job failed on v0.10.0 — the first release to exercise it (the job was added in 462707ae on 2026-04-14, and v0.9.1 predated it).
- Adds the same GHCR login step already used by the `build-containers` job. The top-level `permissions` block grants `GITHUB_TOKEN` `packages: write`, so no secrets or permissions changes are needed.
- Failed run for reference: https://github.com/TetronIO/JIM/actions/runs/24765304524

## Test plan
- [ ] Next release tag push triggers the workflow and the `Publish Documentation Site` job completes the `Extract OpenAPI document from jim-web image` step successfully
- [ ] Site deploys and `docs/api/reference/v1.json` is updated on `gh-pages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)