### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+Thanks for contributing to JIM! Please fill out the sections below.
+This template applies to all PRs against TetronIO/JIM.
+-->
+
+## Description
+
+<!-- What does this PR do? Why is it needed? Link to the relevant Issue or Idea if applicable. -->
+
+Closes #
+
+## Type of change
+
+<!-- Tick all that apply -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactor (no functional change)
+- [ ] Other (describe below)
+
+## Testing
+
+<!-- How have you tested this? -->
+
+- [ ] `dotnet build JIM.sln` succeeds with zero errors
+- [ ] `dotnet test JIM.sln` passes
+- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
+- [ ] Manually tested in a local development environment
+- [ ] Documentation updated (if behaviour changed)
+
+<!-- If integration testing was relevant, briefly describe the scenario(s) you exercised. -->
+
+## Screenshots / output (if applicable)
+
+<!-- For UI changes, include before/after screenshots. For behaviour changes, paste relevant log output (with sensitive data redacted). -->
+
+## Checklist
+
+- [ ] My commit messages are descriptive and reference the relevant Issue (if any)
+- [ ] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
+- [ ] User-facing text uses British English (en-GB)
+- [ ] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)
+
+## Additional context
+
+<!-- Anything else reviewers should know — design decisions, alternatives considered, follow-up work needed. -->


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` to prompt for description, type-of-change, testing performed, and a maintainer-style checklist on every PR opened against `TetronIO/JIM`.
- Originally drafted alongside the CLA Assistant scaffolding (now removed); this PR ships the template standalone.

## Context

This PR is the first of two follow-ups from the 2026-05-04 pause of the CLA rollout. The CLA-related work (CLA.md placeholder, CLA Assistant workflow, activation runbook) has been preserved in JIM-Brain ([raw/regulatory/cla-jim-*.md](https://github.com/TetronIO/JIM-Brain)) and removed from this repo until Tetron resourcing supports solicitor review of the ICLA wording.

The PR template is independent of the CLA decision and useful regardless of whether the CLA gate is in place. The CLA confirmation line that was originally in the template's checklist has been removed; if/when the CLA work resumes, that line can be re-added in a follow-up.

The companion PR (#TBC) removes `CONTRIBUTING.md` from `main` for the same pause.

## Test plan

- [ ] CI status checks pass (build-and-test, base image scans, CodeQL × 3, claude-review)
- [ ] Open a draft PR after merge to confirm the template renders correctly in the GitHub PR creation UI