### PR TITLE
fix(api): correct counts on role and connected-system endpoints + housekeeping

### DIFF
--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -215,6 +215,7 @@ _jim_db_compose() {
 
 # Standalone database (local development workflow)
 jim-db() {
+  _jim_heal_docker_creds
   docker compose $(_jim_db_compose) up -d
 }
 jim-db-stop() {
@@ -227,6 +228,7 @@ jim-db-logs() {
 # Standalone Keycloak IdP (local debugging workflow - use with jim-db + F5)
 # Starts the bundled Keycloak from docker-compose.override.yml without the full stack.
 jim-keycloak() {
+  _jim_heal_docker_creds
   docker compose -f docker-compose.yml -f docker-compose.override.yml up -d jim.keycloak
   _jim_keycloak_bridge
 }
@@ -283,11 +285,33 @@ _jim_kill_local() {
   fi
 }
 
+# Self-heal stale Docker credential helper references at command time.
+# The VS Code Dev Containers extension's per-session credsStore shim
+# (docker-credential-dev-containers-<uuid>) can disappear mid-session
+# (extension reload, host VS Code restart, etc.) while the reference in
+# ~/.docker/config.json persists, making every docker pull/build fail with
+# "error getting credentials - err: exit status 255". setup.sh handles this
+# at container creation; this runs at command time to handle the in-session
+# breakage. See setup.sh for the full background.
+_jim_heal_docker_creds() {
+  local cfg="$HOME/.docker/config.json"
+  [ -f "$cfg" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local creds_store
+  creds_store=$(jq -r '.credsStore // empty' "$cfg" 2>/dev/null)
+  [ -n "$creds_store" ] || return 0
+  command -v "docker-credential-$creds_store" >/dev/null 2>&1 && return 0
+  echo "Stale Docker credsStore '$creds_store' (helper binary missing) - removing from $cfg"
+  local tmp
+  tmp=$(mktemp) && jq 'del(.credsStore)' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+}
+
 # Clear any previous aliases before defining functions (zsh cannot redefine alias as function)
 unalias jim-stack jim-stack-logs jim-stack-down jim-restart jim-build jim-build-light jim-build-web jim-build-worker jim-build-scheduler jim-cleanup jim-reset jim-db jim-db-stop jim-db-logs jim-keycloak jim-keycloak-stop jim-keycloak-logs 2>/dev/null || true
 
 # Docker stack management
 jim-stack() {
+  _jim_heal_docker_creds
   _jim_kill_local
   docker compose $(_jim_compose) up -d
   _jim_keycloak_bridge
@@ -302,6 +326,7 @@ jim-stack-down() {
   docker rm -f samba-ad-primary samba-ad-source samba-ad-target 2>/dev/null || true
 }
 jim-restart() {
+  _jim_heal_docker_creds
   _jim_kill_local
   docker compose $(_jim_compose) down && docker compose $(_jim_compose) up -d --force-recreate
   _jim_keycloak_bridge
@@ -313,26 +338,31 @@ _jim_version_suffix() {
   echo "dev.$(date -u +%Y%m%d).$((10#$(date -u +%H)*60+10#$(date -u +%M)))"
 }
 jim-build() {
+  _jim_heal_docker_creds
   _jim_kill_local
   VERSION_SUFFIX="$(_jim_version_suffix)" docker compose $(_jim_compose) up -d --build
   _jim_keycloak_bridge
 }
 jim-build-web() {
+  _jim_heal_docker_creds
   _jim_kill_local
   local vs="$(_jim_version_suffix)"
   VERSION_SUFFIX="$vs" docker compose $(_jim_compose) build jim.web && VERSION_SUFFIX="$vs" docker compose $(_jim_compose) up -d jim.web
 }
 jim-build-worker() {
+  _jim_heal_docker_creds
   _jim_kill_local
   local vs="$(_jim_version_suffix)"
   VERSION_SUFFIX="$vs" docker compose $(_jim_compose) build jim.worker && VERSION_SUFFIX="$vs" docker compose $(_jim_compose) up -d jim.worker
 }
 jim-build-scheduler() {
+  _jim_heal_docker_creds
   _jim_kill_local
   local vs="$(_jim_version_suffix)"
   VERSION_SUFFIX="$vs" docker compose $(_jim_compose) build jim.scheduler && VERSION_SUFFIX="$vs" docker compose $(_jim_compose) up -d jim.scheduler
 }
 jim-build-light() {
+  _jim_heal_docker_creds
   _jim_kill_local
   docker compose $(_jim_compose) up -d jim.database jim.keycloak
   _jim_keycloak_bridge

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -36,6 +36,37 @@ print_warning() {
 # TODO list, not individual warnings scattered through the setup log.
 PENDING_ACTIONS=""
 
+# Self-heal stale Docker credential helper references.
+# The VS Code Dev Containers extension forwards the host's Docker credentials
+# into the container by writing a per-session entry into ~/.docker/config.json
+# of the form: {"credsStore": "dev-containers-<uuid>"} and installing a shim
+# binary docker-credential-dev-containers-<uuid> on PATH that proxies cred
+# lookups back to the host. The shim is per-VS-Code-session; the config.json
+# entry persists in the home volume across rebuilds. When the UUID rotates
+# (rebuild, extension reload, host restart) the config.json reference becomes
+# stale - Docker tries to exec a binary that no longer exists, gets exit 255,
+# and *every* image pull fails (even anonymous public ones like
+# docker/dockerfile:1) because Docker consults the credential store before
+# deciding the request is anonymous. Symptom: jim-build / jim-stack fail with
+# "error getting credentials - err: exit status 255". Fix: if the configured
+# helper isn't on PATH, drop it. Login-based credentials (docker login) are
+# unaffected because they're stored under "auths", not "credsStore".
+print_step "Checking Docker credential helper..."
+DOCKER_CONFIG_JSON="$HOME/.docker/config.json"
+if [ -f "$DOCKER_CONFIG_JSON" ] && command -v jq >/dev/null 2>&1; then
+    creds_store=$(jq -r '.credsStore // empty' "$DOCKER_CONFIG_JSON" 2>/dev/null)
+    if [ -n "$creds_store" ] && ! command -v "docker-credential-$creds_store" >/dev/null 2>&1; then
+        print_warning "Stale credsStore '$creds_store' references missing binary - removing"
+        tmp=$(mktemp)
+        jq 'del(.credsStore)' "$DOCKER_CONFIG_JSON" > "$tmp" && mv "$tmp" "$DOCKER_CONFIG_JSON"
+        print_success "Removed stale credsStore from $DOCKER_CONFIG_JSON"
+    else
+        print_success "Docker credential helper OK (or none configured)"
+    fi
+else
+    print_success "No Docker config.json or jq unavailable - skipping credsStore check"
+fi
+
 # Check Docker daemon health.
 # The docker-in-docker feature starts its own dockerd inside this container at
 # postCreate time. On some native Linux hosts (notably Fedora and Asahi Linux,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🐛 Interactive `Connect-JIM` against Keycloak deployments previously failed with `Invalid parameter: redirect_uri` because JIM advertised the confidential web client ID to the PowerShell module. Administrators can now register a separate public client (as the [SSO Setup Guide](docs/administration/sso-setup.md) has always instructed) and advertise it to interactive clients via the new `JIM_SSO_PUBLIC_CLIENT_ID` environment variable.
 - 🐛 `Get-JIMRole` and the `GET /api/v1/security/roles` endpoint now report the correct static member count for each role; previously the count was always zero because the underlying query did not load role memberships. The count is now aggregated directly in SQL, so even roles with very large memberships are returned cheaply.
+- 🐛 `Get-JIMRole -Id` and `GET /api/v1/security/roles/{id}` now report the correct static member count when retrieving a single role.
+- 🐛 `Get-JIMMetaverseObjectRole` and `GET /api/v1/security/metaverse-objects/{id}/roles` now report the correct static member count for each role a Metaverse Object belongs to.
+- 🐛 `GET /api/v1/synchronisation/connected-systems/{id}` now reports the correct connected system object count; previously it always returned zero because the navigation property was not loaded. The count is now sourced from a dedicated count query, mirroring how `pendingExportCount` is already computed.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 Interactive `Connect-JIM` against Keycloak deployments previously failed with `Invalid parameter: redirect_uri` because JIM advertised the confidential web client ID to the PowerShell module. Administrators can now register a separate public client (as the [SSO Setup Guide](docs/administration/sso-setup.md) has always instructed) and advertise it to interactive clients via the new `JIM_SSO_PUBLIC_CLIENT_ID` environment variable.
+- 🐛 `Get-JIMRole` and the `GET /api/v1/security/roles` endpoint now report the correct static member count for each role; previously the count was always zero because the underlying query did not load role memberships. The count is now aggregated directly in SQL, so even roles with very large memberships are returned cheaply.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,419 +2,166 @@
 
 > Identity Management System - .NET 10.0, EF Core, PostgreSQL, Blazor
 
+This file holds cross-cutting rules and pointers. Detailed conventions live in folder-specific CLAUDE.md files which load automatically when you work in those subtrees:
+- `src/CLAUDE.md` - code style, copyright headers, layer rules, common dev tasks
+- `src/JIM.Application/CLAUDE.md` - synchronisation integrity (full requirements)
+- `test/CLAUDE.md` - TDD patterns, test data, integration testing
+- `.devcontainer/CLAUDE.md` - commands, aliases, Docker, environment
+- `engineering/CLAUDE.md` - PRDs, plans, changelog, release process
+- `docs/CLAUDE.md` - MkDocs site, diagram embedding, doc style
+
 ## Context7 MCP
 
-Always use Context7 MCP when you need library/API documentation, code generation, setup or configuration steps without the user having to explicitly ask. The MudBlazor library ID is `/mudblazor/mudblazor`.
+Always use Context7 MCP when you need library/API documentation, code generation, or setup steps without the user having to ask. The MudBlazor library ID is `/mudblazor/mudblazor`.
 
-## Project Knowledge vs Personal Memory
+## Critical Rules
 
-When you learn something worth preserving, decide where it lives:
+**Build and test before every commit (.NET code):**
+- Prefer targeted: `dotnet build test/JIM.Worker.Tests/`, `dotnet test test/JIM.Worker.Tests/`
+- Final pre-PR check: `dotnet build JIM.sln` and `dotnet test JIM.sln` - zero errors and warnings
+- Never commit code that has not built and tested locally; never create a PR with failing build/tests
+- If environmental constraints prevent local build/test, mark the PR as draft and state the limitation
 
-- **CLAUDE.md files** (this file, `src/CLAUDE.md`, `test/CLAUDE.md`, `engineering/CLAUDE.md`, `.devcontainer/CLAUDE.md`, `docs/CLAUDE.md`, `src/JIM.Application/CLAUDE.md`): project conventions, architectural rules, workflows, and domain knowledge that apply to **every contributor** working on JIM — human or AI. These are checked into the repo and travel with the codebase. If a new developer joining the project would benefit from knowing it, it belongs here.
+**Build/test exceptions** (no `dotnet build`/`test` required):
+- Scripts (`.ps1`, `.sh`), static assets (CSS/JS/images), `.md` docs, config (`.env.example`, compose files, Dockerfiles, `.gitignore`, `.editorconfig`), CI/CD workflows, diagrams, plan documents
+- **Partial:** UI-only Blazor/Razor changes need `dotnet build` but not `dotnet test` (no UI tests exist)
 
-- **Personal memory** (under `~/.claude/projects/.../memory/`): AI-assistant-specific behaviour, the user's personal preferences and working style, and session-scoped context. Memory is per-devcontainer and does not reach other Claude instances or human contributors.
+**Test-Driven Development (Red -> Green -> Refactor):**
+1. Write a failing test first; confirm it fails for the right reason
+2. Implement the minimum code to pass
+3. Run again, confirm green; refactor without breaking
+4. For bug fixes the test must reproduce the bug and fail before the fix
 
-**Default to CLAUDE.md.** If you catch yourself writing a memory entry about a project convention, coding rule, build workflow, naming pattern, or anything a reviewer would expect to enforce, put it in the appropriate CLAUDE.md instead. Memory is a narrow tool for things that genuinely only concern Claude's interaction with one specific user.
+Never retrofit a test after the fix; never commit new functionality without tests. See `test/CLAUDE.md` for patterns.
 
-When promoting knowledge from memory to CLAUDE.md, delete the memory entry afterwards — duplication causes drift.
+**Ask before significant changes:** New features, architectural choices, or any non-trivial change with multiple sensible approaches - present the options with trade-offs and let the user decide. Do not assume.
 
-## CRITICAL REQUIREMENTS
+**Commit without asking once approved:** When the user has said "yes" or context is clear, just commit. Do not ask "would you like me to commit?".
 
-**YOU MUST BUILD AND TEST BEFORE EVERY COMMIT AND PR (for .NET code):**
+**Plan before building:** For any task with 3+ steps or architectural decisions, use plan mode. If you have spent more than 2-3 attempts on the same problem without progress, stop, re-plan, and consider asking the user - they can often see what you are missing.
 
-1. **ALWAYS** build and test before committing - zero errors and warnings required
-2. **Prefer targeted builds**: Build only affected projects and their dependents, not the full solution. For example, if you changed `JIM.Connectors` and `JIM.Worker.Tests`, run `dotnet build test/JIM.Worker.Tests/` (which transitively builds its dependencies). Only use `dotnet build JIM.sln` for the **final pre-PR check** or when changes span many projects.
-3. **Prefer targeted tests**: Run only the test projects that cover your changes. For example, `dotnet test test/JIM.Worker.Tests/` instead of `dotnet test JIM.sln`. Only run `dotnet test JIM.sln` for the **final pre-PR check**.
-4. **NEVER** commit code that hasn't been built and tested locally
-5. **NEVER** create a PR without verifying **full solution** build and tests pass
-6. **NEVER** assume tests will pass without running them
-
-**EXCEPTIONS - changes that do NOT require dotnet build/test:**
-- **Scripts** (.ps1, .sh, etc.) - do not affect compiled code
-- **Static assets** (CSS, JS, images) - served directly without compilation
-- **Documentation** (`.md` files, `docs/` changes) - no compiled code
-- **Configuration files** (`.env.example`, `docker-compose.yml`, `Dockerfile`, `.gitignore`, `.editorconfig`, etc.) - not compiled
-- **CI/CD workflows** (`.github/workflows/`) - run remotely, not compiled locally
-- **Diagrams** (`workspace.dsl`, exported SVGs) - non-code assets
-- **Plan documents** (`engineering/plans/`) - documentation only
-
-**Partial exception:**
-- **UI-only changes** (Blazor pages, Razor components) require `dotnet build` but do NOT require `dotnet test` - there are no UI tests, so running tests just wastes time
-
-**YOU MUST FOLLOW TEST-DRIVEN DEVELOPMENT (TDD):**
-
-JIM uses TDD as the standard development workflow. Tests are written **before** implementation, not after.
-
-**TDD Workflow (Red → Green → Refactor):**
-1. **Write the test first**: write a failing test that describes the expected behaviour
-2. **Confirm it fails (Red)**: run the test and verify it fails for the right reason (not just a compile error)
-3. **Implement the fix or feature (Green)**: write the minimum code to make the test pass
-4. **Verify it passes**: run the test again and confirm it is green
-5. **Refactor if needed**: clean up without breaking the test
-
-**For bug fixes specifically:**
-1. Write a test that **reproduces the bug** (it must fail before your fix)
-2. Implement the fix
-3. Run the test; it must now pass
-4. This proves the fix is correct and guards against regression
-
-**Rules:**
-1. **ALWAYS** write the test before implementing new classes, methods, or logic
-2. **ALWAYS** write a failing test before fixing a bug; the test must fail first to be meaningful
-3. **ALWAYS** write tests for new API endpoints, extension methods, and utilities
-4. **NEVER** implement a fix and then retrofit a test; that is not TDD
-5. **NEVER** commit new functionality without corresponding tests
-6. Tests should cover: happy path, edge cases, error conditions
-
-**YOU MUST ASK BEFORE IMPLEMENTING SIGNIFICANT CHANGES:**
-
-1. **ALWAYS** ask the user before implementing new features or significant functionality
-2. **ALWAYS** confirm the approach when multiple implementation options exist
-3. **ALWAYS** clarify requirements when there is ambiguity about what the user wants
-4. **NEVER** assume you know what the user wants for non-trivial changes
-5. **NEVER** implement architectural decisions without user confirmation
-6. Present options with trade-offs when relevant, and let the user decide
-
-**COMMIT WITHOUT ASKING:**
-
-1. When the user says "yes" to committing, just commit - don't ask for confirmation
-2. When work is complete and tests pass, commit automatically if the user has indicated approval
-3. Don't ask "Would you like me to commit?" - if the context is clear, just do it
-
-**YOU MUST PLAN BEFORE BUILDING:**
-
-1. **ALWAYS** enter plan mode for any non-trivial task (3+ steps or architectural decisions)
-2. Use plan mode for verification steps, not just building; plan how you will prove it works
-3. **If you've spent more than 2-3 attempts fixing an issue without progress, STOP.** Do not keep pushing down the same path. Step back, re-enter plan mode, review the problem from scratch, and consider whether you are missing something or there is a better approach. If still stuck, ask the user; they have deep developer experience and can often see what you are missing.
-4. **NEVER** mark a task complete without proving it works (build passes, tests pass, behaviour verified)
-5. When relevant, diff behaviour between `main` and your changes to confirm correctness
-
-**YOU MUST DEMAND QUALITY:**
-
-1. **Simplicity First**: Make every change as simple as possible. Impact minimal code.
-2. **Find Root Causes**: No temporary fixes, no workarounds, no band-aids. Diagnose the actual problem and fix it properly. Senior developer standards.
-3. For non-trivial changes, pause and ask: "Is there a more elegant way to do this?"
-4. If a fix feels hacky, step back and implement the clean solution, knowing everything you now know
-5. Skip this for simple, obvious fixes; don't over-engineer
-6. Before presenting work, ask yourself: "Would a staff engineer approve this?"
-
-**Test project locations:**
-- API tests: `test/JIM.Web.Api.Tests/`
-- Model tests: `test/JIM.Models.Tests/`
-- Worker/business logic tests: `test/JIM.Worker.Tests/`
-
-**Failure to build and test wastes CI/CD resources and delays the project.**
-
-If you cannot build/test locally due to environment constraints, you MUST:
-- Clearly state this limitation in the PR description
-- Mark the PR as draft
-- Request manual review and testing before merge
-
-## Subagent Strategy
-
-- Use subagents liberally to keep the main context window clean
-- Offload research, exploration, and parallel analysis to subagents
-- For complex problems, throw more compute at it: use multiple subagents in parallel
-- One task per subagent for focused execution
+**Demand quality:** Simplicity first; find root causes, not band-aids; for non-trivial changes pause and ask "is there a more elegant way?"; would a staff engineer approve this? (Skip the introspection for simple obvious fixes.)
 
 ## Synchronisation Integrity
 
-**SYNCHRONISATION INTEGRITY IS CRITICAL - PRIORITISE IT ABOVE ALL ELSE.**
+**SYNCHRONISATION INTEGRITY IS PARAMOUNT.** Sync operations are the core of JIM; customers depend on it not corrupting their data.
 
-Sync operations are the core of JIM. Customers depend on JIM to synchronise their identity data accurately without corruption or data loss.
-
-**Error Handling Philosophy:**
-1. **Fast/Hard Failures**: Better to stop and report an error than continue with corrupted state
-2. **Comprehensive Reporting**: ALL errors must be reported via RPEIs/Activities - no silent failures
-3. **Defensive Programming**: Anticipate edge cases (duplicates, missing data, type mismatches) and handle explicitly
-4. **Trust and Confidence**: Customers must be able to trust that JIM won't silently corrupt their data
-
-**Key Rules:**
-- NEVER use `First()`/`FirstOrDefault()` when expecting exactly one result - handle multiplicity explicitly
-- All sync operation code MUST be wrapped in try-catch with RPEI error logging
-- Activities with any UnhandledError RPEI items should fail the entire activity
+- Fast/hard failures over corrupted state
+- All errors reported via RPEIs/Activities; never silent
 - Log summary statistics at the end of every batch operation
-- Never silently skip objects due to exceptions
 
-> **Full detailed requirements (7 sections):** See `src/JIM.Application/CLAUDE.md`
+> **Full requirements:** `src/JIM.Application/CLAUDE.md`
 
-## Scripting
+## Code Style
 
-**IMPORTANT: Use PowerShell for ALL scripts:**
-- All automation, integration tests, and utility scripts MUST be written in PowerShell (.ps1)
-- PowerShell is cross-platform and works on Linux, macOS, and Windows
-- Exception: `.devcontainer/setup.sh` is acceptable as it runs during container creation
-- Never create bash/shell scripts for project automation or testing
+Universal rules (apply across code, scripts, docs, comments, UI text):
+- **British English (en-GB) for ALL text** - "authorisation", "synchronisation", "behaviour", "colour"
+- **Never use em dashes (`—`)** - use semicolons, commas, colons, or parentheses instead
+- All new source files carry the Tetron copyright header (`.editorconfig` enforces it for `.cs`)
+
+> **Full conventions** (DateTime quirks, raw SQL parameters, exception handling, copyright header table per file type, retrieval-method taxonomy, Razor/MudBlazor UI rules)**:** `src/CLAUDE.md`
+
+## Testing
+
+- NUnit `[Test]`, `Assert.That()`, Moq; test naming `MethodName_Scenario_ExpectedResult`
+- EF Core in-memory database auto-tracks navigation properties - this masks missing `.Include()` bugs. Run integration tests when modifying repository queries.
+
+Test project locations: `test/JIM.Web.Api.Tests/`, `test/JIM.Models.Tests/`, `test/JIM.Worker.Tests/`.
+
+> **Full patterns, debugging, integration testing runner:** `test/CLAUDE.md`
 
 ## Commands & Environment
 
-> **Full command reference, shell aliases, Docker workflows, dependency policy, environment setup, and troubleshooting:** See `.devcontainer/CLAUDE.md`
-
-**Quick reference:**
+Quick reference:
 - `jim-compile` / `jim-test` / `jim-test-all` - Build and test
 - `jim-db` / `jim-stack` - Start database / full Docker stack
 - `jim-build-light` - Start db + Keycloak, run JIM.Web natively
 - `jim-build-web` / `jim-build-worker` / `jim-build-scheduler` - Rebuild containers after code changes
 
-## MkDocs Documentation Style
+> **Full commands, aliases, Docker workflows, dependency policy, troubleshooting:** `.devcontainer/CLAUDE.md`
 
-**Use `✅` for positive indicators and `❌` for negative indicators in tables** (e.g. feature comparison tables). Do NOT use `:material-check-bold:`, `:material-close:`, or other Material icon syntax -- these render as small monochrome icons. The emoji equivalents render as clear green/red symbols in MkDocs and on GitHub.
+## Scripting
 
-**Use emojis to add energy and aid visual scanning, but keep them purposeful and professional.** JIM documentation should feel alive and modern, not dry -- but never unprofessional.
-
-Where to use them:
-- Table indicators: `✅` / `❌` for yes/no capability comparisons
-- Changelog entries: one leading emoji per entry to signal the type of change (✨ new, 🐛 fix, ⚡ performance, 🔄 changed, 🗑️ removed, 🔒 security, 📦 deployment, 🖥️ UI/UX)
-- Section lead-ins on feature-heavy or conceptual pages: a single emoji before a heading or card title to anchor the concept visually
-- Admonition-style callouts where an emoji reinforces the tone (e.g. a warning or tip paragraph)
-
-Where NOT to use them:
-- Mid-sentence or inline within body text
-- In API/technical reference content (endpoint tables, parameter lists, code comments)
-- More than once per heading or table cell
-- Decoratively on every heading -- only where it genuinely adds meaning or helps the reader navigate
-- As a substitute for checklists: use `- [ ]` / `- [x]` task list syntax instead, which renders as styled checkboxes via the `pymdownx.tasklist` extension
-
-## ASCII Diagrams
-
-When creating ASCII diagrams in documentation or code comments, use only reliably monospaced characters:
-
-| Use         | Instead of    | Purpose                        |
-|-------------|---------------|--------------------------------|
-| `->` `-->`  | `->` `-->` `>` | Arrows (horizontal)           |
-| `<-` `<--`  | special chars | Arrows (reverse)               |
-| `v` / `^`   | `v` `^`       | Arrows (vertical)             |
-| `+`         | box-drawing chars | Corners and junctions      |
-| `-` / `|`   | `=` special chars | Lines (horizontal/vertical)|
-| `-`         | bullets       | Bullet points in diagrams      |
-
-## Code Style & Conventions
-
-**Key rules (always apply):**
-- Use async/await for all I/O operations (method suffix: `Async`)
-- Use constructor injection for all dependencies
-- **CRITICAL: Use British English (en-GB) for ALL text**: "authorisation", "synchronisation", "behaviour", "colour", etc.
-- Use `DateTime.UtcNow`, NEVER `DateTime.Now`
-- **NEVER use em dashes (`—`)** in documentation, comments, or UI text. Use traditional separators instead:
-  - In sentences: semicolons, commas, or colons (e.g. "JIM takes a different approach; it deploys..." not "JIM takes a different approach — it deploys...")
-  - In bullet points: colons to separate a label from its description (e.g. "Attribute Writeback: Keep HR systems current" not "Attribute Writeback — Keep HR systems current")
-  - In parenthetical asides: commas or parentheses
-- One class per file, file names match class names exactly
-- All models/POCOs live in `src/JIM.Models/`; never inline in service files
-
-**Copyright Headers (MANDATORY on all new files):**
-Every new source file MUST include a copyright header as the very first content. The `.editorconfig` enforces this for `.cs` files via `IDE0073`.
-
-| File type | Header |
-|-----------|--------|
-| `.cs` | `// Copyright (c) Tetron Limited. All rights reserved.`<br>`// Licensed under the Tetron Commercial License. See LICENSE file in the project root.` |
-| `.razor` | `@* Copyright (c) Tetron Limited. All rights reserved. *@`<br>`@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@` |
-| `.ps1` | `# Copyright (c) Tetron Limited. All rights reserved.`<br>`# Licensed under the Tetron Commercial License. See LICENSE file in the project root.` |
-| `.sh` | `# Copyright (c) Tetron Limited. All rights reserved.`<br>`# Licensed under the Tetron Commercial License. See LICENSE file in the project root.` |
-
-- For `.cs` and `.ps1` files: place the header at line 1, followed by a blank line, then the file content
-- For `.sh` files: place the header **after** the shebang line (`#!/bin/bash` or similar), no blank line between shebang and header
-- For `.razor` files: place the header **after** all `@` directives (`@page`, `@using`, `@inject`, etc.), followed by a blank line before the markup. Razor requires directives at the start of the file. Do NOT add headers to `_Imports.razor`.
-- Do NOT add headers to auto-generated files (EF migrations, `.Designer.cs`, `.g.cs`, `.AssemblyInfo.cs`)
-
-> **Full conventions (DateTime handling, raw SQL parameters, file organisation, naming patterns, UI sizing, MudBlazor tabs):** See `src/CLAUDE.md`
-
-## Testing
-
-**Before Committing .NET Code (MANDATORY):**
-- Build and test affected projects - must complete with zero errors
-- During development, prefer targeted builds: `dotnet build test/JIM.Worker.Tests/` (builds dependencies transitively)
-- For final pre-PR check: `dotnet build JIM.sln` and `dotnet test JIM.sln` (full solution)
-- **DO NOT proceed to commit if any tests fail or build has errors**
-- See **Exceptions** under Critical Requirements for changes that do not require build/test
-
-**Test Basics:**
-- NUnit with `[Test]` attribute, `Assert.That()` syntax, Moq for mocking
-- Test naming: `MethodName_Scenario_ExpectedResult`
-- EF Core in-memory database auto-tracks navigation properties - this MASKS missing `.Include()` bugs. Run integration tests when modifying repository queries.
-
-> **Full testing patterns, debugging tips, test data generation, and integration testing:** See `test/CLAUDE.md`
+Use PowerShell (`.ps1`) for ALL automation, integration tests, and utility scripts; it is cross-platform. Never create bash/shell scripts for project automation. Exception: `.devcontainer/setup.sh` runs during container creation.
 
 ## Design Principles
 
-**Minimise Environment Variables:**
-- Prefer configuration through admin UI and guided setup wizards over environment variables
-- Environment variables should be a fallback for container/automated deployments, not the primary configuration method
-- Settings that administrators might need to change should be configurable through the web interface
-- Only use environment variables for:
-  - Bootstrap configuration (database connection for initial setup)
-  - Secrets that cannot be stored in the database (encryption keys before encryption is configured)
-  - Container orchestration overrides
+**Minimise environment variables:** Prefer admin UI / setup wizards. Reserve env vars for bootstrap (initial DB connection), pre-encryption secrets, and container orchestration overrides.
 
-**Self-Contained & Air-Gapped Deployable:**
-- JIM must work in air-gapped environments with no internet connectivity
-- No cloud service dependencies (no Azure Key Vault, AWS KMS, etc.)
-- All features must work with on-premises infrastructure only
+**Self-contained and air-gap deployable:** No internet connectivity required. No cloud-service dependencies (Azure Key Vault, AWS KMS, etc.). All features must work on-premises only.
 
-**No Third-Party Product References:**
-- NEVER mention competing or third-party identity management products in code, comments, or documentation
-- This includes products like MIM, FIM, Entra ID, Okta, SailPoint, etc.
-- JIM documentation should stand on its own without comparisons to other products
-- Use generic/abstract terms to preserve context without naming products:
-  - "other identity management systems" or "traditional ILM solutions"
-  - "SQL Server-based ILM systems" instead of naming specific products
-  - "enterprise identity platforms" for general comparisons
-- Exception: Generic industry terms and standards (SCIM, LDAP, OIDC, etc.) are acceptable
+**No third-party product references:** Never name competing identity products (MIM, FIM, Entra ID, Okta, SailPoint, etc.) in code, comments, or docs. Use generic terms ("traditional ILM solutions", "SQL Server-based ILM systems"). Industry standards (SCIM, LDAP, OIDC) are fine.
 
 ## Security
 
-JIM is deployed in high-trust/assurance customer environments, i.e. healthcare, financial services, government, etc. All code MUST meet the security expectations of these sectors.
+JIM is deployed in high-trust environments (healthcare, finance, government); all code must meet those expectations.
 
-**Key security rules (always apply):**
-- Use `[Authorize]` on all API controllers - deny by default
-- NEVER hardcode secrets, credentials, or connection strings in source code
-- NEVER log secrets, tokens, or personal data
-- ALWAYS wrap user-controlled `string?` values with `LogSanitiser.Sanitise()` (from `JIM.Utilities`) before passing them as arguments to any `ILogger` or Serilog log call - prevents log injection (CWE-117). Integers, GUIDs, enums, and DateTimes do not need wrapping.
-- Use parameterised queries (EF Core default) - never bypass with unparameterised raw SQL
+- `[Authorize]` on all API controllers - deny by default
+- Never hardcode secrets, credentials, or connection strings; never log secrets, tokens, or personal data
 - Validate ALL input at system boundaries (API controllers, Blazor form submissions)
-- Use AES-256-GCM for encryption at rest, minimum TLS 1.2 for transit
-- Use `System.Security.Cryptography.RandomNumberGenerator` for security-sensitive random values (never `System.Random`)
+- AES-256-GCM at rest, minimum TLS 1.2 in transit
+- Use `System.Security.Cryptography.RandomNumberGenerator` for security-sensitive random values - never `System.Random`
 
 **CVE suppressions (`.trivyignore`):**
-- Only suppress a CVE when it is a verified false positive, already mitigated at the application layer, or genuinely unreachable in JIM's usage
-- Every entry MUST include a comment block with: CVE ID(s), affected component, why Trivy flags it, where the real mitigation lives, and a review date (~3 months out)
-- Never suppress to skip investigation. "Won't fix" dismissals belong in the GitHub Security tab, not in the codebase
-- When touching `.trivyignore` for any reason, re-evaluate entries whose review date has passed
+- Only suppress when verified false positive, mitigated at the application layer, or genuinely unreachable
+- Every entry needs CVE ID(s), affected component, why Trivy flags it, where the real mitigation lives, and a review date (~3 months out)
+- Never suppress to skip investigation. When touching `.trivyignore`, re-evaluate entries past their review date.
 
-> **Full security development guidelines, OWASP Top 10 details, Secure by Design principles, and compliance mapping:** See `engineering/COMPLIANCE_MAPPING.md` and `engineering/DEVELOPER_GUIDE.md` (section: "Trivy CVE suppressions")
+> **Full guidelines, OWASP details, Secure-by-Design:** `engineering/COMPLIANCE_MAPPING.md` and `engineering/DEVELOPER_GUIDE.md`
 
 ## Third-Party Dependency Governance
 
 Before adding ANY new NuGet package or third-party dependency:
-1. **Notify the user** - state the need and conduct a suitability analysis
-2. **Research**: licence compatibility, maintainer reputation, maintenance status, known vulnerabilities
-3. **Present findings** with comparison table if alternatives exist
-4. **Await user approval** before adding the dependency
+1. Notify the user; state the need and rationale
+2. Research: licence compatibility, maintainer reputation, maintenance status, known vulnerabilities
+3. Present findings (comparison table if alternatives exist)
+4. Await user approval before adding
 
-Prefer: Microsoft-maintained packages > established corporate-backed packages > .NET Foundation projects > well-maintained OSS with identifiable maintainers.
-
-> **Full supply chain security requirements:** See `engineering/COMPLIANCE_MAPPING.md` and `engineering/DEVELOPER_GUIDE.md`
-
-## Feature Planning
-
-**When planning new features or significant changes:**
-1. Run `jim-prd` to create a new PRD from the template (or copy `engineering/prd/PRD_TEMPLATE.md` manually)
-2. Fill in the required sections (Problem Statement, Goals, Non-Goals, User Stories, Requirements, Examples, Acceptance Criteria)
-3. Create a GitHub issue linking to the PRD
-4. Ask Claude to generate the implementation plan from the PRD
-
-> **Full PRD template, plan structure guidelines, and documentation organisation:** See `engineering/CLAUDE.md`
+Preference order: Microsoft-maintained > established corporate-backed > .NET Foundation > well-maintained OSS with identifiable maintainers.
 
 ## Architecture Quick Reference
 
-**Layer Dependencies:** JIM.Web -> JIM.Application -> JIM.Models -> JIM.Data/JIM.PostgresData. **NEVER bypass layers**: UI/API must only call `JimApplication`, never `Jim.Repository.*` directly.
+**Layer dependencies:** JIM.Web -> JIM.Application -> JIM.Models -> JIM.Data/JIM.PostgresData. **Never bypass layers** - UI/API must only call `JimApplication`, never `Jim.Repository.*` directly.
 
-**Metaverse Pattern:** All operations flow through the metaverse (MetaverseObject <-> SyncRule <-> ConnectedSystemObject). Never direct system-to-system.
+**Metaverse pattern:** All operations flow through the metaverse (MetaverseObject <-> SyncRule <-> ConnectedSystemObject). Never direct system-to-system.
 
-> **Full N-tier rules, layer diagram, common development tasks (adding connectors, endpoints, migrations), and project locations:** See `src/CLAUDE.md`
+> **Full N-tier rules, layer diagram, common dev tasks (adding connectors, endpoints, migrations):** `src/CLAUDE.md`
 
 ## Integration Testing
 
 Use `./test/integration/Run-IntegrationTests.ps1` (PowerShell) - never invoke scenario scripts directly. The runner handles setup, environment management, and teardown automatically.
 
-> **Full commands, templates, and runner details:** See `test/CLAUDE.md`
+> **Full commands, templates, runner details:** `test/CLAUDE.md`
 
-## Workflow Best Practices
+## Feature Planning
 
-**Git:**
-- **ALWAYS** work on a feature branch - NEVER commit directly to `main`
-- **NEVER** automatically create a PR or merge to `main` - the user must explicitly instruct you to do so
+For new features or significant changes:
+1. Run `jim-prd` to create a new PRD from the template
+2. Fill in required sections; create a GitHub issue linking to the PRD
+3. Ask Claude to generate the implementation plan from the PRD
+
+> **PRD template, plan structure, plan filing (planned/doing/done):** `engineering/CLAUDE.md`
+
+## Workflow & Git
+
+- Always work on a feature branch; never commit directly to `main`
 - Branch naming: `feature/description`
-- Commit messages: Descriptive, include issue reference if applicable
-- Build and test before every commit of .NET code (see **Exceptions** under Critical Requirements)
-- Push to feature branches, create PRs to main
+- Never automatically create a PR or merge to `main` - the user must explicitly instruct
+- Build and test pass before commit (per Critical Rules); push and PR only when the user asks
 
-**Development Cycle (FOLLOW THIS EXACTLY):**
-1. Create/checkout feature branch (NEVER work on `main`)
-2. Make changes
-3. **For .NET code changes**: Build and test affected projects during development; run full solution build/test (`dotnet build JIM.sln` and `dotnet test JIM.sln`) as a final pre-PR check
-4. For non-.NET changes (scripts, docs, config, CI/CD, diagrams): skip build/test (see Exceptions above)
-5. If build or tests fail, fix errors and repeat step 3
-6. **ONLY AFTER** build and tests pass (or are not required): Commit with clear message
-7. **ONLY AFTER** successful commit and **ONLY when the user explicitly asks**: Push and create PR
-8. **NEVER** create a PR with failing tests or build errors
-9. **NEVER** merge PRs without explicit user instruction
+## Changelog & Release
 
-## Changelog Maintenance
+- Add entries under `## [Unreleased]` in `CHANGELOG.md` for user-facing changes (features, fixes, performance, changed behaviour, removals)
+- Skip changelog entries for docs, CI/CD, dev tooling, refactoring, test-only, and trivial UI tweaks
+- **Never modify `VERSION` without explicit user instruction.** Use `/release <version>` to create a release.
 
-The project uses [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Entries must be kept up to date as changes are made, not deferred until release time.
-
-**Audience and tone:**
-The changelog is a **customer-facing product document**. The audience is administrators and decision-makers wanting to know what's new. Entries should make JIM appear useful, reliable, sophisticated, and exciting.
-- Write entries as product changes, not developer notes: focus on the benefit or outcome, not the implementation detail
-- Use a leading emoji per entry to add energy and visual scanning context (e.g. ✨ for new features, 🐛 for fixes, ⚡ for performance, 🔒 for security)
-- Do NOT include: internal refactoring, test changes, developer tooling, CI/CD tweaks, or anything that has no user-facing impact
-- Trivial changes (renamed a CSS class, moved a file, updated a comment) do NOT belong in the changelog
-
-**When to add an entry:**
-- Add an entry under `## [Unreleased]` with each commit or PR that introduces user-facing changes
-- This includes: new features, bug fixes, performance improvements, changed behaviour, and removed functionality
-
-**When NOT to add an entry:**
-- Documentation-only changes (`.md` files, `docs/` updates)
-- CI/CD workflow changes (`.github/workflows/`)
-- Development tooling changes (`.editorconfig`, devcontainer config)
-- Refactoring with no user-facing impact
-- Test-only changes
-- Trivial UI tweaks with no meaningful user impact
-
-**Categories (use as applicable):**
-- **Added**: new features or capabilities
-- **Changed**: modifications to existing behaviour
-- **Fixed**: bug fixes
-- **Performance**: optimisations and performance improvements
-- **Removed**: removed features (use sparingly)
-
-**Formatting conventions (match existing style):**
-- Use `####` subheadings to group related entries under a larger feature (e.g., `#### Scheduler Service (#168)`)
-- Reference GitHub issue numbers where applicable (e.g., `(#123)`)
-- Keep entries concise: one line per change, describe what changed from the user's perspective
-- Lead each entry with an appropriate emoji (✨ new, 🐛 fix, ⚡ performance, 🔄 changed, 🗑️ removed, 🔒 security, 📦 deployment/infrastructure, 🖥️ UI/UX)
-- Use imperative mood is not required; describe what was added/changed/fixed naturally
-
-**At release time:** Move all `[Unreleased]` entries to a new version section and update comparison links at the bottom of the file. See Release Process below.
-
-## Release Process
-
-**CRITICAL: NEVER modify the `VERSION` file without explicit user instruction to create a release.**
-
-The `VERSION` file is the single source of truth for JIM's version number. It feeds into:
-- All .NET assembly versions (via `Directory.Build.props`)
-- Docker image tags (via release workflow)
-- PowerShell module version (updated at release time)
-- Diagram metadata (via `export-diagrams.js`)
-
-**Versioning scheme:** [Semantic Versioning](https://semver.org/), `X.Y.Z` with optional prerelease suffix (e.g., `0.3.0-alpha`).
-
-**What triggers a version bump:**
-- New feature releases
-- Breaking changes
-- Significant bug fix batches
-- User explicitly requesting a release
-
-**What does NOT trigger a version bump:**
-- Documentation changes
-- Diagram regeneration
-- CI/CD improvements
-- Development tooling changes
-- Refactoring without user-facing changes
-
-**To create a release:** Use `/release <version>`; the skill handles VERSION, CHANGELOG, PowerShell manifest, documentation review, commit, tag, and push.
-
-> **Full release process, air-gapped deployment, and Docker image details:** See `engineering/RELEASE_PROCESS.md`
+> **Full audience/tone, categories, formatting, release procedure:** `engineering/CLAUDE.md`
 
 ## Resources
 
-- **Full Architecture Guide**: `engineering/DEVELOPER_GUIDE.md`
-- **Docs site conventions (diagrams, MkDocs internals)**: `docs/CLAUDE.md`
-- **Repository**: https://github.com/TetronIO/JIM
-- **Documentation**: `README.md`
-- **.NET 10 Docs**: https://learn.microsoft.com/dotnet/
-- **EF Core**: https://learn.microsoft.com/ef/core/
-- **Blazor**: https://learn.microsoft.com/aspnet/core/blazor/
-- **MudBlazor**: https://mudblazor.com/
+- **Architecture Guide:** `engineering/DEVELOPER_GUIDE.md`
+- **Repository:** https://github.com/TetronIO/JIM
+- **.NET 10:** https://learn.microsoft.com/dotnet/
+- **EF Core:** https://learn.microsoft.com/ef/core/
+- **Blazor:** https://learn.microsoft.com/aspnet/core/blazor/
+- **MudBlazor:** https://mudblazor.com/

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,7 +1,39 @@
 # Docs Site Reference
 
-> MkDocs site conventions, diagram embedding, and infrastructure internals.
-> For writing style, emoji usage, and changelog format, see the root `CLAUDE.md`.
+> MkDocs site conventions, diagram embedding, infrastructure internals, and writing style.
+> For changelog format, see `engineering/CLAUDE.md`.
+
+## Documentation Style
+
+**Use `✅` for positive indicators and `❌` for negative indicators in tables** (e.g. feature comparison tables). Do NOT use `:material-check-bold:`, `:material-close:`, or other Material icon syntax -- these render as small monochrome icons. The emoji equivalents render as clear green/red symbols in MkDocs and on GitHub.
+
+**Use emojis to add energy and aid visual scanning, but keep them purposeful and professional.** JIM documentation should feel alive and modern, not dry -- but never unprofessional.
+
+Where to use them:
+- Table indicators: `✅` / `❌` for yes/no capability comparisons
+- Changelog entries: one leading emoji per entry to signal the type of change (✨ new, 🐛 fix, ⚡ performance, 🔄 changed, 🗑️ removed, 🔒 security, 📦 deployment, 🖥️ UI/UX)
+- Section lead-ins on feature-heavy or conceptual pages: a single emoji before a heading or card title to anchor the concept visually
+- Admonition-style callouts where an emoji reinforces the tone (e.g. a warning or tip paragraph)
+
+Where NOT to use them:
+- Mid-sentence or inline within body text
+- In API/technical reference content (endpoint tables, parameter lists, code comments)
+- More than once per heading or table cell
+- Decoratively on every heading -- only where it genuinely adds meaning or helps the reader navigate
+- As a substitute for checklists: use `- [ ]` / `- [x]` task list syntax instead, which renders as styled checkboxes via the `pymdownx.tasklist` extension
+
+## ASCII Diagrams
+
+When creating ASCII diagrams in documentation or code comments, use only reliably monospaced characters:
+
+| Use         | Instead of    | Purpose                        |
+|-------------|---------------|--------------------------------|
+| `->` `-->`  | `->` `-->` `>` | Arrows (horizontal)           |
+| `<-` `<--`  | special chars | Arrows (reverse)               |
+| `v` / `^`   | `v` `^`       | Arrows (vertical)             |
+| `+`         | box-drawing chars | Corners and junctions      |
+| `-` / `|`   | `=` special chars | Lines (horizontal/vertical)|
+| `-`         | bullets       | Bullet points in diagrams      |
 
 ## C4 Architecture Diagrams (SVG)
 

--- a/engineering/CLAUDE.md
+++ b/engineering/CLAUDE.md
@@ -193,3 +193,74 @@ Both documents include a `Document Version` field in their header. This version 
 JIM follows strict security development practices aligned with NCSC, CISA, OWASP ASVS, and UK Software Security Code of Practice standards. Full details are in:
 - `docs/COMPLIANCE_MAPPING.md` - Complete security framework and standards mapping
 - `docs/DEVELOPER_GUIDE.md` - Security development guidelines and patterns
+
+---
+
+## Changelog Maintenance
+
+The project uses [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Entries must be kept up to date as changes are made, not deferred until release time.
+
+**Audience and tone:**
+The changelog is a **customer-facing product document**. The audience is administrators and decision-makers wanting to know what's new. Entries should make JIM appear useful, reliable, sophisticated, and exciting.
+- Write entries as product changes, not developer notes: focus on the benefit or outcome, not the implementation detail
+- Use a leading emoji per entry to add energy and visual scanning context (e.g. ✨ for new features, 🐛 for fixes, ⚡ for performance, 🔒 for security)
+- Do NOT include: internal refactoring, test changes, developer tooling, CI/CD tweaks, or anything that has no user-facing impact
+- Trivial changes (renamed a CSS class, moved a file, updated a comment) do NOT belong in the changelog
+
+**When to add an entry:**
+- Add an entry under `## [Unreleased]` with each commit or PR that introduces user-facing changes
+- This includes: new features, bug fixes, performance improvements, changed behaviour, and removed functionality
+
+**When NOT to add an entry:**
+- Documentation-only changes (`.md` files, `docs/` updates)
+- CI/CD workflow changes (`.github/workflows/`)
+- Development tooling changes (`.editorconfig`, devcontainer config)
+- Refactoring with no user-facing impact
+- Test-only changes
+- Trivial UI tweaks with no meaningful user impact
+
+**Categories (use as applicable):**
+- **Added**: new features or capabilities
+- **Changed**: modifications to existing behaviour
+- **Fixed**: bug fixes
+- **Performance**: optimisations and performance improvements
+- **Removed**: removed features (use sparingly)
+
+**Formatting conventions (match existing style):**
+- Use `####` subheadings to group related entries under a larger feature (e.g., `#### Scheduler Service (#168)`)
+- Reference GitHub issue numbers where applicable (e.g., `(#123)`)
+- Keep entries concise: one line per change, describe what changed from the user's perspective
+- Lead each entry with an appropriate emoji (✨ new, 🐛 fix, ⚡ performance, 🔄 changed, 🗑️ removed, 🔒 security, 📦 deployment/infrastructure, 🖥️ UI/UX)
+
+**At release time:** Move all `[Unreleased]` entries to a new version section and update comparison links at the bottom of the file. See Release Process below.
+
+---
+
+## Release Process
+
+**CRITICAL: NEVER modify the `VERSION` file without explicit user instruction to create a release.**
+
+The `VERSION` file is the single source of truth for JIM's version number. It feeds into:
+- All .NET assembly versions (via `Directory.Build.props`)
+- Docker image tags (via release workflow)
+- PowerShell module version (updated at release time)
+- Diagram metadata (via `export-diagrams.js`)
+
+**Versioning scheme:** [Semantic Versioning](https://semver.org/), `X.Y.Z` with optional prerelease suffix (e.g., `0.3.0-alpha`).
+
+**What triggers a version bump:**
+- New feature releases
+- Breaking changes
+- Significant bug fix batches
+- User explicitly requesting a release
+
+**What does NOT trigger a version bump:**
+- Documentation changes
+- Diagram regeneration
+- CI/CD improvements
+- Development tooling changes
+- Refactoring without user-facing changes
+
+**To create a release:** Use `/release <version>`; the skill handles VERSION, CHANGELOG, PowerShell manifest, documentation review, commit, tag, and push.
+
+> **Full release process, air-gapped deployment, and Docker image details:** See `RELEASE_PROCESS.md`

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -32,6 +32,25 @@
   - Units: Metric only (metres, litres, kilograms, kilometres) - never use imperial units
   - Date/Time: Always use UTC for storage and internal operations; display in user's local time zone where appropriate
   - Exceptions: Technical terms, proper nouns, third-party library names, URLs
+- **NEVER use em dashes (`—`)** in documentation, comments, or UI text. Use traditional separators instead:
+  - In sentences: semicolons, commas, or colons (e.g. "JIM takes a different approach; it deploys..." not "JIM takes a different approach — it deploys...")
+  - In bullet points: colons to separate a label from its description (e.g. "Attribute Writeback: Keep HR systems current" not "Attribute Writeback — Keep HR systems current")
+  - In parenthetical asides: commas or parentheses
+
+**Copyright Headers (MANDATORY on all new files):**
+Every new source file MUST include a copyright header as the very first content. The `.editorconfig` enforces this for `.cs` files via `IDE0073`.
+
+| File type | Header |
+|-----------|--------|
+| `.cs` | `// Copyright (c) Tetron Limited. All rights reserved.`<br>`// Licensed under the Tetron Commercial License. See LICENSE file in the project root.` |
+| `.razor` | `@* Copyright (c) Tetron Limited. All rights reserved. *@`<br>`@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@` |
+| `.ps1` | `# Copyright (c) Tetron Limited. All rights reserved.`<br>`# Licensed under the Tetron Commercial License. See LICENSE file in the project root.` |
+| `.sh` | `# Copyright (c) Tetron Limited. All rights reserved.`<br>`# Licensed under the Tetron Commercial License. See LICENSE file in the project root.` |
+
+- For `.cs` and `.ps1` files: place the header at line 1, followed by a blank line, then the file content
+- For `.sh` files: place the header **after** the shebang line (`#!/bin/bash` or similar), no blank line between shebang and header
+- For `.razor` files: place the header **after** all `@` directives (`@page`, `@using`, `@inject`, etc.), followed by a blank line before the markup. Razor requires directives at the start of the file. Do NOT add headers to `_Imports.razor`.
+- Do NOT add headers to auto-generated files (EF migrations, `.Designer.cs`, `.g.cs`, `.AssemblyInfo.cs`)
 
 **DateTime Handling (IMPORTANT):**
 - Always use `DateTime` type (not `DateTimeOffset`) in models
@@ -41,6 +60,10 @@
 - Code that processes DateTime values from the database must handle BOTH `DateTime` and `DateTimeOffset` types
 - See `DynamicExpressoEvaluator.ToFileTime()` for an example of handling both types
 - This design choice maintains database portability (MySQL, SQL Server, etc. handle DateTimeOffset differently)
+
+**SQL Parameterisation (security):**
+- ALWAYS parameterise SQL. EF Core does this by default. Raw Npgsql is fine on worker hot paths (see "Worker Hot Path - Raw SQL Over EF Projection" below) but must use `NpgsqlParameter` or the `NullableParam` helper.
+- NEVER concatenate or interpolate user-controlled values into a SQL string; always pass them as parameters.
 
 **Raw SQL Nullable Parameters (CRITICAL):**
 - NEVER use `(object?)value ?? DBNull.Value` as a parameter to `ExecuteSqlRawAsync` or `ExecuteSqlInterpolatedAsync`
@@ -53,6 +76,11 @@
 - For file-open code paths (`FileStream`, `Directory.CreateDirectory`, `Path.*`), the expected set is `UnauthorizedAccessException`, `IOException`, `ArgumentException`, `NotSupportedException`, `System.Security.SecurityException`.
 - When several catches share identical fallback behaviour, extract a small private helper (e.g. `FailOpen(path, ex)`) and call it from each typed catch - keeps the catches specific without duplicating the handler body.
 - For JS interop retry patterns in `OnAfterRenderAsync` (e.g. loading user preferences), catch `InvalidOperationException` specifically; this is the exception Blazor throws when JS interop is invoked before the runtime is ready
+
+**Logging Security (CWE-117 - log injection):**
+- ALWAYS wrap user-controlled `string?` values with `LogSanitiser.Sanitise()` (from `JIM.Utilities`) before passing them as arguments to any `ILogger` or Serilog log call
+- Integers, GUIDs, enums, and DateTimes are safe and do not need wrapping
+- NEVER log secrets, tokens, or personal data, sanitised or otherwise
 
 **Worker Hot Path - Raw SQL Over EF Projection:**
 - For queries on the synchronisation hot path (per-page flushes, cross-page resolution, export evaluation, change-record persistence), default to raw Npgsql (`NpgsqlCommand` + `DbDataReader`, or `BeginBinaryImportAsync` for COPY) rather than EF Core - even `AsNoTracking()` projection.

--- a/src/JIM.Application/Servers/SecurityServer.cs
+++ b/src/JIM.Application/Servers/SecurityServer.cs
@@ -3,6 +3,7 @@
 
 using JIM.Models.Core;
 using JIM.Models.Security;
+using JIM.Models.Security.DTOs;
 namespace JIM.Application.Servers;
 
 public class SecurityServer
@@ -17,6 +18,11 @@ public class SecurityServer
     public async Task<List<Role>> GetRolesAsync()
     {
         return await Application.Repository.Security.GetRolesAsync();
+    }
+
+    public async Task<List<RoleHeader>> GetRoleHeadersAsync()
+    {
+        return await Application.Repository.Security.GetRoleHeadersAsync();
     }
 
     public async Task<Role?> GetRoleAsync(string roleName)

--- a/src/JIM.Data/Repositories/ISecurityRepository.cs
+++ b/src/JIM.Data/Repositories/ISecurityRepository.cs
@@ -3,11 +3,18 @@
 
 using JIM.Models.Core;
 using JIM.Models.Security;
+using JIM.Models.Security.DTOs;
 namespace JIM.Data.Repositories;
 
 public interface ISecurityRepository
 {
     public Task<List<Role>> GetRolesAsync();
+
+    /// <summary>
+    /// Returns lightweight role headers for list views, with static member counts
+    /// aggregated directly in SQL.
+    /// </summary>
+    public Task<List<RoleHeader>> GetRoleHeadersAsync();
 
     public Task<Role?> GetRoleAsync(string roleName);
 

--- a/src/JIM.Models/Security/DTOs/RoleHeader.cs
+++ b/src/JIM.Models/Security/DTOs/RoleHeader.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Security.DTOs;
+
+/// <summary>
+/// Lightweight representation of a Role for list views. The static member count is
+/// projected in SQL to avoid materialising the full member list per role.
+/// </summary>
+public class RoleHeader
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public bool BuiltIn { get; set; }
+
+    public DateTime Created { get; set; }
+
+    public int StaticMemberCount { get; set; }
+}

--- a/src/JIM.PostgresData/Repositories/SecurityRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SecurityRepository.cs
@@ -44,12 +44,17 @@ public class SecurityRepository : ISecurityRepository
 
     public async Task<Role?> GetRoleByIdAsync(int roleId)
     {
-        return await Repository.Database.Roles.SingleOrDefaultAsync(q => q.Id == roleId);
+        return await Repository.Database.Roles
+            .Include(q => q.StaticMembers)
+            .SingleOrDefaultAsync(q => q.Id == roleId);
     }
 
     public async Task<List<Role>> GetMetaverseObjectRolesAsync(Guid metaverseObjectId)
     {
-        return await Repository.Database.Roles.Where(q => q.StaticMembers.Any(sm => sm.Id == metaverseObjectId)).ToListAsync();
+        return await Repository.Database.Roles
+            .Include(q => q.StaticMembers)
+            .Where(q => q.StaticMembers.Any(sm => sm.Id == metaverseObjectId))
+            .ToListAsync();
     }
 
     public async Task<bool> IsObjectInRoleAsync(Guid userId, string roleName)

--- a/src/JIM.PostgresData/Repositories/SecurityRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SecurityRepository.cs
@@ -4,6 +4,7 @@
 using JIM.Data.Repositories;
 using JIM.Models.Core;
 using JIM.Models.Security;
+using JIM.Models.Security.DTOs;
 using Microsoft.EntityFrameworkCore;
 namespace JIM.PostgresData.Repositories;
 
@@ -19,6 +20,21 @@ public class SecurityRepository : ISecurityRepository
     public async Task<List<Role>> GetRolesAsync()
     {
         return await Repository.Database.Roles.OrderBy(q => q.Name).ToListAsync();
+    }
+
+    public async Task<List<RoleHeader>> GetRoleHeadersAsync()
+    {
+        return await Repository.Database.Roles
+            .OrderBy(r => r.Name)
+            .Select(r => new RoleHeader
+            {
+                Id = r.Id,
+                Name = r.Name,
+                BuiltIn = r.BuiltIn,
+                Created = r.Created,
+                StaticMemberCount = r.StaticMembers.Count
+            })
+            .ToListAsync();
     }
 
     public async Task<Role?> GetRoleAsync(string roleName)

--- a/src/JIM.Web/Controllers/Api/SecurityController.cs
+++ b/src/JIM.Web/Controllers/Api/SecurityController.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using Asp.Versioning;
 using JIM.Application;
 using JIM.Models.Core;
+using JIM.Models.Security.DTOs;
 using JIM.Web.Models.Api;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -34,14 +35,13 @@ public class SecurityController(ILogger<SecurityController> logger, JimApplicati
     /// </summary>
     /// <returns>A list of all Role definitions.</returns>
     [HttpGet("roles", Name = "GetRoles")]
-    [ProducesResponseType(typeof(IEnumerable<RoleDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(IEnumerable<RoleHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetRolesAsync()
     {
         _logger.LogTrace("Requested roles");
-        var roles = await _application.Security.GetRolesAsync();
-        var dtos = roles.Select(RoleDto.FromEntity);
-        return Ok(dtos);
+        var headers = await _application.Security.GetRoleHeadersAsync();
+        return Ok(headers);
     }
 
     /// <summary>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -88,11 +88,13 @@ public class SynchronisationController(
         if (system == null)
             return NotFound(ApiErrorResponse.NotFound($"Connected system with ID {connectedSystemId} not found."));
 
-        // GetConnectedSystemAsync doesn't load PendingExports (too expensive for the detail query).
-        // Compute the count via a dedicated query, matching how the Blazor UI does it.
+        // GetConnectedSystemAsync doesn't load PendingExports or Objects (too expensive for
+        // the detail query and can be very large). Compute counts via dedicated queries,
+        // matching how the Blazor UI does it.
         var pendingExportCount = await _application.ConnectedSystems.GetPendingExportsCountAsync(connectedSystemId);
+        var objectCount = await _application.ConnectedSystems.GetConnectedSystemObjectCountAsync(connectedSystemId);
 
-        return Ok(ConnectedSystemDetailDto.FromEntity(system, pendingExportCount));
+        return Ok(ConnectedSystemDetailDto.FromEntity(system, pendingExportCount, objectCount));
     }
 
     /// <summary>

--- a/src/JIM.Web/Models/Api/ConnectedSystemDto.cs
+++ b/src/JIM.Web/Models/Api/ConnectedSystemDto.cs
@@ -30,9 +30,13 @@ public class ConnectedSystemDetailDto
     /// <param name="entity">The connected system entity.</param>
     /// <param name="pendingExportCount">
     /// Pre-computed pending export count. Required because GetConnectedSystemAsync
-    /// doesn't load the PendingExports navigation property (too expensive).
+    /// does not load the PendingExports navigation property (too expensive).
     /// </param>
-    public static ConnectedSystemDetailDto FromEntity(ConnectedSystem entity, int pendingExportCount = 0)
+    /// <param name="objectCount">
+    /// Pre-computed connected system object count. Required because GetConnectedSystemAsync
+    /// does not load the Objects navigation property (it can be very large).
+    /// </param>
+    public static ConnectedSystemDetailDto FromEntity(ConnectedSystem entity, int pendingExportCount = 0, int objectCount = 0)
     {
         return new ConnectedSystemDetailDto
         {
@@ -52,7 +56,7 @@ public class ConnectedSystemDetailDto
             ObjectTypes = entity.ObjectTypes?
                 .Select(ConnectedSystemObjectTypeDto.FromEntity)
                 .ToList() ?? new(),
-            ObjectCount = entity.Objects?.Count ?? 0,
+            ObjectCount = objectCount,
             PendingExportCount = pendingExportCount
         };
     }

--- a/test/JIM.Web.Api.Tests/SecurityControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/SecurityControllerTests.cs
@@ -93,6 +93,35 @@ public class SecurityControllerTests
     }
 
     // ──────────────────────────────────────────────
+    // GET /api/v1/security/roles
+    // ──────────────────────────────────────────────
+
+    [Test]
+    public async Task GetRolesAsync_ReturnsOkWithRoleHeadersAsync()
+    {
+        // Arrange
+        var headers = new List<JIM.Models.Security.DTOs.RoleHeader>
+        {
+            new() { Id = 1, Name = "Administrator", BuiltIn = true, Created = DateTime.UtcNow, StaticMemberCount = 3 },
+            new() { Id = 2, Name = "Reader", BuiltIn = true, Created = DateTime.UtcNow, StaticMemberCount = 0 }
+        };
+        _mockSecurityRepo.Setup(r => r.GetRoleHeadersAsync()).ReturnsAsync(headers);
+
+        // Act
+        var result = await _controller.GetRolesAsync();
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = (OkObjectResult)result;
+        var returned = okResult.Value as IEnumerable<JIM.Models.Security.DTOs.RoleHeader>;
+        Assert.That(returned, Is.Not.Null);
+        var list = returned!.ToList();
+        Assert.That(list, Has.Count.EqualTo(2));
+        Assert.That(list.Single(h => h.Name == "Administrator").StaticMemberCount, Is.EqualTo(3));
+        Assert.That(list.Single(h => h.Name == "Reader").StaticMemberCount, Is.EqualTo(0));
+    }
+
+    // ──────────────────────────────────────────────
     // GET /api/v1/security/roles/{roleId}
     // ──────────────────────────────────────────────
 

--- a/test/JIM.Web.Api.Tests/SecurityRepositoryRoleHeadersIntegrationTests.cs
+++ b/test/JIM.Web.Api.Tests/SecurityRepositoryRoleHeadersIntegrationTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JIM.Data;
+using JIM.Models.Core;
+using JIM.Models.Security;
+using JIM.PostgresData;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Integration tests for SecurityRepository.GetRoleHeadersAsync(). Verifies that the static
+/// member count is projected directly in SQL rather than relying on a loaded navigation
+/// property; the original RoleDto path silently returned 0 because GetRolesAsync() did
+/// not Include StaticMembers, and the count was computed in memory.
+/// </summary>
+[TestFixture]
+public class SecurityRepositoryRoleHeadersIntegrationTests
+{
+    private JimDbContext _dbContext = null!;
+    private PostgresDataRepository _repository = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Environment.SetEnvironmentVariable(Constants.Config.DatabaseHostname, "dummy");
+        Environment.SetEnvironmentVariable(Constants.Config.DatabaseName, "dummy");
+        Environment.SetEnvironmentVariable(Constants.Config.DatabaseUsername, "dummy");
+        Environment.SetEnvironmentVariable(Constants.Config.DatabasePassword, "dummy");
+
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        _dbContext = new JimDbContext(options);
+        _repository = new PostgresDataRepository(_dbContext);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext?.Dispose();
+    }
+
+    [Test]
+    public async Task GetRoleHeadersAsync_WithMembers_ReturnsCorrectStaticMemberCountAsync()
+    {
+        // Arrange: create a Person object type, two MetaverseObjects, and an Administrator
+        // role with both objects assigned as static members.
+        var personType = new MetaverseObjectType { Id = 1, Name = "Person", PluralName = "People" };
+        _dbContext.MetaverseObjectTypes.Add(personType);
+
+        var member1 = new MetaverseObject { Id = Guid.NewGuid(), Type = personType };
+        var member2 = new MetaverseObject { Id = Guid.NewGuid(), Type = personType };
+        _dbContext.MetaverseObjects.Add(member1);
+        _dbContext.MetaverseObjects.Add(member2);
+
+        var adminRole = new Role
+        {
+            Id = 1,
+            Name = "Administrator",
+            BuiltIn = true,
+            Created = DateTime.UtcNow,
+            StaticMembers = new List<MetaverseObject> { member1, member2 }
+        };
+        var emptyRole = new Role
+        {
+            Id = 2,
+            Name = "Reader",
+            BuiltIn = true,
+            Created = DateTime.UtcNow,
+            StaticMembers = new List<MetaverseObject>()
+        };
+        _dbContext.Roles.Add(adminRole);
+        _dbContext.Roles.Add(emptyRole);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var headers = await _repository.Security.GetRoleHeadersAsync();
+
+        // Assert
+        Assert.That(headers, Has.Count.EqualTo(2));
+        var admin = headers.Single(h => h.Name == "Administrator");
+        Assert.That(admin.StaticMemberCount, Is.EqualTo(2), "Administrator role should report two static members");
+        Assert.That(admin.Id, Is.EqualTo(1));
+        Assert.That(admin.BuiltIn, Is.True);
+
+        var reader = headers.Single(h => h.Name == "Reader");
+        Assert.That(reader.StaticMemberCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetRoleHeadersAsync_NoRoles_ReturnsEmptyAsync()
+    {
+        var headers = await _repository.Security.GetRoleHeadersAsync();
+        Assert.That(headers, Is.Empty);
+    }
+}

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerGetConnectedSystemTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerGetConnectedSystemTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Application.Expressions;
+using JIM.Application.Interfaces;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+using JIM.Web.Controllers.Api;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for SynchronisationController.GetConnectedSystemAsync. Verifies that the returned
+/// ConnectedSystemDetailDto.ObjectCount reflects a real database count rather than the
+/// in-memory navigation property, which is not loaded by GetConnectedSystemAsync.
+/// </summary>
+[TestFixture]
+public class SynchronisationControllerGetConnectedSystemTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IConnectedSystemRepository> _mockConnectedSystemRepo = null!;
+    private Mock<IApiKeyRepository> _mockApiKeyRepo = null!;
+    private Mock<ILogger<SynchronisationController>> _mockLogger = null!;
+    private Mock<ICredentialProtectionService> _mockCredentialProtection = null!;
+    private IExpressionEvaluator _expressionEvaluator = null!;
+    private JimApplication _application = null!;
+    private SynchronisationController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockConnectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _mockApiKeyRepo = new Mock<IApiKeyRepository>();
+        _mockRepository.Setup(r => r.ConnectedSystems).Returns(_mockConnectedSystemRepo.Object);
+        _mockRepository.Setup(r => r.ApiKeys).Returns(_mockApiKeyRepo.Object);
+        _mockLogger = new Mock<ILogger<SynchronisationController>>();
+        _mockCredentialProtection = new Mock<ICredentialProtectionService>();
+        _expressionEvaluator = new DynamicExpressoEvaluator();
+        _application = new JimApplication(_mockRepository.Object);
+        _controller = new SynchronisationController(_mockLogger.Object, _application, _expressionEvaluator, _mockCredentialProtection.Object);
+
+        var claims = new List<Claim>
+        {
+            new("sub", Guid.NewGuid().ToString()),
+            new(ClaimTypes.Role, "Administrator")
+        };
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+            }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application.Dispose();
+    }
+
+    /// <summary>
+    /// Reproduces the bug where ConnectedSystemDetailDto.ObjectCount silently returned 0
+    /// because GetConnectedSystemAsync did not load the Objects navigation property.
+    /// The controller must compute the count via a dedicated query, the same way it already
+    /// does for PendingExportCount.
+    /// </summary>
+    [Test]
+    public async Task GetConnectedSystemAsync_ReturnsObjectCountFromCountQueryNotEntityCollectionAsync()
+    {
+        // Arrange: simulate the real EF behaviour where Objects is not loaded.
+        var system = new ConnectedSystem
+        {
+            Id = 42,
+            Name = "Active Directory",
+            ConnectorDefinition = new ConnectorDefinition { Id = 1, Name = "LDAP" },
+            ObjectTypes = new List<ConnectedSystemObjectType>(),
+            Objects = new List<ConnectedSystemObject>() // empty / not loaded
+        };
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(42, It.IsAny<bool>())).ReturnsAsync(system);
+        _mockConnectedSystemRepo.Setup(r => r.GetPendingExportsCountAsync(42)).ReturnsAsync(0);
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectCountAsync(42, null)).ReturnsAsync(12345);
+
+        // Act
+        var result = await _controller.GetConnectedSystemAsync(42);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var dto = (ConnectedSystemDetailDto)((OkObjectResult)result).Value!;
+        Assert.That(dto.ObjectCount, Is.EqualTo(12345),
+            "ObjectCount must be sourced from the dedicated count query, not from the unloaded Objects navigation");
+        _mockConnectedSystemRepo.Verify(r => r.GetConnectedSystemObjectCountAsync(42, null), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

Three threads of work:

- **API count bugs**: A class of bug where DTO `*Count` fields were computed from `entity.SomeNavigation?.Count` while the underlying repository query never `.Include`d the navigation, so counts silently returned zero. Found one (role list endpoint), audited the codebase, fixed all instances. Affects `Get-JIMRole`, `Get-JIMRole -Id`, `Get-JIMMetaverseObjectRole`, and `GET /api/v1/synchronisation/connected-systems/{id}`.
- **Documentation reorganisation**: Slimmed root `CLAUDE.md` by moving subtree-specific rules into the folder-level `CLAUDE.md` files where they belong.
- **Devcontainer**: Self-heal stale Docker `credsStore` references.

### API count fixes (the user-visible part)

| Endpoint | Before | After |
|----------|--------|-------|
| `GET /api/v1/security/roles` | `staticMemberCount` always 0 | Aggregated in SQL via new `RoleHeader` DTO + `GetRoleHeadersAsync` |
| `GET /api/v1/security/roles/{id}` | `staticMemberCount` always 0 | `.Include(r => r.StaticMembers)` on `GetRoleByIdAsync` |
| `GET /api/v1/security/metaverse-objects/{id}/roles` | `staticMemberCount` always 0 on each role | `.Include(r => r.StaticMembers)` on `GetMetaverseObjectRolesAsync` |
| `GET /api/v1/synchronisation/connected-systems/{id}` | `objectCount` always 0 | Sourced from existing `GetConnectedSystemObjectCountAsync`, mirroring how `pendingExportCount` was already being passed |

The list endpoint uses SQL projection (`.Select(r => new RoleHeader { ... StaticMemberCount = r.StaticMembers.Count })`) rather than `.Include`, so counts on roles with very large memberships are returned cheaply. Wire shape is preserved.

PowerShell cmdlets are unchanged on the wire — same field names — so no module changes were needed.

## Test plan

- [x] Targeted unit/integration tests for each fix added; full Web.Api.Tests project green (700 tests)
- [x] Full solution build: 0 warnings, 0 errors
- [x] Full solution test: 2,642 passing, pre-existing skips unchanged
- [ ] Manual verification via PowerShell:
  - [ ] `Get-JIMRole | Format-Table id, name, staticMemberCount` shows non-zero for populated roles
  - [ ] `Get-JIMRole -Id 1` reports correct `staticMemberCount`
  - [ ] `Get-JIMMetaverseObjectRole -Id <mvoId>` reports correct `staticMemberCount` per role
  - [ ] `Get-JIMConnectedSystem -Id <id>` reports non-zero `objectCount` for systems with synced objects

### Caveat on test coverage

The two `.Include()` fixes for `GetRoleByIdAsync` and `GetMetaverseObjectRolesAsync` are **not** unit-tested. EF Core's in-memory provider auto-tracks navigation properties (documented in `test/CLAUDE.md`), which would mask a missing `.Include` and produce a false-pass. The list endpoint and connected-system fixes are covered by tests that exercise SQL projection / mocked count queries respectively, neither of which depends on EF tracking behaviour. The `.Include` fixes will be exercised by real-Postgres integration scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)