### PR TITLE
fix(devcontainer): make Claude state mount and Dev Kit runtime pin actually work

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -140,6 +140,18 @@ All dependency updates from Dependabot require human review before merging - the
 - PostgreSQL memory settings automatically optimized
 - Use `jim-db` or `jim-stack` aliases (already configured)
 
+## Persistent State Across Rebuilds
+
+`/home/vscode/.claude` is mounted from a Docker named volume `claude-state` so Claude Code's project memory, user-level settings, credentials and session backups survive `Rebuild Container`. Without the volume, that directory sits in the container's writable layer and is wiped on every rebuild.
+
+**Why the generic name (not `jim-claude-state`):** Claude already namespaces per-project memory under `.claude/projects/<workspace-slug>/`, so a single host-wide volume cleanly holds state for multiple devcontainer-based projects without collision. If you work on other projects that also mount `claude-state` at `/home/vscode/.claude`, you share user-level state (auth, settings) once and keep per-project memories isolated by Claude's own path slugs. Each developer's host has its own volume; nothing is synced across machines.
+
+**Cross-platform:** Works identically on Docker Desktop (macOS / Windows) and native Linux Docker. Lives inside Docker Desktop's VM or under `/var/lib/docker/volumes/` respectively. Lost only on explicit `docker volume rm claude-state` or a Docker factory reset.
+
+**Codespaces caveat:** Codespaces honours the named-volume mount, but each Codespace is its own VM and the volume is scoped to that one VM. State survives container rebuilds within the same Codespace (the common case) but does not survive Codespace deletion, and is not shared across Codespaces. Codespaces users therefore get partial benefit: less memory loss day-to-day, but no cross-project sharing.
+
+**To start fresh:** `docker volume rm claude-state` (Docker Desktop / Linux Docker) before the next rebuild. Codespaces users delete the Codespace.
+
 ## Troubleshooting
 
 **Build fails:**

--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -142,15 +142,17 @@ All dependency updates from Dependabot require human review before merging - the
 
 ## Persistent State Across Rebuilds
 
-`/home/vscode/.claude` is mounted from a Docker named volume `claude-state` so Claude Code's project memory, user-level settings, credentials and session backups survive `Rebuild Container`. Without the volume, that directory sits in the container's writable layer and is wiped on every rebuild.
+`/home/vscode/.claude` is mounted from a Docker named volume `jim-claude-state` so Claude Code's project memory, user-level settings, credentials and session backups survive `Rebuild Container`. Without the volume, that directory sits in the container's writable layer and is wiped on every rebuild.
 
-**Why the generic name (not `jim-claude-state`):** Claude already namespaces per-project memory under `.claude/projects/<workspace-slug>/`, so a single host-wide volume cleanly holds state for multiple devcontainer-based projects without collision. If you work on other projects that also mount `claude-state` at `/home/vscode/.claude`, you share user-level state (auth, settings) once and keep per-project memories isolated by Claude's own path slugs. Each developer's host has its own volume; nothing is synced across machines.
+**Why JIM-scoped (not a generic shared name):** A host-wide volume shared across every devcontainer-based project means signing in to Claude Code in any project authenticates all of them as the same Anthropic account. That's a footgun if you want different accounts per project (e.g. personal vs work). The JIM-scoped name keeps user-level state (auth, global settings) isolated to this project. Per-project memories are already isolated by Claude's path slugs under `.claude/projects/<workspace-slug>/`; the volume scope is purely about user-level state.
 
-**Cross-platform:** Works identically on Docker Desktop (macOS / Windows) and native Linux Docker. Lives inside Docker Desktop's VM or under `/var/lib/docker/volumes/` respectively. Lost only on explicit `docker volume rm claude-state` or a Docker factory reset.
+**Permissions:** Fresh named volumes mount as `root:root` 0755, so the `vscode` user can't write into `/home/vscode/.claude` until ownership is fixed. `postStartCommand` in `devcontainer.json` runs `sudo chown -R vscode:vscode /home/vscode/.claude` on every container start; this is idempotent. Without that chown, Claude Code's OAuth flow completes against the server but the local credential write fails with `EACCES` and the extension stays in "No authentication found".
 
