### PR TITLE
chore(devcontainer): pin Playwright MCP server version

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,9 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@playwright/mcp@latest",
-        "--executable-path",
-        "/home/vscode/.cache/ms-playwright/chromium-1224/chrome-linux/chrome",
+        "@playwright/mcp@0.0.75",
         "--headless",
         "--isolated",
         "--no-sandbox"


### PR DESCRIPTION
## Summary

- `setup.sh` installs the Playwright MCP browser pinned to `@playwright/mcp@0.0.75`, but `.mcp.json` floated `@latest` and hardcoded the `chromium-1224` executable path. Over a container's life those drift (the server is launched many times via `npx`, the browser is installed once at create), which is the same class of breakage #787 fixed.
- Pin `.mcp.json` to the same `0.0.75` and drop the hardcoded `--executable-path` so the server resolves its own matching browser. Keeps the two halves in lockstep.

## Test plan

- [x] Config-only change (`.mcp.json`); no `.cs` touched, so the `dotnet build`/`test` gate does not apply per the CLAUDE.md exception list.
- [x] `.mcp.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)