### PR TITLE
fix(devcontainer): pre-create SSH socket source so rebuild works on W…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -179,6 +179,40 @@
   },
   // Container user
   "remoteUser": "vscode",
+  // Pre-create the host-services SSH socket source path inside the Docker
+  // daemon's filesystem before the devcontainer is built. The SSH bind mount
+  // in the "mounts" array below uses type=bind, which is strict: if the
+  // source path does not exist on the daemon side, the container fails to
+  // start with "A mount config is invalid. Make sure it has the right format
+  // and a source folder that exists on the machine where the Docker daemon
+  // is running."
+  //
+  // Docker Desktop on macOS creates /run/host-services/ssh-auth.sock itself
+  // as part of its SSH agent forwarding feature, but Docker Desktop on
+  // Windows and native Linux Docker do not - so the rebuild breaks for
+  // those developers with no obvious link to the SSH-forwarding change.
+  //
+  // This one-shot busybox container bind-mounts the daemon's /run into
+  // itself and idempotently touches an empty placeholder at the expected
+  // path if nothing already lives there. The "[ -e ]" guard preserves the
+  // real socket on macOS (sockets satisfy -e). On Windows / Linux it leaves
+  // an empty file, so the subsequent bind mount succeeds and SSH forwarding
+  // silently no-ops, which is what the inline mounts comment has always
+  // promised. Argv (array) form is used so PowerShell on Windows and bash
+  // on macOS/Linux invoke docker identically; shell logic stays inside the
+  // busybox container, not the host shell. See
+  // engineering/notes/DEVCONTAINER_SSH_FORWARDING_LINUX_RISK.md for history.
+  "initializeCommand": [
+    "docker",
+    "run",
+    "--rm",
+    "-v",
+    "/run:/run",
+    "busybox",
+    "sh",
+    "-c",
+    "mkdir -p /run/host-services && [ -e /run/host-services/ssh-auth.sock ] || touch /run/host-services/ssh-auth.sock"
+  ],
   // Lifecycle scripts
   "postCreateCommand": "bash .devcontainer/setup.sh",
   // Make the bind-mounted SSH agent socket accessible to the non-root
@@ -219,16 +253,24 @@
   //  - Docker socket for Docker-in-Docker.
   //  - SSH agent socket from Docker Desktop's host-services bridge, used for
   //    git commit signing inside the container. The path
-  //    /run/host-services/ssh-auth.sock is provided by Docker Desktop on
-  //    macOS and Windows; it proxies the host's ssh-agent into containers.
-  //    VS Code's Dev Containers extension forwards SSH_AUTH_SOCK automatically
-  //    as a non-spec feature, but Zed and the official devcontainer CLI do
-  //    not - hence the explicit mount here so signing works regardless of
-  //    launcher. On native Linux Docker (no Docker Desktop) the source path
-  //    does not exist; Docker creates an empty directory at that path and
-  //    bind-mounts it, so the container still starts but SSH forwarding
-  //    silently no-ops. Codespaces uses a separate signing path (gh-gpgsign)
-  //    and does not depend on this mount.
+  //    /run/host-services/ssh-auth.sock is created by Docker Desktop on macOS
+  //    as part of its SSH agent forwarding feature; it proxies the host's
+  //    ssh-agent into containers. VS Code's Dev Containers extension forwards
+  //    SSH_AUTH_SOCK automatically as a non-spec feature, but Zed and the
+  //    official devcontainer CLI do not - hence the explicit mount here so
+  //    signing works regardless of launcher.
+  //
+  //    On Docker Desktop for Windows and native Linux Docker, the source path
+  //    is NOT auto-created. type=bind is strict, so without intervention the
+  //    devcontainer would fail to start with "A mount config is invalid" on
+  //    those hosts. The "initializeCommand" higher up in this file runs a
+  //    one-shot container that touches an empty placeholder at the expected
+  //    path if nothing is already there, leaving real sockets alone. The
+  //    bind then succeeds everywhere; SSH forwarding only actually works
+  //    where Docker Desktop populates the socket for real (macOS).
+  //
+  //    Codespaces uses a separate signing path (gh-gpgsign) and does not
+  //    depend on this mount.
   //  - Named volume "jim-claude-state" mounted at /home/vscode/.claude so
   //    Claude Code's project memory, user-level settings, credentials and
   //    session backups survive devcontainer rebuilds. Without this they

