### PR TITLE
docs: shrink README logo to 400px

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Junctional Identity Manager (JIM)
 
 <p align="center">
-  <img src="https://junctional.io/assets/jim-logo.png" alt="JIM"/>
+  <img src="https://junctional.io/assets/jim-logo.png" alt="JIM" width="400"/>
 </p>
 
 [![CI](https://github.com/TetronIO/JIM/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/TetronIO/JIM/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- Logo image was rendering at its natural ~3158px width — too large on the README, and well below retina density at that scale.
- Constrained the `<img>` to `width="400"`, giving roughly 8x source-to-displayed pixel density.

## Test plan
- [x] N/A: docs-only change (README), no build/test required per CLAUDE.md exception list
- [x] Visual check: GitHub will re-render the README with the new width once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)