### PR TITLE
chore: update release skill for junctional.io and add pr-merge skill

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: pr-merge
+description: Take a feature branch through to a clean squash-merge — rebase on origin/main, build/test, open PR, resolve code-quality bot feedback, queue auto-merge, then clean up local + remote refs.
+argument-hint: "[optional PR title — under 70 chars; if omitted, derive one from the commit log]"
+---
+
+# Take a JIM feature branch from in-progress to merged
+
+This skill drives the full happy-path between "I have committed work on a feature branch" and "the work is on `main` and my workspace is back on a clean main." It encodes the lessons from prior PRs:
+
+- **Strict mode is on for `main`.** A PR opened while the feature branch is behind `origin/main` will sit in `mergeStateStatus: BEHIND` and `--auto` cannot land it. Get the branch up to date *before* the PR exists.
+- **`github-code-quality` runs on every PR.** It almost always finds something. Build that fix loop into the flow rather than treating it as an exception.
+- **`gh pr merge ... --auto`** is the right command; the immediate failure right after `gh pr create` is expected, not a blocker.
+- **Squash-merge means `git branch -D`** is correct for cleanup, not `-d`.
+
+If `$ARGUMENTS` is non-empty, treat it as the proposed PR title (still under 70 chars). Otherwise derive a title from the commit log.
+
+## Pre-flight
+
+1. **Verify the working state:**
+   ```
+   git status
+   git branch --show-current
+   ```
+   - You MUST be on a feature branch (not `main`). If on `main`, stop and ask the user which branch they meant.
+   - Working tree MUST be clean. If there are uncommitted changes, stop and ask whether they should be committed first or stashed.
+
+2. **Check there is something to PR:**
+   ```
+   git fetch origin --prune
+   git log --oneline origin/main..HEAD
+   ```
+   - If empty, stop: there's nothing to merge.
+
+3. **Check whether a PR already exists for this branch:**
+   ```
+   gh pr list --head "$(git branch --show-current)" --state open --json number,title,mergeStateStatus,autoMergeRequest
+   ```
+   - If a PR already exists, skip the "Create PR" step below and resume from "Queue auto-merge" / "Resolve code-quality issues" depending on its state. Note the existing number.
+
+## Get the branch up to date with origin/main (CRITICAL)
+
+This is the step previously missed. Strict mode means it has to happen *before* the PR exists, otherwise the PR is born BEHIND and `--auto` is blocked.
+
+1. **Update local `main`:**
+   ```
+   git checkout main
+   git pull --ff-only
+   git checkout -
+   ```
+
+2. **Decide whether the branch is already up to date:**
+   ```
+   git log --oneline HEAD..origin/main
+   ```
+   - If empty, the branch is already current — skip to the build/test step.
+   - If non-empty, rebase onto `origin/main`:
+     ```
+     git rebase origin/main
+     ```
+   - **If the rebase produces conflicts**, stop and surface them to the user. Do NOT auto-resolve; the user has to decide.
+   - After a successful rebase, force-push with lease:
+     ```
+     git push --force-with-lease
+     ```
+
+   Fallback: if for some reason the rebase route is unavailable (e.g. user has explicitly asked not to rewrite history), create the PR first and then `gh pr update-branch <n>` immediately. This produces a merge commit on the feature branch, but the squash-merge collapses it away.
+
+## Build and test
+
+Per JIM CLAUDE.md, never open a PR with a failing build or tests.
+
+```
+dotnet build JIM.sln
+dotnet test JIM.sln
+```
+
+- Both must complete with **zero errors and zero warnings**.
+- If either fails, stop and report. Do not paper over warnings — fix them.
+- Exception: changes that only touch scripts / static assets / docs / config / CI workflows / diagrams skip these per the CLAUDE.md exception list. UI-only Razor changes need `dotnet build` but not `dotnet test`. Use judgement on the actual diff.
+
+## Create the PR
+
+Skip if a PR already exists for this branch.
+
+1. **Derive the title and body:**
+   - If `$ARGUMENTS` is set, use it as the title (still verify it is under 70 characters).
+   - Otherwise, look at `git log --oneline origin/main..HEAD` to summarise. Lead with the dominant theme. Conventional prefixes (`perf:`, `feat:`, `fix:`, `docs:`, `chore:`) are encouraged.
+   - Title MUST be under 70 characters.
+   - Body MUST follow the JIM template:
+     ```
+     ## Summary
+     <2–6 bullet points covering what changed and why>
+
+     ## Test plan
+     - [x] `dotnet build JIM.sln` clean
+     - [x] `dotnet test JIM.sln` clean
+     - [x] <feature-specific manual verification, if applicable>
+
+     🤖 Generated with [Claude Code](https://claude.com/claude-code)
+     ```
+   - Use a HEREDOC for the body so the formatting survives:
+     ```
+     gh pr create --title "<title>" --body "$(cat <<'EOF'
+     ## Summary
+     ...
+     EOF
+     )"
+     ```
+   - Capture the PR number from the returned URL.
+
+## Queue auto-merge
+
+```
+gh pr merge <n> --squash --delete-branch --auto
+```
+
+- An immediate failure right after `gh pr create` is **expected, not a blocker** (checks haven't started). The `--auto` flag queues the merge for when checks pass.
+- **NEVER use `--admin` to bypass.** The harness will refuse it, correctly.
+
+## Resolve code-quality bot issues
+
+`github-code-quality` will post review comments within a couple of minutes. Don't assume it'll be silent.
+
+1. **Poll for the bot's review:**
+   ```
+   gh api repos/TetronIO/JIM/pulls/<n>/comments
+   ```
+   - Look for comments authored by `github-code-quality[bot]`.
+   - Also check `gh pr checks <n>` for any failed required checks (build-and-test, scan-base-images-summary, three CodeQL analyses, claude-review).
+
+2. **For each comment, decide whether to apply:**
+   - **Apply when** the suggestion is correct on the merits (genuine null-safety, clear redundancy, security issue, or a pattern called out in `src/CLAUDE.md` under "Code Quality"). Common JIM patterns:
+     - Replace `nullable.Value` inside LINQ projections with the bare nullable; lifted equality covers it (we already do this in `ConnectedSystemRepository`).
+     - After `Assert.That(x, Is.Not.Null)` in tests, use `x!` on every subsequent dereference, not just the first one.
+     - "Useless assignment", "Missed opportunity to use Where", redundant null-conditional after early return — fix at source per `src/CLAUDE.md`.
+   - **Push back when** the suggestion would change behaviour, hide a real bug, or just be cosmetic noise. Surface those to the user with a short rationale rather than blindly applying.
+
+3. **Apply, build, test, commit, push:**
+   - Make the edits with `Edit`.
+   - Re-run `dotnet build JIM.sln` and `dotnet test JIM.sln`.
+   - Commit as a separate `fix(code-quality): ...` commit (the squash-merge collapses it away). Use a HEREDOC commit message with the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+   - `git push` — the auto-merge stays queued and re-evaluates against the new HEAD.
+
+4. **Repeat until the bot has nothing left to say** and `gh pr checks <n>` shows all required checks passing or pending merge.
+
+## Wait for the merge to land
+
+Use a Bash background command, not ScheduleWakeup or sleep-polling:
+
+```
+until [ "$(gh pr view <n> --json state -q .state)" = "MERGED" ]; do sleep 30; done
+```
+
+Run with `run_in_background: true`. The harness will notify you when it exits. Do not poll proactively in the meantime.
+
+If the PR transitions to BEHIND while waiting (e.g. another PR landed on `main` first), run `gh pr update-branch <n>` to re-trigger checks, then re-arm the waiter.
+
+## Clean up
+
+Once the merge notification fires:
+
+```
+git checkout main
+git pull --ff-only
+git fetch --prune
+git branch -D <feature-branch>
+```
+
+- Use `-D` (capital), not `-d`. We squash-merge, so the feature branch's commits are not ancestors of `main` and `git branch -d` would refuse with "not fully merged".
+- If you were checked out on the feature branch when the auto-delete fired, the local ref may already be gone; `-D` will then report "branch not found", which is success.
+
+End the skill on a one-line confirmation: PR number, squash-commit SHA on `main`, and the cleaned-up branch name.
+
+## Out of scope
+
+- **Releasing.** This skill ends at "merged to main". Cutting a tagged release is `/release`.
+- **Force-merging past failed checks.** If a required check stays red after a real fix attempt, stop and ask the user. Do not use `--admin`.
+- **Retrying flaky checks.** If a single check fails for an obviously transient reason (e.g. infrastructure timeout), surface it; don't auto-rerun without confirmation.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -137,27 +137,38 @@ Verify that pages embedding or linking to diagrams are up to date:
 
 If new diagrams were added or existing ones renamed/removed, update these references accordingly.
 
-### 4. Review marketing site content
+### 4. Generate junctional.io site update prompt
 
-Fetch the public marketing site at `https://tetron.io/jim/` and compare its content against the current state of JIM:
+Fetch the public marketing site at `https://junctional.io/` and compare its content against the current state of JIM. Areas to inspect:
 
-1. **Feature claims** — Are all listed features still accurate? Are significant new features missing?
+1. **Feature claims** — Are listed features still accurate? Are significant new features missing?
 2. **Architecture descriptions** — Does the site's description of JIM's architecture match the current state?
-3. **Connector/integration list** — Are all supported connectors and integrations listed?
+3. **Connector/integration list** — Are all supported connectors and integrations represented?
 4. **Deployment/requirements** — Are prerequisites and deployment descriptions current?
 5. **Screenshots or visuals** — Are they representative of the current UI?
 
-The release agent cannot update the marketing site directly. Instead, present a clear summary of recommended changes to the user, structured so that a website development agent can implement them easily:
-- List each recommended change with: **what to change**, **where on the page**, **what the current text/content says**, and **what it should say or show instead**
-- Include any new feature descriptions that should be added, written in marketing-appropriate language
-- Flag any content that should be removed (e.g., features that were deprecated or renamed)
+> Note: the legacy `tetron.io/jim` page has been retired; do NOT fetch or reference it.
+
+This skill **does not edit the marketing site directly, and does not present marketing recommendations inline in chat**. The junctional.io site has its own dedicated agent which is authoritative on the site's structure, tone, and conventions, and will know more about the site than you do. Your job here is to **prime that agent with content-change suggestions**, not to dictate changes or critique the site's structure.
+
+Produce a markdown prompt document at `/tmp/junctional-site-prompt-v<version>.md` (outside the JIM repo — do NOT add it to git, do NOT place it under the workspace). The user will copy this file out and hand it to the junctional.io site agent in a separate session.
+
+The prompt should:
+- Open with context: this is an advisory list of content suggestions arising from the JIM v<version> release; the site agent is authoritative and should treat each item as a suggestion to evaluate, refine, or reject as it sees fit
+- Be written in second person addressed to the site agent ("you may want to consider …"), not as instructions to a human
+- Group suggestions by area (features, connectors, architecture, deployment, visuals, removals) so the site agent can prioritise
+- For each suggestion, include: **what area it relates to**, **what changed in JIM** (with a brief technical reason or pointer to the changelog entry), **what the site currently says or shows** (if you observed it during the fetch), and **a suggestion for what could be added/changed/removed** — phrased as "consider …", "you may want to …", or "this might be worth refreshing because …", never as "change X to Y"
+- Highlight any deprecations or removals that the site might still be advertising
+- Close with a note that screenshots/visuals are out of scope of this prompt; the site agent should request fresh screenshots from the user separately if it decides any are needed
+
+After writing the file, tell the user the absolute path to the prompt and remind them it is intentionally outside the repo and should be handed to the junctional.io site agent. Do NOT stage or commit the file.
 
 ### 5. Present documentation changes for review
 
 Show the user a summary of all documentation and diagram changes made:
 - List of files updated and what changed in each
 - Any new diagrams added
-- Marketing site recommendations (for manual action)
+- The path to the junctional.io site prompt file (e.g. `/tmp/junctional-site-prompt-v<version>.md`), noted as out-of-repo content for the user to hand to the junctional.io site agent
 - Ask the user to confirm before proceeding to changelog validation
 
 Once confirmed, commit the documentation updates on a release branch (do NOT commit to `main` directly — branch protection blocks that). If you are not already on a release branch, create one first:


### PR DESCRIPTION
## Summary
- Release skill now generates an out-of-repo markdown prompt at `/tmp/junctional-site-prompt-v<version>.md` for the junctional.io site agent instead of presenting marketing recommendations inline; the retired `tetron.io/jim` page is no longer fetched or referenced.
- Suggestions in the prompt are framed as advisory ("consider …", "you may want to …"), grouped by area, addressed to the site agent which is treated as authoritative on site structure, tone, and conventions.
- Adds a new `pr-merge` skill that drives a feature branch from in-progress to squash-merged on `main` (rebase, build/test, PR, code-quality fix loop, auto-merge, cleanup), encoding lessons learned from prior PRs (strict-mode BEHIND, expected post-create `--auto` failure, `git branch -D` for squash-merge cleanup).

## Test plan
- [x] Skill files only (`.claude/skills/*/SKILL.md`) — falls under CLAUDE.md docs exception, no `dotnet build`/`test` required
- [ ] Verified by exercising the skills on a future release / PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)