### PR TITLE
fix(ci): skip claude-review for jim-automation[bot] PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,22 +20,30 @@ jobs:
       id-token: write
 
     steps:
-      # Dependabot PRs skip the automated review but the job still reports
-      # success so the required status check is satisfied. Without this,
-      # a job-level `if` skip causes the check to be absent/failed, which
-      # blocks merge when claude-review is a required check.
-      - name: Skip review for Dependabot
-        if: github.actor == 'dependabot[bot]'
-        run: echo "Skipping automated review for Dependabot PRs"
+      # Automated dependency PRs skip the AI review but the job still reports
+      # success so the required status check is satisfied. Without this, a
+      # job-level `if` skip causes the check to be absent/failed, which blocks
+      # merge when claude-review is a required check.
+      #
+      # Two actors are exempt:
+      #   - dependabot[bot]: NuGet/Docker/Actions version bumps.
+      #   - jim-automation[bot]: the App that opens the apt-pin-check and
+      #     tooling-pin-check version-bump PRs. These are mechanical pin bumps
+      #     that do not warrant an AI review, and the review action cannot
+      #     authenticate on a bot-authored PR anyway (it dies trying to mint an
+      #     installation token), so it must be skipped, not merely allowed to run.
+      - name: Skip review for automation bots
+        if: github.actor == 'dependabot[bot]' || github.actor == 'jim-automation[bot]'
+        run: echo "Skipping automated review for ${{ github.actor }} PRs"
 
       - name: Checkout repository
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]' && github.actor != 'jim-automation[bot]'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]' && github.actor != 'jim-automation[bot]'
         id: claude-review
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251  # v1.0.133
         with:


### PR DESCRIPTION
## Summary
- The `apt-pin-check` and `tooling-pin-check` bots open version-bump PRs authored by the `jim-automation[bot]` App.
- `claude-review` only skipped `dependabot[bot]`, so bot PRs ran the full AI review, which **cannot authenticate on a bot-authored PR** (it fails minting an installation token) and left the required check permanently red, blocking merge (observed on #790).
- Extends the existing dependabot skip to also cover `jim-automation[bot]`: the job reports success without running the review, exactly as for dependabot. Mechanical pin bumps don't warrant an AI review.
- One allow-list entry fixes **both** automation bots, since they share the same App identity.

## Test plan
- [x] Workflow YAML parses; three step conditions updated consistently
- [x] No build/test (CI workflow only, per CLAUDE.md exception list)
- [ ] After merge: re-trigger #790; `claude-review` reports skip-success and the PR can merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)