### PR TITLE
chore(ci): add tooling-pin-check bot for Dependabot-invisible dev tooling pins

### DIFF
--- a/.github/scripts/check-tooling-pins.ps1
+++ b/.github/scripts/check-tooling-pins.ps1
@@ -1,0 +1,234 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Detects when newer versions of the manually-pinned development tooling (npm
+    and NuGet packages installed outside any manifest Dependabot can read) are
+    available, and (optionally) rewrites the pins in place so a bump can be
+    proposed for evaluation.
+
+.DESCRIPTION
+    A few development tools are pinned to exact versions in places Dependabot does
+    not look:
+
+      - `@playwright/mcp` (the Playwright MCP server used for UI validation) is
+        pinned in BOTH `.devcontainer/setup.sh` (the install-at-create step) and
+        `.mcp.json` (the launch-at-runtime config). The two MUST move together or
+        the installed browser and the server drift apart.
+      - `dotnet-ef` (the EF Core CLI) is pinned in `.devcontainer/setup.sh`.
+
+    Dependabot only reads real manifests (`package.json`, `.csproj`, Dockerfile
+    FROM lines, workflow `uses:`). None of these pins live in one, so without this
+    check a newer release sits unnoticed until someone happens to look.
+
+    This script closes that gap:
+
+      1. For each tool, reads the currently-pinned version from its file(s).
+      2. Queries the upstream registry (npm or NuGet) for the latest stable
+         version.
+      3. Flags any tool whose pinned version is behind the latest.
+
+    Default mode reports findings as a table. `-Apply` additionally rewrites the
+    bumps into the pin files in place (used by the tooling-pin-check workflow to
+    produce a PR for evaluation). When a tool is pinned in more than one file,
+    every location is rewritten to the same new version, healing any drift.
+
+    Runnable locally from the repository root for ad hoc checks:
+
+        pwsh -NoProfile -File .github/scripts/check-tooling-pins.ps1
+
+    Requires outbound HTTPS to registry.npmjs.org and api.nuget.org. Unlike the
+    apt pin check it needs no Docker; these are registry HTTP lookups.
+
+.PARAMETER Apply
+    Rewrite the available bumps into the pin files in place. Without it, the
+    script only reports.
+
+.NOTES
+    Exit codes:
+      0  success; no updates available (or -Apply applied them cleanly)
+      1  an error occurred (a registry query failed, a pin could not be parsed)
+      2  updates are available (lets a scheduled check branch on "is there
+         anything to evaluate")
+
+    Like the apt pin check, a registry query that fails is treated as a hard
+    error (exit 1), never as "current": a silent false negative would leave the
+    pin unmonitored while looking healthy.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Get-Location).Path
+
+# --- The pin manifest --------------------------------------------------------
+# Each tool: a display name, the registry to query, the registry package id, and
+# one or more locations. A location is a file plus a .NET regex whose ENTIRE
+# match is the version string (achieved with look-around), so applying a bump is
+# a straight [regex]::Replace of the match with the new version. Multiple
+# occurrences within a file are all replaced.
+$tools = @(
+    @{
+        name      = '@playwright/mcp'
+        registry  = 'npm'
+        id        = '@playwright/mcp'
+        locations = @(
+            @{ file = '.devcontainer/setup.sh'; pattern = '(?<=PLAYWRIGHT_MCP_VERSION=")[^"]+' }
+            @{ file = '.mcp.json';              pattern = '(?<=@playwright/mcp@)[^"]+' }
+        )
+    },
+    @{
+        name      = 'dotnet-ef'
+        registry  = 'nuget'
+        id        = 'dotnet-ef'
+        locations = @(
+            @{ file = '.devcontainer/setup.sh'; pattern = '(?<=dotnet-ef --version )\d[\w.\-]*' }
+            @{ file = '.devcontainer/setup.sh'; pattern = '(?<=dotnet-ef )\d[\w.\-]*(?= installed globally)' }
+        )
+    }
+)
+
+# --- Registry queries --------------------------------------------------------
+
+function Get-LatestNpmVersion {
+    param([string]$Id)
+    # Scoped names (@scope/name) must have the slash encoded for the registry path.
+    $encoded = $Id -replace '/', '%2F'
+    $resp = Invoke-RestMethod -Uri "https://registry.npmjs.org/$encoded" -TimeoutSec 30
+    $latest = $resp.'dist-tags'.latest
+    if (-not $latest) { throw "npm returned no dist-tags.latest for $Id." }
+    return $latest
+}
+
+function Get-LatestNuGetVersion {
+    param([string]$Id)
+    # The flat-container id segment is lower-cased.
+    $resp = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$($Id.ToLower())/index.json" -TimeoutSec 30
+    # Versions are ascending; exclude prereleases (a '-' suffix) and take the last.
+    $stable = @($resp.versions | Where-Object { $_ -notmatch '-' })
+    if ($stable.Count -eq 0) { throw "NuGet returned no stable versions for $Id." }
+    return $stable[-1]
+}
+
+function Compare-Version {
+    # Returns $true if $Candidate is strictly newer than $Current.
+    param([string]$Candidate, [string]$Current)
+    try {
+        return ([version]$Candidate) -gt ([version]$Current)
+    } catch {
+        throw "Could not compare versions '$Candidate' and '$Current' as [version]: $_"
+    }
+}
+
+# --- Read the current pins ---------------------------------------------------
+
+function Get-PinnedVersion {
+    param([hashtable]$Location)
+    $path = Join-Path $repoRoot $Location.file
+    if (-not (Test-Path $path)) { throw "Pin file not found: $($Location.file)" }
+    $text = Get-Content -Path $path -Raw
+    $m = [regex]::Match($text, $Location.pattern)
+    if (-not $m.Success) { throw "Pattern did not match in $($Location.file): $($Location.pattern)" }
+    return $m.Value
+}
+
+# --- Detect ------------------------------------------------------------------
+
+$queryFailures = @()
+$findings = @()  # one per tool that is behind
+
+foreach ($tool in $tools) {
+    # Read every location's current version. They should all agree; if they have
+    # drifted, use the lowest as "current" so we never propose a downgrade and
+    # the -Apply rewrite heals all locations up to the latest.
+    $currents = @()
+    foreach ($loc in $tool.locations) {
+        $currents += Get-PinnedVersion -Location $loc
+    }
+    $distinct = @($currents | Select-Object -Unique)
+    if ($distinct.Count -gt 1) {
+        Write-Host "WARNING: $($tool.name) is pinned inconsistently across files: $($distinct -join ', '). Will heal to the latest."
+    }
+    # Lowest current via [version] sort.
+    $current = (@($distinct | Sort-Object { [version]$_ }))[0]
+
+    try {
+        $latest = switch ($tool.registry) {
+            'npm'   { Get-LatestNpmVersion   -Id $tool.id }
+            'nuget' { Get-LatestNuGetVersion -Id $tool.id }
+            default { throw "Unknown registry '$($tool.registry)' for $($tool.name)." }
+        }
+    } catch {
+        $queryFailures += $tool.name
+        Write-Host "ERROR: could not query $($tool.registry) for $($tool.name): $_"
+        continue
+    }
+
+    $behind = Compare-Version -Candidate $latest -Current $current
+    $state = if ($behind) { 'UPDATE' } else { 'current' }
+    Write-Host ("  {0,-22} {1,-12} -> {2,-12} {3}" -f $tool.name, $current, $latest, $state)
+
+    if ($behind) {
+        $findings += [pscustomobject]@{
+            name    = $tool.name
+            current = ($distinct -join ', ')
+            latest  = $latest
+            files   = (@($tool.locations | ForEach-Object { $_.file } | Select-Object -Unique) -join ', ')
+            tool    = $tool
+        }
+    }
+}
+
+if ($queryFailures.Count -gt 0) {
+    Write-Host ''
+    Write-Host "FATAL: tooling pin check could not complete for: $($queryFailures -join ', ')"
+    Write-Host 'Refusing to report a result; these pins are NOT confirmed current.'
+    exit 1
+}
+
+Write-Host ''
+if ($findings.Count -eq 0) {
+    Write-Host 'All manually-pinned tooling is current. Nothing to evaluate.'
+    exit 0
+}
+
+Write-Host "$($findings.Count) pinned tool(s) have a newer version available to evaluate."
+
+# --- PR body + machine-readable outputs --------------------------------------
+
+$bodyLines = @('| Tool | Pinned | Available | Files |', '| --- | --- | --- | --- |')
+foreach ($f in $findings) {
+    $bodyLines += "| ``$($f.name)`` | $($f.current) | $($f.latest) | $($f.files) |"
+}
+$body = $bodyLines -join "`n"
+Set-Content -Path (Join-Path $repoRoot 'tooling-pin-pr-body.md') -Value $body -Encoding utf8
+
+if ($env:GITHUB_OUTPUT) {
+    "has_updates=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "update_count=$($findings.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}
+
+# --- Apply -------------------------------------------------------------------
+
+if ($Apply) {
+    Write-Host ''
+    Write-Host 'Applying bumps to pin files ...'
+    foreach ($f in $findings) {
+        foreach ($loc in $f.tool.locations) {
+            $path = Join-Path $repoRoot $loc.file
+            $text = Get-Content -Path $path -Raw
+            $new  = [regex]::Replace($text, $loc.pattern, $f.latest)
+            if ($new -ne $text) {
+                Set-Content -Path $path -Value $new -NoNewline
+                Write-Host "  $($loc.file): $($f.name) -> $($f.latest)"
+            }
+        }
+    }
+}
+
+exit 2

--- a/.github/scripts/open-pin-pr.ps1
+++ b/.github/scripts/open-pin-pr.ps1
@@ -3,12 +3,16 @@
 
 <#
 .SYNOPSIS
-    Opens (or updates) a pull request bumping the apt package pins that
-    check-apt-pins.ps1 -Apply has rewritten in the working tree.
+    Opens (or updates) a pull request publishing the version-pin bumps that a
+    `check-*-pins.ps1 -Apply` step has rewritten in the working tree.
 
 .DESCRIPTION
-    Run after `check-apt-pins.ps1 -Apply` has modified one or more Dockerfiles.
-    It publishes those changes as a PR for human evaluation.
+    Run after a detection script (check-apt-pins.ps1, check-tooling-pins.ps1, ...)
+    has rewritten one or more pinned versions in place. This script publishes
+    those changes as a PR for human evaluation. It is pin-source agnostic: what
+    set of files it commits, the commit message, the branch, and the PR label are
+    all supplied by the caller, so the same signed-commit machinery serves every
+    Dependabot-invisible pin bot.
 
     Two constraints shape the implementation:
 
@@ -18,25 +22,41 @@
          show as "Verified", so this script commits via the GraphQL
          createCommitOnBranch mutation rather than git.
 
-      2. CI does not build the JIM images on a PR, so the bump is not build-tested
-         in CI. check-apt-pins.ps1 already validates installability against the
-         base image before proposing, which is the mitigation; this script only
+      2. CI does not necessarily build/test the bump on a PR. Each detection
+         script is responsible for validating its own bumps before proposing
+         (e.g. check-apt-pins.ps1 proves installability); this script only
          publishes what that step validated.
 
-    Idempotency: the bot uses a single stable branch. On each run the branch is
+    Idempotency: each bot uses a single stable branch. On each run the branch is
     reset to the tip of the base branch and a fresh single commit is applied, so
     an already-open PR is updated in place rather than duplicated, and the branch
     never accumulates stale history.
 
     Requires: GH_TOKEN set to a token carrying `contents: write` and
-    `pull-requests: write`. In the apt-pin-check workflow this is a GitHub App
+    `pull-requests: write`. In the pin-check workflows this is a GitHub App
     installation token (a service principal), not a personal or GITHUB_TOKEN
     credential. $env:GITHUB_REPOSITORY must be set (it is in Actions); otherwise
     pass -Repository owner/repo.
 
 .PARAMETER BodyFile
     Path to a file containing the markdown table of proposed bumps (the `pr_body`
-    output of check-apt-pins.ps1). Embedded in the PR description.
+    output of the detection script). Embedded in the PR description.
+
+.PARAMETER FilePattern
+    Regex matched against `git diff --name-only` to select which changed files to
+    commit. Scopes the commit strictly to the pin files and guards against
+    committing a stray working-tree artefact (e.g. the generated *-pr-body.md).
+    Defaults to Dockerfiles (the apt bot).
+
+.PARAMETER CommitHeadline
+    The commit/PR title. Defaults to the apt bot's headline.
+
+.PARAMETER CommitBodyIntro
+    The prose paragraph placed above the bump table in the commit/PR body.
+    Defaults to the apt bot's intro.
+
+.PARAMETER Label
+    The label applied to a newly-created PR. Defaults to 'dependencies'.
 
 .PARAMETER BaseBranch
     The branch to target and reset from. Defaults to 'main'.
