### PR TITLE
docs: add GitHub Discussion templates for ideas and Q&A

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,58 @@
+title: "[Idea] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea. The most useful idea posts focus on the underlying problem first, and the proposed solution second, that gives us the flexibility to consider alternative approaches that might solve your need even better than your initial proposal.
+
+        Before posting, please search existing ideas in case yours has already been raised, and if it has, upvote it rather than creating a duplicate. The upvote signal genuinely informs roadmap prioritisation.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the underlying need or pain point. Avoid jumping straight to a solution, the problem statement is what we'll evaluate.
+      placeholder: |
+        e.g. "When onboarding a new HR system, I have no way to preview how attribute flow rules will behave before running a full sync, which makes me nervous about committing changes to production."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Your suggested approach. Rough sketches are fine, we don't expect a fully-specified design.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about and why they fall short. This is genuinely useful, it helps us avoid suggesting an approach you've already ruled out.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: deployment-context
+    attributes:
+      label: Deployment context (optional)
+      description: What kind of environment would benefit from this? Helps us understand the audience for the idea.
+      options:
+        - Air-gapped / disconnected
+        - Highly regulated (healthcare, finance, government, defence, etc.)
+        - Standard enterprise
+        - Small / mid-market
+        - Evaluation / proof-of-concept
+        - Not specific to a deployment context
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Use cases, links to relevant standards, examples from other identity tooling (without naming specific products), or any other context.
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,79 @@
+title: "[Q&A] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking a question. A few details up front make it much easier for us, or another community member, to help you quickly. Before posting, please search existing Q&A threads in case your question has already been answered.
+
+        ⚠️ **Please redact sensitive information** from any logs, configuration, or examples you share: real usernames, email addresses, internal hostnames, LDAP DNs with real OU paths, tokens, and any other data that would identify a specific person or organisation.
+
+  - type: input
+    id: jim-version
+    attributes:
+      label: JIM version
+      description: Which version of JIM are you running? Found in the UI footer or `docker inspect` on the JIM container image tag.
+      placeholder: "e.g. v0.9.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment-method
+    attributes:
+      label: Deployment method
+      description: How is JIM deployed in your environment?
+      options:
+        - Docker Compose
+        - Kubernetes
+        - Other / custom
+        - Not yet deployed (evaluation)
+    validations:
+      required: true
+
+  - type: input
+    id: oidc-provider
+    attributes:
+      label: OIDC provider
+      description: Which identity provider is JIM federated with for sign-in?
+      placeholder: "e.g. Entra ID, Keycloak, ADFS, etc."
+    validations:
+      required: false
+
+  - type: input
+    id: connectors
+    attributes:
+      label: Connector(s) involved
+      description: Which JIM connector(s) are relevant to your question?
+      placeholder: "e.g. CSV, LDAP, Generic Database"
+    validations:
+      required: false
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to do, and what's the specific question or behaviour you'd like help with?
+      placeholder: |
+        Describe what you're trying to achieve and the specific point you're stuck on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Steps you've already attempted, documentation you've consulted, or hypotheses you've ruled out. This helps us avoid suggesting things you've already tested.
+      placeholder: |
+        - Tried X, which produced Y
+        - Reviewed docs section Z
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or configuration (redacted)
+      description: Paste any relevant log snippets or sync rule configuration. Wrap them in triple backticks for formatting. **Redact sensitive data.**
+      render: text
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds an **Ideas** discussion template that focuses on the underlying problem first, then the proposed solution, with optional alternatives and deployment context.
- Adds a **Q&A** discussion template that captures JIM version, deployment method, OIDC provider, and connector(s), and prompts users to redact sensitive data from logs.

## Test plan
- [ ] After merge, open a new GitHub Discussion and confirm both templates appear and render the expected fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)