### PR TITLE
fix(ci): stabilise Trivy SARIF categories + clear stale alerts; pin ws

### DIFF
--- a/.github/scripts/discover-base-images.ps1
+++ b/.github/scripts/discover-base-images.ps1
@@ -122,11 +122,25 @@ foreach ($dockerfile in $dockerfiles) {
             continue
         }
 
+        # Derive a stable category slug from the image repository (registry +
+        # path), stripping the tag and digest. This is what the downstream scan
+        # job uses as the SARIF category. It MUST be stable across line-number
+        # changes and digest bumps: the category was previously keyed by
+        # Dockerfile line number, so any FROM-line move (or a change in which
+        # deduplicated occurrence represented an image) orphaned the old category.
+        # Orphaned categories are never scanned again, so their alerts could never
+        # auto-close; they stayed open forever showing stale package versions.
+        # Keying by repository makes the category stable so fixed findings close.
+        #   mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:... -> mcr-microsoft-com-dotnet-aspnet
+        $repository = (($imageRef -split '@')[0]) -replace ':[^/:]+$', ''
+        $imageName  = ($repository -replace '[^A-Za-z0-9]+', '-').Trim('-')
+
         Write-Host "  line ${lineNumber}: $imageRef (ok)"
         $results += [pscustomobject]@{
             dockerfile = $relativePath
             line       = $lineNumber
             image_ref  = $imageRef
+            image_name = $imageName
         }
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,10 @@ jobs:
       uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
       with:
         sarif_file: trivy-results.sarif
-        category: trivy-base-image-${{ matrix.dockerfile }}-line${{ matrix.line }}
+        # Category is keyed by image repository (stable), not Dockerfile line
+        # number. A line-keyed category orphaned its alerts whenever a FROM line
+        # moved, leaving fixed findings stuck open. See discover-base-images.ps1.
+        category: trivy-base-image-${{ matrix.image_name }}
 
   scan-base-images-summary:
     # Stable-name gate for the dynamic scan-base-images matrix. Matrix leg

--- a/engineering/diagrams/structurizr/package-lock.json
+++ b/engineering/diagrams/structurizr/package-lock.json
@@ -1057,9 +1057,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/engineering/diagrams/structurizr/package.json
+++ b/engineering/diagrams/structurizr/package.json
@@ -11,6 +11,7 @@
   },
   "overrides": {
     "basic-ftp": ">=5.3.1",
-    "ip-address": ">=10.1.1"
+    "ip-address": ">=10.1.1",
+    "ws": ">=8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

Two security-housekeeping fixes surfaced while investigating the inflated code-scanning alert list (was 70 open Trivy alerts).

### 1. Trivy SARIF category was keyed by Dockerfile line number (root cause of phantom alerts)

`ci.yml` uploaded base-image scan results under a category embedding the Dockerfile line number (`trivy-base-image-<dockerfile>-line<line>`). Whenever a `FROM` line moved, or the deduplicated occurrence representing an image changed, the category string changed and the previous category orphaned. Orphaned categories are never scanned again, so GitHub could never auto-close their alerts; they stayed open indefinitely showing **stale package versions that were already patched** in the current pinned images.

This inflated the Security tab with phantom alerts (openssl, libssl3, libcap2, sed, dpkg, NuGet build tooling) on top of the genuinely-open gnutls findings.

**Fix:** `discover-base-images.ps1` now emits a stable `image_name` slug derived from the image repository (registry + path, tag and digest stripped), and `ci.yml` keys the SARIF category by it. The category is now stable across line moves and digest bumps, so fixed findings auto-close on the next scan.

### 2. Pin `ws >= 8.20.1` in structurizr diagram tooling (Dependabot #17)

Resolves CVE-2026-45736 / GHSA-58qx-3vcg-4xpx (ws uninitialised memory disclosure, fixed in 8.20.1). `ws` is a transitive dependency of `puppeteer-core` in the dev-only diagram export tooling; added to the existing `overrides` block, resolving to 8.21.0.

## Alert cleanup performed

Deleted 460 orphaned analyses across 7 dead line-keyed categories, clearing all 31 stale phantom alerts. Open Trivy alerts went **70 → 39**; the remaining 39 are the genuine `libgnutls30t64` findings (low/medium), still awaiting Microsoft's next base-image rebuild to pick up Ubuntu's `…ubuntu3.6` gnutls (it is not on JIM's TLS path, which uses OpenSSL).

## Post-merge follow-up

Once this merges and CI runs on `main`, the gnutls findings re-home under the new stable categories and the three old line-keyed gnutls categories (`Web-line14`, `Web-line55`, `Worker-line10`) will orphan; they will be deleted in a follow-up cleanup to avoid transient doubled gnutls alerts.

## Testing

- `discover-base-images.ps1` run locally; matrix emits stable `image_name` slugs (`mcr-microsoft-com-dotnet-{aspnet,runtime,sdk}`).
- No `.cs` changes; CI/CD + script + npm tooling only, so no `dotnet build`/`test` gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)