@@ -55,6 +75,14 @@
 [CmdletBinding()]
 param(
     [string]$BodyFile,
+    [string]$FilePattern = '(^|/)Dockerfile$',
+    [string]$CommitHeadline = 'chore(deps): bump pinned apt package versions',
+    [string]$CommitBodyIntro = @'
+Newer versions of apt packages pinned in production Dockerfiles are available in
+the Ubuntu archive and have been validated as installable against the pinned base
+image. Raised for evaluation by the apt-pin-check workflow.
+'@,
+    [string]$Label = 'dependencies',
     [string]$BaseBranch = 'main',
     [string]$Branch = 'automation/apt-pin-updates',
     [string]$Repository = $env:GITHUB_REPOSITORY,
@@ -65,11 +93,11 @@ $ErrorActionPreference = 'Stop'
 
 if (-not $Repository) { throw 'Repository not set. Pass -Repository owner/repo or set GITHUB_REPOSITORY.' }
 
-# Files changed by the -Apply step. Scope strictly to Dockerfiles: the bump only
-# ever rewrites pinned versions in Dockerfiles, and this guards against
-# committing any other stray working-tree artefact (e.g. the generated
-# apt-pin-pr-body.md).
-$changed = @(git diff --name-only | Where-Object { $_ -match '(^|/)Dockerfile$' })
+# Files changed by the -Apply step. Scope strictly to the pin files via the
+# caller-supplied pattern: the bump only ever rewrites pinned versions in those
+# files, and this guards against committing any other stray working-tree
+# artefact (e.g. the generated *-pr-body.md).
+$changed = @(git diff --name-only | Where-Object { $_ -match $FilePattern })
 if ($changed.Count -eq 0) {
     Write-Host 'No working-tree changes; nothing to propose.'
     exit 0
@@ -78,11 +106,9 @@ if ($changed.Count -eq 0) {
 Write-Host "Changed files:"; $changed | ForEach-Object { Write-Host "  $_" }
 
 $prBody = if ($BodyFile -and (Test-Path $BodyFile)) { Get-Content -Path $BodyFile -Raw } else { '' }
-$commitHeadline = 'chore(deps): bump pinned apt package versions'
+$commitHeadline = $CommitHeadline
 $commitBody = @"
-Newer versions of apt packages pinned in production Dockerfiles are available in
-the Ubuntu archive and have been validated as installable against the pinned base
-image. Raised for evaluation by the apt-pin-check workflow.
+$CommitBodyIntro
 
 $prBody
 "@
@@ -175,5 +201,5 @@ if ($openPr) {
 } else {
     Write-Host 'Opening new PR ...'
     Invoke-Gh @('pr', 'create', '--repo', $Repository, '--base', $BaseBranch, '--head', $Branch,
-        '--title', $commitHeadline, '--body', $commitBody, '--label', 'dependencies') | Out-Null
+        '--title', $commitHeadline, '--body', $commitBody, '--label', $Label) | Out-Null
 }

--- a/.github/workflows/apt-pin-check.yml
+++ b/.github/workflows/apt-pin-check.yml
@@ -9,13 +9,13 @@
 # newer package, security or otherwise, sits unnoticed until release time.
 #
 # See .github/scripts/check-apt-pins.ps1 (detection + installability validation)
-# and .github/scripts/open-apt-pin-pr.ps1 (signed-commit PR).
+# and .github/scripts/open-pin-pr.ps1 (the shared signed-commit PR opener).
 #
 # Identity / token choice.
 #   The PR is opened as a GitHub App (an org-owned service principal), not a
 #   personal token. Two reasons:
 #     1. `main` requires signed commits; commits created via the GitHub API (here,
-#        the GraphQL createCommitOnBranch mutation in open-apt-pin-pr.ps1) are
+#        the GraphQL createCommitOnBranch mutation in open-pin-pr.ps1) are
 #        signed by GitHub, and an App installation token authorises them.
 #     2. A PR opened with the default GITHUB_TOKEN does NOT trigger the CI /
 #        required-check workflows, so it could never satisfy branch protection.
@@ -72,4 +72,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: ./.github/scripts/open-apt-pin-pr.ps1 -BodyFile apt-pin-pr-body.md
+        run: ./.github/scripts/open-pin-pr.ps1 -BodyFile apt-pin-pr-body.md

--- a/.github/workflows/tooling-pin-check.yml
+++ b/.github/workflows/tooling-pin-check.yml
@@ -1,0 +1,89 @@
+# Detects when newer versions of the development tooling pinned outside any
+# Dependabot-readable manifest are available, and raises a PR bumping them for
+# evaluation.
+#
+# What it covers (and why Dependabot can't):
+#   - @playwright/mcp, pinned in BOTH .devcontainer/setup.sh and .mcp.json. These
+#     live in a shell script and an MCP config, not a package.json, so Dependabot's
+#     npm ecosystem never sees them. The two pins must move in lockstep or the
+#     installed browser and the MCP server drift apart.
+#   - dotnet-ef, installed via `dotnet tool install` in .devcontainer/setup.sh.
+#     Not a .csproj reference, so Dependabot's nuget ecosystem never sees it.
+#
+# See .github/scripts/check-tooling-pins.ps1 (detection: npm/NuGet registry
+# lookups, no Docker) and .github/scripts/open-pin-pr.ps1 (the shared
+# signed-commit PR opener, also used by apt-pin-check).
+#
+# Identity / token choice is identical to apt-pin-check: the PR is opened by the
+# APT_PIN_BOT GitHub App, not the default GITHUB_TOKEN. Two reasons:
+#   1. `main` requires signed commits; commits created via the GitHub API (the
+#      GraphQL createCommitOnBranch mutation in open-pin-pr.ps1) are signed by
+#      GitHub, and an App installation token authorises them.
+#   2. A PR opened with GITHUB_TOKEN does NOT trigger the required-check
+#      workflows, so it could never satisfy branch protection. App-authored
+#      events DO trigger them, so the bump PR runs CI and can merge.
+# The App's credentials are reused from apt-pin-check (APT_PIN_BOT_APP_ID /
+# APT_PIN_BOT_PRIVATE_KEY); the App is already scoped to Contents and Pull
+# requests (read/write) on this repository, which is all this workflow needs.
+
+name: tooling-pin-check
+
+on:
+  schedule:
+    # Weekly, Mondays at 06:00 UTC. Dev tooling moves far slower than the daily
+    # Ubuntu archive the apt check watches, so a weekly poll is ample.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: tooling-pin-check
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Detect and apply available tooling pin updates
+        id: check
+        shell: pwsh
+        run: |
+          ./.github/scripts/check-tooling-pins.ps1 -Apply
+          # Exit 2 means "updates applied"; treat as success for the workflow.
+          if ($LASTEXITCODE -eq 2) { exit 0 }
+          exit $LASTEXITCODE
+
+      - name: Mint GitHub App installation token
+        if: steps.check.outputs.has_updates == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APT_PIN_BOT_APP_ID }}
+          private-key: ${{ secrets.APT_PIN_BOT_PRIVATE_KEY }}
+
+      - name: Open or update bump PR
+        if: steps.check.outputs.has_updates == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          $intro = @'
+          Newer versions of development tooling pinned outside any Dependabot-readable
+          manifest (.devcontainer/setup.sh, .mcp.json) are available upstream. Raised
+          for evaluation by the tooling-pin-check workflow. Where a tool is pinned in
+          more than one file, every location has been moved to the same version.
+          '@
+          ./.github/scripts/open-pin-pr.ps1 `
+            -BodyFile tooling-pin-pr-body.md `
+            -FilePattern '(^|/)(setup\.sh|\.mcp\.json)$' `
+            -Branch 'automation/tooling-pin-updates' `
+            -CommitHeadline 'chore(deps): bump pinned development tooling versions' `
+            -CommitBodyIntro $intro `
+            -Label 'dependencies'