-**Codespaces caveat:** Codespaces honours the named-volume mount, but each Codespace is its own VM and the volume is scoped to that one VM. State survives container rebuilds within the same Codespace (the common case) but does not survive Codespace deletion, and is not shared across Codespaces. Codespaces users therefore get partial benefit: less memory loss day-to-day, but no cross-project sharing.
+**Cross-platform:** Works identically on Docker Desktop (macOS / Windows) and native Linux Docker. Lives inside Docker Desktop's VM or under `/var/lib/docker/volumes/` respectively. Lost only on explicit `docker volume rm jim-claude-state` or a Docker factory reset.
 
-**To start fresh:** `docker volume rm claude-state` (Docker Desktop / Linux Docker) before the next rebuild. Codespaces users delete the Codespace.
+**Codespaces caveat:** Codespaces honours the named-volume mount, but each Codespace is its own VM and the volume is scoped to that one VM. State survives container rebuilds within the same Codespace (the common case) but does not survive Codespace deletion.
+
+**To start fresh:** `docker volume rm jim-claude-state` (Docker Desktop / Linux Docker) before the next rebuild. Codespaces users delete the Codespace. If you have a stale `claude-state` volume from an earlier version of this devcontainer, remove it with `docker volume rm claude-state` to free disk space.
 
 ## Troubleshooting
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,26 @@
 FROM mcr.microsoft.com/devcontainers/dotnet:1-10.0-noble
 
-# Install pinned .NET SDK version to match global.json.
-# The base image can ship with an SDK that predates global.json's pin
-# (e.g. 10.0.100-rc.2 on arm64 at time of writing), which fails
-# rollForward: latestFeature against 10.0.200. Layer the pinned SDK in
-# explicitly so builds are deterministic across architectures and image
-# refresh cycles, regardless of what the base image happens to bundle.
+# Install pinned .NET SDK version to match global.json's rollForward target.
+# Two reasons this is an explicit install rather than relying on the base image:
+#  1. The base image can ship with an SDK that predates global.json's pin
+#     (e.g. 10.0.100-rc.2 on arm64 at time of writing), which fails
+#     rollForward: latestFeature against 10.0.200. Layer the pinned SDK in
+#     explicitly so builds are deterministic across architectures and image
+#     refresh cycles, regardless of what the base image happens to bundle.
+#  2. The C# Dev Kit's Roslyn LSP hardcodes a runtime version lookup
+#     (currently 10.0.5). If /usr/share/dotnet doesn't satisfy that lookup,
+#     ms-dotnettools.vscode-dotnet-runtime falls back to acquiring its own
+#     sandbox runtime in globalStorage, which has produced MEF composition
+#     crashes (FileNotFoundException for System.Numerics.Vectors 10.0.0.0).
+#     SDK 10.0.203 ships .NET runtime + ASP.NET Core runtime 10.0.7, which
+#     covers the Dev Kit's 10.0.5 lookup with margin. Pair this with the
+#     dotnetAcquisitionExtension.existingDotnetPath setting in
+#     devcontainer.json so both ms-dotnettools.csharp and .csdevkit use
+#     this install instead of acquiring their own. Bump in lockstep when
+#     the Dev Kit's required runtime version moves past what 10.0.203 ships.
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && chmod +x /tmp/dotnet-install.sh \
-    && /tmp/dotnet-install.sh --version 10.0.200 --install-dir /usr/share/dotnet --no-path \
+    && /tmp/dotnet-install.sh --version 10.0.203 --install-dir /usr/share/dotnet --no-path \
     && rm /tmp/dotnet-install.sh
 
 # Remove stale Yarn apt repo that breaks feature installs (expired GPG key)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,6 +65,26 @@
         "omnisharp.enableEditorConfigSupport": true,
         "omnisharp.enableImportCompletion": true,
         "omnisharp.organizeImportsOnFormat": true,
