### PR TITLE
chore: ignore C# Dev Kit language service cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ bld/
 !.vscode/tasks.json
 !.vscode/settings.json
 
+# C# Dev Kit language service cache (regenerated automatically)
+*.lscache
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
## Summary
- The C# Dev Kit VS Code extension writes `*.csproj.lscache` files next to each project for language service performance.
- These files are regenerated automatically and not intended to be tracked (they say so themselves).
- Added `*.lscache` to `.gitignore` under the VS Code section.

## Test plan
- [x] N/A: config-only change (gitignore), no build/test required per CLAUDE.md exception list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)