### PR TITLE
Add dedicated API endpoints for individual predefined search retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ Predefined Searches can now be retrieved individually via the API and PowerShell module: new `GET /api/v1/predefined-searches/{id}` and `GET /api/v1/predefined-searches/by-uri/{uri}` endpoints return the full search graph, and `Get-JIMPredefinedSearch -Id` / `-Uri` now resolve directly against the server instead of filtering the list client-side (#154)
+
 ## [0.10.1] - 2026-04-27
 
 ### Added

--- a/docs/api/predefined-searches/index.md
+++ b/docs/api/predefined-searches/index.md
@@ -13,6 +13,8 @@ Disabled searches are hidden from the portal, the end-user search API, and the s
 
 ## The Predefined Search Header Object
 
+Returned by [List Predefined Searches](#list-predefined-searches).
+
 ```json
 {
   "id": 3,
@@ -39,11 +41,28 @@ Disabled searches are hidden from the portal, the end-user search API, and the s
 | `metaverseAttributeCount` | integer | Number of attributes surfaced in the search results |
 | `created` | datetime | UTC creation timestamp |
 
+## The Predefined Search Object
+
+Returned by [Get a Predefined Search by ID](#get-a-predefined-search-by-id) and [Get a Predefined Search by URI](#get-a-predefined-search-by-uri). Includes the full search graph: header fields plus the displayed attributes and the criteria-group tree.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Unique identifier |
+| `name` | string | Human-readable display name |
+| `uri` | string | Stable slug used in URLs and as a search identifier |
+| `isEnabled` | boolean | Whether the search is currently visible to end users |
+| `builtIn` | boolean | Whether the search ships with JIM (as opposed to being administrator-defined) |
+| `isDefaultForMetaverseObjectType` | boolean | Whether this is the default search for its object type |
+| `metaverseObjectType` | object | The Metaverse Object Type the search targets |
+| `attributes` | array | Attributes surfaced in the search results, ordered by `position` |
+| `criteriaGroups` | array | Criteria groups that filter which objects match the search |
+| `created` | datetime | UTC creation timestamp |
+
 ---
 
 ## List Predefined Searches
 
-Returns all Predefined Searches, including any that are currently disabled, so administrators can discover their IDs and current state.
+Returns all Predefined Searches as lightweight headers, including any that are currently disabled, so administrators can discover their IDs and current state.
 
 ```
 GET /api/v1/predefined-searches
@@ -68,7 +87,7 @@ GET /api/v1/predefined-searches
 
 ### Response
 
-Returns `200 OK` with an array of header objects.
+Returns `200 OK` with an array of [header objects](#the-predefined-search-header-object).
 
 ### Errors
 
@@ -76,6 +95,97 @@ Returns `200 OK` with an array of header objects.
 |--------|------|-------------|
 | `401` | `UNAUTHORISED` | Authentication required |
 | `403` | `FORBIDDEN` | Insufficient permissions (Administrator role required) |
+
+---
+
+## Get a Predefined Search by ID
+
+Returns the full graph (attributes and criteria groups) for the search with the given integer ID. The ID is the canonical identifier; for lookup by URI slug see [Get a Predefined Search by URI](#get-a-predefined-search-by-uri).
+
+```
+GET /api/v1/predefined-searches/{id}
+```
+
+### Request
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | integer (route) | The unique identifier of the Predefined Search |
+
+### Examples
+
+=== "curl"
+
+    ```bash
+    curl https://jim.example.com/api/v1/predefined-searches/3 \
+      -H "X-Api-Key: jim_xxxxxxxxxxxx"
+    ```
+
+=== "PowerShell"
+
+    ```powershell
+    Get-JIMPredefinedSearch -Id 3
+    ```
+
+### Response
+
+Returns `200 OK` with a [Predefined Search Object](#the-predefined-search-object).
+
+### Errors
+
+| Status | Code | Description |
+|--------|------|-------------|
+| `401` | `UNAUTHORISED` | Authentication required |
+| `403` | `FORBIDDEN` | Insufficient permissions (Administrator role required) |
+| `404` | `NOT_FOUND` | No Predefined Search exists with the supplied ID |
+
+---
+
+## Get a Predefined Search by URI
+
+Convenience lookup by the search's stable, human-readable slug (for example `people` or `security-groups`). Returns the same full graph as the by-ID endpoint.
+
+```
+GET /api/v1/predefined-searches/by-uri/{uri}
+```
+
+### Request
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `uri` | string (route) | The URI slug of the Predefined Search |
+
+### Examples
+
+=== "curl"
+
+    ```bash
+    curl https://jim.example.com/api/v1/predefined-searches/by-uri/people \
+      -H "X-Api-Key: jim_xxxxxxxxxxxx"
+    ```
+
+=== "PowerShell"
+
+    ```powershell
+    Get-JIMPredefinedSearch -Uri people
+    ```
+
+### Response
+
+Returns `200 OK` with a [Predefined Search Object](#the-predefined-search-object).
+
+### Errors
+
+| Status | Code | Description |
+|--------|------|-------------|
+| `400` | `BAD_REQUEST` | URI was empty or whitespace |
+| `401` | `UNAUTHORISED` | Authentication required |
+| `403` | `FORBIDDEN` | Insufficient permissions (Administrator role required) |
+| `404` | `NOT_FOUND` | No Predefined Search exists with the supplied URI |
+
+### Notes
+
+- The integer ID returned in the response is the canonical identifier. Subsequent write operations (PATCH) must be keyed by ID, not URI.
 
 ---
 

--- a/docs/powershell/predefined-searches.md
+++ b/docs/powershell/predefined-searches.md
@@ -13,7 +13,12 @@ Cmdlets for administering Predefined Searches. Predefined Searches are named, re
 
 ## Get-JIMPredefinedSearch
 
-Lists Predefined Searches. Administrators see all searches, including any that are currently disabled, so they can be discovered and enabled via [`Set-JIMPredefinedSearch`](#set-jimpredefinedsearch).
+Gets Predefined Searches. Administrators see all searches, including any that are currently disabled, so they can be discovered and enabled via [`Set-JIMPredefinedSearch`](#set-jimpredefinedsearch).
+
+The shape of the returned object depends on how you call the cmdlet:
+
+- **No parameters** or a wildcard `-Uri`: returns lightweight headers (one per search), suitable for browsing and discovery.
+- **`-Id`** or a literal `-Uri`: resolves directly against a dedicated server endpoint and returns the full search graph (header fields plus the displayed attributes and criteria groups).
 
 ### Syntax
 
@@ -32,12 +37,12 @@ Get-JIMPredefinedSearch -Uri <string>
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `Id` | `int` | Yes (ById) | | Return only the search with this ID. Accepts pipeline input by property name. |
-| `Uri` | `string` | Yes (ByUri) | | Return only the search with this URI (e.g. `people`, `security-groups`). Supports wildcards. Accepts pipeline input by property name. |
+| `Id` | `int` | Yes (ById) | | Return only the search with this ID. Resolves to a single full search via the server. Accepts pipeline input by property name. |
+| `Uri` | `string` | Yes (ByUri) | | Return only the search with this URI (e.g. `people`, `security-groups`). Supports wildcards: a literal value resolves to a single full search via the server; a wildcard pattern is filtered client-side against the list of headers. Accepts pipeline input by property name. |
 
 ### Output
 
-Returns one or more `PSCustomObject` instances with the following properties:
+The list view and wildcard `-Uri` lookups return one or more header `PSCustomObject` instances:
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -51,14 +56,30 @@ Returns one or more `PSCustomObject` instances with the following properties:
 | `metaverseAttributeCount` | `int` | Number of attributes surfaced in the search results |
 | `created` | `datetime` | When the search was created |
 
+`-Id` and literal `-Uri` lookups return a single full search with all of the header fields plus:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `metaverseObjectType` | `object` | The Metaverse Object Type the search targets |
+| `attributes` | `array` | Attributes surfaced in the search results, ordered by `position` |
+| `criteriaGroups` | `array` | Criteria groups that filter which objects match the search |
+
 ### Examples
 
-```powershell title="List all Predefined Searches (including disabled ones)"
+```powershell title="List all Predefined Searches as headers (including disabled ones)"
 Get-JIMPredefinedSearch
 ```
 
-```powershell title="Find the 'people' search"
+```powershell title="Get the full 'people' search by URI"
 Get-JIMPredefinedSearch -Uri people
+```
+
+```powershell title="Get the full search by ID"
+Get-JIMPredefinedSearch -Id 3
+```
+
+```powershell title="Filter headers by wildcard URI"
+Get-JIMPredefinedSearch -Uri 'sec*'
 ```
 
 ```powershell title="List every disabled search"

--- a/src/JIM.Application/Servers/SearchServer.cs
+++ b/src/JIM.Application/Servers/SearchServer.cs
@@ -25,6 +25,19 @@ public class SearchServer
         return await Application.Repository.Search.GetPredefinedSearchHeadersAsync();
     }
 
+    /// <summary>
+    /// Full retrieval of a predefined search by ID, including the attributes and criteria graph.
+    /// Use for read-only display where the full graph is needed (e.g. an API GET).
+    /// </summary>
+    public async Task<PredefinedSearch?> GetPredefinedSearchAsync(int id)
+    {
+        var predefinedSearch = await Application.Repository.Search.GetPredefinedSearchAsync(id);
+        if (predefinedSearch != null)
+            predefinedSearch = PostProcessPredefinedSearch(predefinedSearch);
+
+        return predefinedSearch;
+    }
+
     public async Task<PredefinedSearch?> GetPredefinedSearchAsync(string uri)
     {
         var predefinedSearch = await Application.Repository.Search.GetPredefinedSearchAsync(uri);

--- a/src/JIM.Data/Repositories/ISearchRepository.cs
+++ b/src/JIM.Data/Repositories/ISearchRepository.cs
@@ -10,6 +10,8 @@ public interface ISearchRepository
 {
     public Task<IList<PredefinedSearchHeader>> GetPredefinedSearchHeadersAsync();
 
+    public Task<PredefinedSearch?> GetPredefinedSearchAsync(int id);
+
     public Task<PredefinedSearch?> GetPredefinedSearchAsync(string uri);
 
     public Task<PredefinedSearch?> GetPredefinedSearchAsync(MetaverseObjectType metaverseObjectType);

--- a/src/JIM.PostgresData/Repositories/SearchRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SearchRepository.cs
@@ -35,6 +35,19 @@ public class SearchRepository : ISearchRepository
         return predefinedSearchHeaders;
     }
 
+    public async Task<PredefinedSearch?> GetPredefinedSearchAsync(int id)
+    {
+        return await Repository.Database.PredefinedSearches.
+            AsSplitQuery(). // Use split query to avoid cartesian explosion from multiple collection includes
+            Include(q => q.Attributes).
+            ThenInclude(q => q.MetaverseAttribute).
+            Include(q => q.MetaverseObjectType).
+            Include(q => q.CriteriaGroups).
+            ThenInclude(cg => cg.Criteria).
+            ThenInclude(c => c.MetaverseAttribute).
+            SingleOrDefaultAsync(q => q.Id == id);
+    }
+
     public async Task<PredefinedSearch?> GetPredefinedSearchAsync(string uri)
     {
         return await Repository.Database.PredefinedSearches.

--- a/src/JIM.PowerShell/Public/Search/Get-JIMPredefinedSearch.ps1
+++ b/src/JIM.PowerShell/Public/Search/Get-JIMPredefinedSearch.ps1
@@ -11,30 +11,42 @@ function Get-JIMPredefinedSearch {
         including those that are currently disabled, so that they can be enabled or updated
         via Set-JIMPredefinedSearch.
 
+        When -Id or a literal -Uri is supplied the cmdlet calls a dedicated server endpoint
+        and returns the full search graph (attributes and criteria). Wildcard -Uri patterns
+        and the unfiltered list view return lightweight headers.
+
     .PARAMETER Id
-        Return only the search with this ID.
+        Return only the search with this ID. Resolves to a single full search via the server.
 
     .PARAMETER Uri
         Return only the search with this URI (the stable, human-readable slug such as
-        "people" or "security-groups"). Supports wildcards.
+        "people" or "security-groups"). Supports wildcards. A literal URI resolves to a
+        single full search via the server; a wildcard pattern is filtered client-side
+        against the list of headers.
 
     .OUTPUTS
-        PSCustomObject representing a Predefined Search header.
+        PSCustomObject. For -Id and literal -Uri lookups, the full Predefined Search
+        including its attributes and criteria. Otherwise, Predefined Search headers.
 
     .EXAMPLE
         Get-JIMPredefinedSearch
 
-        Lists all Predefined Searches, including any that are disabled.
+        Lists all Predefined Searches as headers, including any that are disabled.
 
     .EXAMPLE
         Get-JIMPredefinedSearch -Uri 'people'
 
-        Returns the Predefined Search identified by the URI 'people'.
+        Returns the full Predefined Search identified by the URI 'people'.
+
+    .EXAMPLE
+        Get-JIMPredefinedSearch -Uri 'sec*'
+
+        Returns headers for all Predefined Searches whose URI starts with "sec".
 
     .EXAMPLE
         Get-JIMPredefinedSearch -Id 3
 
-        Returns the Predefined Search with ID 3.
+        Returns the full Predefined Search with ID 3.
 
     .LINK
         Set-JIMPredefinedSearch
@@ -58,22 +70,57 @@ function Get-JIMPredefinedSearch {
             return
         }
 
-        Write-Verbose "Listing Predefined Searches"
-
-        try {
-            $response = Invoke-JIMApi -Endpoint "/api/v1/predefined-searches"
-        }
-        catch {
-            Write-Error "Failed to list Predefined Searches: $_"
-            return
-        }
-
-        $items = if ($null -ne $response.items) { $response.items } else { $response }
-
         switch ($PSCmdlet.ParameterSetName) {
-            'ById'  { $items | Where-Object { $_.id -eq $Id } }
-            'ByUri' { $items | Where-Object { $_.uri -like $Uri } }
-            default { $items }
+            'ById' {
+                Write-Verbose "Getting Predefined Search by ID $Id"
+                try {
+                    Invoke-JIMApi -Endpoint "/api/v1/predefined-searches/$Id"
+                }
+                catch {
+                    if ($_.Exception.Message -like '*not found*') { return }
+                    Write-Error "Failed to get Predefined Search with ID '$Id': $_"
+                }
+                return
+            }
+
+            'ByUri' {
+                if ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($Uri)) {
+                    Write-Verbose "Listing Predefined Searches and filtering by wildcard URI '$Uri'"
+                    try {
+                        $response = Invoke-JIMApi -Endpoint "/api/v1/predefined-searches"
+                    }
+                    catch {
+                        Write-Error "Failed to list Predefined Searches: $_"
+                        return
+                    }
+                    $items = if ($null -ne $response.items) { $response.items } else { $response }
+                    $items | Where-Object { $_.uri -like $Uri }
+                    return
+                }
+
+                Write-Verbose "Getting Predefined Search by URI '$Uri'"
+                try {
+                    $encoded = [System.Uri]::EscapeDataString($Uri)
+                    Invoke-JIMApi -Endpoint "/api/v1/predefined-searches/by-uri/$encoded"
+                }
+                catch {
+                    if ($_.Exception.Message -like '*not found*') { return }
+                    Write-Error "Failed to get Predefined Search with URI '$Uri': $_"
+                }
+                return
+            }
+
+            default {
+                Write-Verbose "Listing Predefined Searches"
+                try {
+                    $response = Invoke-JIMApi -Endpoint "/api/v1/predefined-searches"
+                }
+                catch {
+                    Write-Error "Failed to list Predefined Searches: $_"
+                    return
+                }
+                if ($null -ne $response.items) { $response.items } else { $response }
+            }
         }
     }
 }

--- a/src/JIM.Web/Controllers/Api/PredefinedSearchesController.cs
+++ b/src/JIM.Web/Controllers/Api/PredefinedSearchesController.cs
@@ -3,7 +3,9 @@
 
 using Asp.Versioning;
 using JIM.Application;
+using JIM.Models.Search;
 using JIM.Models.Search.DTOs;
+using JIM.Utilities;
 using JIM.Web.Models.Api;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -47,6 +49,62 @@ public class PredefinedSearchesController(ILogger<PredefinedSearchesController> 
 
         var headers = await _application.Search.GetPredefinedSearchHeadersAsync();
         return Ok(headers);
+    }
+
+    /// <summary>
+    /// Get a predefined search by ID.
+    /// </summary>
+    /// <remarks>
+    /// Returns the full predefined search graph including the displayed attributes and the
+    /// criteria-group tree. ID is the canonical identifier; for lookup by the human-readable
+    /// slug use <c>GET /by-uri/{uri}</c>.
+    /// </remarks>
+    /// <param name="id">The unique identifier of the predefined search.</param>
+    /// <returns>The predefined search; 404 Not Found if no search has that ID.</returns>
+    [HttpGet("{id:int}", Name = "GetPredefinedSearchById")]
+    [ProducesResponseType(typeof(PredefinedSearch), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetByIdAsync([FromRoute] int id)
+    {
+        _logger.LogTrace("Getting predefined search {Id}", id);
+
+        var search = await _application.Search.GetPredefinedSearchAsync(id);
+        if (search == null)
+            return NotFound(ApiErrorResponse.NotFound($"Predefined search with ID {id} not found."));
+
+        return Ok(search);
+    }
+
+    /// <summary>
+    /// Get a predefined search by URI.
+    /// </summary>
+    /// <remarks>
+    /// Convenience lookup by the predefined search's stable, human-readable slug (for example
+    /// <c>people</c> or <c>security-groups</c>). The canonical identifier is the integer ID;
+    /// callers performing subsequent updates should resolve to ID via this endpoint and PATCH by ID.
+    /// </remarks>
+    /// <param name="uri">The URI slug of the predefined search.</param>
+    /// <returns>The predefined search; 404 Not Found if no search has that URI.</returns>
+    [HttpGet("by-uri/{uri}", Name = "GetPredefinedSearchByUri")]
+    [ProducesResponseType(typeof(PredefinedSearch), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetByUriAsync([FromRoute] string uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+            return BadRequest(ApiErrorResponse.BadRequest("URI must not be empty."));
+
+        _logger.LogTrace("Getting predefined search by URI {Uri}", LogSanitiser.Sanitise(uri));
+
+        var search = await _application.Search.GetPredefinedSearchAsync(uri);
+        if (search == null)
+            return NotFound(ApiErrorResponse.NotFound($"Predefined search with URI '{uri}' not found."));
+
+        return Ok(search);
     }
 
     /// <summary>

--- a/test/JIM.Web.Api.Tests/PredefinedSearchesControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/PredefinedSearchesControllerTests.cs
@@ -52,6 +52,61 @@ public class PredefinedSearchesControllerTests
     };
 
     [Test]
+    public async Task GetByIdAsync_WithExistingId_ReturnsOkWithEntityAsync()
+    {
+        var existing = BuildSearch(7, isEnabled: true);
+        _mockSearchRepo.Setup(r => r.GetPredefinedSearchAsync(7)).ReturnsAsync(existing);
+
+        var result = await _controller.GetByIdAsync(7);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = (OkObjectResult)result;
+        Assert.That(okResult.Value, Is.SameAs(existing));
+    }
+
+    [Test]
+    public async Task GetByIdAsync_WithUnknownId_ReturnsNotFoundAsync()
+    {
+        _mockSearchRepo.Setup(r => r.GetPredefinedSearchAsync(999)).ReturnsAsync((PredefinedSearch?)null);
+
+        var result = await _controller.GetByIdAsync(999);
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task GetByUriAsync_WithExistingUri_ReturnsOkWithEntityAsync()
+    {
+        var existing = BuildSearch(7, isEnabled: true);
+        _mockSearchRepo.Setup(r => r.GetPredefinedSearchAsync("people")).ReturnsAsync(existing);
+
+        var result = await _controller.GetByUriAsync("people");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = (OkObjectResult)result;
+        Assert.That(okResult.Value, Is.SameAs(existing));
+    }
+
+    [Test]
+    public async Task GetByUriAsync_WithUnknownUri_ReturnsNotFoundAsync()
+    {
+        _mockSearchRepo.Setup(r => r.GetPredefinedSearchAsync("nope")).ReturnsAsync((PredefinedSearch?)null);
+
+        var result = await _controller.GetByUriAsync("nope");
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task GetByUriAsync_WithEmptyUri_ReturnsBadRequestAsync()
+    {
+        var result = await _controller.GetByUriAsync(string.Empty);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockSearchRepo.Verify(r => r.GetPredefinedSearchAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
     public async Task GetAllAsync_ReturnsAllHeadersIncludingDisabledAsync()
     {
         var headers = new List<PredefinedSearchHeader>


### PR DESCRIPTION
## Summary
This PR adds dedicated server endpoints for retrieving individual predefined searches by ID or URI, returning the full search graph (attributes and criteria). The PowerShell cmdlet is updated to leverage these endpoints for direct lookups while maintaining client-side filtering for wildcard URI patterns.

## Key Changes

- **API Endpoints**: Added two new endpoints to `PredefinedSearchesController`:
  - `GET /api/v1/predefined-searches/{id}` - Retrieve full search by integer ID
  - `GET /api/v1/predefined-searches/by-uri/{uri}` - Retrieve full search by URI slug
  - Both return 404 Not Found when the search doesn't exist
  - URI endpoint validates non-empty input and returns 400 Bad Request if empty

- **Data Layer**: Extended `ISearchRepository` and implementations:
  - Added `GetPredefinedSearchAsync(int id)` method in `SearchRepository`
  - Uses split queries to avoid cartesian explosion from multiple collection includes
  - Eagerly loads attributes, object type, and criteria graph

- **Application Layer**: Added corresponding method in `SearchServer`:
  - `GetPredefinedSearchAsync(int id)` with post-processing of the predefined search

- **PowerShell Cmdlet**: Updated `Get-JIMPredefinedSearch` behavior:
  - `-Id` parameter now calls dedicated endpoint instead of filtering the list
  - `-Uri` with literal value calls dedicated endpoint; wildcard patterns still filter client-side
  - Updated documentation to clarify when full search vs. headers are returned
  - Added example showing wildcard URI filtering

- **Tests**: Added comprehensive test coverage for new endpoints:
  - Tests for successful retrieval by ID and URI
  - Tests for 404 Not Found scenarios
  - Test for 400 Bad Request on empty URI

## Implementation Details

- URI parameter is URL-encoded when passed to the API endpoint to handle special characters safely
- The cmdlet intelligently detects wildcard characters using `WildcardPattern.ContainsWildcardCharacters()` to determine whether to use the dedicated endpoint or client-side filtering
- Error handling distinguishes between "not found" errors (silent return) and other failures (logged errors)
- Documentation updated to clarify the distinction between lightweight headers (list view) and full search graphs (individual lookups)

https://claude.ai/code/session_01N7ahQ4jE6kJAxJT5Znzp98