### PR TITLE
test: add higher-tier long-tail scale templates (200k/500k/750k/1m)

### DIFF
--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -58,10 +58,15 @@ This single script handles everything:
 ./test/integration/Run-IntegrationTests.ps1 -Template MediumLarge
 ./test/integration/Run-IntegrationTests.ps1 -Template Large
 ./test/integration/Run-IntegrationTests.ps1 -Template Scale100k50Groups
+./test/integration/Run-IntegrationTests.ps1 -Template Scale100k5kGroups       # long-tail, OpenLDAP + Scenario 8 only
 ./test/integration/Run-IntegrationTests.ps1 -Template Scale200k55Groups
+./test/integration/Run-IntegrationTests.ps1 -Template Scale200k10kGroups      # long-tail, OpenLDAP + Scenario 8 only
 ./test/integration/Run-IntegrationTests.ps1 -Template Scale500k65Groups
+./test/integration/Run-IntegrationTests.ps1 -Template Scale500k25kGroups      # long-tail, OpenLDAP + Scenario 8 only
 ./test/integration/Run-IntegrationTests.ps1 -Template Scale750k70Groups
+./test/integration/Run-IntegrationTests.ps1 -Template Scale750k40kGroups      # long-tail, OpenLDAP + Scenario 8 only
 ./test/integration/Run-IntegrationTests.ps1 -Template Scale1m80Groups
+./test/integration/Run-IntegrationTests.ps1 -Template Scale1m60kGroups        # long-tail, OpenLDAP + Scenario 8 only
 
 # Run only a specific test step (steps vary by scenario)
 ./test/integration/Run-IntegrationTests.ps1 -Step Joiner                          # Scenario 1: Joiner, Mover, Leaver, Reconnection
@@ -125,8 +130,12 @@ Choose a template based on your testing goals:
 - **Scale200k55Groups**: 200,000 users, 55 groups - **TBD** - Very large enterprise, extended stress testing (**requires 24+ GB host RAM**)
 - **Scale500k65Groups**: 500,000 users, 65 groups - **TBD** - Massive enterprise, scale validation (**requires 32+ GB host RAM**)
 - **Scale750k70Groups**: 750,000 users, 70 groups - **TBD** - Near-million scale validation (**requires 32+ GB host RAM**)
-- **Scale1m80Groups**: 1,000,000 users, 70 groups - **TBD** - Global enterprise, scale limits (**requires 64+ GB host RAM**). _Note: the name's "80" reflects the originally planned group count; the actual count is 70. Group-count reshaping for the 200k-1m tier is deferred to a follow-up._
+- **Scale1m80Groups**: 1,000,000 users, 70 groups - **TBD** - Global enterprise, scale limits (**requires 64+ GB host RAM**). _Note: the name's "80" reflects the originally planned group count; the actual count is 70. The capped-groups Samba-friendly templates above are kept for Samba scale testing; long-tail counterparts (Scale*k*kGroups) are listed below._
 - **Scale100k5kGroups**: 100,000 users, 5,027 groups (realistic long-tail shape) - **< 2 hours** - Scenario 8 entitlement sync against representative enterprise group topology. **OpenLDAP only**; rejected on Samba AD. Same memory requirements as Scale100k50Groups.
