### PR TITLE
fix(sync,ui): export RPEI CSO FK + pending reference rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 Export Run Profile Execution Items and their linked Connected System Object Change rows now persist with the correct `ConnectedSystemObjectId` foreign key, restoring causality navigation from Operations into the CSO detail page and preventing exported objects from being mis-labelled as "Deleted" on the activity item detail page (#683).
+- 🐛 Pending-export reference values in the Causality Tree attribute change table now render the resolved identifier (e.g. group member DN) alongside a clickable link to the stub Connected System Object, instead of showing only a clock icon with no value.
+
+### Changed
+
+- 💄 The Activity Run Profile Execution Item detail page no longer duplicates the Connected System Object's external ID in the Execution Summary prose; the identifier is already shown as a chip directly below.
 
 ## [0.10.2] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Export Run Profile Execution Items and their linked Connected System Object Change rows now persist with the correct `ConnectedSystemObjectId` foreign key, restoring causality navigation from Operations into the CSO detail page and preventing exported objects from being mis-labelled as "Deleted" on the activity item detail page (#683).
+
 ## [0.10.2] - 2026-04-29
 
 ### Added

--- a/src/JIM.Application/Utilities/ExportChangeHistoryBuilder.cs
+++ b/src/JIM.Application/Utilities/ExportChangeHistoryBuilder.cs
@@ -35,10 +35,16 @@ public static class ExportChangeHistoryBuilder
             _ => ObjectChangeType.Exported
         };
 