--- a/engineering/notes/DEVCONTAINER_SSH_FORWARDING_LINUX_RISK.md
+++ b/engineering/notes/DEVCONTAINER_SSH_FORWARDING_LINUX_RISK.md
@@ -1,8 +1,14 @@
-# Devcontainer SSH agent forwarding: risk on native Linux Docker hosts
+# Devcontainer SSH agent forwarding: bind mount on hosts without `/run/host-services/ssh-auth.sock`
 
-## Status: Known risk, not remediated (2026-05-12). Recorded so we do not lose context.
+## Status: Remediated 2026-05-15.
 
-The SSH agent forwarding added to `.devcontainer/devcontainer.json` (commit `27285950`, branch `feature/devcontainer-ssh-forwarding`) was introduced to make git commit signing work for developers using Zed and the official devcontainer CLI, which (unlike VS Code's Dev Containers extension) do not implicitly forward `SSH_AUTH_SOCK`. The fix bind-mounts Docker Desktop's host-services socket into the container:
+Originally recorded 2026-05-12 as a known risk for native Linux Docker hosts. The risk materialised earlier than expected: a developer rebuilding the devcontainer on Docker Desktop for Windows hit the predicted failure mode (`A mount config is invalid. Make sure it has the right format and a source folder that exists on the machine where the Docker daemon is running.`), which contradicted the assumption baked into PR [#716](https://github.com/TetronIO/JIM/pull/716) that the bind mount worked on Docker Desktop on macOS *and* Windows. In practice only the macOS Docker Desktop case populates `/run/host-services/ssh-auth.sock`; on Windows and on native Linux Docker the path is absent and the strict `type=bind` mount aborts container startup.
+
+This note is preserved as a postmortem so the next time a launcher-specific assumption sneaks into a mount config we can recognise the pattern.
+
+## Background
+
+The SSH agent forwarding added to `.devcontainer/devcontainer.json` in commit `27285950` (PR [#716](https://github.com/TetronIO/JIM/pull/716), branch `feature/devcontainer-ssh-forwarding`) was introduced to make git commit signing work for developers using Zed and the official devcontainer CLI, which (unlike VS Code's Dev Containers extension) do not implicitly forward `SSH_AUTH_SOCK`. The fix bind-mounted Docker Desktop's host-services socket into the container:
 
 ```jsonc
 "mounts": [
@@ -10,53 +16,53 @@ The SSH agent forwarding added to `.devcontainer/devcontainer.json` (commit `272
 ]
 ```
 
-This was verified end-to-end on Docker Desktop (macOS host, Zed launcher). It was **not** verified on native Linux Docker.
+This was verified end-to-end on Docker Desktop for macOS only. The original PR description and the inline comment in `devcontainer.json` asserted that it also worked on Docker Desktop for Windows, on the (untested) assumption that Docker Desktop populated the same host-services socket path on both operating systems. It does not.
 
-## The risk
+## The failure mode
 
-On a host running native Linux Docker (no Docker Desktop), `/run/host-services/ssh-auth.sock` does not exist. The bind mount in devcontainer.json is `type=bind`, which corresponds to `docker run --mount type=bind,...`. Modern `--mount type=bind` is strict: if the source path does not exist on the host, the command fails with `bind source path does not exist: /run/host-services/ssh-auth.sock` and the container never starts.
+On any Docker daemon where `/run/host-services/ssh-auth.sock` does not exist (Docker Desktop for Windows; native Linux Docker), `--mount type=bind,source=/run/host-services/ssh-auth.sock,...` fails strictly. Modern `--mount type=bind` does not auto-create missing sources; it errors with `bind source path does not exist: /run/host-services/ssh-auth.sock` and the container never starts. This differs from the older `-v` / `--volume` syntax, which silently created an empty directory at the source.
 
-This differs from the older `-v` / `--volume` syntax, which silently created an empty directory at the source path. The current `devcontainer.json` comment claims the latter behaviour applies here:
+The previous inline comment in `devcontainer.json` claimed Docker silently created an empty directory at the path on hosts without the socket. That was wishful thinking; the strict `--mount` form does not do this.
 
-> On native Linux Docker (no Docker Desktop) the source path does not exist; Docker creates an empty directory at that path and bind-mounts it, so the container still starts but SSH forwarding silently no-ops.
+## Affected hosts
 
-The Dev Containers extension *may* be pre-creating the source path on the host before invoking docker (which would make the claim correct), but we have not confirmed that. If it does not, every native-Linux rebuild of this devcontainer will fail at startup with no obvious connection to the SSH-forwarding change.
+- Docker Desktop for Windows (confirmed 2026-05-15).
+- Native Linux Docker (predicted at PR #716 time; remains true).
+- Codespaces (also Linux Docker) has not surfaced the issue, presumably because the Codespaces runtime pre-creates `/run/host-services` or tolerates the missing source. Codespaces signing uses `gh-gpgsign` and does not depend on this mount, so functionality is unaffected even where the mount degrades.
 
-## Who this affects
+## Remediation
 
-- **Local Linux Docker users** (any launcher: VS Code, Zed, devcontainer CLI) rebuilding the devcontainer.
-- Currently a small population. We do not actively develop on Linux Docker hosts day-to-day.
+Implemented option 1 from the original list of remediation options ("Pre-create the source via `initializeCommand`"), adapted to be cross-platform safe. The original note's example was a host-side `sudo touch`, which is bash-specific and assumes the path lives on the host filesystem. On Docker Desktop the `/run/host-services/` path lives inside the daemon's Linux VM, so a Windows PowerShell `touch` against the Windows host filesystem would not help.
 
-Codespaces also runs on a Linux Docker host, but in practice the bind mount has not surfaced an issue there - either the Codespaces runtime creates the path, or it tolerates the missing source. Codespaces signing uses `gh-gpgsign` and does not depend on this socket, so functionality is unaffected even when the mount degrades.
+The fix instead delegates the touch to a one-shot busybox container that bind-mounts the daemon's `/run` into itself, so the same `initializeCommand` works on every host that has Docker available (which is a precondition for using the devcontainer):
 
-## Symptoms if the risk materialises
+```jsonc
+"initializeCommand": [
+  "docker", "run", "--rm",
+  "-v", "/run:/run",
+  "busybox", "sh", "-c",
+  "mkdir -p /run/host-services && [ -e /run/host-services/ssh-auth.sock ] || touch /run/host-services/ssh-auth.sock"
+]
+```
 
-- `Dev Containers: Rebuild Container` (VS Code) or `devcontainer up` (CLI) on a native Linux host fails with an error containing `bind source path does not exist: /run/host-services/ssh-auth.sock`.
-- The container will not enter a running state. Setup never reaches `configure-signing.sh`.
+The `[ -e ]` guard preserves the real socket on macOS Docker Desktop (sockets satisfy the existence test). On Windows / Linux it leaves an empty regular file, which `--mount type=bind` accepts, after which the subsequent `postStartCommand` chown to `vscode` is harmless. SSH forwarding only actually works where Docker Desktop populates the socket for real (macOS); elsewhere the mount is a silent no-op, exactly as the inline comment has always promised but only now reliably delivers.
 
-## Remediation options, in order of preference
+The array (argv) form is used in `initializeCommand` rather than a single string, so PowerShell on Windows and bash on macOS/Linux invoke `docker` identically without per-platform shell escaping pitfalls.
 
-1. **Pre-create the source via `initializeCommand`.** Add an `initializeCommand` to `devcontainer.json` that runs on the host before docker:
+## Why not the alternatives
 
-   ```jsonc
-   "initializeCommand": "test -e /run/host-services/ssh-auth.sock || sudo mkdir -p /run/host-services && sudo touch /run/host-services/ssh-auth.sock"
-   ```
+- **`type=volume` instead of `type=bind`** (option 2 in the original note): always succeeds, but kills the real SSH forwarding on macOS too, defeating the purpose of PR #716.
+- **Per-host conditional mount** (option 3): `devcontainer.json` does not support host-conditional mounts directly. A `docker-compose.local.yml` overlay or a separate `devcontainer.windows.json` would solve it, but each adds machinery that is hard to justify against a one-line `initializeCommand`.
+- **Document and require manual removal** (option 4): cheap but ugly, and the symptom error message is opaque enough that affected developers will lose time before finding the note.
 
-   Caveats: must be cross-platform-safe (Windows PowerShell needs a different command); creates a regular file at the socket path, not a socket, which `--mount type=bind` will still accept and which our `postStartCommand` chown will tolerate. The result on Linux is the same harmless no-op as the comment claims today, but reliably.
+## Lessons for next time
 
-2. **Switch the mount from `type=bind` to `type=volume` with no source.** A named volume always exists. SSH forwarding via the volume would not work, but the container would always start. This is the lowest-risk option for "make the rebuild succeed everywhere" but kills SSH forwarding on Docker Desktop too, which defeats the purpose.
+- Mount source paths that depend on a host-side runtime (Docker Desktop's macOS-only host-services proxy, in this case) must be either pre-created by an `initializeCommand` or made tolerant via volume mounts. Asserting "this also works on Windows" without testing on Windows is the same class of error as asserting "this also works on Linux" without testing on Linux. PR #716 made the latter explicit in this very note while making the former implicit in the PR description.
+- When introducing a launcher-specific or platform-specific workaround into shared configuration, document the verification matrix in the PR description (which OS / which launcher / what was tested), not just the intent.
 
-3. **Make the mount conditional.** `devcontainer.json` does not support per-host conditional mounts directly. Workarounds: use `initializeCommand` to write a `docker-compose.local.yml` overlay (we already use this pattern for postgres tuning), or maintain a separate `devcontainer.linux.json`. Both add machinery that is hard to justify for an edge case.
-
-4. **Document the limitation and require Linux users to remove the mount locally.** Cheapest, ugliest. Worth keeping in mind as a fallback if (1) proves brittle.
-
-The intended path when this becomes worth the work is **option 1**.
-
-## Verification trigger
+## Review trigger
 
 Re-evaluate this note when any of the following happens:
-- A developer reports a rebuild failure with the symptom above.
-- We start actively supporting Linux Docker hosts as a first-class developer environment.
-- We migrate to a different launcher (or VS Code changes its Dev Containers extension behaviour) that no longer pre-creates the mount source.
-
-Review date: 2026-08-12 (~3 months out). If no new evidence by then, refresh or remove.
+- A developer reports a rebuild failure that bypasses the `initializeCommand` (e.g., because their Docker setup blocks the one-shot container).
+- VS Code's Dev Containers extension or Zed changes its SSH forwarding behaviour in a way that makes the host-services mount unnecessary.
+- We move to a docker-compose-based devcontainer where per-host overlays become the natural fit.


### PR DESCRIPTION
…indows / Linux Docker

PR #716 bind-mounted /run/host-services/ssh-auth.sock so commit signing would work from Zed and the devcontainer CLI without depending on VS Code's non-spec SSH_AUTH_SOCK auto-forwarding. The change asserted the mount worked on Docker Desktop for macOS and Windows, but only the macOS side was actually verified. Docker Desktop for Windows does not populate that host-services path, so the strict type=bind mount aborted container startup with "A mount config is invalid. Make sure it has the right format and a source folder that exists on the machine where the Docker daemon is running." The same failure mode applies to native Linux Docker and was flagged at PR #716 time as an unremediated risk.

Pre-create the source path inside the Docker daemon's filesystem via an initializeCommand that runs a one-shot busybox container bind-mounting /run from the daemon. The container idempotently touches an empty placeholder file only if nothing already lives at the path; the guard preserves the real socket on macOS (sockets satisfy -e). Everywhere else the empty file makes the subsequent bind succeed and SSH forwarding becomes a silent no-op, which is what the original inline comment already promised but did not reliably deliver.

The argv (array) form of initializeCommand sidesteps per-shell quoting between PowerShell on Windows and bash on macOS/Linux; the conditional logic stays inside the busybox container.

Update the corresponding risk doc from "Known risk, not remediated" to "Remediated", record that the symptom materialised on Windows (not Linux as originally predicted), and capture the lessons-learned about launcher-specific assumptions in shared mount configs.

<!--
Thanks for contributing to JIM! Please fill out the sections below.
This template applies to all PRs against TetronIO/JIM.
-->

## Description

<!-- What does this PR do? Why is it needed? Link to the relevant Issue or Idea if applicable. -->

Closes #

## Type of change

<!-- Tick all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

<!-- How have you tested this? -->

- [ ] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment
- [ ] Documentation updated (if behaviour changed)

<!-- If integration testing was relevant, briefly describe the scenario(s) you exercised. -->

## Screenshots / output (if applicable)

<!-- For UI changes, include before/after screenshots. For behaviour changes, paste relevant log output (with sensitive data redacted). -->

## Checklist

- [ ] My commit messages are descriptive and reference the relevant Issue (if any)
- [ ] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [ ] User-facing text uses British English (en-GB)
- [ ] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

<!-- Anything else reviewers should know — design decisions, alternatives considered, follow-up work needed. -->
