### PR TITLE
fix: restore top border on CSO attributes table header row

### DIFF
--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
@@ -166,7 +166,7 @@
                       Elevation="0" Rounded="true" ApplyEffectsToContainer="false" Outlined="true" TabPanelsClass="pa-0 mt-6">
         <MudTabPanel Text="Attributes" Icon="@Icons.Material.Filled.ListAlt">
             <MudPaper Class="pa-0" Outlined="true">
-                <MudTable Items="@GetGroupedAttributes()" Hover="true" Dense="@_dense" Elevation="0"
+                <MudTable Items="@GetGroupedAttributes()" Hover="true" Dense="@_dense" Elevation="0" Outlined="true"
                     Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")"
                     Breakpoint="Breakpoint.None">
                     <ToolBarContent>


### PR DESCRIPTION
## Summary
- The MudTable on the connector space object detail page was missing `Outlined="true"`, so MudBlazor's `.mud-table-outlined>.mud-table-toolbar` selector did not draw a bottom border under the density-toggle toolbar; visually, the header row was missing its top border.
- Added `Outlined="true"` to the table, matching the pattern already used in `PendingExportDetail.razor:227`. The wrapping `MudPaper` is `pa-0`, so the table border sits flush with the paper border and renders as a single line.

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors)
- [ ] Manually verified at `/admin/connected-systems/{id}/connector-space/{guid}` that the attributes table column-headings row now has matching top and bottom borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)