+        // Set the scalar FK alongside the navigation: ConnectedSystemObjectChange rows are persisted
+        // via the raw COPY path (BulkInsertCsoChangesRawAsync), which reads ConnectedSystemObjectId
+        // directly and does not trigger EF's automatic FK fix-up from the navigation. Without the
+        // explicit assignment the column is inserted as NULL, breaking Causality Tree rendering for
+        // export change history (#683).
         var change = new ConnectedSystemObjectChange
         {
             ConnectedSystemId = connectedSystemId,
             ConnectedSystemObject = exportItem.ConnectedSystemObject,
+            ConnectedSystemObjectId = exportItem.ConnectedSystemObject?.Id,
             ChangeType = changeType,
             ChangeTime = DateTime.UtcNow,
             ActivityRunProfileExecutionItem = executionItem,

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -1440,59 +1440,30 @@ else if (_activityRunProfileExecutionItem.ObjectChangeType == ObjectChangeType.N
 
     private string GetStatusDescription()
     {
-        // Get the external ID if available
-        var externalId = _externalIdAttributeValue?.ToStringNoName()
-        ?? _activityRunProfileExecutionItem?.ExternalIdSnapshot;
-
-        // Only include the identifier in parentheses if we have a specific external ID
-        var hasExternalId = !string.IsNullOrEmpty(externalId);
-
+        // The connected system object's external ID is rendered as a separate chip immediately
+        // below this summary line, so we deliberately omit it from the prose to avoid duplication.
         if (_activityRunProfileExecutionItem?.ErrorType != ActivityRunProfileExecutionItemErrorType.NotSet)
-            return hasExternalId
-            ? $"An error occurred while synchronising the connected system object ({externalId})."
-            : "An error occurred while synchronising the connected system object.";
+            return "An error occurred while synchronising the connected system object.";
 
         return _activityRunProfileExecutionItem?.ObjectChangeType switch
         {
             // Import operations
-            ObjectChangeType.Added => hasExternalId
-            ? $"A new connected system object ({externalId}) was imported and added to the connector space."
-            : "A new connected system object was imported and added to the connector space.",
-            ObjectChangeType.Updated => hasExternalId
-            ? $"The connected system object ({externalId}) was updated with new attribute values."
-            : "The connected system object was updated with new attribute values.",
+            ObjectChangeType.Added => "A new connected system object was imported and added to the connector space.",
+            ObjectChangeType.Updated => "The connected system object was updated with new attribute values.",
             ObjectChangeType.Deleted => IsSyncContext()
-            ? (hasExternalId
-            ? $"The connected system object ({externalId}) was removed from the connector space after the source system deletion was confirmed."
-            : "The connected system object was removed from the connector space after the source system deletion was confirmed.")
-            : (hasExternalId
-            ? $"The connected system object ({externalId}) was detected as deleted from the source system and marked for removal."
-            : "The connected system object was detected as deleted from the source system and marked for removal."),
+                ? "The connected system object was removed from the connector space after the source system deletion was confirmed."
+                : "The connected system object was detected as deleted from the source system and marked for removal.",
             // Sync operations
             ObjectChangeType.Projected => "A new metaverse object was created via projection from the connected system object.",
-            ObjectChangeType.Joined => hasExternalId
-            ? $"The connected system object ({externalId}) was joined to an existing metaverse object."
-            : "The connected system object was joined to an existing metaverse object.",
-            ObjectChangeType.AttributeFlow => hasExternalId
-            ? $"Attributes were flowed for the connected system object ({externalId})."
-            : "Attributes were flowed between the connected system object and metaverse.",
-            ObjectChangeType.Disconnected => hasExternalId
-            ? $"The connected system object ({externalId}) was disconnected from the metaverse. Join and metaverse deletion rules were evaluated."
-            : "The connected system object was disconnected from the metaverse. Join and metaverse deletion rules were evaluated.",
+            ObjectChangeType.Joined => "The connected system object was joined to an existing metaverse object.",
+            ObjectChangeType.AttributeFlow => "Attributes were flowed between the connected system object and metaverse.",
+            ObjectChangeType.Disconnected => "The connected system object was disconnected from the metaverse. Join and metaverse deletion rules were evaluated.",
             // Export operations
-            ObjectChangeType.Exported => hasExternalId
-            ? $"The connected system object ({externalId}) was exported to the target system."
-            : "The connected system object was exported to the target system.",
-            ObjectChangeType.Deprovisioned => hasExternalId
-            ? $"The connected system object ({externalId}) was deprovisioned from the target system."
-            : "The connected system object was deprovisioned from the target system.",
+            ObjectChangeType.Exported => "The connected system object was exported to the target system.",
+            ObjectChangeType.Deprovisioned => "The connected system object was deprovisioned from the target system.",
             // Other
-            ObjectChangeType.NoChange => hasExternalId
-            ? $"The connected system object ({externalId}) was already up to date."
-            : "The connected system object was already up to date.",
-            _ => hasExternalId
-            ? $"Synchronisation completed for the connected system object ({externalId})."
-            : "Synchronisation completed for the connected system object."
+            ObjectChangeType.NoChange => "The connected system object was already up to date.",
+            _ => "Synchronisation completed for the connected system object."
         };
     }
 

--- a/src/JIM.Web/Shared/AttributeChangeTable.razor
+++ b/src/JIM.Web/Shared/AttributeChangeTable.razor
@@ -110,12 +110,27 @@
             }
             else if (context.IsPendingExportStub)
             {
-                @* Pending reference - matched but awaiting export or confirming import *@
+                @* Pending reference: matched and resolved, but the referenced object is not yet
+                   confirmed in the target system. Render the same chip+link affordance as a fully
+                   resolved reference so the operator can navigate to the (pending) stub CSO, with
+                   a clock badge to indicate its provisional status. *@
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                    <MudTooltip Text="Pending — this reference has been resolved but the object has not yet been fully confirmed in the target system.">
+                    <MudTooltip Text="Pending: this reference has been resolved but the referenced object has not yet been fully confirmed in the target system." Arrow="true" Placement="Placement.Top">
                         <MudIcon Icon="@Icons.Material.Filled.Schedule" Color="Color.Info" Size="Size.Small" />
                     </MudTooltip>
-                    <MudText Class="mud-text-secondary">@context.DisplayValue</MudText>
+                    @if (context.ReferenceValue != null)
+                    {
+                        <MudChip T="string" Color="Color.Default">@context.ReferenceValue.TypeName</MudChip>
+                        <MudLink Href="@context.ReferenceValue.Href">
+                            @context.ReferenceValue.DisplayName
+                        </MudLink>
+                    }
+                    else if (!string.IsNullOrEmpty(context.DisplayValue))
+                    {
+                        @* Fallback for legacy rows or unresolved cross-batch references where the
+                           stub CSO link is unavailable: show the resolved identifier as plain text. *@
+                        <MudText Class="mud-text-secondary">@context.DisplayValue</MudText>
+                    }
                 </MudStack>
             }
             else if (context.ReferenceValue != null)
@@ -226,11 +241,19 @@
                 {
                     AttributeName = ac.AttributeName,
                     ChangeType = vc.ValueChangeType,
+                    // Keep the string fallback when there is no reference navigation to chip; pending-export
+                    // stubs may have ReferenceValue == null on legacy rows or unresolved cross-batch cases,
+                    // and StringValue still carries the resolved DN for display in those situations.
                     Value = vc.ReferenceValue == null ? vc.ToString() : null,
                     ReferenceValue = vc.ReferenceValue != null ? new ReferenceValueInfo
                     {
                         TypeName = vc.ReferenceValue.Type?.Name ?? "Unknown",
-                        DisplayName = GetReferenceDisplayName(vc.ReferenceValue),
+                        // For pending-export stubs, prefer the resolved identifier (DN) captured in
+                        // StringValue: it is the value the operator recognises, whereas the stub CSO
+                        // has not yet acquired its post-export display attributes.
+                        DisplayName = vc.IsPendingExportStub && !string.IsNullOrEmpty(vc.StringValue)
+                            ? vc.StringValue
+                            : GetReferenceDisplayName(vc.ReferenceValue),
                         Href = Utilities.GetConnectedSystemObjectHref(vc.ReferenceValue)
                     } : null,
                     IsMultiValued = ac.Attribute?.AttributePlurality == AttributePlurality.MultiValued,

--- a/src/JIM.Worker/Processors/SyncExportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncExportTaskProcessor.cs
@@ -237,10 +237,15 @@ public class SyncExportTaskProcessor
                 },
             };
 
