### PR TITLE
chore: pin devcontainer Features and track via Dependabot

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.16.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
+      "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/devcontainers/features/powershell:1": {
+      "version": "1.5.1",
+      "resolved": "ghcr.io/devcontainers/features/powershell@sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18",
+      "integrity": "sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,24 +11,40 @@
   // /workspaces/JIM path disagrees with what VS Code has opened.
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/JIM,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/JIM",
-  // Features - pre-built development tools
+  // Features - pre-built development tools.
+  //
+  // Each Feature is a third-party script that runs as root during image
+  // build, so the supply-chain risk is equivalent to apt-installing a
+  // package. Versions are pinned (not "latest") for reproducibility and
+  // so Dependabot tracks them via the devcontainers ecosystem; see
+  // .github/dependabot.yml. The devcontainer CLI writes resolved digests
+  // to .devcontainer/devcontainer-lock.json, which is committed.
+  // Bump these in lockstep with a Dependabot PR review.
+  // Note on the two "version" concepts:
+  //  - The colon-tag on the Feature ID (e.g. :2.16.1) pins which version of
+  //    the Feature *script itself* to download. This is what Dependabot
+  //    tracks and is the supply-chain pin.
+  //  - The "version" key inside the Feature options is the Feature script's
+  //    own runtime parameter (e.g. for docker-in-docker, which Docker CE
+  //    version to install). "latest" here means "let the Feature pick" and
+  //    is independent of the script pin above; do not conflate the two.
   "features": {
     // Docker-in-Docker for running docker-compose
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
       "version": "latest",
       "moby": true,
       "dockerDashComposeVersion": "v2"
     },
     // Node.js - required by Claude Code extension
-    "ghcr.io/devcontainers/features/node:1": {
+    "ghcr.io/devcontainers/features/node:1.7.1": {
       "version": "20"
     },
     // GitHub CLI
-    "ghcr.io/devcontainers/features/github-cli:1": {
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "latest"
     },
     // PowerShell - standard scripting platform
-    "ghcr.io/devcontainers/features/powershell:1": {
+    "ghcr.io/devcontainers/features/powershell:1.5.1": {
       "version": "latest"
     }
   },

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -186,6 +186,31 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # Devcontainer Features (.devcontainer/devcontainer.json).
+  #
+  # Each Feature is a third-party script that runs as root during devcontainer
+  # image build, so it sits in the same supply-chain risk class as base images
+  # and NuGet packages. Pinned by colon-tag in devcontainer.json with resolved
+  # digests captured in devcontainer-lock.json; Dependabot proposes weekly PRs
+  # when upstream Features publish new versions. Polled weekly (not daily) like
+  # NuGet and Actions since Features change infrequently and each bump needs a
+  # full devcontainer rebuild to validate.
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    reviewers:
+      - "TetronIO/jim-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Closes the supply-chain loop on devcontainer Features. They were the last floating third-party code in the repo (`"version": "latest"` for docker-in-docker, node, github-cli, powershell) while NuGet packages, base image digests, GitHub Actions, and compose files are all pinned and Dependabot-tracked. Devcontainer Features are shell scripts that run as root during image build, so the supply-chain risk class is identical to those others; floating them was an unprincipled exception.

- **Pin the Feature script versions** in `.devcontainer/devcontainer.json` via exact-version colon-tags (e.g. `docker-in-docker:2` → `docker-in-docker:2.16.1`). Versions taken from the devcontainer CLI's last resolution. The Feature *runtime options* `"version": "latest"` stay as-is — those are the Feature script's own parameters (e.g. which Docker CE version docker-in-docker installs), distinct from the script-version pin and out of Dependabot's scope. Inline comments call out the two concepts to prevent future confusion.
- **Commit `devcontainer-lock.json`.** Auto-generated by the devcontainer CLI on resolve; records SHA256 digests for each Feature on top of the version pin. Previously sat untracked across multiple sessions — the worst of both worlds (not pinned, also a perpetual `git status` nag). Now it's the second line of defence (digest pin) under the version pin.
- **Add `package-ecosystem: "devcontainers"` to `.github/dependabot.yml`** so Dependabot proposes bumps when upstream Features publish new versions. Weekly cadence matching NuGet and Actions (Features change infrequently and each bump needs a full devcontainer rebuild to validate). Major-version bumps ignored per project-wide policy. Reviewers, commit prefix, and labels match the other entries.

## Test plan

Build/test gate waived per `CLAUDE.md` exception list (only `devcontainer.json`, `dependabot.yml`, and the lockfile JSON touched — no .NET code).

- [x] `devcontainer.json` JSON is valid (parsed by editor; comments stripped automatically by devcontainer CLI on resolve)
- [x] `dependabot.yml` YAML is valid; new block follows existing conventions (reviewers, commit-message prefix, ignore policy, schedule shape)
- [x] Feature script tag versions in `devcontainer.json` match the resolved versions in `devcontainer-lock.json` (2.16.1, 1.7.1, 1.1.0, 1.5.1)
- [ ] **Post-merge:** next devcontainer rebuild on a developer machine should produce no diff to `devcontainer-lock.json` (digests already correct). Any new Feature bumps will arrive via Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)