### PR TITLE
fix(devcontainer): permanently heal stale Docker credsStore

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -183,9 +183,10 @@ mkdir -p ~/.ssh && chmod 700 ~/.ssh
 
 **Image pull / build fails with `error getting credentials - err: exit status 255`:**
 - Symptom: `jim-build`, `jim-stack`, or integration tests fail at the BuildKit image-resolve step, even for public images like `docker/dockerfile:1`.
-- Cause: a stale VS Code Dev Containers credential-forwarding shim (`credsStore: dev-containers-<uuid>` in `~/.docker/config.json`) whose host peer has gone away after a rebuild/reconnect. BuildKit treats the helper's non-zero exit as fatal where the Docker CLI tolerates it.
-- Auto-heal: `.devcontainer/heal-docker-creds.sh` runs on every container start via `postStartCommand` and strips dev-containers shims unconditionally (`docker login` credentials under `auths` are preserved).
-- Manual fix if you hit it before the next start: `bash .devcontainer/heal-docker-creds.sh` then retry.
+- Cause: the VS Code Dev Containers credential-forwarding shim (`credsStore: dev-containers-<uuid>` in `~/.docker/config.json`) proxies credential lookups to the host VS Code over a `/tmp` IPC. When that peer is momentarily unreachable (reconnect, extension reload, or a build firing before VS Code re-establishes it) the shim exits 255 and BuildKit aborts resolving even public images. The shim is unreliable even when its helper binary is present, so the heal strips it on sight rather than only when the binary is missing.
+- Prevented at source: `dev.containers.dockerCredentialHelper: false` in `devcontainer.json` tells VS Code not to inject the credsStore at all. This setting is read host-side, so it is not guaranteed to apply on every client (plain `devcontainer` CLI, Codespaces, older extension versions); the heal below is the safety net.
+- Auto-heal: `.devcontainer/heal-docker-creds.sh` strips any `dev-containers-*` credsStore unconditionally (`docker login` credentials under `auths` are preserved). It runs at container create (`setup.sh`), on every start (`postStartCommand`), and at command time before every build/stack/test via the `jim-*` aliases, which all delegate to that one script. The command-time run is what catches mid-session re-poisoning, since VS Code re-injects the credsStore on reconnect after `postStartCommand` has already run.
+- Manual fix if you ever hit it: `bash .devcontainer/heal-docker-creds.sh` then retry.
 
 **Sync Activities Failing with UnhandledError:**
 - UnhandledError items in Activities indicate code/logic bugs, not data problems

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -141,7 +141,25 @@
           "initialise"
         ],
         // Port forwarding - use localhost instead of 127.0.0.1 for Entra ID compatibility
-        "remote.localPortHost": "localhost"
+        "remote.localPortHost": "localhost",
+        // Stop the Dev Containers extension forwarding host Docker credentials
+        // into the container by writing { "credsStore": "dev-containers-<uuid>" }
+        // to ~/.docker/config.json and installing a matching shim binary. That
+        // shim proxies credential lookups back to the host VS Code over a /tmp
+        // IPC; when the peer is momentarily unreachable (reconnect, extension
+        // reload, a build firing before VS Code re-establishes it) the shim
+        // exits 255 and BuildKit aborts resolving even public images like
+        // docker/dockerfile:1 ("error getting credentials - err: exit status
+        // 255"). JIM's builds only pull public images, so forwarding host
+        // credentials buys nothing and is pure liability here.
+        //
+        // NOTE: dev.containers.* is read host-side, so this committed value is
+        // not guaranteed to take effect on every client (plain devcontainer
+        // CLI, Codespaces, older extension versions). The command-time heal in
+        // jim-aliases.sh (delegating to .devcontainer/heal-docker-creds.sh)
+        // remains the safety net that strips any dev-containers-* credsStore
+        // before each build regardless of client.
+        "dev.containers.dockerCredentialHelper": false
       }
     }
   },

--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -289,24 +289,34 @@ _jim_kill_local() {
 }
 
 # Self-heal stale Docker credential helper references at command time.
+#
 # The VS Code Dev Containers extension's per-session credsStore shim
