### PR TITLE
docs: cross-link GitHub Discussions from README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,19 @@ JIM has reached MVP completion (100%). The core identity lifecycle is fully func
 
 For detailed feature checklists and post-MVP roadmap, see the [Roadmap](https://tetronio.github.io/JIM/reference/roadmap/).
 
+## Community & Support
+
+JIM is built in the open and we'd love to hear from people running it, evaluating it, or thinking about it. The best place to engage with us and other users is [GitHub Discussions](https://github.com/TetronIO/JIM/discussions).
+
+- **Questions and setup help:** Open a thread in the [Q&A](https://github.com/TetronIO/JIM/discussions/categories/q-a) category. Search existing threads first; if your question is already there, add to it rather than starting a new one.
+- **Feature ideas and suggestions:** Post in the [Ideas](https://github.com/TetronIO/JIM/discussions/categories/ideas) category. Upvotes on existing ideas genuinely inform roadmap prioritisation, so prefer adding signal to a duplicate over creating a new thread.
+- **Bug reports:** Open a [GitHub Issue](https://github.com/TetronIO/JIM/issues). If it turns out to be a usage question, we may convert it to a Discussion.
+- **Security vulnerabilities:** Follow the responsible disclosure process in [SECURITY.md](SECURITY.md); please do not report security issues in public Issues or Discussions.
+
 ## Licensing
 JIM uses a Source-Available model where it is free to use in non-production scenarios, but requires a commercial license for use in production scenarios. [﻿Full details can be found here](https://tetron.io/jim/#licensing).
 
 ## More Information
 - **Documentation:** [tetronio.github.io/JIM](https://tetronio.github.io/JIM/)
+- **Discussions:** [github.com/TetronIO/JIM/discussions](https://github.com/TetronIO/JIM/discussions)
 - **Product site:** [tetron.io/jim](https://tetron.io/jim)

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -13,6 +13,8 @@ JIM is a source-available project. This page covers the guidelines and expectati
 3. Review the code style and conventions below
 4. Pick an issue or propose a change
 
+For anything beyond a small, self-contained fix (a new feature, a connector, an architectural change, a non-trivial refactor), please start a thread in [GitHub Discussions](https://github.com/TetronIO/JIM/discussions) before opening a pull request. The [Ideas](https://github.com/TetronIO/JIM/discussions/categories/ideas) category is the right home for proposals; this lets us shape the approach together and avoids you investing time in something that might not land.
+
 ## Code Style
 
 ### Language and Spelling

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -67,6 +67,8 @@ This guide covers everything you need to get started as a contributor: setting u
 | Resource | Description |
 |----------|-------------|
 | [Repository](https://github.com/TetronIO/JIM) | Source code on GitHub |
+| [Discussions](https://github.com/TetronIO/JIM/discussions) | Q&A, feature ideas, and design conversations |
+| [Issues](https://github.com/TetronIO/JIM/issues) | Bug reports and tracked work |
 | [Expression Language Guide](../concepts/expressions.md) | C#-like expression language for attribute mappings |
 | [SSO Setup Guide](../administration/sso-setup.md) | Configure OIDC authentication for any identity provider |
 | [Deployment Guide](../administration/deployment.md) | Production deployment instructions |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -48,3 +48,7 @@ Getting JIM running involves three main steps:
 3. **Configure your first synchronisation:** Connect a source system, define synchronisation rules, and verify data flows correctly through the metaverse.
 
 Once deployed, JIM is accessible via a web portal at `http://localhost:5200` by default. You can also interact with JIM through its REST API or the cross-platform PowerShell module.
+
+## Stuck?
+
+If something does not behave the way you expect, the [Q&A category in GitHub Discussions](https://github.com/TetronIO/JIM/discussions/categories/q-a) is the place to ask. Search first; if your question is already there, add to that thread rather than starting a new one. For confirmed bugs, open a [GitHub Issue](https://github.com/TetronIO/JIM/issues) instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,15 @@ JIM has reached MVP completion. The core identity lifecycle is fully functional:
 - **Export** changes to target systems with pending export management
 - **Schedule** automated synchronisation using cron or interval-based triggers
 
+## 💬 Community & Support
+
+JIM is built in the open. [GitHub Discussions](https://github.com/TetronIO/JIM/discussions) is the place to engage with the maintainers and other users.
+
+- **Questions and setup help**<br /> Start a thread in the [Q&A](https://github.com/TetronIO/JIM/discussions/categories/q-a) category. Search existing threads first.
+- **Feature ideas and suggestions**<br /> Post in the [Ideas](https://github.com/TetronIO/JIM/discussions/categories/ideas) category. Upvotes on existing ideas inform roadmap prioritisation; prefer adding signal to a duplicate over creating a new thread.
+- **Bug reports**<br /> Open a [GitHub Issue](https://github.com/TetronIO/JIM/issues).
+- **Security vulnerabilities**<br /> Follow the [Security Policy](https://github.com/TetronIO/JIM/security/policy); please do not report security issues in public Issues or Discussions.
+
 ## Licensing
 
 JIM uses a Source-Available model where it is free to use in non-production scenarios, but requires a commercial licence for use in production scenarios. [Full details can be found here](https://tetron.io/jim/#licensing).


### PR DESCRIPTION
## Summary
- Add a "Community & Support" section to the README pointing users at GitHub Discussions (Q&A and Ideas), Issues for bugs, and SECURITY.md for vulnerabilities
- Mirror the same entry points on the docs home (`docs/index.md`) using the term-and-description bullet style
- Add a "Stuck?" callout to `docs/getting-started/index.md` so first-time users know where to ask
- Suggest in `docs/developer/contributing.md` that non-trivial proposals start as a Discussion before a PR
- Surface Discussions and Issues rows in the Developer Guide Quick Reference table

Closes the "Update README.md: add or refine the 'Community' / 'Get help' section" task from the GitHub Discussions deployment list.

## Test plan
- [ ] Visual review of rendered README on the PR page
- [ ] Build the docs site locally (`mkdocs serve`) and confirm the new sections render correctly on the home, getting-started index, developer index, and contributing pages
- [ ] Verify all Discussions / Issues / Security links resolve to the right destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)