### PR TITLE
fix(deps): patch basic-ftp/ip-address vulns and track npm via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -186,6 +186,33 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # npm packages used by diagram tooling (engineering/diagrams/structurizr/).
+  #
+  # Currently the only npm manifest in the repo; puppeteer is the sole direct
+  # dependency, but its proxy-agent stack pulls in transitive packages
+  # (basic-ftp, ip-address) that periodically need security patches. This
+  # manifest has needed manual override edits five times to date because no
+  # automated update loop existed; adding the ecosystem here so Dependabot
+  # proposes PRs for both version updates and security advisories going
+  # forward, on the same review-required cadence as every other ecosystem.
+  # Weekly schedule matching NuGet and Actions. Major-version bumps ignored
+  # per the project-wide policy.
+  - package-ecosystem: "npm"
+    directory: "/engineering/diagrams/structurizr"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/London"
+    reviewers:
+      - "TetronIO/jim-maintainers"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   # Devcontainer Features (.devcontainer/devcontainer.json).
   #
   # Each Feature is a third-party script that runs as root during devcontainer

--- a/engineering/diagrams/structurizr/package-lock.json
+++ b/engineering/diagrams/structurizr/package-lock.json
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-6.0.1.tgz",
+      "integrity": "sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/engineering/diagrams/structurizr/package.json
+++ b/engineering/diagrams/structurizr/package.json
@@ -10,6 +10,7 @@
     "puppeteer": "^24.0.0"
   },
   "overrides": {
-    "basic-ftp": ">=5.3.0"
+    "basic-ftp": ">=5.3.1",
+    "ip-address": ">=10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Closes two open Dependabot security alerts on `main` and adds the npm ecosystem to `dependabot.yml` so future advisories arrive as auto-PRs instead of needing manual override edits.

**Vulnerabilities patched (both in `engineering/diagrams/structurizr/package-lock.json`):**

| Alert | Package | Was | Now | Severity | Reachability |
|---|---|---|---|---|---|
| GHSA-rpmf-866q-6p89 / CVE-2026-44240 | `basic-ftp` | 5.3.0 | 6.0.1 | High | Transitive via `puppeteer` → `pac-proxy-agent`. DoS only triggered on outbound FTP; diagram export never makes FTP calls. |
| GHSA-v2v4-37r5-5v8g / CVE-2026-42338 | `ip-address` | 10.1.0 | 10.2.0 | Medium | Transitive via `puppeteer` → `socks`. XSS only on `Address6` HTML-emitting methods with attacker input; diagram export passes no user input. |

Practical exploitability in JIM's diagram-export workflow is effectively zero for both, but project posture is "patch advertised vulns" so we close them.

**Why the recurring fix:**

This manifest has needed a manual security override **five times** for basic-ftp alone (#491, #546, #587, plus earlier). Each one a manual edit because there was no Dependabot npm coverage to auto-propose fixes. Adding the npm ecosystem closes that loop on the same review-required cadence used for NuGet, Actions, devcontainers, etc.

**Changes:**

- `engineering/diagrams/structurizr/package.json`: tightened existing `basic-ftp` override `>=5.3.0` → `>=5.3.1` (the old constraint still allowed the now-vulnerable 5.3.0). Added `ip-address` override `>=10.1.1`.
- `engineering/diagrams/structurizr/package-lock.json`: regenerated via `npm install --package-lock-only` inside the devcontainer (node 20). Only the two intended packages changed; no transitive drift.
- `.github/dependabot.yml`: new `package-ecosystem: "npm"` block scoped to `/engineering/diagrams/structurizr`, weekly schedule matching NuGet and Actions, major-version ignore policy, same reviewers/labels/commit prefix as existing entries.

## Test plan

Build/test gate waived per `CLAUDE.md` exception list (no .NET code; only npm lockfile / package.json and dependabot config).

- [x] Lockfile diff confirms both target packages bumped past their patched thresholds (`basic-ftp` 6.0.1 ≥ 5.3.1, `ip-address` 10.2.0 ≥ 10.1.1).
- [x] No unrelated transitive package versions changed (12-line diff, entirely on the two targets).
- [x] `dependabot.yml` YAML valid; new block follows existing conventions (reviewers, prefix, ignore policy, schedule shape).
- [ ] **Post-merge:** Dependabot alerts #15 and #16 should auto-close once GitHub re-scans `main`.

No changelog entry per `engineering/CLAUDE.md` (dev tooling / no user-facing impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)