### PR TITLE
style(docs): refine docs site header aesthetics

### DIFF
--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -42,9 +42,21 @@
   border: 1px solid rgba(30, 58, 95, 0.28);  /* --mud-palette-lines-default */
 }
 
-/* Light mode — header/footer border to separate from page */
+/* Light mode: header/footer border to separate from page */
 [data-md-color-scheme="default"] .md-header,
 [data-md-color-scheme="default"] .md-footer {
+  border-bottom: 1px solid rgba(30, 58, 95, 0.12);
+}
+
+/* Light mode: when tabs row is present, shift the separator to its bottom edge */
+[data-md-color-scheme="default"] .md-header:has(+ .md-tabs) {
+  border-bottom: none;
+}
+
+/* Light mode: tabs bar matches the header for a unified header block */
+[data-md-color-scheme="default"] .md-tabs {
+  background-color: #f3f3f3;
+  color: #121b29;
   border-bottom: 1px solid rgba(30, 58, 95, 0.12);
 }
 
@@ -104,9 +116,9 @@
   border: 1px solid #243a52;                  /* --mud-palette-lines-default */
 }
 
-/* Dark mode — tabs bar slightly darker than header for separation */
+/* Dark mode: tabs bar in deep plum, bridging header to purple hero */
 [data-md-color-scheme="slate"] .md-tabs {
-  background-color: #15132b;
+  background-color: #1d1a3d;
 }
 
 [data-md-color-scheme="slate"] .md-typeset a:hover,

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -60,6 +60,11 @@
   border-bottom: 1px solid rgba(30, 58, 95, 0.12);
 }
 
+/* Light mode: soften the scroll drop-shadow; the default reads too strongly on a pale header */
+[data-md-color-scheme="default"] .md-header--shadow {
+  box-shadow: 0 0 0.2rem rgba(0, 0, 0, 0.07), 0 0.2rem 0.4rem rgba(0, 0, 0, 0.1);
+}
+
 [data-md-color-scheme="default"] .md-footer {
   border-bottom: none;
   border-top: 1px solid rgba(30, 58, 95, 0.12);


### PR DESCRIPTION
## Summary
- Unify header and tabs row colours in both light and dark mode so the top of the page reads as a single header block rather than a three-tier stripe.
- Dark mode tabs row now matches the header (`#1d1a3d`) instead of the near-black `#15132b`, smoothing the transition into the purple hero.
- Light mode tabs row matches the header (`#f3f3f3`); the separator border shifts from the header's bottom to the tabs' bottom when tabs are present (via `:has(+ .md-tabs)`).
- Soften the light-mode scroll drop-shadow on the header: Material's default reads too strongly against the pale surface. Keeps depth cue, dials down intensity.

## Test plan
- [ ] Serve docs locally (`mkdocs serve`) and visually verify the home page in light mode, dark mode, and during scroll in both modes.
- [ ] Check a non-top-level page where the tabs row is hidden; header border should still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)