### PR TITLE
test: remove redundant EMEA Import Users sync rule from Scenario 8

### DIFF
--- a/test/integration/Setup-Scenario8.ps1
+++ b/test/integration/Setup-Scenario8.ps1
@@ -735,22 +735,9 @@ else {
     Write-Host "  Sync rule '$targetUserExportRuleName' already exists" -ForegroundColor Gray
 }
 
-# Target Import (users - for confirming import)
-$targetUserImportRuleName = "$targetLabel Import Users"
-$targetUserImportRule = $existingRules | Where-Object { $_.name -eq $targetUserImportRuleName }
-if (-not $targetUserImportRule) {
-    $targetUserImportRule = New-JIMSyncRule `
-        -Name $targetUserImportRuleName `
-        -ConnectedSystemId $targetSystem.id `
-        -ConnectedSystemObjectTypeId $targetUserType.id `
-        -MetaverseObjectTypeId $mvUserType.id `
-        -Direction Import `
-        -PassThru
-    Write-Host "  ✓ Created: $targetUserImportRuleName" -ForegroundColor Green
-}
-else {
-    Write-Host "  Sync rule '$targetUserImportRuleName' already exists" -ForegroundColor Gray
-}
+# Note: no target Import Users sync rule. The target system is provisioned-only in this
+# scenario and contributes no attributes to the metaverse. Confirming-import joins are
+# handled by the connected system's Simple Mode matching rules (configured below).
 
 # --- Group Sync Rules ---
 # Source Import (groups)


### PR DESCRIPTION
## Summary

- Scenario 8's setup created an `EMEA LDAP Import Users` (or `EMEA AD Import Users`) sync rule with no attribute flow mappings, no `ProjectToMetaverse`, and no scoping criteria.
- EMEA is the provisioned-only target in this scenario and contributes no attributes to the metaverse, so the rule did nothing at runtime.
- The Connected System uses Simple Mode matching rules, and the worker's simple-mode fallback (`SyncTaskProcessorBase.AttemptJoinAsync`) handles confirming-import joins from the object type's matching rules without needing an empty Import sync rule.
- Removes the rule creation block; leaves an inline note explaining the deliberate absence so a future reader does not "fix" it back in.
- Related: #745 captures the longer-term work to add a dedicated bi-directional sync scenario with scoping criteria.

## Test plan

- [x] PowerShell parse check on `Setup-Scenario8.ps1` clean
- [ ] Scenario 8 integration run still passes end-to-end (will validate on next nightly run / pre-release sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)