### PR TITLE
fix(devcontainer): stop native JIM processes in jim-reset

### DIFF
--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -424,8 +424,20 @@ _jim_prune_images_preserving_snapshots() {
   docker image prune -f 2>/dev/null || true
 }
 
-# Reset (preserves Samba AD and OpenLDAP snapshot images — they take a long time to build)
+# Reset (preserves Samba AD and OpenLDAP snapshot images; they take a long time to build)
 jim-reset() {
+  # Stop any natively-run JIM.Web/Worker/Scheduler processes so they don't squat on host ports (e.g. 5200)
+  local native_pids
+  native_pids=$(pgrep -f '/JIM\.(Web|Worker|Scheduler)$' 2>/dev/null || true)
+  if [ -n "$native_pids" ]; then
+    echo "Stopping native JIM processes: $(echo $native_pids | tr '\n' ' ')"
+    echo "$native_pids" | xargs -r kill 2>/dev/null || true
+    sleep 1
+    # Force-kill any survivors
+    native_pids=$(pgrep -f '/JIM\.(Web|Worker|Scheduler)$' 2>/dev/null || true)
+    [ -n "$native_pids" ] && echo "$native_pids" | xargs -r kill -9 2>/dev/null || true
+  fi
+
   docker compose $(_jim_compose) down --volumes
   docker compose -f docker-compose.integration-tests.yml --profile scenario2 --profile scenario8 down --volumes --remove-orphans 2>/dev/null || true
   docker rm -f samba-ad-primary samba-ad-source samba-ad-target sqlserver-hris-a oracle-hris-b postgres-target openldap-test mysql-test 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 💄 Example data generation now reports live, batch-level persistence progress with a rolling ETA on the Activity record and progress bar, so administrators can see exactly where a large generation run is up to.
 - 💄 Compact row spacing on the Metaverse Object detail Table view now extends to multi-valued reference rows (e.g. group Owners, Static Members), keeping large memberships readable at a glance.
+- 🛠️ `jim-reset` now stops any natively-run JIM.Web/Worker/Scheduler processes before tearing down the Docker stack, preventing port collisions (e.g. host port 5200) when the Docker stack is restarted after a `jim-build-light` debug session.
 
 ## [0.10.1] - 2026-04-27
 


### PR DESCRIPTION
## Summary

`jim-reset` now terminates any natively-run `JIM.Web`/`JIM.Worker`/`JIM.Scheduler` processes before tearing down the Docker stack, preventing port collisions (e.g. host port 5200) when the Docker stack is restarted after a `jim-build-light` debug session.

Also includes a tiny style fix (em dash → semicolon) in a comment in the same function.

## Test plan

- [ ] Run a `jim-build-light` session so a native `JIM.Web` is bound to host port 5200
- [ ] Run `jim-reset` and confirm the native process is killed before the Docker teardown
- [ ] Run `jim-stack` afterwards and confirm port 5200 is available for the containerised `jim.web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)