+        // Force the C# extension and C# Dev Kit to use the .NET runtime that
+        // ships in the container image (pinned via the Dockerfile base image
+        // digest) instead of letting ms-dotnettools.vscode-dotnet-runtime
+        // download a separate runtime into its own sandbox. The sandboxed
+        // runtime has produced MEF composition crashes in the Roslyn LSP
+        // (FileNotFoundException for System.Numerics.Vectors 10.0.0.0 -
+        // a TypeLoadException masquerading as a missing-file error) when
+        // the LSP's expected runtime version doesn't match what gets
+        // acquired. Using the system install keeps everyone on the same
+        // pinned version and bypasses the failing acquisition path.
+        "dotnetAcquisitionExtension.existingDotnetPath": [
+          {
+            "extensionId": "ms-dotnettools.csharp",
+            "path": "/usr/share/dotnet/dotnet"
+          },
+          {
+            "extensionId": "ms-dotnettools.csdevkit",
+            "path": "/usr/share/dotnet/dotnet"
+          }
+        ],
         // C# settings
         "csharp.semanticHighlighting.enabled": true,
         "csharp.suppressDotnetInstallWarning": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -166,7 +166,14 @@
   // dash in front of sudo makes this a no-op on native Linux Docker
   // (no host-services socket) and in Codespaces, where the path
   // either doesn't exist or isn't a real socket.
-  "postStartCommand": "sudo chown vscode:vscode /ssh-agent 2>/dev/null || true",
+  // The /ssh-agent chown is for git commit signing (see mounts comment).
+  // The chown of /home/vscode/.claude is required because Docker initialises
+  // a fresh named-volume mountpoint as root:root, so the vscode user can't
+  // write credentials, sessions, backups, or .last-cleanup into it; the
+  // Claude Code OAuth flow then completes against the server but the local
+  // token write fails with EACCES and the agent stays unauthenticated. The
+  // chown is idempotent and safe to re-run on every container start.
+  "postStartCommand": "sudo chown vscode:vscode /ssh-agent 2>/dev/null || true; sudo chown -R vscode:vscode /home/vscode/.claude || true",
   // Mounts:
   //  - Docker socket for Docker-in-Docker.
   //  - SSH agent socket from Docker Desktop's host-services bridge, used for
@@ -181,20 +188,25 @@
   //    bind-mounts it, so the container still starts but SSH forwarding
   //    silently no-ops. Codespaces uses a separate signing path (gh-gpgsign)
   //    and does not depend on this mount.
-  //  - Named volume "claude-state" mounted at /home/vscode/.claude so
+  //  - Named volume "jim-claude-state" mounted at /home/vscode/.claude so
   //    Claude Code's project memory, user-level settings, credentials and
   //    session backups survive devcontainer rebuilds. Without this they
   //    sit in the container's writable layer and get wiped on every
-  //    rebuild. The volume name is generic (not JIM-specific) so the
-  //    same volume can be mounted by any devcontainer-based project on
-  //    the same host; Claude's per-project path slugs under
-  //    .claude/projects/ keep memories isolated by workspace. See
+  //    rebuild. The volume name is JIM-scoped (not shared with other
+  //    devcontainer projects) so auth state and user-level settings
+  //    don't bleed across projects on the same host; e.g. a personal
+  //    Anthropic account used in one project does not end up authenticated
+  //    in an unrelated work project. Per-project memories are already
+  //    isolated by Claude's path slugs under .claude/projects/<slug>/;
+  //    the volume scope is purely about user-level state. See
   //    .devcontainer/CLAUDE.md "Persistent State Across Rebuilds" for
-  //    the Codespaces caveat and cross-platform notes.
+  //    the Codespaces caveat and cross-platform notes. Note: fresh
+  //    named volumes mount as root:root; postStartCommand chowns the
+  //    mountpoint to vscode so Claude Code can write into it.
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind",
     "source=/run/host-services/ssh-auth.sock,target=/ssh-agent,type=bind",
-    "source=claude-state,target=/home/vscode/.claude,type=volume"
+    "source=jim-claude-state,target=/home/vscode/.claude,type=volume"
   ],
   // Container environment variables
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -181,9 +181,20 @@
   //    bind-mounts it, so the container still starts but SSH forwarding
   //    silently no-ops. Codespaces uses a separate signing path (gh-gpgsign)
   //    and does not depend on this mount.
