### PR TITLE
chore(diagrams): refresh structurizr package-lock.json

### DIFF
--- a/engineering/diagrams/structurizr/package-lock.json
+++ b/engineering/diagrams/structurizr/package-lock.json
@@ -375,8 +375,7 @@
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",


### PR DESCRIPTION
## Summary
- npm regenerated the lockfile during devcontainer setup (`setup.sh` runs `npm install` in `engineering/diagrams/structurizr`), dropping a stale `"peer": true` marker on the `devtools-protocol` entry
- No functional change; just resyncs the committed lockfile with what npm produces in a clean container

## Test plan
- [x] No source changes; build/test exempt per CLAUDE.md (lockfile only)
- [ ] Verify a fresh devcontainer build no longer leaves the working tree dirty

🤖 Generated with [Claude Code](https://claude.com/claude-code)