-# (docker-credential-dev-containers-<uuid>) can disappear mid-session
-# (extension reload, host VS Code restart, etc.) while the reference in
-# ~/.docker/config.json persists, making every docker pull/build fail with
-# "error getting credentials - err: exit status 255". setup.sh handles this
-# at container creation; this runs at command time to handle the in-session
-# breakage. See setup.sh for the full background.
+# (docker-credential-dev-containers-<uuid>) is unreliable from BuildKit even
+# when its helper binary is present: it proxies credential lookups to the host
+# VS Code over a /tmp IPC, and when that peer is momentarily unreachable
+# (extension reload, reconnect, a build firing before VS Code re-establishes
+# it) the shim exits 255 and BuildKit aborts resolving even public images,
+# failing with "error getting credentials - err: exit status 255". setup.sh
+# and postStartCommand heal this at container create/start, but VS Code
+# re-injects the credsStore on every reconnect, so we re-run the heal here,
+# immediately before each docker build/up.
+#
+# Delegates to the canonical .devcontainer/heal-docker-creds.sh so heal logic
+# lives in exactly one place. This was previously a separate inline copy that
+# only stripped when the helper binary was *missing*; it drifted from the
+# canonical script (which strips any dev-containers-* shim unconditionally),
+# let the unreliable-but-present shim through, and broke jim-build. Do not
+# reintroduce inline logic here - fix heal-docker-creds.sh instead.
 _jim_heal_docker_creds() {
-  local cfg="$HOME/.docker/config.json"
-  [ -f "$cfg" ] || return 0
-  command -v jq >/dev/null 2>&1 || return 0
-  local creds_store
-  creds_store=$(jq -r '.credsStore // empty' "$cfg" 2>/dev/null)
-  [ -n "$creds_store" ] || return 0
-  command -v "docker-credential-$creds_store" >/dev/null 2>&1 && return 0
-  echo "Stale Docker credsStore '$creds_store' (helper binary missing) - removing from $cfg"
-  local tmp
-  tmp=$(mktemp) && jq 'del(.credsStore)' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+  local script
+  if [ -f "$HOME/.devcontainer/heal-docker-creds.sh" ]; then
+    script="$HOME/.devcontainer/heal-docker-creds.sh"
+  elif [ -f "/workspaces/JIM/.devcontainer/heal-docker-creds.sh" ]; then
+    script="/workspaces/JIM/.devcontainer/heal-docker-creds.sh"
+  else
+    return 0
+  fi
+  bash "$script"
 }
 
 # Clear any previous aliases before defining functions (zsh cannot redefine alias as function)


### PR DESCRIPTION
## Summary
- `jim-build` and the other `jim-*` aliases called an inline `_jim_heal_docker_creds` that only stripped a stale Docker `credsStore` when the helper binary was *missing*. It had drifted from the canonical `.devcontainer/heal-docker-creds.sh`, which strips any `dev-containers-*` shim unconditionally.
- The VS Code Dev Containers credential-forwarding shim is unreliable from BuildKit even when its binary is present: it proxies credential lookups to the host over a `/tmp` IPC and exits 255 when that peer is momentarily unreachable, aborting resolution of even public images like `docker/dockerfile:1` (`error getting credentials - err: exit status 255`).
- Because the binary is normally present, the inline copy returned early and left the poison in place, so `jim-build` ran straight into the broken shim. `postCreate`/`postStart` healing does not save it: VS Code re-injects the credsStore on every reconnect, after those hooks run, so a fresh clone is exposed on its first build too.
- **Fix, two layers:** (1) `_jim_heal_docker_creds` now delegates to the canonical `heal-docker-creds.sh` (single source of truth), so the build path strips `dev-containers-*` unconditionally before every build; (2) `dev.containers.dockerCredentialHelper: false` in `devcontainer.json` stops VS Code injecting the credsStore at source (read host-side, so the heal stays as the safety net).
- Updated `.devcontainer/CLAUDE.md` troubleshooting to match.

## Test plan
This change touches only a shell script, devcontainer config, and Markdown docs, so it falls under the CLAUDE.md build/test exception (no `dotnet build`/`test` required).
- [x] `bash -n .devcontainer/jim-aliases.sh` parses cleanly
- [x] `devcontainer.json` validated as well-formed JSONC; `dev.containers.dockerCredentialHelper` reads `false`
- [x] End-to-end: invoking `_jim_heal_docker_creds` stripped a live `dev-containers-*` credsStore (config reduced to `{}`), confirming the alias now delegates to the canonical heal

🤖 Generated with [Claude Code](https://claude.com/claude-code)