### PR TITLE
fix(security): patch DataProtection to 10.0.7 (CVE-2026-40372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- 🔒 Patched `Microsoft.AspNetCore.DataProtection` to 10.0.7 to address CVE-2026-40372 (GHSA-9mv3-2cwr-p262, high-severity elevation of privilege / authentication cookie forgery in ASP.NET Core Data Protection). Also drops the now-redundant transitive override of `System.Security.Cryptography.Xml`, which Data Protection 10.0.7 brings in at a patched version directly.
+
 ## [0.10.0] - 2026-04-22
 
 ### Added

--- a/src/JIM.Application/JIM.Application.csproj
+++ b/src/JIM.Application/JIM.Application.csproj
@@ -12,15 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="DynamicExpresso.Core" Version="2.19.3" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
-    <!-- Transitive override: pulled in by Microsoft.AspNetCore.DataProtection.Extensions 10.0.5,
-         which carries System.Security.Cryptography.Xml 10.0.5 (CVE-2026-33116, GHSA-37gx-xxp4-5rgx,
-         GHSA-w3x6-4m5h-cxqf). DataProtection 10.0.6 has a regression breaking round-trip MAC
-         validation, so we pin the underlying package to 10.0.6 instead of bumping DataProtection. -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JIM.Scheduler/JIM.Scheduler.csproj
+++ b/src/JIM.Scheduler/JIM.Scheduler.csproj
@@ -10,10 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <!-- Transitive override: see JIM.Application.csproj for rationale (CVE-2026-33116). -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/src/JIM.Worker/JIM.Worker.csproj
+++ b/src/JIM.Worker/JIM.Worker.csproj
@@ -14,10 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <!-- Transitive override: see JIM.Application.csproj for rationale (CVE-2026-33116). -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />


### PR DESCRIPTION
## Summary

Patches three open Dependabot alerts (#12, #13, #14) for **CVE-2026-40372** / GHSA-9mv3-2cwr-p262 — an authentication cookie forgery / elevation-of-privilege bug in `Microsoft.AspNetCore.DataProtection` 10.0.0–10.0.6 (CVSS 8.1 high, CWE-347 improper cryptographic signature verification).

- Bumps `Microsoft.AspNetCore.DataProtection` and `.Extensions` from **10.0.5 → 10.0.7** in JIM.Application, JIM.Worker, and JIM.Scheduler.
- Drops the `System.Security.Cryptography.Xml` 10.0.6 transitive override from all three `.csproj` files. It was only there because DataProtection 10.0.6 had a MAC-validation regression; 10.0.7 resolves that regression and brings Xml 10.0.7 transitively, so keeping the explicit 10.0.6 pin would silently downgrade Xml from the newer patched version.

## Why this matters for JIM

Per the advisory the "not affected" cases include running on Windows, or running framework-dependent on `net10.0` where the ASP.NET Core shared framework version is ≥ the PackageReference version.

- **JIM.Web** is on `dotnet/aspnet` and uses `Microsoft.NET.Sdk.Web`, so the shared-framework copy is loaded and the NuGet binary is pruned — not listed on Dependabot and consistent with "not affected".
- **JIM.Worker** and **JIM.Scheduler** use `Microsoft.NET.Sdk.Worker` on the `dotnet/runtime` base image (no ASP.NET Core shared framework). On Linux this means the NuGet 10.0.5 DataProtection DLL is what actually loads at runtime, which is the primary affected configuration.
- **JIM.Application** is a class library referencing DataProtection directly; the risk flows through its hosts.

## Test plan

- [x] Targeted build of JIM.Worker.Tests (transitively JIM.Application + JIM.Worker) — 0 errors, 0 warnings
- [x] Targeted build of JIM.Scheduler — 0 errors, 0 warnings
- [x] Targeted test run — `test/JIM.Worker.Tests` 1,582/1,582 passed
- [x] Final full solution build — `dotnet build JIM.sln` clean (0 errors, 0 warnings)
- [x] Final full solution test — `dotnet test JIM.sln` 2,631/2,631 passed across 6 test projects
- [ ] CodeQL / container scan / dependency scan green on CI
- [ ] Dependabot alerts #12/#13/#14 auto-close on merge to `main`

## Follow-up to decide

The advisory's remediation step 2 is to **rotate the DataProtection key ring** for any environment that ran 10.0.0–10.0.6 on Linux with a non-Web SDK. JIM is pre-GA and I don't believe any persistent-keyring deployment of Worker/Scheduler exists yet; please confirm before closing this out.

Closes #12, #13, #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)