### PR TITLE
fix(ci): make apt-pin-check work on GitHub-hosted runners

### DIFF
--- a/.github/scripts/check-apt-pins.ps1
+++ b/.github/scripts/check-apt-pins.ps1
@@ -167,7 +167,13 @@ for spec in "$@"; do
 done
 '@
 
+# Normalise to LF: this file may be checked out with CRLF line endings (git
+# autocrlf on .ps1), and carriage returns inside the script break bash when it
+# is passed via `bash -c` ("syntax error near unexpected token $'do\r'").
+$containerScript = $containerScript -replace "`r", ''
+
 $results = @()
+$queryFailures = @()
 
 foreach ($group in ($pins | Group-Object image_ref)) {
     $imageRef = $group.Name
@@ -182,13 +188,16 @@ foreach ($group in ($pins | Group-Object image_ref)) {
 
     $specs = @($group.Group | ForEach-Object { "$($_.package)|$($_.version)" })
 
-    # `bash -s -- <args>` reads the script from stdin (the here-string piped in)
-    # and exposes <args> as positional parameters ($@). Pull happened above so
-    # this run is offline-fast.
-    $raw = $containerScript | docker run --rm --platform $platform --user root --entrypoint bash -i $imageRef -s -- @specs 2>$null | Out-String
+    # Pass the script as a `bash -c` argument with the specs as positional
+    # parameters ($@). This is more portable than piping the script on stdin
+    # (`bash -s`), which silently delivered nothing on the GitHub-hosted runner.
+    # Capture stderr too so a container failure is diagnosable rather than silent.
+    $raw = docker run --rm --platform $platform --user root --entrypoint bash $imageRef -c $containerScript -- @specs 2>&1 | Out-String
 
+    $rowCount = 0
     foreach ($rln in ($raw -split "`n")) {
         if ($rln -notmatch '^RESULT\|') { continue }
+        $rowCount++
         $f = $rln.Trim() -split '\|'
         $results += [pscustomobject]@{
             image_ref   = $imageRef
@@ -200,6 +209,23 @@ foreach ($group in ($pins | Group-Object image_ref)) {
             security    = ($f[6] -eq 'yes')
         }
     }
+
+    # A query that returns no rows for an image we have pins for means the check
+    # did not actually run (e.g. apt-get update failed, or the container errored).
+    # Treat that as a hard failure, never as "all current": a silent false
+    # negative would leave the pins unmonitored while looking healthy.
+    if ($rowCount -lt $specs.Count) {
+        $queryFailures += $imageRef
+        Write-Host "ERROR: expected $($specs.Count) result(s) from $imageRef but got $rowCount. Container output:"
+        Write-Host ($raw.Trim())
+    }
+}
+
+if ($queryFailures.Count -gt 0) {
+    Write-Host ''
+    Write-Host "FATAL: apt pin check could not complete for $($queryFailures.Count) base image(s): $($queryFailures -join ', ')"
+    Write-Host 'Refusing to report a result; the pins are NOT confirmed current.'
+    exit 1
 }
 
 # --- Report -----------------------------------------------------------------

--- a/.github/scripts/open-apt-pin-pr.ps1
+++ b/.github/scripts/open-apt-pin-pr.ps1
@@ -136,24 +136,31 @@ if ($DryRun) {
 }
 
 # Reset (or create) the bot branch at the base tip so the PR contains exactly one
-# fresh commit and updates cleanly in place.
+# fresh commit and updates cleanly in place. Note: native `gh` failures do NOT
+# raise a terminating error in PowerShell, so branch existence is probed via
+# $LASTEXITCODE, not try/catch, and each mutation's exit code is checked.
 $refPath = "repos/$Repository/git/refs/heads/$Branch"
-$exists = $true
-try { Invoke-Gh @('api', $refPath, '--silent') } catch { $exists = $false }
-if ($exists) {
+Invoke-Gh @('api', $refPath, '--silent') 2>$null
+$branchExists = ($LASTEXITCODE -eq 0)
+if ($branchExists) {
     Write-Host "Resetting $Branch to $baseSha"
     Invoke-Gh @('api', '-X', 'PATCH', $refPath, '-f', "sha=$baseSha", '-F', 'force=true') | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to reset branch $Branch to $baseSha." }
 } else {
     Write-Host "Creating $Branch at $baseSha"
     Invoke-Gh @('api', '-X', 'POST', "repos/$Repository/git/refs", '-f', "ref=refs/heads/$Branch", '-f', "sha=$baseSha") | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to create branch $Branch at $baseSha." }
 }
 
-# Create the signed commit via GraphQL.
+# Create the signed commit via GraphQL. Parse the response explicitly so a
+# GraphQL-level error (which still exits 0 in some cases) is caught.
 $tmp = New-TemporaryFile
 try {
     $payload | Out-File -FilePath $tmp -Encoding utf8
-    $commitOid = (Get-Content -Raw $tmp | & gh api graphql --input - --jq '.data.createCommitOnBranch.commit.oid').Trim()
-    if (-not $commitOid) { throw 'createCommitOnBranch returned no commit oid.' }
+    $resp = Get-Content -Raw $tmp | & gh api graphql --input -
+    if ($LASTEXITCODE -ne 0) { throw "createCommitOnBranch call failed (exit $LASTEXITCODE): $resp" }
+    $commitOid = ($resp | ConvertFrom-Json).data.createCommitOnBranch.commit.oid
+    if (-not $commitOid) { throw "createCommitOnBranch returned no commit oid: $resp" }
     Write-Host "Created signed commit $commitOid on $Branch"
 } finally {
     Remove-Item $tmp -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

The `apt-pin-check` automation (merged in #773) had two runner-only bugs, found via a controlled end-to-end smoke test (temporarily downgraded a pin, dispatched the workflow against a throwaway branch). Both passed local validation but failed on the GitHub-hosted runner.

### `check-apt-pins.ps1`
- **Stdin script delivery failed on the runner.** The in-container query was piped to `bash -s` (with `-i`) on stdin; on the runner this delivered nothing, so every package returned no candidate and the script wrongly concluded "all current". Switched to `bash -c <script> -- <specs>` (script as argument, specs as positional parameters).
- **CRLF in the embedded shell script** (git autocrlf on `.ps1`) broke bash with `syntax error near unexpected token $'do\r'`. Normalise to LF before invoking.
- **Hard-fail guard added:** if a base image returns fewer rows than it has pins, the check did not actually run, so exit 1 with diagnostics rather than silently reporting "current". A silent false negative would leave the pins unmonitored while looking healthy.

### `open-apt-pin-pr.ps1`
- **Branch existence was probed with `try/catch` around a native `gh` call**, but native non-zero exits don't raise terminating errors in PowerShell, so a missing branch read as existing. It then PATCHed a non-existent ref (422), never created the branch, and `createCommitOnBranch` failed. Now probes via `$LASTEXITCODE`, checks each ref mutation's exit code, and parses the GraphQL response explicitly.

## Verification

Full path confirmed on a runner after the fix: detect stale pin → mint App token → **signed (verified=true) commit** → PR opened by `jim-automation[bot]` → **CI triggered** on the App PR. The earlier-merged version would have silently reported "all current" forever; this is the fix that makes the automation actually function.

Scripts only; no `.cs` changes, so no `dotnet build`/`test` gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)