### PR TITLE
Document CSO.Type include asymmetry on export batch queries (#638)

### DIFF
--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -2573,6 +2573,9 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     {
         var now = DateTime.UtcNow;
 
+        // CSO.Type is intentionally not included here: the file connector (the only consumer
+        // of this query) never reads it. The calls-path sibling query, GetExecutableExportBatchAsync,
+        // does include Type because LdapConnectorExport requires it.
         return await Repository.Database.PendingExports
             .AsNoTracking()
             .AsSplitQuery()
@@ -2606,6 +2609,11 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             .AsSplitQuery()
             .Include(pe => pe.AttributeValueChanges)
                 .ThenInclude(avc => avc.Attribute)
+            // CSO.Type is required by LdapConnectorExport: GetObjectClass() reads Type.Name as
+            // an object-class fallback, and InjectPlaceholderModificationsIfNeeded() assigns
+            // the Type entity onto synthesised placeholder attribute changes. The file-path
+            // sibling query (GetExecutableExportsAsync) does not include Type because the
+            // file connector never reads it.
             .Include(pe => pe.ConnectedSystemObject)
                 .ThenInclude(cso => cso!.Type)
             .Include(pe => pe.ConnectedSystemObject)


### PR DESCRIPTION
## Summary
- Audited `.Include(cso => cso!.Type)` on `GetExecutableExportBatchAsync` per issue #638.
- The include is **required**: `LdapConnectorExport.GetObjectClass()` reads `Type.Name` as an object-class fallback, and `InjectPlaceholderModificationsIfNeeded()` assigns the `Type` entity onto synthesised placeholder attribute changes.
- No other calls-path consumer (`ExportExecutionServer`, `FileConnectorExport`, `MockCallConnector`) reads `.Type`.
- Added a comment on the batch query naming the caller that needs it, and a symmetric comment on the file-path sibling `GetExecutableExportsAsync` recording that Type is deliberately omitted there.

No behaviour change; comments only.

Closes #638

## Test plan
- [x] `dotnet build src/JIM.PostgresData/` — clean, 0 warnings
- [x] No runtime behaviour change; no new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)