### PR TITLE
chore(deps): pin postgres to 18.3 and teach review-dependabot to detect no-op re-tags

### DIFF
--- a/.claude/skills/review-dependabot/SKILL.md
+++ b/.claude/skills/review-dependabot/SKILL.md
@@ -34,7 +34,18 @@ Categorise each PR into one of three ecosystems:
 - Check: Does the update stay within the same major.minor version (e.g., 9.0)?
 - Check: Is the publisher Microsoft (`mcr.microsoft.com`) or another trusted source?
 - Check: Is the change digest-only (`@sha256:` swap) or a tag change?
-- **CRITICAL - Apt Package Pinning**: JIM Dockerfiles pin functional apt packages to exact versions. Before approving ANY Docker base image digest update:
+- **No-op re-tag detection (digest-only swaps)**: Docker Official Images (Postgres, Keycloak, Redis, etc.) are periodically re-tagged upstream without any filesystem change; the manifest is refreshed (re-signed, annotations updated, multi-arch manifest list repacked) but every layer is byte-for-byte identical. Dependabot still raises a PR for these because it tracks the manifest digest. Before investigating further, rule this out:
+  1. Pull both digests and compare root filesystem layers:
+     ```bash
+     docker pull <image>@<old-digest> && docker pull <image>@<new-digest>
+     OLD=$(docker inspect <image>@<old-digest> --format '{{range .RootFS.Layers}}{{println .}}{{end}}')
+     NEW=$(docker inspect <image>@<new-digest> --format '{{range .RootFS.Layers}}{{println .}}{{end}}')
+     diff <(echo "$OLD") <(echo "$NEW")
+     ```
+  2. If the diff is empty, this is a **no-op re-tag**. Mark it as such in the assessment (`Security: No-op (identical layers)`) and recommend **Merge**; the apt pin check below is redundant because the filesystem is unchanged. Still run a final CI check, but skip deeper investigation.
+  3. If any layer differs, treat this as a real image change and continue with the apt-pinning and CVE checks below.
+  4. **Best-effort caveat**: if `docker pull` of the *old* digest fails (e.g., `manifest verification failed`), the upstream has garbage-collected it and you cannot confirm. Note this in the assessment ("old digest no longer resolvable, no-op status unconfirmed") and proceed with the normal Docker checks rather than blocking.
+- **CRITICAL - Apt Package Pinning** (skip if the no-op check above confirmed identical layers): JIM Dockerfiles pin functional apt packages to exact versions. Before approving ANY Docker base image digest update:
   1. Identify which Dockerfiles have pinned apt packages by reading the changed Dockerfile
   2. For each pinned package, verify it is still available at the same version in the new base image:
      ```bash
@@ -81,9 +92,12 @@ Note whether the update addresses any known CVEs - this increases urgency to mer
 Create a summary table with columns:
 | PR | Update | Service | CI Status | Pinning Check | Security | Recommendation |
 
+The `Security` column should note one of: CVEs addressed (list them), `No-op (identical layers)` for confirmed upstream re-tags, `No-op unconfirmed (old digest unresolvable)` if the upstream GC'd the prior digest, or `None` if no CVE implications.
+
 Recommendations should be one of:
 - **Merge** - All checks pass
 - **Merge (security)** - Addresses a CVE, prioritise
+- **Merge (no-op re-tag)** - Layer-identical upstream manifest refresh, safe to merge without further investigation
 - **Hold** - Needs investigation (explain why)
 - **Reject** - Fails assessment (explain why)
 

--- a/db.yml
+++ b/db.yml
@@ -1,7 +1,7 @@
 services:
   jim.database:
     container_name: JIM.Database
-    image: postgres:18@sha256:69e8582b781cb44fa4557b98ed586fe68361e320d9b12f9707494335634f4f3d
+    image: postgres:18.3@sha256:78481659c47e862334611ccdaf7c369c986b3046da9857112f3b309114a65fb4
     restart: always
     # shm_size must be >= shared_buffers - see docker-compose.yml for sizing guidance
     shm_size: '512mb'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
 
   jim.database:
     container_name: jim.database
-    image: postgres:18@sha256:059fa0289cc5a184034e05a1f4f6d6fd79f69dc718b8b04ab60b6b469eed411e
+    image: postgres:18.3@sha256:78481659c47e862334611ccdaf7c369c986b3046da9857112f3b309114a65fb4
     profiles:
       - with-db
     # PostgreSQL tuning - customise for your environment using https://pgtune.leopard.in.ua/


### PR DESCRIPTION
## Summary

- Pin the Postgres image in `docker-compose.yml` and `db.yml` to `postgres:18.3@sha256:...` (from the floating `postgres:18@sha256:...`). The specific point-release tag makes Dependabot PR titles tell the truth: `"18.3 to 18.3"` is an upstream manifest re-tag, `"18.3 to 18.4"` is a real PG patch. Prior titles said `"18 to 18"` for both cases, which made four successive PRs this month indistinguishable without manual digest inspection. Also brings `db.yml` into sync with `docker-compose.yml` (it had drifted because `db.yml` isn't tracked by Dependabot's `docker-compose` ecosystem).
- Extend the `/review-dependabot` skill with a **no-op re-tag detection** step: pull old and new digests, compare `RootFS.Layers`, and if identical, short-circuit to a `Merge (no-op re-tag)` recommendation and skip the apt-pin verification (redundant when the filesystem is unchanged). Falls back gracefully if the old digest has been garbage-collected upstream. This will apply equally to Keycloak, Redis, and any other Docker Official Image JIM consumes.

The pinned digest matches what Dependabot PR #660 was targeting, so #660 will be closed as superseded once this merges.

## Test plan

- [x] `docker compose -f docker-compose.yml config --quiet` passes
- [x] `docker compose -f db.yml config --quiet` passes
- [x] `Build-ReleaseBundle.ps1` regex (`postgres:[^\s]+`) still matches the new pinned reference
- [x] `postgres:18.3` currently resolves to digest `78481659…` (confirmed via `docker pull`)
- [x] No em-dashes introduced (per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)