### PR TITLE
Add comprehensive documentation for sync rule scoping behavior

### DIFF
--- a/engineering/SYNC_RULE_SCOPING.md
+++ b/engineering/SYNC_RULE_SCOPING.md
@@ -1,0 +1,153 @@
+# Sync Rule Scoping
+
+| | |
+|---|---|
+| **Created** | 2026-04-23 |
+| **Last Updated** | 2026-04-23 |
+| **Status** | Active |
+
+This document describes the behaviour of sync rule scoping in JIM, the administrator-facing scenarios it supports, and how each scenario is realised in code.
+
+## Business scenarios supported today
+
+Scoping rules on a sync rule determine which connected system objects (CSOs) or metaverse objects (MVOs) the rule applies to. Transitions in and out of scope drive the following business scenarios:
+
+- **Onboarding**: a new CSO from an authoritative system (for example HR) enters scope of an import rule, causing the identity to be projected into the metaverse and subsequently provisioned into downstream systems by matching export rules.
+- **Ongoing attribute updates**: CSOs and MVOs that remain in scope have their attribute changes flowed through the normal precedence logic.
+- **Role or department change**: an attribute change to an MVO (typically flowed from HR) shifts the MVO in or out of scope of one or more export rules. Downstream systems gain or lose the account to match the new role, without any separate manual step.
+- **Targeted access removal**: an MVO falls out of scope of an export rule because an administrator edits the rule, or because an attribute on the MVO changes. The matching downstream CSO is either disconnected or deleted depending on configuration.
+- **Attribute contribution cut-off without breakage**: a CSO falls out of scope of an import rule, but the join to its MVO is preserved. The CSO no longer contributes attributes, but the historical linkage remains for audit, manual review, or a later back-in-scope transition.
+- **Leaver cascade**: an authoritative source stops reporting an identity. The MVO's deletion rule triggers and every downstream provisioned CSO is removed from its target system in a single coordinated pass.
+- **Soft disconnect versus hard delete**: for both inbound and outbound deprovisioning, administrators choose whether "out of scope" means "break the link but leave the target object alone" (suitable for audit, legal hold, or shared accounts) or "remove the target object entirely".
+- **Cross-system cascade in one pass**: an inbound attribute change can trigger an outbound deprovision in the same sync page. Administrators do not have to wait for a separate export run for the effect to propagate.
+
+The rest of this document shows the specific code paths that realise these scenarios, grouped by direction.
+
+## Configuration summary
+
+| Property | Location | Values | Default |
+|---|---|---|---|
+| `SyncRule.InboundOutOfScopeAction` | Import rules | `Disconnect`, `RemainJoined` | `Disconnect` |
+| `SyncRule.OutboundDeprovisionAction` | Export rules | `Disconnect`, `Delete` | `Disconnect` |
+| `MetaverseObjectType.DeletionRule` | Metaverse object type | `Manual`, `WhenLastConnectorDisconnected`, `WhenAuthoritativeSourceDisconnected` | per type |
+| `MetaverseObjectType.DeletionTriggerConnectedSystemIds` | Metaverse object type | Set of connected system IDs | empty |
+| `MetaverseObjectType.DeletionGracePeriod` | Metaverse object type | Timespan (nullable) | null (immediate) |
+
+## Inbound (import rule) scope transitions
+
+An import rule's scoping rules control whether a CSO contributes to the metaverse. The state machine below applies every time an import sync processes a CSO.
+
+```mermaid
+flowchart TD
+    Start([Import sync evaluates CSO against import rule scoping]) --> Prev{Previous state<br/>of CSO?}
+
+    Prev -->|Out of scope| OutNow{Now in scope?}
+    OutNow -->|No| NoOpOut([No-op])
+    OutNow -->|Yes| ProjectJoin[Project or join MVO<br/>and flow attributes<br/>Change type: Projected / Joined]
+
+    Prev -->|In scope| InNow{Still in scope?}
+    InNow -->|Yes| FlowUpdate[Flow attribute updates to MVO<br/>Change type: AttributeFlow]
+    InNow -->|No| OutAction{InboundOutOfScopeAction}
+
+    OutAction -->|RemainJoined| Retain[Keep join, stop attribute flow<br/>Change type: OutOfScopeRetainJoin]
+    OutAction -->|Disconnect| Disconnect[Recall CSO's attributes from MVO<br/>Break join<br/>Evaluate MVO deletion rule<br/>Change type: DisconnectedOutOfScope]
+
+    Disconnect --> MvoDeletion([See: MVO deletion cascade])
+```
+
+Relevant code:
+
+- `src/JIM.Application/Servers/ScopingEvaluationServer.cs` — criterion evaluation (`IsCsoInScopeForImportRule`).
+- `src/JIM.Worker/Processors/SyncTaskProcessorBase.cs` — `GetInScopeImportRulesAsync` (line 3050), the out-of-scope handler `HandleCsoOutOfScopeAsync` (line 3091).
+- `src/JIM.Models/Enums/ObjectChangeType.cs` — `DisconnectedOutOfScope`, `OutOfScopeRetainJoin`.
+
+## Outbound (export rule) scope transitions
+
+An export rule's scoping rules control whether an MVO projects into a target connected system. Re-evaluation happens in two places: inline during inbound sync when an MVO's attributes change, and during a normal export run.
+
+```mermaid
+flowchart TD
+    Start([MVO evaluated against export rule scoping]) --> Prev{Previous state<br/>of MVO for this rule?}
+
+    Prev -->|Out of scope| OutNow{Now in scope?}
+    OutNow -->|No| NoOpOut([No-op])
+    OutNow -->|Yes| Provision[Provision CSO in target system<br/>if rule projects, otherwise match<br/>existing CSO]
+
+    Prev -->|In scope| InNow{Still in scope?}
+    InNow -->|Yes| FlowExport[Flow attribute updates<br/>to target CSO via export]
+    InNow -->|No| OutAction{OutboundDeprovisionAction}
+
+    OutAction -->|Disconnect| SoftDisconnect[Break join<br/>CSO remains in target system<br/>JIM stops managing it]
+    OutAction -->|Delete| HardDelete[Create PendingExport with<br/>ChangeType = Delete<br/>Target row/object removed<br/>on next export run]
+```
+
+Relevant code:
+
+- `src/JIM.Application/Servers/ExportEvaluationServer.cs` — `EvaluateOutOfScopeExportsAsync` (line 180 non-cached, line 404 cached) and `HandleOutboundDeprovisioningAsync` (line 464).
+- `src/JIM.Worker/Processors/SyncTaskProcessorBase.cs` — the call site at line 1364 that performs outbound re-evaluation during inbound sync.
+
+## MVO deletion cascade
+
+Triggered either by an import disconnection that satisfies the MVO type's deletion rule, or by a CSO going obsolete on an import run. The cascade is the mechanism by which a leaver in an authoritative system results in downstream accounts being removed.
+
+```mermaid
+flowchart TD
+    Start([CSO disconnected from MVO]) --> Rule{MetaverseObjectType.DeletionRule}
+
+    Rule -->|Manual| NoDelete([No deletion])
+    Rule -->|WhenLastConnectorDisconnected| LastCheck{Any other CSOs<br/>still joined to MVO?}
+    Rule -->|WhenAuthoritativeSourceDisconnected| AuthCheck{Disconnecting system in<br/>DeletionTriggerConnectedSystemIds?}
+
+    LastCheck -->|Yes| NoDelete
+    LastCheck -->|No| Grace{Grace period configured?}
+    AuthCheck -->|No| NoDelete
+    AuthCheck -->|Yes| Grace
+
+    Grace -->|No| Immediate[Queue MVO for deletion<br/>at end of current sync page<br/>FlushPendingMvoDeletionsAsync]
+    Grace -->|Yes| Deferred[Set LastConnectorDisconnectedDate<br/>Housekeeping deletes MVO once<br/>DeletionEligibleDate passes]
+
+    Immediate --> Evaluate[EvaluateMvoDeletionAsync]
+    Deferred --> Evaluate
+
+    Evaluate --> PerCso{For each CSO<br/>joined to MVO}
+    PerCso -->|JoinType = Provisioned| CreateDelete[Create PendingExport<br/>with ChangeType = Delete<br/>Target object removed on<br/>next export run]
+    PerCso -->|JoinType = Joined or Projected| DisconnectOnly[Disconnect CSO from MVO<br/>Leave target object untouched<br/>See issue #655]
+```
+
+Relevant code:
+
+- `src/JIM.Worker/Processors/SyncTaskProcessorBase.cs` — `ProcessMvoDeletionRuleAsync` (line 836), `FlushPendingMvoDeletionsAsync` (line 2398).
+- `src/JIM.Application/Servers/SyncEngine.cs` — `EvaluateMvoDeletionRule` (line 151).
+- `src/JIM.Application/Servers/ExportEvaluationServer.cs` — `EvaluateMvoDeletionAsync` (line 541). The `JoinType == Provisioned` gate at line 551 is currently under review (see [issue #655](https://github.com/TetronIO/JIM/issues/655)): administrators may want to deprovision joined or matched CSOs too, not only those JIM provisioned.
+- `src/JIM.Worker/Worker.cs` — line 596, the housekeeping entry point for grace-period deletions.
+
+## Cross-system cascade
+
+This is the integration point that lets inbound attribute changes take effect in downstream systems within the same sync page, without requiring a subsequent export run.
+
+```mermaid
+flowchart LR
+    HR[HR import flows<br/>attribute change] --> Process[ProcessMetaverseObjectChangesAsync<br/>applies change to MVO]
+    Process --> Eval[EvaluateOutOfScopeExportsAsync<br/>for every export rule on MVO's type]
+    Eval --> Outbound([Outbound scope transition<br/>see previous diagram])
+
+    Export[Outbound sync run] --> Eval
+```
+
+The inline call at `SyncTaskProcessorBase.cs:1364` is what makes "HR changes department, DB row removed in the same sync" work. Without it, the deprovision would be deferred to the next export run against the target connected system.
+
+## What scoping does not do today
+
+The following behaviours are out of scope for the current implementation. They are captured here for administrators planning deployments and for future design work.
+
+- **Deprovision joined or matched CSOs on MVO deletion**: the cascade in `EvaluateMvoDeletionAsync` only issues delete `PendingExport`s for CSOs with `JoinType = Provisioned`. CSOs that JIM matched onto pre-existing target objects are disconnected but not removed from the target system. Review in progress in [issue #655](https://github.com/TetronIO/JIM/issues/655).
+- **Cascade back to the source connected system**: an outbound deprovision does not trigger a write back to the originating system. This is intentional to prevent circular exports.
+- **End-to-end integration test coverage of the full scope transition matrix**: individual transitions are covered by unit tests, but no single integration scenario exercises every combination against a running stack. Tracked in [issue #656](https://github.com/TetronIO/JIM/issues/656).
+
+## References
+
+- Models: `src/JIM.Models/Logic/SyncRule.cs`, `src/JIM.Models/Core/CoreEnums.cs`, `src/JIM.Models/Enums/ObjectChangeType.cs`.
+- Inbound flow: `src/JIM.Worker/Processors/SyncTaskProcessorBase.cs`, `src/JIM.Application/Servers/ScopingEvaluationServer.cs`.
+- Outbound flow: `src/JIM.Application/Servers/ExportEvaluationServer.cs`.
+- Deletion rule evaluation: `src/JIM.Application/Servers/SyncEngine.cs`.
+- Tests: `test/JIM.Worker.Tests/Synchronisation/ScopingEvaluationTests.cs`, `OutOfScopeChangeTypeTests.cs`, `test/JIM.Worker.Tests/SyncEngineTests/SyncEngineOutOfScopeTests.cs`, `DeletionRuleWorkflowTests.cs`, `test/JIM.Worker.Tests/ExportEvaluationTests.cs`.


### PR DESCRIPTION
## Summary
This PR adds a new engineering documentation file that comprehensively describes the sync rule scoping behavior in JIM, including the business scenarios it supports, configuration options, and the specific code paths that implement each scenario.

## Changes
- **New file**: `engineering/SYNC_RULE_SCOPING.md` — A detailed technical guide covering:
  - Eight key business scenarios enabled by sync rule scoping (onboarding, attribute updates, role changes, access removal, etc.)
  - Configuration summary table for scoping-related properties
  - State machine diagrams for inbound (import rule) scope transitions
  - State machine diagrams for outbound (export rule) scope transitions
  - MVO deletion cascade logic with grace period support
  - Cross-system cascade mechanism that enables same-page propagation of changes
  - Known limitations and out-of-scope behaviors
  - Direct references to relevant source code locations and test files

## Notable Details
- Includes Mermaid flowcharts visualizing the scope transition state machines for both inbound and outbound flows
- Maps configuration properties to their locations in the codebase
- Provides specific line numbers and file paths for key implementation details
- Documents the integration point (`SyncTaskProcessorBase.cs:1364`) that enables inbound changes to trigger outbound deprovisioning in the same sync page
- References open issues (#655, #656) for known limitations and future work
- Serves as a reference guide for administrators planning deployments and developers working on related features

https://claude.ai/code/session_01SUGKbrfoZoxe2rcG9Ug3gt