### PR TITLE
fix(devcontainer): hold moby-containerd at 2.2.x to avoid broken 2.3.0 packaging

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,6 +28,21 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null; \
     rm -f /etc/apt/keyrings/yarn.gpg 2>/dev/null; \
     apt-get update || true
 
+# Hold moby-containerd on the 2.2.x line so the docker-in-docker Feature picks
+# a working version when it runs (Features execute after the Dockerfile, so
+# this pin is in place before apt sees the Feature's install request).
+# moby-containerd 2.3.0 on packages.microsoft.com/microsoft-ubuntu-noble-prod
+# ships without the io.containerd.transfer.v1 plugin that dockerd's libcontainerd
+# client requires; dockerd fails to start with "failed to start containerd:
+# timeout waiting for containerd to start" and Unimplemented errors for the
+# events.v1.Events, introspection.v1.Introspection, and grpc.health.v1.Health
+# gRPC services. The DinD Feature's "version" option only governs moby-engine,
+# not moby-containerd, so the pin has to live here. Priority 1001 forces the
+# downgrade even if 2.3.x somehow lands first during the Feature's apt run.
+# Re-evaluate when moby-containerd 2.3.x exposes transfer.v1 again upstream.
+RUN printf 'Package: moby-containerd\nPin: version 2.2.*\nPin-Priority: 1001\n' \
+    > /etc/apt/preferences.d/moby-containerd-pin
+
 # Install socat for Keycloak port-forwarding bridge.
 # Docker-in-Docker proxy ports aren't auto-forwarded by VS Code Dev Containers;
 # socat provides a userspace bridge that VS Code detects and forwards to the host.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,21 +1,21 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
       "version": "2.16.1",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
       "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/devcontainers/features/node:1": {
+    "ghcr.io/devcontainers/features/node:1.7.1": {
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
       "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
-    "ghcr.io/devcontainers/features/powershell:1": {
+    "ghcr.io/devcontainers/features/powershell:1.5.1": {
       "version": "1.5.1",
       "resolved": "ghcr.io/devcontainers/features/powershell@sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18",
       "integrity": "sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,9 +29,17 @@
   //    version to install). "latest" here means "let the Feature pick" and
   //    is independent of the script pin above; do not conflate the two.
   "features": {
-    // Docker-in-Docker for running docker-compose
+    // Docker-in-Docker for running docker-compose.
+    // The Docker CE "version" is held to the 28.x major track as a precaution
+    // while the upstream moby packaging on packages.microsoft.com is settling.
+    // The acute breakage that prompted this pin was actually in moby-containerd
+    // 2.3.0 (missing the io.containerd.transfer.v1 plugin), not moby-engine -
+    // see the moby-containerd Pin in .devcontainer/Dockerfile for the real fix.
+    // Docker 28 has been validated against the pinned containerd 2.2.x; whether
+    // Docker 29.x also works once containerd is fixed has not been tested.
+    // Revisit both pins together when moby-containerd 2.3.x is repaired.
     "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
-      "version": "latest",
+      "version": "28",
       "moby": true,
       "dockerDashComposeVersion": "v2"
     },


### PR DESCRIPTION
## Summary

- `moby-containerd 2.3.0` from `packages.microsoft.com/microsoft-ubuntu-noble-prod` ships without the `io.containerd.transfer.v1` plugin that dockerd's libcontainerd client requires. A clean devcontainer rebuild leaves dockerd unable to start: it logs `failed to start containerd: timeout waiting for containerd to start` and `Unimplemented` errors for the `events.v1.Events`, `introspection.v1.Introspection`, and `grpc.health.v1.Health` gRPC services, then exits. `jim-build`, `jim-stack`, `jim-reset` all fail with "Cannot connect to the Docker daemon".
- Add an apt-preference file in the Dockerfile pinning `moby-containerd` to `2.2.*` with priority 1001, so the docker-in-docker Feature's apt install (which runs after the Dockerfile) picks 2.2.3 instead of 2.3.0. Validated locally: containerd 2.2.3 + Docker CE 28.5.2 brings dockerd up cleanly.
- Also pin the docker-in-docker Feature's Docker CE `version` to the 28.x major track as a precaution while the 29.x line in the same repo stabilises; 29.x was not retested once containerd was downgraded, so the pin avoids the unknown.
- Resync `.devcontainer/devcontainer-lock.json` to the colon-tag form introduced by #719's pin commit (same digests, just the key form updated to match `:2.16.1` instead of `:2`).

## Why this is the durable fix

The DinD Feature's `version` option only governs `moby-engine`, not `moby-containerd`, which the Feature pulls separately via apt. So a `devcontainer.json`-only pin cannot hold containerd at a working version. The apt preference in `.devcontainer/Dockerfile` is the right scope — it is in place before the Feature's apt run and survives rebuilds.

Re-evaluate the pin when `moby-containerd 2.3.x` upstream restores the `transfer.v1` plugin; both this and the Docker CE 28 pin can come off together.

## Test plan

- [ ] Rebuild devcontainer (Dev Containers: Rebuild Container) on a clean checkout of this branch
- [ ] After rebuild, `docker info` reports Server Version 28.5.2 (or latest 28.x) and the daemon is responsive
- [ ] `docker version` shows containerd 2.2.x
- [ ] `jim-build` succeeds (or `jim-stack` brings the stack up)
- [ ] Existing devcontainer Features (node, github-cli, powershell) still come up normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)