### PR TITLE
fix(devcontainer): re-run signing setup in postAttachCommand to survive VS Code gitconfig sync

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -190,6 +190,23 @@
   // token write fails with EACCES and the agent stays unauthenticated. The
   // chown is idempotent and safe to re-run on every container start.
   "postStartCommand": "sudo chown vscode:vscode /ssh-agent 2>/dev/null || true; sudo chown -R vscode:vscode /home/vscode/.claude || true",
+  // Re-run configure-signing.sh on every attach. This compensates for VS
+  // Code's Dev Containers extension syncing the host ~/.gitconfig into the
+  // container during the attach phase, *after* setup.sh's initial call from
+  // postCreateCommand has already configured signing. The host's
+  // user.signingkey on most developers' machines is a literal file path
+  // (e.g. ~/.ssh/id_ed25519) that doesn't resolve inside the container,
+  // so once VS Code's sync overwrites configure-signing.sh's in-container
+  // form (key::ssh-ed25519 AAAA...), git can't load the public key and the
+  // pre-commit signing hook rejects every commit. postAttachCommand runs
+  // AFTER the attach (and therefore after the gitconfig sync), so its
+  // re-run is the last word and the in-container form survives.
+  // The script is idempotent and exits with a clear banner if the SSH
+  // agent isn't forwarded; the `|| true` keeps a missing-agent state from
+  // failing the whole lifecycle. On non-VS Code launchers (Zed,
+  // devcontainer CLI) the host gitconfig sync doesn't happen, but
+  // re-running here is still a harmless idempotent no-op.
+  "postAttachCommand": "bash .devcontainer/configure-signing.sh || true",
   // Mounts:
   //  - Docker socket for Docker-in-Docker.
   //  - SSH agent socket from Docker Desktop's host-services bridge, used for


### PR DESCRIPTION
## Summary

- After a clean devcontainer rebuild on VS Code, every commit gets rejected by the pre-commit signing hook (introduced in #522) with `Couldn't load public key /home/vscode/.ssh/id_ed25519: No such file or directory`, even though the SSH agent is forwarded correctly and the key is loaded.
- Root cause: VS Code's Dev Containers extension syncs the host `~/.gitconfig` into the container during the attach phase, **after** `postCreateCommand` runs `setup.sh` and its embedded `configure-signing.sh` call. On most developers' machines the host's `user.signingkey` is a literal file path (e.g. `~/.ssh/id_ed25519`) that resolves on the host but not in the container, so VS Code's sync clobbers `configure-signing.sh`'s correct `key::ssh-ed25519 AAAA...` inline form with the broken-in-container path. Signing then fails until the developer manually re-runs `.devcontainer/configure-signing.sh`.
- Regression introduced when the SSH-signing-via-script system landed in #515 / #522 to support non-VS Code launchers (Zed, devcontainer CLI). On those launchers no host gitconfig sync happens; `setup.sh`'s call is sufficient. On VS Code it isn't.
- Fix: add a `postAttachCommand` that re-runs `configure-signing.sh`. `postAttach` runs after the client attaches (and therefore after any gitconfig sync that attach triggers), so its writes are the last word. The script is explicitly designed to be idempotent and re-invocable (see [configure-signing.sh:24-26](.devcontainer/configure-signing.sh#L24-L26)), so the duplication with `setup.sh`'s call is harmless. `|| true` tolerates a missing SSH agent without failing the lifecycle; the script prints its own diagnostic banner in that case.

## Why postAttachCommand rather than postStartCommand

- `postStartCommand` runs when the container starts, which can be before VS Code's attach phase completes (and therefore before the gitconfig sync). `postAttachCommand` runs strictly after attach, so it's the only hook guaranteed to win against VS Code's sync.
- Cost: one ~1s script execution per VS Code attach. The script is fast and only touches user-scope git config; no system state.

## Why not just remove `setup.sh`'s call

- `setup.sh`'s call surfaces failures (missing SSH agent, missing `user.name`/`user.email`) into the visible setup summary via `PENDING_ACTIONS`. `postAttachCommand` failures are silent (VS Code logs only). Keeping both preserves the diagnostic UX for first-time setup while closing the regression window for steady-state use.

## Test plan

- [ ] Rebuild devcontainer (Dev Containers: Rebuild Container) on a clean checkout of this branch
- [ ] After rebuild + attach, `git config --get user.signingkey` returns `key::ssh-ed25519 AAAA...` (the inline form), NOT the host file-path form
- [ ] `git commit --allow-empty -m "test"` succeeds and produces a signed commit (`git log --show-signature -1`)
- [ ] Re-attach to the same container (close + reopen VS Code) and re-check `user.signingkey` — should still be the `key::` form
- [ ] On a Zed or devcontainer CLI launcher, the same rebuild + commit cycle still works (`setup.sh`'s call covers it; `postAttach` is a no-op duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)