+- **Scale200k10kGroups**: 200,000 users, 9,984 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. Same memory profile as Scale200k55Groups plus additional RAM for the larger group/membership working set (~28+ GB recommended).
+- **Scale500k25kGroups**: 500,000 users, 24,997 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. ~40+ GB recommended.
+- **Scale750k40kGroups**: 750,000 users, 40,011 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. ~48+ GB recommended.
+- **Scale1m60kGroups**: 1,000,000 users, 60,073 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. ~64+ GB recommended; also requires raising the OpenLDAP accesslog `olcDbMaxSize` proportionally (see Troubleshooting → "OpenLDAP accesslog full" below).
 
 > **Memory requirements for large templates:** The Scale100k50Groups and above templates require significantly more memory than smaller templates. The worker loads all imported objects into memory during processing; a 100K object import produces a worker peak working set of approximately 2.3 GB, plus 1–2 GB for the database during bulk inserts. **A 16 GB machine is not sufficient for Scale100k50Groups**; the worker will be OOM-killed during the save phase even without IDE overhead. In a GitHub Codespace (16 GB total), the problem is worse because the IDE and dev tools consume additional memory. Run Scale100k50Groups tests on a machine with at least 20–24 GB total RAM. See the [Deployment Guide - Memory Scaling](../DEPLOYMENT_GUIDE.md#memory-scaling-by-identity-object-count) for detailed requirements.
 
@@ -231,7 +240,7 @@ For automated testing in GitHub Actions:
 
 ```mermaid
 flowchart TD
-    T["<b>WORKFLOW TRIGGER</b> (Manual via workflow_dispatch)<br/>- Select Template: Micro / Small / Medium / Large / Scale100k50Groups-Scale1m80Groups / Scale100k5kGroups<br/>- Select Phase: 1 (MVP) or 2 (Post-MVP)"]
+    T["<b>WORKFLOW TRIGGER</b> (Manual via workflow_dispatch)<br/>- Select Template: Micro / Small / Medium / Large / Scale100k50Groups-Scale1m80Groups / Scale100k5kGroups-Scale1m60kGroups (long-tail, OpenLDAP only)<br/>- Select Phase: 1 (MVP) or 2 (Post-MVP)"]
     S1["<b>1. STAND UP</b><br/>- JIM stack<br/>- External systems"]
     S2["<b>2. BUILD JIM</b><br/>- dotnet build<br/>- Wait ready"]
     S3["<b>3. CONFIGURE</b><br/>- Setup scripts<br/>- Populate data"]
@@ -306,7 +315,7 @@ Each scenario script supports a `-Step` parameter that controls which test case 
 
 **Common parameters across all scenario scripts**:
 - `-Step <StepName>` - Execute a specific test step (or `All` for full sequence)
-- `-Template <Size>` - Data scale template (Nano, Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+- `-Template <Size>` - Data scale template (Nano, Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 - `-TemplateSambaAD <Size>` - Override `-Template` for Samba AD when using `-DirectoryType All`
 - `-TemplateOpenLDAP <Size>` - Override `-Template` for OpenLDAP when using `-DirectoryType All`
 - `-WaitSeconds <N>` - Override default wait time between steps (default: 60)
@@ -384,9 +393,13 @@ Choose the appropriate template based on test goals:
 | **Scale100k50Groups** | 100,000   | 50      | 12              | 100,050       | Very large enterprise, stress     | < 2 hours  |
 | **Scale100k5kGroups** | 100,000   | 5,027   | ~9 (measured)   | 105,027       | Scenario 8 long-tail group shape (OpenLDAP only) | < 2 hours |
 | **Scale200k55Groups** | 200,000   | 55      | 12              | 200,055       | Very large enterprise, extended   | TBD        |
+| **Scale200k10kGroups** | 200,000  | 9,984   | ~8              | 209,984       | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
 | **Scale500k65Groups** | 500,000   | 65      | 13              | 500,065       | Massive enterprise, validation    | TBD        |
+| **Scale500k25kGroups** | 500,000  | 24,997  | ~10             | 524,997       | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
 | **Scale750k70Groups** | 750,000   | 70      | 14              | 750,070       | Near-million scale validation     | TBD        |
+| **Scale750k40kGroups** | 750,000  | 40,011  | ~11             | 790,011       | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
 | **Scale1m80Groups** | 1,000,000 | 70      | 15              | 1,000,070     | Global enterprise, scale limits (group count reshape pending) | TBD |
+| **Scale1m60kGroups** | 1,000,000 | 60,073 | ~13             | 1,060,073     | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
 
 ### Data Characteristics
 
@@ -1195,7 +1208,7 @@ Integration tests run manually via GitHub Actions `workflow_dispatch` to avoid e
 2. Select **Integration Tests** workflow
 3. Click **Run workflow**
 4. Choose:
-   - **Template**: Data scale (Micro to Scale1m80Groups)
+   - **Template**: Data scale (Micro to Scale1m80Groups; or Scale100k5kGroups-Scale1m60kGroups for long-tail / OpenLDAP-only)
    - **Phase**: 1 (MVP) or 2 (Post-MVP)
 5. Click **Run workflow**
 
@@ -1237,7 +1250,7 @@ See `.github/workflows/integration-tests.yml` for complete workflow definition.
     [Detailed description of what this scenario validates]
 
 .PARAMETER Template
-    Data scale template (Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .EXAMPLE
     ./Invoke-ScenarioX-Name.ps1 -Template Medium
@@ -1245,7 +1258,7 @@ See `.github/workflows/integration-tests.yml` for complete workflow definition.
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small"
 )
 
@@ -1536,7 +1549,7 @@ The diagnostics infrastructure uses `System.Diagnostics.ActivitySource` (the .NE
 
 For larger templates (Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups), populating Samba AD with test data (users, groups, memberships) can take **many hours**. To avoid repeating this on every test run, the framework supports **snapshot images**: pre-populated Docker images that start in seconds.
 
-> Note: `Scale100k5kGroups` is OpenLDAP-only (it hard-fails on Samba AD), so Samba snapshots don't apply. OpenLDAP snapshots are built via [`Build-OpenLDAPSnapshots.ps1`](../test/integration/Build-OpenLDAPSnapshots.ps1).
+> Note: the long-tail templates (`Scale100k5kGroups`, `Scale200k10kGroups`, `Scale500k25kGroups`, `Scale750k40kGroups`, `Scale1m60kGroups`) are OpenLDAP-only (they hard-fail on Samba AD), so Samba snapshots don't apply. OpenLDAP snapshots are built via [`Build-OpenLDAPSnapshots.ps1`](../test/integration/Build-OpenLDAPSnapshots.ps1).
 
 ### How Snapshots Work
 
@@ -1676,7 +1689,7 @@ If the file size matches `olcDbMaxSize`, the map is full.
 
 **Fix:**
 
-Increase the map size in `test/integration/docker/openldap/scripts/01-add-second-suffix.sh` and rebuild the OpenLDAP container. Current setting: 8 GB (sufficient for Scale100k50Groups / 100K objects with large group membership operations). For larger templates, estimate ~10 MB per 1,000 objects for initial population plus additional capacity for sync cycles and group membership writes.
+Increase the map size in `test/integration/docker/openldap/scripts/01-add-second-suffix.sh` and rebuild the OpenLDAP container. Current setting: 8 GB (sufficient for Scale100k50Groups / 100K objects with large group membership operations, and tested against Scale100k5kGroups at ~5,000 groups / ~1M memberships). For higher-tier long-tail templates (Scale200k10kGroups through Scale1m60kGroups), raise the limit proportionally; estimate ~10 MB per 1,000 objects for initial population plus additional capacity for sync cycles and group membership writes. Scale1m60kGroups (~1.06M total objects, ~10M memberships) needs at least 32 GB; size headroom generously rather than tuning to the limit.
 
 The map size cannot be reliably increased on a running instance; it requires a container rebuild.
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -154,7 +154,7 @@ cd /workspaces/JIM
 # Run a specific scenario directly
 ./test/integration/Run-IntegrationTests.ps1 -Scenario Scenario1-HRToIdentityDirectory
 
-# Run with a specific template size (Nano, Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups)
+# Run with a specific template size (Nano, Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups; or long-tail / OpenLDAP-only Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 ./test/integration/Run-IntegrationTests.ps1 -Template Small
 
 # Run against OpenLDAP instead of Samba AD
@@ -222,12 +222,13 @@ These flags are for human developer iteration only. Claude must not use them bec
 - **Large**: 10,000 users, 500 groups (~15 min) - Large enterprise
 - **Scale100k50Groups**: 100,000 users, 50 groups - Requires 20+ GB host RAM (OOM-killed on 16 GB machines; a 16 GB Codespace is not sufficient)
 - **Scale100k5kGroups**: 100,000 users, ~5,027 groups (realistic long-tail shape) - OpenLDAP only, Scenario 8 only. Hard-fails if combined with `-DirectoryType SambaAD` or any non-Scenario-8 scenario. Same memory requirements as Scale100k50Groups.
+- **Scale200k10kGroups / Scale500k25kGroups / Scale750k40kGroups / Scale1m60kGroups**: long-tail templates extending the Scale100k5kGroups model to 200k/500k/750k/1m users. OpenLDAP only, Scenario 8 only — same hard-fail behaviour as Scale100k5kGroups. RAM requirements scale roughly with user count (28+ / 40+ / 48+ / 64+ GB recommended). The 1m60k tier also needs the OpenLDAP accesslog `olcDbMaxSize` raised proportionally; see the section below.
 
 **OpenLDAP accesslog MDB map size (IMPORTANT for large templates):**
 
 The OpenLDAP accesslog database uses an MDB storage engine with a fixed maximum map size (`olcDbMaxSize`). When the map is full, OpenLDAP **silently stops recording changes**; delta imports will find zero modifications and sync changes will be lost. There is no error message; the writes just stop.
 
-The map size is configured in `test/integration/docker/openldap/scripts/01-add-second-suffix.sh`. Current setting: **8 GB** (sufficient for Scale100k50Groups / 100K objects with large group membership operations). If adding templates beyond Scale100k50Groups (e.g. Scale1m80Groups / 1M objects), increase the accesslog `olcDbMaxSize` proportionally (estimate ~10 MB per 1,000 objects for the initial population, plus additional capacity for sync cycles and group membership writes).
+The map size is configured in `test/integration/docker/openldap/scripts/01-add-second-suffix.sh`. Current setting: **8 GB** (sufficient for Scale100k50Groups / 100K objects with large group membership operations, and tested against Scale100k5kGroups at ~5,000 groups / ~1M memberships). For higher-tier long-tail templates (Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups) or templates beyond Scale100k50Groups (e.g. Scale1m80Groups / 1M objects), increase the accesslog `olcDbMaxSize` proportionally (estimate ~10 MB per 1,000 objects for the initial population, plus additional capacity for sync cycles and group membership writes). Scale1m60kGroups (~1.06M objects, ~10M memberships) needs at least 32 GB; raise it before running.
 
 ## CSV cache
 

--- a/test/integration/Analyse-QueryPerformance.ps1
+++ b/test/integration/Analyse-QueryPerformance.ps1
@@ -55,7 +55,7 @@
 param(
     [string]$Scenario = "Scenario8-CrossDomainEntitlementSync",
 
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Medium",
 
     [ValidateSet("SambaAD", "OpenLDAP")]

--- a/test/integration/Build-OpenLDAPSnapshots.ps1
+++ b/test/integration/Build-OpenLDAPSnapshots.ps1
@@ -23,7 +23,7 @@
     Which scenario to build snapshots for (General, Scenario8, All)
 
 .PARAMETER Template
-    Data size template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data size template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER Registry
     Container registry prefix (default: local, no registry prefix)
@@ -47,7 +47,7 @@ param(
     [string]$Scenario = "All",
 
     [Parameter(Mandatory = $true)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template,
 
     [Parameter(Mandatory = $false)]

--- a/test/integration/Build-SambaSnapshots.ps1
+++ b/test/integration/Build-SambaSnapshots.ps1
@@ -22,7 +22,7 @@
     Which scenario to build snapshots for (Scenario1, Scenario8, All)
 
 .PARAMETER Template
-    Data size template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data size template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER Registry
     Container registry prefix (default: local, no registry prefix)
@@ -46,7 +46,7 @@ param(
     [string]$Scenario = "All",
 
     [Parameter(Mandatory = $true)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template,
 
     [Parameter(Mandatory = $false)]

--- a/test/integration/Generate-TestCSV.ps1
+++ b/test/integration/Generate-TestCSV.ps1
@@ -10,7 +10,7 @@
     Files are created in the shared volume for JIM File connector testing
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER OutputPath
     Path where CSV files should be created (default: ./test-data)
@@ -26,7 +26,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/Get-OrGenerate-TestCSV.ps1
+++ b/test/integration/Get-OrGenerate-TestCSV.ps1
@@ -47,7 +47,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/Invoke-IntegrationTests.ps1
+++ b/test/integration/Invoke-IntegrationTests.ps1
@@ -17,7 +17,7 @@
     8. Tear down systems (optional)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER Phase
     Test phase (1 = MVP with LDAP/CSV, 2 = Post-MVP with databases)
@@ -46,7 +46,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/Populate-OpenLDAP-Scenario8.ps1
+++ b/test/integration/Populate-OpenLDAP-Scenario8.ps1
@@ -21,7 +21,7 @@
     - ou=Entitlements (empty — JIM provisions groups here)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER Instance
     Which suffix to populate (Source or Target)
@@ -37,7 +37,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",
 
     [Parameter(Mandatory=$false)]
@@ -422,8 +422,10 @@ if ($groupScale.Projects -gt 0) {
 }
 
 # ----------------------------------------------------------------------------
-# Long-tail categories (Scale100k5kGroups). Each group's category-internal
-# index drives Get-LongTailGroupSize during membership assignment below.
+# Long-tail categories (Scale100k5kGroups / Scale200k10kGroups /
+# Scale500k25kGroups / Scale750k40kGroups / Scale1m60kGroups). Each group's
+# category-internal index drives Get-LongTailGroupSize during membership
+# assignment below.
 # ----------------------------------------------------------------------------
 
 # Read possibly-missing scale fields with default 0 (legacy templates don't
@@ -607,8 +609,9 @@ Write-Host "  Created $($createdGroups.Count) groups" -ForegroundColor Green
 #
 # Membership assignment is batched across multiple groups per docker exec call.
 # Each ldapmodify invocation processes ~5000 member lines spanning many groups,
-# which is essential for Scale100k5kGroups (~5000 groups, ~1M memberships) and
-# improves smaller templates harmlessly.
+# which is essential for the long-tail templates (Scale100k5kGroups through
+# Scale1m60kGroups, up to ~60k groups and ~10M memberships) and improves
+# smaller templates harmlessly.
 # ============================================================================
 Write-TestStep "Step 4" "Assigning group memberships (batched ldapmodify)"
 

--- a/test/integration/Populate-OpenLDAP.ps1
+++ b/test/integration/Populate-OpenLDAP.ps1
@@ -15,7 +15,7 @@
     Users are split: odd indices go to Yellowstone, even indices go to Glitterband.
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .EXAMPLE
     ./Populate-OpenLDAP.ps1 -Template Micro
@@ -23,7 +23,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/Populate-SambaAD-Scenario8.ps1
+++ b/test/integration/Populate-SambaAD-Scenario8.ps1
@@ -16,7 +16,7 @@
       - OU=Entitlements (entitlement groups)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER Instance
     Which Samba AD instance to populate (Source or Target)
@@ -32,7 +32,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",
 
     [Parameter(Mandatory=$false)]
@@ -46,12 +46,14 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# Hard-fail: the long-tail Scale100k5kGroups template is OpenLDAP only.
-# Samba AD's per-call LDB write lock makes ~5000 groups / ~1M memberships
-# impractical within the time budget. Surface the constraint immediately
-# rather than letting the run start and time out hours later.
-if ($Template -eq "Scale100k5kGroups") {
-    throw "Template 'Scale100k5kGroups' is not supported on Samba AD. Use 'Scale100k50Groups' for Samba scale testing, or run this template with -DirectoryType OpenLDAP."
+# Hard-fail: the long-tail templates are OpenLDAP only.
+# Samba AD's per-call LDB write lock makes the long-tail shape (thousands of
+# groups, millions of memberships) impractical within the time budget. Surface
+# the constraint immediately rather than letting the run start and time out
+# hours later.
+$longTailTemplates = @("Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
+if ($Template -in $longTailTemplates) {
+    throw "Template '$Template' is not supported on Samba AD. Use 'Scale100k50Groups' or another capped-groups template for Samba scale testing, or run this template with -DirectoryType OpenLDAP."
 }
 
 # Import helpers

--- a/test/integration/Populate-SambaAD.ps1
+++ b/test/integration/Populate-SambaAD.ps1
@@ -10,7 +10,7 @@
     based on the specified template scale
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER Instance
     Which Samba AD instance to populate (Primary, Source, Target)
@@ -21,7 +21,7 @@
 
 param(
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]
@@ -35,10 +35,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# Hard-fail: Scale100k5kGroups is the long-tail OpenLDAP-only template used by
-# Scenario 8. It is not valid for the basic Samba populator either.
-if ($Template -eq "Scale100k5kGroups") {
-    throw "Template 'Scale100k5kGroups' is not supported on Samba AD. Use 'Scale100k50Groups' for Samba scale testing, or run with -DirectoryType OpenLDAP."
+# Hard-fail: the long-tail templates are OpenLDAP-only Scenario 8 templates.
+# They are not valid for the basic Samba populator either.
+$longTailTemplates = @("Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
+if ($Template -in $longTailTemplates) {
+    throw "Template '$Template' is not supported on Samba AD. Use 'Scale100k50Groups' or another capped-groups template for Samba scale testing, or run this template with -DirectoryType OpenLDAP."
 }
 
 # Import helpers

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -173,7 +173,7 @@ param(
     [string]$Scenario,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",
 
     [Parameter(Mandatory=$false)]
@@ -215,11 +215,11 @@ param(
     [switch]$DisableChangeTracking,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$TemplateSambaAD,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$TemplateOpenLDAP,
 
     [Parameter(Mandatory=$false)]
@@ -250,25 +250,26 @@ $repoRoot = (Get-Item $scriptRoot).Parent.Parent.FullName
 # Import helpers early so Get-DirectoryConfig is available
 . "$scriptRoot/utils/Test-Helpers.ps1"
 
-# Hard-fail: Scale100k5kGroups is OpenLDAP only. Reject early at the orchestrator
-# level so users discover the constraint at selection time, not 30 minutes into
-# population. The populator scripts have matching guards (defence in depth).
-function Test-Scale100k5kGroupsCompatibility {
+# Hard-fail: the long-tail templates (Scale100k5kGroups through Scale1m60kGroups)
+# are OpenLDAP only. Reject early at the orchestrator level so users discover
+# the constraint at selection time, not hours into population. The populator
+# scripts have matching guards (defence in depth).
+$script:LongTailTemplates = @("Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
+function Test-LongTailTemplateCompatibility {
     param([string]$Template, [string]$DirectoryType, [string]$TemplateSambaAD, [string]$TemplateOpenLDAP)
-    # The new template is OpenLDAP only.
     $offendingValues = @()
-    if ($Template -eq "Scale100k5kGroups" -and $DirectoryType -in @("SambaAD", "All")) {
-        $offendingValues += "-Template Scale100k5kGroups -DirectoryType $DirectoryType"
+    if ($Template -in $script:LongTailTemplates -and $DirectoryType -in @("SambaAD", "All")) {
+        $offendingValues += "-Template $Template -DirectoryType $DirectoryType"
     }
-    if ($TemplateSambaAD -eq "Scale100k5kGroups") {
-        $offendingValues += "-TemplateSambaAD Scale100k5kGroups"
+    if ($TemplateSambaAD -in $script:LongTailTemplates) {
+        $offendingValues += "-TemplateSambaAD $TemplateSambaAD"
     }
     if ($offendingValues.Count -gt 0) {
-        $msg = "Scale100k5kGroups is OpenLDAP only (Scenario 8 long-tail group shape). Samba AD cannot populate ~5000 groups within the time budget. Rejected: $($offendingValues -join ', '). Use -Template Scale100k50Groups for Samba scale testing, or pin to -DirectoryType OpenLDAP."
+        $msg = "The long-tail templates ($($script:LongTailTemplates -join ', ')) are OpenLDAP only (Scenario 8 long-tail group shape). Samba AD cannot populate thousands of groups within the time budget. Rejected: $($offendingValues -join ', '). Use -Template Scale100k50Groups or another capped-groups template for Samba scale testing, or pin to -DirectoryType OpenLDAP."
         throw $msg
     }
 }
-Test-Scale100k5kGroupsCompatibility -Template $Template -DirectoryType $DirectoryType `
+Test-LongTailTemplateCompatibility -Template $Template -DirectoryType $DirectoryType `
     -TemplateSambaAD $TemplateSambaAD -TemplateOpenLDAP $TemplateOpenLDAP
 
 # Resolve directory configuration (used throughout for Docker profiles, population, setup)
@@ -670,11 +671,25 @@ function Show-TemplateMenu {
             Time = "~2 hours"
         }
         @{
+            Name = "Scale200k10kGroups"
+            Users = 200000
+            Groups = 9984
+            Description = "200K users, long-tail group shape (OpenLDAP + Scenario 8 only)"
+            Time = "~3 hours"
+        }
+        @{
             Name = "Scale500k65Groups"
             Users = 500000
             Groups = 65
             Description = "500K users"
             Time = "~3 hours"
+        }
+        @{
+            Name = "Scale500k25kGroups"
+            Users = 500000
+            Groups = 24997
+            Description = "500K users, long-tail group shape (OpenLDAP + Scenario 8 only)"
+            Time = "~6 hours"
         }
         @{
             Name = "Scale750k70Groups"
@@ -684,11 +699,25 @@ function Show-TemplateMenu {
             Time = "~4 hours"
         }
         @{
+            Name = "Scale750k40kGroups"
+            Users = 750000
+            Groups = 40011
+            Description = "750K users, long-tail group shape (OpenLDAP + Scenario 8 only)"
+            Time = "~9 hours"
+        }
+        @{
             Name = "Scale1m80Groups"
             Users = 1000000
             Groups = 80
             Description = "1M users, stress testing"
             Time = "~6 hours"
+        }
+        @{
+            Name = "Scale1m60kGroups"
+            Users = 1000000
+            Groups = 60073
+            Description = "1M users, long-tail group shape (OpenLDAP + Scenario 8 only)"
+            Time = "~12 hours"
         }
     )
 
@@ -2115,7 +2144,7 @@ if ($Scenario -like "*Scenario8*" -and $DirectoryType -ne "OpenLDAP") {
     # Scale Samba container memory for larger templates (ldbadd is memory-intensive —
     # it loads the full LDB into memory, so memory needs grow with user count)
     # Only needed when NOT using snapshots (snapshots don't run ldbadd)
-    if (-not $script:UsingSnapshots -and $Template -in @("Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")) {
+    if (-not $script:UsingSnapshots -and $Template -in @("Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")) {
         $env:SAMBA_SOURCE_MEMORY = "8G"
         $env:SAMBA_TARGET_MEMORY = "4G"
         Write-Host "  Samba source memory scaled to 8G for $Template template" -ForegroundColor Gray
@@ -2766,7 +2795,7 @@ Write-Section "Step 6: Capturing Performance Metrics"
 # Skip detailed metrics capture for large templates - parsing the worker logs becomes
 # prohibitively expensive (CPU and memory) due to the volume of DiagnosticListener lines.
 # Use -CaptureMetrics to force capture regardless of template size.
-$metricsSkippedTemplates = @("MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")
+$metricsSkippedTemplates = @("MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
 if ($Template -in $metricsSkippedTemplates -and -not $CaptureMetrics) {
     Write-Warning "Skipping detailed performance metrics for '$Template' template (log volume too large for efficient parsing)"
     Write-Step "Use -CaptureMetrics to force capture (this will be slow)"

--- a/test/integration/Setup-Scenario1.ps1
+++ b/test/integration/Setup-Scenario1.ps1
@@ -20,7 +20,7 @@
     API key for authentication (if not provided, will attempt to create one)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .EXAMPLE
     ./Setup-Scenario1.ps1 -JIMUrl "http://localhost:5200" -ApiKey "jim_abc123..."
@@ -43,7 +43,7 @@ param(
     [string]$ApiKey,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/Setup-Scenario2.ps1
+++ b/test/integration/Setup-Scenario2.ps1
@@ -20,7 +20,7 @@
     API key for authentication (if not provided, will attempt to create one)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .EXAMPLE
     ./Setup-Scenario2.ps1 -JIMUrl "http://localhost:5200" -ApiKey "jim_abc123..."
@@ -43,7 +43,7 @@ param(
     [string]$ApiKey,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/Setup-Scenario8.ps1
+++ b/test/integration/Setup-Scenario8.ps1
@@ -25,7 +25,7 @@
     API key for authentication
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .EXAMPLE
     ./Setup-Scenario8.ps1 -ApiKey "jim_abc123..."
@@ -42,7 +42,7 @@ param(
     [string]$ApiKey,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
+++ b/test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1
@@ -16,7 +16,7 @@
     Which test step to execute (Joiner, Leaver, Mover, Reconnection, All)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER JIMUrl
     The URL of the JIM instance (default: http://localhost:5200 for host access)
@@ -47,7 +47,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]
@@ -79,11 +79,12 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ConfirmPreference = 'None'  # Disable confirmation prompts for non-interactive execution
 
-# Hard-fail: Scale100k5kGroups is a Scenario 8 (Cross-Domain Entitlement Sync)
-# template; the long-tail group shape it generates is only meaningful there.
-# Other scenarios should use Scale100k50Groups or smaller.
-if ($Template -eq "Scale100k5kGroups") {
-    throw "Template 'Scale100k5kGroups' is only valid for Scenario 8 (Cross-Domain Entitlement Sync). Use 'Scale100k50Groups' or smaller for this scenario."
+# Hard-fail: the long-tail templates are Scenario 8 (Cross-Domain Entitlement
+# Sync) only; the long-tail group shape they generate is only meaningful
+# there. Other scenarios should use Scale100k50Groups or smaller.
+$longTailTemplates = @("Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
+if ($Template -in $longTailTemplates) {
+    throw "Template '$Template' is only valid for Scenario 8 (Cross-Domain Entitlement Sync). Use 'Scale100k50Groups' or smaller for this scenario."
 }
 
 # Default to SambaAD Primary if no config provided

--- a/test/integration/scenarios/Invoke-Scenario2-CrossDomainSync.ps1
+++ b/test/integration/scenarios/Invoke-Scenario2-CrossDomainSync.ps1
@@ -14,7 +14,7 @@
     Which test step to execute (Provision, ForwardSync, DetectDrift, ReassertState, All)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER JIMUrl
     The URL of the JIM instance (default: http://localhost:5200 for host access)
@@ -38,7 +38,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario3-GALSYNC.ps1
+++ b/test/integration/scenarios/Invoke-Scenario3-GALSYNC.ps1
@@ -15,7 +15,7 @@
     Which test step to execute (Export, Update, Delete, All)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER WaitSeconds
     Seconds to wait between steps for JIM processing (default: 60)
@@ -33,7 +33,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario4-DeletionRules.ps1
+++ b/test/integration/scenarios/Invoke-Scenario4-DeletionRules.ps1
@@ -75,7 +75,7 @@
     Which test step to execute
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER JIMUrl
     The URL of the JIM instance (default: http://localhost:5200 for host access)
@@ -108,7 +108,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario5-MatchingRules.ps1
+++ b/test/integration/scenarios/Invoke-Scenario5-MatchingRules.ps1
@@ -17,7 +17,7 @@
     Which test step to execute (Projection, Join, DuplicatePrevention, MultiplRules, All)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER JIMUrl
     The URL of the JIM instance (default: http://localhost:5200 for host access)
@@ -41,7 +41,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario6-SchedulerService.ps1
+++ b/test/integration/scenarios/Invoke-Scenario6-SchedulerService.ps1
@@ -57,7 +57,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",  # Accepted but ignored - scheduler tests don't use test data templates
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario7-ClearConnectedSystemObjects.ps1
+++ b/test/integration/scenarios/Invoke-Scenario7-ClearConnectedSystemObjects.ps1
@@ -30,7 +30,7 @@
     Which test step to execute
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER JIMUrl
     The URL of the JIM instance (default: http://localhost:5200 for host access)
@@ -54,7 +54,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Small",
 
     [Parameter(Mandatory=$false)]
@@ -76,9 +76,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# Hard-fail: Scale100k5kGroups is a Scenario 8 template only.
-if ($Template -eq "Scale100k5kGroups") {
-    throw "Template 'Scale100k5kGroups' is only valid for Scenario 8 (Cross-Domain Entitlement Sync). Use 'Scale100k50Groups' or smaller for this scenario."
+# Hard-fail: the long-tail templates are Scenario 8 only.
+$longTailTemplates = @("Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
+if ($Template -in $longTailTemplates) {
+    throw "Template '$Template' is only valid for Scenario 8 (Cross-Domain Entitlement Sync). Use 'Scale100k50Groups' or smaller for this scenario."
 }
 
 # Import helpers

--- a/test/integration/scenarios/Invoke-Scenario8-CrossDomainEntitlementSync.ps1
+++ b/test/integration/scenarios/Invoke-Scenario8-CrossDomainEntitlementSync.ps1
@@ -21,7 +21,7 @@
     Which test step to execute (InitialSync, ForwardSync, DetectDrift, ReassertState, NewGroup, DeleteGroup, All)
 
 .PARAMETER Template
-    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups)
+    Data scale template (Nano, Micro, Small, Medium, MediumLarge, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
 
 .PARAMETER JIMUrl
     The URL of the JIM instance (default: http://localhost:5200 for host access)
@@ -45,7 +45,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",
 
     [Parameter(Mandatory=$false)]

--- a/test/integration/scenarios/Invoke-Scenario9-PartitionScopedImports.ps1
+++ b/test/integration/scenarios/Invoke-Scenario9-PartitionScopedImports.ps1
@@ -53,7 +53,7 @@ param(
     [string]$Step = "All",
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+    [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
     [string]$Template = "Nano",
 
     [Parameter(Mandatory=$false)]
@@ -81,9 +81,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# Hard-fail: Scale100k5kGroups is a Scenario 8 template only.
-if ($Template -eq "Scale100k5kGroups") {
-    throw "Template 'Scale100k5kGroups' is only valid for Scenario 8 (Cross-Domain Entitlement Sync). Use 'Scale100k50Groups' or smaller for this scenario."
+# Hard-fail: the long-tail templates are Scenario 8 only.
+$longTailTemplates = @("Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")
+if ($Template -in $longTailTemplates) {
+    throw "Template '$Template' is only valid for Scenario 8 (Cross-Domain Entitlement Sync). Use 'Scale100k50Groups' or smaller for this scenario."
 }
 
 # Default to SambaAD Primary if no config provided

--- a/test/integration/utils/Test-GroupHelpers.ps1
+++ b/test/integration/utils/Test-GroupHelpers.ps1
@@ -61,7 +61,7 @@ function Get-Scenario8GroupScale {
     #>
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+        [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
         [string]$Template
     )
 
@@ -176,6 +176,65 @@ function Get-Scenario8GroupScale {
             Roles             = 400     # ~20-500 members each
             TotalGroups       = 5027
             Users             = 100000
+        }
+        # Higher-tier long-tail templates. Same category model as Scale100k5kGroups,
+        # scaled sub-linearly for org-structure categories (AllStaff/Divisions/
+        # Locations/Departments) and roughly linearly for the ad-hoc tail
+        # (Projects/DistributionLists). OpenLDAP only; Samba populators hard-fail.
+        # Per-category absolute sizes (e.g. project = 5-30 members) come from
+        # Get-LongTailGroupSize unchanged; the bigger user pool gets distributed
+        # across a larger group count rather than inflating per-group sizes.
+        Scale200k10kGroups = @{
+            Companies         = 0
+            AllStaff          = 2
+            Divisions         = 12
+            Locations         = 20
+            Departments       = 150
+            Applications      = 800
+            Projects          = 6000
+            DistributionLists = 2000
+            Roles             = 1000
+            TotalGroups       = 9984
+            Users             = 200000
+        }
+        Scale500k25kGroups = @{
+            Companies         = 0
+            AllStaff          = 2
+            Divisions         = 15
+            Locations         = 30
+            Departments       = 250
+            Applications      = 1500
+            Projects          = 16000
+            DistributionLists = 5000
+            Roles             = 2200
+            TotalGroups       = 24997
+            Users             = 500000
+        }
+        Scale750k40kGroups = @{
+            Companies         = 0
+            AllStaff          = 3
+            Divisions         = 18
+            Locations         = 40
+            Departments       = 350
+            Applications      = 2500
+            Projects          = 27000
+            DistributionLists = 7500
+            Roles             = 2600
+            TotalGroups       = 40011
+            Users             = 750000
+        }
+        Scale1m60kGroups = @{
+            Companies         = 0
+            AllStaff          = 3
+            Divisions         = 20
+            Locations         = 50
+            Departments       = 500
+            Applications      = 4000
+            Projects          = 38000
+            DistributionLists = 13000
+            Roles             = 4500
+            TotalGroups       = 60073
+            Users             = 1000000
         }
     }
 
@@ -824,7 +883,7 @@ function New-Scenario8GroupSet {
     #>
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+        [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
         [string]$Template,
 
         [Parameter(Mandatory=$false)]
@@ -862,14 +921,14 @@ function New-Scenario8GroupSet {
         $globalIndex++
     }
 
-    # AllStaff groups (Scale100k5kGroups)
+    # AllStaff groups (long-tail templates)
     for ($i = 0; $i -lt $allStaffCount; $i++) {
         $name = $script:AllStaffNames[$i % $script:AllStaffNames.Count]
         [void]$groups.Add((New-TestGroup -Category "AllStaff" -Name $name -Index $globalIndex -Domain $Domain))
         $globalIndex++
     }
 
-    # Division groups (Scale100k5kGroups)
+    # Division groups (long-tail templates)
     for ($i = 0; $i -lt $divisionCount; $i++) {
         $name = $script:DivisionNames[$i % $script:DivisionNames.Count]
         [void]$groups.Add((New-TestGroup -Category "Division" -Name $name -Index $globalIndex -Domain $Domain))
@@ -906,7 +965,7 @@ function New-Scenario8GroupSet {
         }
     }
 
-    # Application access groups (Scale100k5kGroups)
+    # Application access groups (long-tail templates)
     if ($applicationCount -gt 0) {
         $appNames = Get-CombinatorialNames -Count $applicationCount `
             -Prefixes $script:ApplicationCoreNames `
@@ -917,7 +976,7 @@ function New-Scenario8GroupSet {
         }
     }
 
-    # Distribution lists (Scale100k5kGroups)
+    # Distribution lists (long-tail templates)
     if ($distributionCount -gt 0) {
         $dlNames = Get-CombinatorialNames -Count $distributionCount `
             -Prefixes $script:DistributionListTopics `
@@ -928,7 +987,7 @@ function New-Scenario8GroupSet {
         }
     }
 
-    # Roles (Scale100k5kGroups)
+    # Roles (long-tail templates)
     if ($roleCount -gt 0) {
         $roleNames = Get-CombinatorialNames -Count $roleCount `
             -Prefixes $script:RoleQualifiers `

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -181,7 +181,7 @@ function Get-TemplateScale {
     #>
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups")]
+        [ValidateSet("Nano", "Micro", "Small", "Medium", "MediumLarge", "Large", "Scale100k50Groups", "Scale200k55Groups", "Scale500k65Groups", "Scale750k70Groups", "Scale1m80Groups", "Scale100k5kGroups", "Scale200k10kGroups", "Scale500k25kGroups", "Scale750k40kGroups", "Scale1m60kGroups")]
         [string]$Template
     )
 
@@ -254,6 +254,32 @@ function Get-TemplateScale {
             Users = 100000
             Groups = 5027
             AvgMemberships = 9
+        }
+        # Higher-tier long-tail templates. Same Scenario 8 + OpenLDAP-only constraint
+        # as Scale100k5kGroups: category counts grow sub-linearly for org-structure
+        # categories (Divisions, Locations, Departments) and roughly linearly for the
+        # ad-hoc tail (Projects, DistributionLists). The AvgMemberships values below
+        # are informational; the populator emits the real distribution via
+        # Get-LongTailGroupSize.
+        Scale200k10kGroups = @{
+            Users = 200000
+            Groups = 9984
+            AvgMemberships = 8
+        }
+        Scale500k25kGroups = @{
+            Users = 500000
+            Groups = 24997
+            AvgMemberships = 10
+        }
+        Scale750k40kGroups = @{
+            Users = 750000
+            Groups = 40011
+            AvgMemberships = 11
+        }
+        Scale1m60kGroups = @{
+            Users = 1000000
+            Groups = 60073
+            AvgMemberships = 13
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds four new integration-test templates extending the proven `Scale100k5kGroups` long-tail group shape to higher tiers:
  - `Scale200k10kGroups` (200k users, 9,984 groups)
  - `Scale500k25kGroups` (500k users, 24,997 groups)
  - `Scale750k40kGroups` (750k users, 40,011 groups)
  - `Scale1m60kGroups` (1m users, 60,073 groups)
- Each template scales the eight-category enterprise topology (AllStaff, Divisions, Locations, Departments, Applications, Projects, Distribution Lists, Roles) so larger-user runs exercise sync against realistic group counts rather than the legacy capped (50–80) Samba-friendly shape.
- OpenLDAP + Scenario 8 only. Samba populators and non-Scenario-8 scripts hard-fail with a clear message before population starts; the runner's compatibility check generalised to `Test-LongTailTemplateCompatibility` against a single `$LongTailTemplates` list.
- Interactive menu in `Run-IntegrationTests.ps1` lists each new long-tail entry directly after its capped-groups peer (e.g. `Scale200k10kGroups` after `Scale200k55Groups`).
- Documentation (`engineering/INTEGRATION_TESTING.md`, `test/CLAUDE.md`) updated for the new templates including memory requirements and the OpenLDAP accesslog `olcDbMaxSize` note for `Scale1m60kGroups`.

## Test plan

- [x] All edited PowerShell files parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`)
- [x] `Get-TemplateScale` and `Get-Scenario8GroupScale` resolve each new template; category sums match declared `TotalGroups`
- [x] All five long-tail templates listed in the renamed `Test-LongTailTemplateCompatibility` and in every Samba populator / Scenario 1/7/9 hard-fail guard
- [ ] End-to-end population not yet executed at higher tiers; same shape as `Scale100k5kGroups` (validated in #743) so confidence is in the template, not the run

Scope excludes `dotnet build` / `dotnet test` per the CLAUDE.md exception list — diff is PowerShell scripts and Markdown docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)