### PR TITLE
fix(devcontainer): Windows SSH dir mount fails when HOME is unset

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -301,11 +301,14 @@
   //    stays read-only, so the container can never modify your host keys.
   //    If your host doesn't have ~/.ssh yet, create it before opening the
   //    devcontainer: `mkdir -p ~/.ssh && chmod 700 ~/.ssh`.
+  //    Cross-platform path: USERPROFILE is set on Windows, HOME is set on
+  //    macOS/Linux; the concatenation ${localEnv:USERPROFILE}${localEnv:HOME}
+  //    resolves correctly on every platform because exactly one is non-empty.
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind",
     "source=/run/host-services/ssh-auth.sock,target=/ssh-agent,type=bind",
     "source=jim-claude-state,target=/home/vscode/.claude,type=volume",
-    "source=${localEnv:HOME}/.ssh,target=/host-ssh,type=bind,readonly"
+    "source=${localEnv:USERPROFILE}${localEnv:HOME}/.ssh,target=/host-ssh,type=bind,readonly"
   ],
   // Container environment variables
   "containerEnv": {


### PR DESCRIPTION
## Summary
- `${localEnv:HOME}` expands to empty on Windows because `HOME` is not a standard Windows environment variable (`USERPROFILE` is); this caused the host SSH directory bind mount to resolve to `/.ssh`, which does not exist in the Docker daemon's filesystem, and the container failed to start
- Fixed by using `${localEnv:USERPROFILE}${localEnv:HOME}` — exactly one of the two variables is set on any given platform: `USERPROFILE` on Windows, `HOME` on macOS/Linux; the concatenation resolves to the correct home directory on all hosts
- Docker Desktop on Windows handles the resulting Windows-style path (`C:\Users\...\`) the same way it handles the workspace folder bind mount, so no further translation is needed
- Updated the inline comment to explain the cross-platform rationale

## Test plan
- [x] Devcontainer rebuild confirmed working on Docker Desktop for Windows after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)