### PR TITLE
feat(ui): add junctional.io link with monotone JIM logo to footer

### DIFF
--- a/src/JIM.Web/Shared/MainLayout.razor
+++ b/src/JIM.Web/Shared/MainLayout.razor
@@ -99,6 +99,12 @@ else
                                 <span>@_serviceName</span>
                             }
                             <span class="jim-page-footer-sep">|</span>
+                            <MudLink Href="https://junctional.io" Target="_blank"
+                                     Color="Color.Inherit" Underline="Underline.Hover" Class="jim-page-footer-junctional">
+                                <span class="jim-page-footer-junctional-icon" aria-hidden="true"></span>
+                                <span>junctional.io</span>
+                            </MudLink>
+                            <span class="jim-page-footer-sep">|</span>
                             <MudLink Href="https://github.com/TetronIO/JIM" Target="_blank"
                                      Color="Color.Inherit" Underline="Underline.Hover" Class="jim-page-footer-github">
                                 <MudIcon Icon="@Icons.Custom.Brands.GitHub" Size="Size.Small" Class="jim-page-footer-github-icon" />

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -722,6 +722,22 @@ body.jim-dark-mode .jim-instance-bar .jim-title-accent {
     width: 1rem !important;
 }
 
+.jim-page-footer-junctional {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.jim-page-footer-junctional-icon {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    background-color: currentColor;
+    -webkit-mask: url('/images/jim-logo.png') no-repeat center / contain;
+    mask: url('/images/jim-logo.png') no-repeat center / contain;
+}
+
 .jim-nowrap {
     white-space: nowrap;
 }


### PR DESCRIPTION
## Description

Adds a `junctional.io` link to the page footer, sitting between the optional service-name segment and the existing GitHub link. The link is preceded by the JIM logo rendered as a monotone 1rem icon (same size as the GitHub icon).

The icon is implemented as a CSS `mask-image` of `jim-logo.png` filled with `background-color: currentColor`. Because the surrounding `MudLink` uses `Color="Color.Inherit"`, the icon picks up the secondary text colour of the active theme — same mechanism the GitHub icon font already uses, so no per-theme overrides are needed and it works across all 12 themes automatically.

Closes #

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [ ] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment
- [ ] Documentation updated (if behaviour changed)

Build/test not run locally: change was authored from a host worktree without `dotnet` on PATH. The change is markup + CSS only and mirrors the existing GitHub-link pattern, but CI will be the first build. No tests added — UI-only footer tweak, no UI test suite exists per `CLAUDE.md`.

## Screenshots / output (if applicable)

Before/after screenshots to be attached after a devcontainer build; the visual change is a new `| [logo] junctional.io |` segment immediately before the existing GitHub link in the footer.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in `docs/DEVELOPER_GUIDE.md`
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

- No CHANGELOG entry: per `CLAUDE.md`, trivial UI tweaks are excluded.
- `mask-image` is supported in all current evergreen browsers; the `-webkit-` prefix is included for older WebKit-based clients.
- The icon tracks `currentColor`, so it will follow MudLink's hover state (slightly darker). If a static colour is preferred we can swap `currentColor` for `var(--mud-palette-text-secondary)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)