### PR TITLE
docs: switch security contact to security@junctional.io

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ We take security vulnerabilities seriously. If you discover a security issue in 
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please send an email to: **security@tetron.io**
+Instead, please send an email to: **security@junctional.io**
 
 Include as much of the following information as possible:
 

--- a/engineering/COMPLIANCE_MAPPING.md
+++ b/engineering/COMPLIANCE_MAPPING.md
@@ -155,7 +155,7 @@ The UK Government's Software Security Code of Practice defines 14 principles acr
 
 | Principle | Requirement | JIM Alignment | Status |
 |-----------|-------------|---------------|--------|
-| 11 | Report vulnerabilities responsibly | SECURITY.md with dedicated security@tetron.io email | Aligned |
+| 11 | Report vulnerabilities responsibly | SECURITY.md with dedicated security@junctional.io email | Aligned |
 | 12 | Provide vulnerability information to customers | Coordinated disclosure, security advisories | Aligned |
 | 13 | Publish accurate CVE information | In progress - GitHub Security Advisories integration | Aligned |
 | 14 | Provide security documentation | SECURITY.md, deployment guidance, this compliance mapping | Aligned |


### PR DESCRIPTION
## Summary
- Update `SECURITY.md` vulnerability reporting address from `security@tetron.io` to `security@junctional.io`
- Update the matching reference in `engineering/COMPLIANCE_MAPPING.md` (UK Software Security Code of Practice, Principle 11)

Email is now provisioned on `junctional.io` (the JIM project domain), so the security contact should live there. No other `@tetron.io` email addresses were found in the repo; the remaining `tetron.io` references are website URLs and `*.tetron.io` test fixture data, both of which stay as-is.

## Test plan
- [x] `git diff` reviewed: only the two intended string replacements
- [x] No code changes; docs-only edit (no build/test required per CLAUDE.md exceptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)