+  //  - Named volume "claude-state" mounted at /home/vscode/.claude so
+  //    Claude Code's project memory, user-level settings, credentials and
+  //    session backups survive devcontainer rebuilds. Without this they
+  //    sit in the container's writable layer and get wiped on every
+  //    rebuild. The volume name is generic (not JIM-specific) so the
+  //    same volume can be mounted by any devcontainer-based project on
+  //    the same host; Claude's per-project path slugs under
+  //    .claude/projects/ keep memories isolated by workspace. See
+  //    .devcontainer/CLAUDE.md "Persistent State Across Rebuilds" for
+  //    the Codespaces caveat and cross-platform notes.
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind",
-    "source=/run/host-services/ssh-auth.sock,target=/ssh-agent,type=bind"
+    "source=/run/host-services/ssh-auth.sock,target=/ssh-agent,type=bind",
+    "source=claude-state,target=/home/vscode/.claude,type=volume"
   ],
   // Container environment variables
   "containerEnv": {


### PR DESCRIPTION
## Summary

This branch ships two correlated devcontainer improvements that, taken together, give us (a) a stable C# Dev Kit experience and (b) Claude Code state that survives `Rebuild Container`. The first-pass commits for each landed but were incomplete in ways only visible at runtime; the follow-up commits finish them.

- **Claude state persistence.** The `claude-state` named volume from 89969d2 mounted root-owned on first creation, so the `vscode` user couldn't write `.credentials.json`, `sessions/`, `backups/`, or `.last-cleanup`. The OAuth flow completed against the server but every local write into `.claude/` failed with `EACCES`, leaving VS Code's and Zed's Claude extensions stuck in "No authentication found" after every rebuild. Fix: `postStartCommand` now `chown -R vscode:vscode /home/vscode/.claude` (idempotent, no-op once owned). Also renamed the volume `claude-state` → `jim-claude-state` to scope it to this project — the generic name would have shared user-level auth across every devcontainer project on the host, which is a footgun for anyone with personal vs work Anthropic accounts.
- **C# Dev Kit runtime.** The `dotnetAcquisitionExtension.existingDotnetPath` pin from e79ce2a is only honoured if the path actually contains the version the Dev Kit's LSP asks for (currently 10.0.5). SDK 10.0.200 ships runtime 10.0.4, so the pin was silently rejected and `ms-dotnettools.vscode-dotnet-runtime` fell back to acquiring a 10.0.7 sandbox runtime in globalStorage. That mismatched runtime is what then crashed the LSP at MEF composition time with `FileNotFoundException: System.Numerics.Vectors, Version=10.0.0.0`. Bump the Dockerfile's explicit SDK install to 10.0.203, which ships runtime 10.0.7 and covers the 10.0.5 lookup with margin. `global.json` stays at 10.0.200 because `rollForward: latestFeature` picks the highest installed patch in the same feature band.

The previous fix attempts (89969d2, e79ce2a) shipped without end-to-end verification, which is how the gaps reached `main`-bound history; documenting the cause-and-effect chain in commit messages here so future bumps (especially the Dev Kit's runtime version moving past 10.0.7) are not mysterious.

## Test plan

Build/test gate waived per `CLAUDE.md` exception list (only `Dockerfile`, `devcontainer.json`, and `.devcontainer/CLAUDE.md` touched — no .NET code). Verified manually inside a fresh Zed-built devcontainer on this branch:

- [x] **Auth (Fix A):** Zed's Claude Agent panel completed sign-in and state persisted; previously the auth flow looked successful but the extension stayed in "No authentication found". Verified the new container's `/home/vscode/.claude` is backed by `jim-claude-state`, owned `vscode:vscode 755`, and populated by Claude (`.credentials.json`, `projects/-workspaces-JIM/`, `sessions/`, `backups/`, `cache/`, `ide/`, `settings.json`, `.last-cleanup`).
- [x] **LSP (Fix B):** C# extension log shows the Roslyn LSP loading against `/usr/share/dotnet/sdk/10.0.203/MSBuild.dll`; no `FileNotFoundException` for `System.Numerics.Vectors`, no fallback acquisition into `~/.vscode-server/.../ms-dotnettools.vscode-dotnet-runtime/.dotnet/`. IntelliSense, hover, and go-to-definition all responsive on `.cs` files.
- [x] **Volume independence:** Confirmed `jim-claude-state` is a host-scoped Docker named volume independent of container lifecycle (mounted contents visible from a throwaway alpine container with the same volume attached). Survives container delete + rebuild by definition of named volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)