-            // Link to the Connected System Object if available
+            // Link to the Connected System Object if available.
+            // Set the scalar FK alongside the navigation: RPEIs are persisted via raw SQL / COPY
+            // (BulkInsertRpeisRawAsync), which does not trigger EF's automatic FK fix-up from the
+            // navigation. Without the explicit assignment the column is inserted as NULL, breaking
+            // the audit-trail link from the Activity into the CSO detail page (#683).
             if (exportItem.ConnectedSystemObject != null)
             {
                 executionItem.ConnectedSystemObject = exportItem.ConnectedSystemObject;
+                executionItem.ConnectedSystemObjectId = exportItem.ConnectedSystemObject.Id;
                 executionItem.SnapshotCsoDisplayFields(exportItem.ConnectedSystemObject);
             }
 

--- a/test/integration/scenarios/Invoke-Scenario8-CrossDomainEntitlementSync.ps1
+++ b/test/integration/scenarios/Invoke-Scenario8-CrossDomainEntitlementSync.ps1
@@ -477,6 +477,7 @@ try {
         Write-Host "    Exporting to Target AD..." -ForegroundColor Gray
         $exportResult = Start-JIMRunProfile -ConnectedSystemId $targetSystem.id -RunProfileId $targetExportProfile.id -Wait -PassThru
         Assert-ExportSuccess -ActivityId $exportResult.activityId -Name "Target Export$contextSuffix"
+        Assert-ExportRpeisHaveCsoLink -ActivityId $exportResult.activityId -Name "Target Export$contextSuffix"
         Start-Sleep -Seconds $WaitSeconds
 
         # Step 6: Full Confirming Import from Target
@@ -541,6 +542,7 @@ try {
         Write-Host "    Exporting to Target AD..." -ForegroundColor Gray
         $exportResult = Start-JIMRunProfile -ConnectedSystemId $targetSystem.id -RunProfileId $targetExportProfile.id -Wait -PassThru
         Assert-ExportSuccess -ActivityId $exportResult.activityId -Name "Target Export$contextSuffix"
+        Assert-ExportRpeisHaveCsoLink -ActivityId $exportResult.activityId -Name "Target Export$contextSuffix"
         Start-Sleep -Seconds $WaitSeconds
 
         # Step 4: Delta Confirming Import from Target
@@ -1199,6 +1201,7 @@ try {
         Write-Host "    Exporting corrections to Target AD..." -ForegroundColor Gray
         $exportResult = Start-JIMRunProfile -ConnectedSystemId $targetSystem.id -RunProfileId $targetExportProfile.id -Wait -PassThru
         Assert-ExportSuccess -ActivityId $exportResult.activityId -Name "Target Export (reassert state)"
+        Assert-ExportRpeisHaveCsoLink -ActivityId $exportResult.activityId -Name "Target Export (reassert state)"
         Start-Sleep -Seconds $WaitSeconds
 
         # Confirming Import

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -1652,6 +1652,103 @@ function Assert-ExportSuccess {
     }
 }
 
+function Assert-ExportRpeisHaveCsoLink {
+    <#
+    .SYNOPSIS
+        Assert that every Exported / Deprovisioned RPEI for a just-completed export Activity
+        has its ConnectedSystemObjectId FK populated, and that the linked
+        ConnectedSystemObjectChange row (when present) also has its ConnectedSystemObjectId populated.
+
+    .DESCRIPTION
+        Guards against a regression where the export pipeline writes RPEIs through the raw-SQL /
+        COPY bulk-insert path with only the navigation property set. EF's automatic FK fix-up
+        does not run on raw SQL, so the scalar FK ends up NULL and the audit trail loses its
+        link from the Activity into the CSO detail page (issue #683).
+
+        This check MUST be performed against a real Postgres instance; in-memory EF auto-tracks
+        navigations and would silently mask the bug. The helper queries the database directly
+        via psql in the jim.database container.
+
+        Scope: only checks Exported (11) and Deprovisioned (12) RPEIs. Other ObjectChangeType
+        values legitimately have NULL ConnectedSystemObjectId in some flows (e.g. CSO already
+        deleted via ON DELETE SET NULL on a historical activity).
+
+    .PARAMETER ActivityId
+        The Activity ID (GUID) of a just-completed export Activity.
+
+    .PARAMETER Name
+        A friendly name for the export Activity (used in output messages).
+
+    .EXAMPLE
+        Assert-ExportRpeisHaveCsoLink -ActivityId $exportResult.activityId -Name "Target Export"
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$ActivityId,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Name
+    )
+
+    # Validate ActivityId is a well-formed GUID before substituting into SQL.
+    # The query interpolates ActivityId directly because psql -c does not support bind parameters
+    # over docker compose exec; restricting to a GUID closes the only realistic injection vector.
+    $parsedId = [Guid]::Empty
+    if (-not [Guid]::TryParse($ActivityId, [ref]$parsedId)) {
+        throw "Assert-ExportRpeisHaveCsoLink: ActivityId '$ActivityId' is not a valid GUID."
+    }
+    $safeActivityId = $parsedId.ToString()
+
+    # ObjectChangeType values: Exported = 11, Deprovisioned = 12
+    $rpeiQuery = @"
+SELECT COUNT(*) FROM "ActivityRunProfileExecutionItems"
+WHERE "ActivityId" = '$safeActivityId'
+  AND "ObjectChangeType" IN (11, 12)
+  AND "ConnectedSystemObjectId" IS NULL
+  AND "ErrorType" IS NULL;
+"@
+
+    $rpeiNullCount = docker compose exec -T jim.database psql -t -A -U jim -d jim -c $rpeiQuery 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Assert-ExportRpeisHaveCsoLink: psql query failed for '$Name' (ActivityId: $ActivityId). Output: $rpeiNullCount"
+    }
+
+    $rpeiNullCount = [int]($rpeiNullCount | Out-String).Trim()
+    if ($rpeiNullCount -gt 0) {
+        Write-Host "  ✗ $Name - $rpeiNullCount export RPEI(s) persisted with NULL ConnectedSystemObjectId" -ForegroundColor Red
+        Write-Host "    This breaks audit-trail navigation from Operations into CSO detail (#683)" -ForegroundColor Red
+        Write-Host "    ActivityId: $ActivityId" -ForegroundColor Red
+        throw "Export '$Name' persisted $rpeiNullCount RPEI row(s) with NULL ConnectedSystemObjectId (ActivityId: $ActivityId)"
+    }
+
+    # Also check the linked ConnectedSystemObjectChange rows. These are written through the same
+    # raw-SQL/COPY path and exhibit the same defect (the change row's FK was set on the navigation
+    # only, not the scalar). Restrict to changes linked to the export Activity's RPEIs.
+    $changeQuery = @"
+SELECT COUNT(*) FROM "ConnectedSystemObjectChanges" c
+JOIN "ActivityRunProfileExecutionItems" r ON c."ActivityRunProfileExecutionItemId" = r."Id"
+WHERE r."ActivityId" = '$safeActivityId'
+  AND r."ObjectChangeType" IN (11, 12)
+  AND r."ErrorType" IS NULL
+  AND c."ConnectedSystemObjectId" IS NULL;
+"@
+
+    $changeNullCount = docker compose exec -T jim.database psql -t -A -U jim -d jim -c $changeQuery 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Assert-ExportRpeisHaveCsoLink: psql query failed (change rows) for '$Name' (ActivityId: $ActivityId). Output: $changeNullCount"
+    }
+
+    $changeNullCount = [int]($changeNullCount | Out-String).Trim()
+    if ($changeNullCount -gt 0) {
+        Write-Host "  ✗ $Name - $changeNullCount ConnectedSystemObjectChange row(s) persisted with NULL ConnectedSystemObjectId" -ForegroundColor Red
+        Write-Host "    Causality Tree will fail to render attribute-level export detail (#683)" -ForegroundColor Red
+        Write-Host "    ActivityId: $ActivityId" -ForegroundColor Red
+        throw "Export '$Name' persisted $changeNullCount ConnectedSystemObjectChange row(s) with NULL ConnectedSystemObjectId (ActivityId: $ActivityId)"
+    }
+
+    Write-Host "  ✓ $Name - all export RPEIs and change rows have populated ConnectedSystemObjectId FKs" -ForegroundColor Green
+}
+
 function Assert-ActivityHasChanges {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Summary

- Set the scalar `ConnectedSystemObjectId` FK on export RPEIs and their linked `ConnectedSystemObjectChange` rows. The raw-SQL/COPY bulk-insert path doesn't trigger EF's FK fix-up from a navigation property, so setting only the navigation left the FK NULL on every export, breaking causality navigation from Operations into the CSO detail page and causing exported objects to be mis-labelled as "Deleted" on the activity item detail page.
- Render pending-export reference values (e.g. group member DNs) as a clickable type chip + link to the stub CSO, with the clock icon retained as a status badge. Previously these rows showed only the clock icon with no value because the UI mapping nulled out the string value whenever the navigation was loaded, and the stub render branch read DisplayValue only.
- Trim the Execution Summary prose on the activity item detail page: the external ID is rendered as a chip immediately below, so duplicating it inline added noise without information.

Closes #683.

## Test plan

- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors)
- [x] `dotnet test JIM.sln` — 2652 passed, 0 failed
- [x] Scenario 8 integration test (Small / SambaAD) re-run by user — passed, including the new `Assert-ExportRpeisHaveCsoLink` assertion that fires after every export
- [x] Manual visual confirmation: Operations → export RPEI now shows the CSO chip with link instead of "Deleted: <guid>"; member rows now show `[type] uid=...,ou=People,dc=...` with a clock badge
- [ ] Reviewer to confirm the immutable-snapshot semantics of `IsPendingExportStub` are still appropriate (column is persisted at export time and never mutated by later activities — see PR discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)