--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -1005,7 +1005,7 @@ The `apt-pin-check` workflow ([`.github/workflows/apt-pin-check.yml`](../.github
 3. **Validates that the candidate is actually installable** in that base image (`apt-get install --dry-run`) before proposing it. This matters because CI does not build the JIM images on a PR, so the bot must not propose an unbuildable version.
 4. Raises, or updates in place, a single pull request bumping the validated pins, for the same human review every other dependency update gets.
 
-Backing scripts: [`.github/scripts/check-apt-pins.ps1`](../.github/scripts/check-apt-pins.ps1) (detection, installability validation, and the `-Apply` rewrite) and [`.github/scripts/open-apt-pin-pr.ps1`](../.github/scripts/open-apt-pin-pr.ps1) (PR creation). Both run locally from the repository root for ad hoc checks; `check-apt-pins.ps1` needs Docker.
+Backing scripts: [`.github/scripts/check-apt-pins.ps1`](../.github/scripts/check-apt-pins.ps1) (detection, installability validation, and the `-Apply` rewrite) and [`.github/scripts/open-pin-pr.ps1`](../.github/scripts/open-pin-pr.ps1) (the shared signed-commit PR opener, also used by `tooling-pin-check` below). Both run locally from the repository root for ad hoc checks; `check-apt-pins.ps1` needs Docker.
 
 **Identity.** The PR is opened by the `jim-automation` GitHub App, an org-owned service principal, not a personal token. This is deliberate:
 
@@ -1017,6 +1017,23 @@ The App's credentials are the `APT_PIN_BOT_APP_ID` and `APT_PIN_BOT_PRIVATE_KEY`
 **Adding a new pinned apt package** needs no change here: pin it as `pkg=version` in a production Dockerfile and the next run picks it up automatically, the same zero-config story as digest discovery.
 
 Evaluate an `apt-pin-check` PR the same way as a Docker digest update: review the package changelog, run the LDAP/AD integration tests for any libldap or krb5 change, then squash-merge.
+
+##### Automated tooling pin update detection (`tooling-pin-check`)
+
+A handful of development tools are pinned to exact versions in places Dependabot does not read, for the same reason apt pins are invisible to it: they are not in a manifest its ecosystems parse.
+
+- **`@playwright/mcp`** (the Playwright MCP server used for UI validation) is pinned in **both** `.devcontainer/setup.sh` (install-at-create) and `.mcp.json` (launch-at-runtime). The two must move in lockstep or the installed browser and the running server drift apart.
+- **`dotnet-ef`** (the EF Core CLI) is installed via `dotnet tool install` in `.devcontainer/setup.sh`; it is not a `.csproj` reference, so the nuget ecosystem never sees it.
+
+The `tooling-pin-check` workflow ([`.github/workflows/tooling-pin-check.yml`](../.github/workflows/tooling-pin-check.yml)) closes the gap. Weekly, and on demand via *Run workflow*, it reads each pinned version, queries the upstream registry (npm or NuGet) for the latest stable release, and raises (or updates in place) a single PR bumping any that are behind. When a tool is pinned in more than one file, every location is rewritten to the same version, so a Playwright bump can never leave the two files inconsistent. A registry query that fails is treated as a hard error, never as "current", so a stale pin is never silently masked.
+
+Backing scripts: [`.github/scripts/check-tooling-pins.ps1`](../.github/scripts/check-tooling-pins.ps1) (detection via registry HTTP lookups; no Docker needed) and the shared [`.github/scripts/open-pin-pr.ps1`](../.github/scripts/open-pin-pr.ps1). Both run locally from the repository root for ad hoc checks.
+
+**Identity** is the same as `apt-pin-check`, and it reuses the **same** `APT_PIN_BOT` App and its `APT_PIN_BOT_APP_ID` / `APT_PIN_BOT_PRIVATE_KEY` secrets: a signed commit via `createCommitOnBranch`, App-authored so CI's required checks fire and the PR is mergeable. The App is already scoped to Contents and Pull requests (read/write) on this repository, which is all this workflow needs, so adding it required no new credential.
+
+**Adding a new manually-pinned tool:** add an entry to the `$tools` manifest at the top of `check-tooling-pins.ps1` (name, registry, package id, and one regex-located pin site per file). The next run picks it up. This is the single place to look when you pin a new dev tool outside a Dependabot-readable manifest.
+
+Ranges (e.g. the `mkdocs>=1.6,<2` pins in `setup.sh`) are deliberately out of scope: a range already absorbs minor and patch releases, so only the upper bound is a periodic judgment call rather than an automatable bump.
 
 ##### When the scan-base-images gate blocks on an upstream-only CVE
 


### PR DESCRIPTION
## Summary
- Adds `tooling-pin-check`, a weekly scheduled workflow that detects newer versions of development tooling pinned outside any Dependabot-readable manifest and raises a signed auto-PR for any that are behind.
- Covers `@playwright/mcp` (pinned in **both** `.devcontainer/setup.sh` and `.mcp.json`; rewritten in lockstep) and `dotnet-ef` (installed via `dotnet tool install` in `setup.sh`, not a `.csproj` reference).
- Detection (`check-tooling-pins.ps1`) is npm/NuGet registry HTTP lookups; no Docker. A failed query is a hard error, never silently "current".
- Generalises the existing apt PR-opener to a shared `open-pin-pr.ps1` (parameterised file filter, commit message, branch, label; apt values as defaults, so `apt-pin-check` is behaviourally unchanged).
- Reuses the existing `APT_PIN_BOT` GitHub App and its secrets, so **no new credential** was required. Documented in `DEVELOPER_GUIDE.md`.
- Ranges (`mkdocs>=1.6,<2` etc.) are deliberately out of scope.

## Test plan
- [x] `check-tooling-pins.ps1` run locally: correctly flagged `dotnet-ef` 10.0.3 → 10.0.8 behind, `@playwright/mcp` current
- [x] `-Apply` rewrote all three `dotnet-ef` sites, left `.mcp.json` untouched; reverted after
- [x] Generalised `open-pin-pr.ps1` dry-run validated for both apt defaults and tooling overrides; GraphQL payload builds correctly
- [x] Workflow YAML parses; here-string terminator lands at column 0 after dedent
- [x] No `dotnet build`/`test` (scripts/workflow/docs only, per CLAUDE.md exception list)
- [ ] Post-merge: `gh workflow run tooling-pin-check.yml` to prove the live PR path opens the `dotnet-ef` bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)