### PR TITLE
refactor(ui): shared table components and schema panel refinements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 
 This file holds cross-cutting rules and pointers. Detailed conventions live in folder-specific CLAUDE.md files which load automatically when you work in those subtrees:
 - `src/CLAUDE.md` - code style, copyright headers, layer rules, common dev tasks
+- `src/JIM.Web/CLAUDE.md` - Blazor/MudBlazor UI conventions, shared UI components
 - `src/JIM.Application/CLAUDE.md` - synchronisation integrity (full requirements)
 - `test/CLAUDE.md` - TDD patterns, test data, integration testing
 - `.devcontainer/CLAUDE.md` - commands, aliases, Docker, environment

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -118,9 +118,6 @@ CodeQL runs on every PR via the github-code-quality bot and comments on rule vio
 - **Redundant null-conditional**: do not use `?.` on a variable that has already been null-checked with an early return. The `?.` is redundant once control flow guarantees non-null, and CodeQL flags it.
 - **Implicit filter in `foreach`**: do not write `foreach (var x in xs) { if (predicate) ... }` - CodeQL flags this as "Missed opportunity to use Where". Push the predicate into the iterator: `foreach (var x in xs.Where(x => predicate)) ...`. This applies whenever the body's first (or only) statement is an `if` whose single branch acts on `x`; the guard should move into the sequence so the loop iterates only matching elements.
 
-**Nullable Dereference in Razor:**
-- When accessing a nullable `.Value` property in Razor markup (e.g. `context.LastUpdated.Value`), capture it into a local variable inside the `@if (x.HasValue)` block: `var lastUpdated = context.LastUpdated.Value;` then use the local variable in markup expressions. This avoids repeated nullable dereference warnings from code analysis.
-
 **File Organisation:**
 - One class per file - each class should have its own `.cs` file named after the class
 - Exception: Enums are grouped into a single file per area/folder (e.g., `ConnectedSystemEnums.cs`, `PendingExportEnums.cs`)
@@ -160,48 +157,7 @@ Repository and server methods that load a single entity follow a weight-based ta
 
 **When adding a new retrieval method, start from the lightest variant that works**; only promote to a heavier one if the caller actually needs the additional data.
 
-**Razor Comments:**
-- **Section headers**: Use box-drawing delimiters: `@* ─── Section Title ─── *@` (U+2500 horizontal box-drawing character). One line, standing alone between markup blocks, to visually separate major page sections.
-- **Inline comments**: Use plain comments: `@* Explanation of what follows *@`. Brief, contextual, placed immediately above or beside the relevant markup.
-- Do NOT use multi-line banner comments (`===`, `amamam`, or similar filler characters). One line is enough.
-
-**Tabs:**
-- Use `<NavigableMudTabs>` instead of `<MudTabs>` for all top-level page tabs; it syncs the active tab with a `?t=slug` query string, enabling browser back/forward navigation
-- Use plain `<MudTabs>` only for tabs inside dialogs or nested sub-tabs where URL navigation is not needed
-
-**Alerts:**
-- ALWAYS use `Variant="Variant.Outlined"` on all `<MudAlert>` components
-- This ensures a consistent outlined style across the entire UI
-
-**Panel Spacing (target: uniform `mt-6` visual gaps between all block-level sections):**
-- Use `Class="pa-4 mt-6"` on `<MudPaper Outlined="true">` panels to ensure consistent vertical spacing between sections
-- Exception: the **first** panel on a page should omit `mt-6` (use just `Class="pa-4"`) so there is no unnecessary top margin
-- **After intro text**: `MudText` with `Typo.subtitle1` renders as a `<p>` with its own bottom margin (~16px). The first panel after intro text should use `mt-4` (not `mt-6`) so the combined gap matches `mt-6` visually
-- **Tab content spacing**: Use `TabPanelsClass="pa-0 mt-6"` on `NavigableMudTabs` / `MudTabs` so the gap between tab headers and tab panel content matches the surrounding spacing
-- **Tabs margin**: `NavigableMudTabs` may not honour `Class` for outer margin; wrap in `<div class="mt-6">` to guarantee spacing above the tab bar
-
-**Tooltips:**
-- ALWAYS use `Arrow="true" Placement="Placement.Top"` on all `<MudTooltip>` components
-- This ensures tooltips appear above the element with a downward-pointing arrow, consistent across the entire UI
-- **Exception:** tooltips anchored to elements inside the mini-drawer (e.g. the `DrawerUserMenu` avatar when the drawer is collapsed) should use `Placement.Right` so they emerge into the main content area rather than overlapping the drawer itself. This exception is scoped to drawer-anchored tooltips only; do not extend it to other contexts.
-
-**UI Element Sizing:**
-- ALWAYS use normal/default sizes for ALL UI elements when adding new components
-- Text: Use `Typo.body1` (default readable size)
-- Chips: Use `Size.Medium` or omit Size parameter entirely (defaults to Medium)
-- Buttons: Use `Size.Medium` or omit Size parameter entirely (defaults to Medium)
-- Icons: Use `Size.Medium` or omit Size parameter entirely (defaults to Medium)
-- Other MudBlazor components: Omit Size parameter to use default sizing
-- Only use smaller sizes (`Typo.body2`, `Size.Small`, etc.) when explicitly requested by the user
-- Users prefer readable, appropriately-sized UI elements by default
-
-**MudTable Row Density:**
-- All new data tables should include a density toggle allowing users to switch between normal and compact row spacing
-- Use `Dense="@_dense"` and `Class="@(_dense ? "dense-body-only" : "")"` on the `MudTable`; the `dense-body-only` CSS class keeps header rows at normal height while body rows are compact
-- Add a `MudButton` with `StartIcon` (not `MudIconButton`, which renders circular) in the `ToolBarContent` to toggle density, using `Icons.Material.Filled.DensitySmall` / `DensityMedium`
-- Persist the preference via `IUserPreferenceService.GetTableDenseAsync()` / `SetTableDenseAsync()` (stored in browser localStorage under a single shared key, so the setting applies globally across all pages)
-- Default to normal spacing (`_dense = false`); load the saved preference in `OnAfterRenderAsync` with `catch (InvalidOperationException)` for JS interop retry
-- See `Pages/Types/Index.razor` for the reference implementation
+**Blazor / MudBlazor UI conventions live in `JIM.Web/CLAUDE.md`** (loads automatically when working under `JIM.Web`): row density, empty values, tooltips, alerts, panel spacing, element sizing, tabs, Razor comments, and nullable dereference in Razor. Shared components: `<TableDensityToggle>` (the compact-row toggle) and `<EmptyValue>` (the low-lighted empty-cell hyphen). Prefer these over hand-rolled markup.
 
 ## Architecture Quick Reference
 

--- a/src/JIM.Web/CLAUDE.md
+++ b/src/JIM.Web/CLAUDE.md
@@ -1,0 +1,97 @@
+# JIM.Web UI Conventions
+
+> Blazor/MudBlazor presentation rules for `src/JIM.Web`. These are JIM-specific conventions **beyond** standard MudBlazor practice. This file loads automatically (alongside `src/CLAUDE.md`) when working anywhere under `JIM.Web`.
+
+Universal text rules (British English, no em dashes, copyright headers) and general C# conventions live in `src/CLAUDE.md` and the root `CLAUDE.md`. This file covers only the UI layer.
+
+## Conventions hierarchy (read first)
+
+Prefer enforcement over documentation. When a UI convention is repeated across pages, the right home for it is a **shared component or CSS class** that makes the wrong thing inexpressible, not a paragraph here that every author must remember. A convention only lives as prose in this file when it genuinely cannot be componentised (sizing defaults, spacing, comment style). If you find yourself copy-pasting the same markup onto a third page, extract a component into `JIM.Web/Shared/` and document it in the table below instead of adding another prose rule.
+
+## Shared UI components (use these; do not hand-roll)
+
+These components exist so a convention has a single source of truth. Prefer the component over copy-pasting markup; they live in `JIM.Web/Shared/` and are globally available (no `@using` needed).
+
+| Component | Use for | See |
+|-----------|---------|-----|
+| `<TableDensityToggle @bind-Dense="_dense" />` | The compact/normal row toggle in a table's `ToolBarContent` | "Row density" below |
+| `<EmptyValue />` | A table cell or inline value that is null/empty | "Empty values" below |
+
+## Row density (compact-row toggle)
+
+All data tables should let users switch between normal and compact row spacing, persisted globally so the choice follows the user across every table.
+
+- Put `<TableDensityToggle @bind-Dense="_dense" />` as the **first** item in the table's `ToolBarContent`. If other controls sit to its left, follow it with a `<MudText Class="mx-2 mud-text-disabled">|</MudText>` separator.
+- On the `MudTable` / `MudSimpleTable`: set `Dense="@_dense"` and add the `dense-body-only` class, e.g. `Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")"`. The `dense-body-only` class keeps header rows at normal height while compacting body rows.
+- The page owns a `private bool _dense;` field and loads the saved preference on first render, so the table paints at the correct density immediately:
+  ```csharp
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+      if (firstRender)
+      {
+          _dense = await PreferenceService.GetTableDenseAsync() == true;
+          StateHasChanged();
+      }
+  }
+  ```
+  Inject `IUserPreferenceService PreferenceService`. No `try`/`catch` is needed here: `GetTableDenseAsync` swallows the "JS interop not ready" `InvalidOperationException` internally. Pages that gate their whole render on a `_preferencesLoaded` flag should load `_dense` alongside their other preferences inside that same gate (so there is no flash of normal-then-dense).
+- `<TableDensityToggle>` owns the toolbar button and persists the toggle; do **not** add an `OnToggleDense` method or build the tooltip/icon button by hand.
+- Default to normal spacing (`_dense = false`).
+
+## Empty values
+
+For a table cell (or inline value) that is null/empty, render `<EmptyValue />` (a low-lighted hyphen) rather than leaving the cell blank or hand-writing a dimmed span/`MudText`:
+
+```razor
+<MudTd DataLabel="Description">
+    @if (string.IsNullOrEmpty(context.Description))
+    {
+        <EmptyValue />
+    }
+    else
+    {
+        @context.Description
+    }
+</MudTd>
+```
+
+- Only use it where the value can genuinely be empty (a nullable string, an optional date, etc.). Do **not** add a hyphen branch to columns that are always populated; that is dead code.
+- `<EmptyValue />` renders inline. If a cell needs the placeholder centred to match the column's populated rows, wrap it: `<div class="d-flex justify-center align-center" style="height: 100%; width: 100%;"><EmptyValue /></div>`.
+
+## Tooltips
+- ALWAYS use `Arrow="true" Placement="Placement.Top"` on all `<MudTooltip>` components
+- This ensures tooltips appear above the element with a downward-pointing arrow, consistent across the entire UI
+- **Exception:** tooltips anchored to elements inside the mini-drawer (e.g. the `DrawerUserMenu` avatar when the drawer is collapsed) should use `Placement.Right` so they emerge into the main content area rather than overlapping the drawer itself. This exception is scoped to drawer-anchored tooltips only; do not extend it to other contexts.
+
+## Alerts
+- ALWAYS use `Variant="Variant.Outlined"` on all `<MudAlert>` components
+- This ensures a consistent outlined style across the entire UI
+
+## Panel spacing (target: uniform `mt-6` visual gaps between all block-level sections)
+- Use `Class="pa-4 mt-6"` on `<MudPaper Outlined="true">` panels to ensure consistent vertical spacing between sections
+- Exception: the **first** panel on a page should omit `mt-6` (use just `Class="pa-4"`) so there is no unnecessary top margin
+- **After intro text**: `MudText` with `Typo.subtitle1` renders as a `<p>` with its own bottom margin (~16px). The first panel after intro text should use `mt-4` (not `mt-6`) so the combined gap matches `mt-6` visually
+- **Tab content spacing**: Use `TabPanelsClass="pa-0 mt-6"` on `NavigableMudTabs` / `MudTabs` so the gap between tab headers and tab panel content matches the surrounding spacing
+- **Tabs margin**: `NavigableMudTabs` may not honour `Class` for outer margin; wrap in `<div class="mt-6">` to guarantee spacing above the tab bar
+
+## UI element sizing
+- ALWAYS use normal/default sizes for ALL UI elements when adding new components
+- Text: Use `Typo.body1` (default readable size)
+- Chips: Use `Size.Medium` or omit Size parameter entirely (defaults to Medium)
+- Buttons: Use `Size.Medium` or omit Size parameter entirely (defaults to Medium)
+- Icons: Use `Size.Medium` or omit Size parameter entirely (defaults to Medium)
+- Other MudBlazor components: Omit Size parameter to use default sizing
+- Only use smaller sizes (`Typo.body2`, `Size.Small`, etc.) when explicitly requested by the user
+- Users prefer readable, appropriately-sized UI elements by default
+
+## Tabs
+- Use `<NavigableMudTabs>` instead of `<MudTabs>` for all top-level page tabs; it syncs the active tab with a `?t=slug` query string, enabling browser back/forward navigation
+- Use plain `<MudTabs>` only for tabs inside dialogs or nested sub-tabs where URL navigation is not needed
+
+## Razor comments
+- **Section headers**: Use box-drawing delimiters: `@* ─── Section Title ─── *@` (U+2500 horizontal box-drawing character). One line, standing alone between markup blocks, to visually separate major page sections.
+- **Inline comments**: Use plain comments: `@* Explanation of what follows *@`. Brief, contextual, placed immediately above or beside the relevant markup.
+- Do NOT use multi-line banner comments (`===`, `amamam`, or similar filler characters). One line is enough.
+
+## Nullable dereference in Razor
+- When accessing a nullable `.Value` property in Razor markup (e.g. `context.LastUpdated.Value`), capture it into a local variable inside the `@if (x.HasValue)` block: `var lastUpdated = context.LastUpdated.Value;` then use the local variable in markup expressions. This avoids repeated nullable dereference warnings from code analysis.

--- a/src/JIM.Web/Pages/ActivityDetail.razor
+++ b/src/JIM.Web/Pages/ActivityDetail.razor
@@ -608,7 +608,7 @@
                     }
                     else
                     {
-                        <span class="mud-text-disabled">-</span>
+                        <EmptyValue />
                     }
                 </MudTd>
             </RowTemplate>
@@ -664,7 +664,7 @@
                     }
                     else
                     {
-                        <span class="mud-text-disabled">-</span>
+                        <EmptyValue />
                     }
                 </MudTd>
                 <MudTd DataLabel="Message">
@@ -674,7 +674,7 @@
                     }
                     else
                     {
-                        <span class="mud-text-disabled">-</span>
+                        <EmptyValue />
                     }
                 </MudTd>
                 <MudTd DataLabel="Status">
@@ -687,7 +687,7 @@
                     }
                     else
                     {
-                        <span class="mud-text-disabled">-</span>
+                        <EmptyValue />
                     }
                 </MudTd>
                 <MudTd DataLabel="Duration">@(context.ExecutionTime?.ToAbbreviatedString() ?? "-")</MudTd>

--- a/src/JIM.Web/Pages/ActivityList.razor
+++ b/src/JIM.Web/Pages/ActivityList.razor
@@ -180,7 +180,7 @@
             }
             else
             {
-                <MudText Typo="Typo.body2" Class="mud-text-disabled">-</MudText>
+                <EmptyValue />
             }
         </MudTd>
         <MudTd DataLabel="Outcomes">
@@ -404,7 +404,7 @@
             else
             {
                 @* Stats not applicable for this activity type *@
-                <MudText Typo="Typo.body2" Class="mud-text-disabled" Style="display: flex; align-items: center; justify-content: center; height: 100%; width: 100%;">-</MudText>
+                <EmptyValue />
             }
         </MudTd>
         <MudTd DataLabel="Type">@context.TargetType.ToString().SplitOnCapitalLetters()</MudTd>

--- a/src/JIM.Web/Pages/Admin/ApiKeyList.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyList.razor
@@ -26,10 +26,7 @@
 <MudTable Items="@_apiKeys" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
     Filter="new Func<ApiKey, bool>(FilterFunc)" Outlined="true" Elevation="0" Loading="@_loading">
     <ToolBarContent>
-        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-        </MudTooltip>
+        <TableDensityToggle @bind-Dense="_dense" />
         <MudText Class="mx-2 mud-text-disabled">|</MudText>
         <MudButton OnClick="ShowCreateDialog" StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled" Color="Color.Primary"
             DropShadow="false">Create API Key</MudButton>
@@ -335,12 +332,6 @@
         _apiKeys = await jim.Repository.ApiKeys.GetAllAsync();
         _availableRoles = await jim.Security.GetRolesAsync();
         _loading = false;
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private bool FilterFunc(ApiKey element)

--- a/src/JIM.Web/Pages/Admin/CertificateList.razor
+++ b/src/JIM.Web/Pages/Admin/CertificateList.razor
@@ -24,10 +24,7 @@
 <MudTable Items="@_certificates" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
     Filter="new Func<TrustedCertificate, bool>(FilterFunc)" Outlined="true" Elevation="0" Loading="@_loading">
     <ToolBarContent>
-        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-        </MudTooltip>
+        <TableDensityToggle @bind-Dense="_dense" />
         <MudText Class="mx-2 mud-text-disabled">|</MudText>
         <MudButtonGroup Variant="Variant.Filled" Color="Color.Primary">
             <MudButton OnClick="ShowUploadDialog" StartIcon="@Icons.Material.Filled.Upload" DropShadow="false">Upload Certificate</MudButton>
@@ -356,12 +353,6 @@ new("Certificates", href: null, disabled: true)
         _loading = true;
         _certificates = await jim.Certificates.GetAllAsync();
         _loading = false;
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private bool FilterFunc(TrustedCertificate element)

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSchemaTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSchemaTab.razor
@@ -99,35 +99,35 @@
                         {
                             <tr>
                                 <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Success" Class="me-1" /><span>Object Types Added</span></div></td>
-                                <td>@string.Join(", ", result.AddedObjectTypes)</td>
+                                <td class="jim-text-code">@string.Join(", ", result.AddedObjectTypes)</td>
                             </tr>
                         }
                         @if (result.RemovedObjectTypes.Count > 0)
                         {
                             <tr>
                                 <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Remove" Color="Color.Error" Class="me-1" /><span>Object Types Removed</span></div></td>
-                                <td>@string.Join(", ", result.RemovedObjectTypes)</td>
+                                <td class="jim-text-code">@string.Join(", ", result.RemovedObjectTypes)</td>
                             </tr>
                         }
                         @if (result.UpdatedObjectTypes.Count > 0)
                         {
                             <tr>
                                 <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Update" Color="Color.Info" Class="me-1" /><span>Object Types Updated</span></div></td>
-                                <td>@string.Join(", ", result.UpdatedObjectTypes)</td>
+                                <td class="jim-text-code">@string.Join(", ", result.UpdatedObjectTypes)</td>
                             </tr>
                         }
                         @foreach (var kvp in result.AddedAttributes)
                         {
                             <tr>
                                 <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Success" Class="me-1" /><span>Attributes Added (@kvp.Key)</span></div></td>
-                                <td>@string.Join(", ", kvp.Value)</td>
+                                <td class="jim-text-code">@string.Join(", ", kvp.Value)</td>
                             </tr>
                         }
                         @foreach (var kvp in result.RemovedAttributes)
                         {
                             <tr>
                                 <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Remove" Color="Color.Warning" Class="me-1" /><span>Attributes Removed (@kvp.Key)</span></div></td>
-                                <td>@string.Join(", ", kvp.Value)</td>
+                                <td class="jim-text-code">@string.Join(", ", kvp.Value)</td>
                             </tr>
                         }
                     </tbody>

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSchemaTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSchemaTab.razor
@@ -72,7 +72,7 @@
               ShowCloseIcon="true"
               CloseIconClicked="HandleCloseSchemaRefreshResult">
         <MudText Typo="Typo.subtitle1" Class="mb-2">
-            Schema Refresh @(result.Success ? "Complete" : "Failed")
+            <strong>Schema Refresh @(result.Success ? "Complete" : "Failed")</strong>
         </MudText>
 
         @if (result.Success)
@@ -87,7 +87,7 @@
             }
             else
             {
-                <MudSimpleTable Dense="true" Hover="true" Bordered="true" Class="mt-2">
+                <MudSimpleTable Dense="true" Hover="true" Bordered="true" Elevation="0" Class="mt-2 jim-schema-change-table">
                     <thead>
                         <tr>
                             <th>Change Type</th>
@@ -98,35 +98,35 @@
                         @if (result.AddedObjectTypes.Count > 0)
                         {
                             <tr>
-                                <td><MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Success" Class="me-1" /> Object Types Added</td>
+                                <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Success" Class="me-1" /><span>Object Types Added</span></div></td>
                                 <td>@string.Join(", ", result.AddedObjectTypes)</td>
                             </tr>
                         }
                         @if (result.RemovedObjectTypes.Count > 0)
                         {
                             <tr>
-                                <td><MudIcon Icon="@Icons.Material.Filled.Remove" Color="Color.Error" Class="me-1" /> Object Types Removed</td>
+                                <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Remove" Color="Color.Error" Class="me-1" /><span>Object Types Removed</span></div></td>
                                 <td>@string.Join(", ", result.RemovedObjectTypes)</td>
                             </tr>
                         }
                         @if (result.UpdatedObjectTypes.Count > 0)
                         {
                             <tr>
-                                <td><MudIcon Icon="@Icons.Material.Filled.Update" Color="Color.Info" Class="me-1" /> Object Types Updated</td>
+                                <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Update" Color="Color.Info" Class="me-1" /><span>Object Types Updated</span></div></td>
                                 <td>@string.Join(", ", result.UpdatedObjectTypes)</td>
                             </tr>
                         }
                         @foreach (var kvp in result.AddedAttributes)
                         {
                             <tr>
-                                <td><MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Success" Class="me-1" /> Attributes Added (@kvp.Key)</td>
+                                <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Success" Class="me-1" /><span>Attributes Added (@kvp.Key)</span></div></td>
                                 <td>@string.Join(", ", kvp.Value)</td>
                             </tr>
                         }
                         @foreach (var kvp in result.RemovedAttributes)
                         {
                             <tr>
-                                <td><MudIcon Icon="@Icons.Material.Filled.Remove" Color="Color.Warning" Class="me-1" /> Attributes Removed (@kvp.Key)</td>
+                                <td><div class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Remove" Color="Color.Warning" Class="me-1" /><span>Attributes Removed (@kvp.Key)</span></div></td>
                                 <td>@string.Join(", ", kvp.Value)</td>
                             </tr>
                         }

--- a/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
@@ -172,7 +172,7 @@
                 }
                 else
                 {
-                    <MudText Typo="Typo.body2" Class="mud-text-disabled">-</MudText>
+                    <EmptyValue />
                 }
             </MudTd>
             <MudTd DataLabel="Run Profile">
@@ -182,7 +182,7 @@
                 }
                 else
                 {
-                    <MudText Typo="Typo.body2" Class="mud-text-disabled">-</MudText>
+                    <EmptyValue />
                 }
             </MudTd>
             <MudTd DataLabel="Stats">
@@ -402,7 +402,7 @@
                 }
                 else
                 {
-                    <MudText Typo="Typo.body2" Class="mud-text-disabled">-</MudText>
+                    <EmptyValue />
                 }
             </MudTd>
         </RowTemplate>

--- a/src/JIM.Web/Pages/Admin/Components/OperationsSchedulesTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsSchedulesTab.razor
@@ -95,7 +95,7 @@
                 }
                 else
                 {
-                    <MudText Typo="Typo.body1" Class="mud-text-disabled">-</MudText>
+                    <EmptyValue />
                 }
             </MudTd>
             <MudTd DataLabel="Last Run">

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemCreate.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemCreate.razor
@@ -16,7 +16,7 @@
     Provide some basic details here, and then we'll move on to configuring the Connected System.
 </MudText>
 
-<MudPaper Class="pa-4" Outlined="true">
+<MudPaper Class="pa-4 mt-4" Outlined="true">
     <MudForm @bind-IsValid="@_isFormValid" @bind-Errors="@_formErrors">
         <MudSelect T="string" Label="Connector" Placeholder="Please select a connector..." Required="true"
                    @bind-Value="_model.ConnectorId" AdornmentIcon="@Icons.Material.Filled.Power" Adornment="Adornment.Start"

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
@@ -32,10 +32,7 @@
 
 <MudTable Items="@_connectedSystemHeaders" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By" Filter="new Func<ConnectedSystemHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
     <ToolBarContent>
-        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-        </MudTooltip>
+        <TableDensityToggle @bind-Dense="_dense" />
         <MudSpacer />
         <MudTextField @bind-Value="_searchString" Variant="Variant.Outlined" Placeholder="Search" Margin="Margin.Dense" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
@@ -49,7 +46,16 @@
     </HeaderContent>
     <RowTemplate>
         <MudTd DataLabel="Name"><MudLink Href="@(Utilities.GetConnectedSystemHref(context))">@context.Name</MudLink></MudTd>
-        <MudTd DataLabel="Description">@context.Description</MudTd>
+        <MudTd DataLabel="Description">
+            @if (string.IsNullOrEmpty(context.Description))
+            {
+                <EmptyValue />
+            }
+            else
+            {
+                @context.Description
+            }
+        </MudTd>
         <MudTd DataLabel="Stats">
             <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                 <MudTooltip Text="Objects" Arrow="true" Placement="Placement.Top">
@@ -121,12 +127,6 @@
             _dense = await PreferenceService.GetTableDenseAsync() == true;
             StateHasChanged();
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private static int GetPercentage(int total, int part)

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
@@ -2,8 +2,10 @@
 @attribute [Authorize(Roles = "Administrator")]
 @using JIM.Models.Staging.DTOs
 @using JIM.Utilities;
+@using JIM.Web.Services
 @using System;
 @inject IJimApplicationFactory JimFactory
+@inject IUserPreferenceService PreferenceService
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -28,8 +30,12 @@
     <MudButton StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled" Href="/admin/connected-systems/new" Color="Color.Primary" DropShadow="false">Create Connected System</MudButton>
 </div>
 
-<MudTable Items="@_connectedSystemHeaders" Hover="true" Breakpoint="Breakpoint.Sm" Class="mt-5 mb-5" SortLabel="Sort By" Filter="new Func<ConnectedSystemHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
+<MudTable Items="@_connectedSystemHeaders" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By" Filter="new Func<ConnectedSystemHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
     <ToolBarContent>
+        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+        </MudTooltip>
         <MudSpacer />
         <MudTextField @bind-Value="_searchString" Variant="Variant.Outlined" Placeholder="Search" Margin="Margin.Dense" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
@@ -94,6 +100,7 @@
 @code {
     private IList<ConnectedSystemHeader>? _connectedSystemHeaders;
     private string _searchString = "";
+    private bool _dense;
 
     private readonly List<BreadcrumbItem> _breadcrumbs = new()
     {
@@ -105,6 +112,21 @@
     {
         using var jim = JimFactory.Create();
         _connectedSystemHeaders = await jim.ConnectedSystems.GetConnectedSystemHeadersAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dense = await PreferenceService.GetTableDenseAsync() == true;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private static int GetPercentage(int total, int part)

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemObjectDetail.razor
@@ -181,10 +181,7 @@
                     Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")"
                     Breakpoint="Breakpoint.None">
                     <ToolBarContent>
-                        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-                        </MudTooltip>
+                        <TableDensityToggle @bind-Dense="_dense" />
                     </ToolBarContent>
                     <HeaderContent>
                         <MudTh Class="jim-attr-header-name">
@@ -375,12 +372,6 @@
                 // JS interop not yet available, will retry on next render
             }
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     protected override async Task OnParametersSetAsync()

--- a/src/JIM.Web/Pages/Admin/ConnectorList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectorList.razor
@@ -23,10 +23,7 @@
 
 <MudTable Items="@_headers" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By" Filter="new Func<ConnectorDefinitionHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
     <ToolBarContent>
-        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-        </MudTooltip>
+        <TableDensityToggle @bind-Dense="_dense" />
         <MudText Class="mx-2 mud-text-disabled">|</MudText>
         <MudText Typo="Typo.h6">Connectors</MudText>
         <MudSpacer />
@@ -41,10 +38,28 @@
     </HeaderContent>
     <RowTemplate>
         <MudTd DataLabel="Name" Class="jim-nowrap"><MudLink Href="@("/admin/connected-systems/connectors/"+context.Id)">@context.Name</MudLink></MudTd>
-        <MudTd DataLabel="Description">@context.Description</MudTd>
+        <MudTd DataLabel="Description">
+            @if (string.IsNullOrEmpty(context.Description))
+            {
+                <EmptyValue />
+            }
+            else
+            {
+                @context.Description
+            }
+        </MudTd>
         <MudTd DataLabel="Built-in?">@(context.BuiltIn ? "Yes" : "No")</MudTd>
         <MudTd DataLabel="In-use?">@(context.InUse ? "Yes" : "No")</MudTd>
-        <MudTd DataLabel="Version(s)">@(!string.IsNullOrEmpty(context.Versions) ? context.Versions :"-")</MudTd>
+        <MudTd DataLabel="Version(s)">
+            @if (string.IsNullOrEmpty(context.Versions))
+            {
+                <EmptyValue />
+            }
+            else
+            {
+                @context.Versions
+            }
+        </MudTd>
     </RowTemplate>
     <NoRecordsContent>
         There are no connectors
@@ -76,12 +91,6 @@
             _dense = await PreferenceService.GetTableDenseAsync() == true;
             StateHasChanged();
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private bool FilterFunc1(ConnectorDefinitionHeader element) => FilterFunc(element, _searchString);

--- a/src/JIM.Web/Pages/Admin/ConnectorList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectorList.razor
@@ -1,7 +1,9 @@
 ﻿@page "/admin/connected-systems/connectors"
 @attribute [Authorize(Roles = "Administrator")]
 @using JIM.Models.Staging.DTOs
+@using JIM.Web.Services
 @inject IJimApplicationFactory JimFactory
+@inject IUserPreferenceService PreferenceService
 
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
@@ -19,8 +21,13 @@
     <MudButton Variant="Variant.Filled" Color="Color.Primary">Connectors</MudButton>
 </MudButtonGroup>
 
-<MudTable Items="@_headers" Hover="true" Breakpoint="Breakpoint.Sm" Class="mt-5 mb-5" SortLabel="Sort By" Filter="new Func<ConnectorDefinitionHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
+<MudTable Items="@_headers" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By" Filter="new Func<ConnectorDefinitionHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
     <ToolBarContent>
+        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
+        </MudTooltip>
+        <MudText Class="mx-2 mud-text-disabled">|</MudText>
         <MudText Typo="Typo.h6">Connectors</MudText>
         <MudSpacer />
         <MudTextField @bind-Value="_searchString" Variant="Variant.Outlined" Placeholder="Search" Margin="Margin.Dense" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
@@ -47,6 +54,7 @@
 @code {
     private IList<ConnectorDefinitionHeader>? _headers;
     private string _searchString = "";
+    private bool _dense;
 
     private readonly List<BreadcrumbItem> _breadcrumbs = new List<BreadcrumbItem>
     {
@@ -59,6 +67,21 @@
     {
         using var jim = JimFactory.Create();
         _headers = await jim.ConnectedSystems.GetConnectorDefinitionHeadersAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dense = await PreferenceService.GetTableDenseAsync() == true;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnToggleDense()
+    {
+        _dense = !_dense;
+        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private bool FilterFunc1(ConnectorDefinitionHeader element) => FilterFunc(element, _searchString);

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -228,10 +228,7 @@
                                   Filter="new Func<AttributeChangeGroup, bool>(FilterFunc)"
                                   Class="@(_dense ? "jim-attribute-table dense-body-only" : "jim-attribute-table")" Breakpoint="Breakpoint.None">
                             <ToolBarContent>
-                                <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                                    <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                                                   Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-                                </MudTooltip>
+                                <TableDensityToggle @bind-Dense="_dense" />
                                 <MudSpacer />
                                 <MudTextField @bind-Value="_searchString"
                                               Variant="Variant.Outlined"
@@ -380,12 +377,6 @@ else
                 // JS interop not yet available, will retry on next render
             }
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     protected override async Task OnParametersSetAsync()

--- a/src/JIM.Web/Pages/Admin/PendingExportList.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportList.razor
@@ -52,10 +52,7 @@
               Loading="@_loading"
               LoadingProgressColor="Color.Primary">
         <ToolBarContent>
-            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-            </MudTooltip>
+            <TableDensityToggle @bind-Dense="_dense" />
             <MudSpacer />
             <MudTextField T="string"
                           ValueChanged="@(s => OnSearch(s))"
@@ -236,12 +233,6 @@ else
                 // JS interop not yet available, will retry on next render
             }
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private async Task OnRowsPerPageChanged(int newSize)

--- a/src/JIM.Web/Pages/Admin/PredefinedSearchList.razor
+++ b/src/JIM.Web/Pages/Admin/PredefinedSearchList.razor
@@ -30,10 +30,7 @@
           Loading="@_loading"
           LoadingProgressColor="Color.Primary">
     <ToolBarContent>
-        <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-            <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                           Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-        </MudTooltip>
+        <TableDensityToggle @bind-Dense="_dense" />
         <MudSpacer />
         <MudTextField @bind-Value="_searchString"
                       Variant="Variant.Outlined"
@@ -150,12 +147,6 @@
             return true;
 
         return false;
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private void HandleRowClick(TableRowClickEventArgs<PredefinedSearchHeader> args)

--- a/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleDetail.razor
@@ -663,7 +663,7 @@ else if (_syncRule != null)
                     }
                     else
                     {
-                        <MudText Typo="Typo.body2" Class="mud-text-disabled">-</MudText>
+                        <EmptyValue />
                     }
                 </MudTd>
                 <MudTd>

--- a/src/JIM.Web/Pages/Admin/SyncRuleList.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleList.razor
@@ -25,10 +25,7 @@
     <MudTable Items="@_syncRuleHeaders" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
               Filter="new Func<SyncRuleHeader, bool>(FilterFunc1)" Outlined="true" Elevation="0">
         <ToolBarContent>
-            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-            </MudTooltip>
+            <TableDensityToggle @bind-Dense="_dense" />
             <MudText Class="mx-2 mud-text-disabled">|</MudText>
             <MudButton StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled" Href="/admin/sync-rules/new"
                        Color="Color.Primary" Disabled="@(!_canCreateSyncRules)" DropShadow="false">Create Synchronisation Rule
@@ -216,12 +213,6 @@
         if (element.Direction == SyncRuleDirection.Export && element.ProvisionToConnectedSystem == true)
             return "Provisions";
         return "";
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private static bool FilterFunc(SyncRuleHeader element, string searchString)

--- a/src/JIM.Web/Pages/Index.razor
+++ b/src/JIM.Web/Pages/Index.razor
@@ -209,7 +209,7 @@
                         }
                         else
                         {
-                            <MudText Typo="Typo.body1" Class="mud-text-disabled">-</MudText>
+                            <EmptyValue />
                         }
                     </MudTd>
                     <MudTd DataLabel="Status">

--- a/src/JIM.Web/Pages/Types/Index.razor
+++ b/src/JIM.Web/Pages/Types/Index.razor
@@ -25,10 +25,7 @@
         Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 dense-body-only" : "mt-5")" Outlined="true" Elevation="0" OnRowClick="HandleRowClick"
         RowClass="cursor-pointer" Loading="@_loading" LoadingProgressColor="Color.Primary">
         <ToolBarContent>
-            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Placement="Placement.Top">
-                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-            </MudTooltip>
+            <TableDensityToggle @bind-Dense="_dense" />
             <MudSpacer />
             <MudTextField T="string" ValueChanged="@(s => OnSearch(s))" Variant="Variant.Outlined" Placeholder="Search..." Margin="Margin.Dense"
                 Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium"
@@ -55,7 +52,7 @@
                 <MudTd DataLabel="@psa.MetaverseAttribute.Name">
                     @if (string.IsNullOrEmpty(value))
                     {
-                        <span class="mud-text-disabled">-</span>
+                        <EmptyValue />
                     }
                     else
                     {
@@ -263,12 +260,6 @@ else if (_isInitialised)
         if (int.TryParse(pageStr, out var page) && page > 0)
             return page;
         return 1; // Default to page 1
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private void HandleRowClick(TableRowClickEventArgs<MetaverseObjectHeader> args)

--- a/src/JIM.Web/Shared/EmptyValue.razor
+++ b/src/JIM.Web/Shared/EmptyValue.razor
@@ -1,0 +1,7 @@
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+@* Low-lighted hyphen placeholder for a table cell (or inline value) that has no value. *@
+@* Use inside the empty branch of a cell, e.g. @if (string.IsNullOrEmpty(x)) { <EmptyValue /> } else { @x }. *@
+@* See JIM.Web/CLAUDE.md "Empty values". *@
+<span class="mud-text-disabled">-</span>

--- a/src/JIM.Web/Shared/MvoDetailsTable.razor
+++ b/src/JIM.Web/Shared/MvoDetailsTable.razor
@@ -10,10 +10,7 @@
 {
     <MudPaper Class="pa-0 mt-3" Outlined="true">
         <div class="d-flex justify-start pa-2 jim-attribute-table-toolbar">
-            <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                               Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-            </MudTooltip>
+            <TableDensityToggle @bind-Dense="_dense" />
         </div>
         <MudSimpleTable Hover="true" Dense="@_dense" Elevation="0" Class="jim-attribute-table">
             <thead>
@@ -197,12 +194,6 @@
                 // JS interop not yet available, will retry on next render
             }
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private record MvoAttributeTableGroup(

--- a/src/JIM.Web/Shared/MvoMvaDialog.razor
+++ b/src/JIM.Web/Shared/MvoMvaDialog.razor
@@ -20,10 +20,7 @@
                       FixedHeader="true" Height="400px"
                       Loading="@_loading" LoadingProgressColor="Color.Primary">
                 <ToolBarContent>
-                    <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                        <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                                       Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-                    </MudTooltip>
+                    <TableDensityToggle @bind-Dense="_dense" />
                     <MudSpacer />
                     <MudTextField T="string" Value="@_searchText"
                                   ValueChanged="@OnSearch"
@@ -73,10 +70,7 @@
                       FixedHeader="true" Height="400px"
                       Loading="@_loading" LoadingProgressColor="Color.Primary">
                 <ToolBarContent>
-                    <MudTooltip Text="@(_dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
-                        <MudIconButton Icon="@(_dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
-                                       Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="OnToggleDense" />
-                    </MudTooltip>
+                    <TableDensityToggle @bind-Dense="_dense" />
                     <MudSpacer />
                     <MudTextField T="string" Value="@_searchText"
                                   ValueChanged="@OnSearch"
@@ -148,12 +142,6 @@
                 // JS interop not yet available, will retry on next render
             }
         }
-    }
-
-    private async Task OnToggleDense()
-    {
-        _dense = !_dense;
-        await PreferenceService.SetTableDenseAsync(_dense);
     }
 
     private async Task<TableData<MetaverseObjectAttributeValue>> ServerReloadAsync(

--- a/src/JIM.Web/Shared/TableDensityToggle.razor
+++ b/src/JIM.Web/Shared/TableDensityToggle.razor
@@ -1,0 +1,31 @@
+@inject IUserPreferenceService PreferenceService
+
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+@* Toolbar control that toggles a MudTable between normal and compact (dense) row spacing. *@
+@* Two-way bind Dense to the page's _dense field (@bind-Dense="_dense"); this control persists the *@
+@* choice globally via IUserPreferenceService. The page must still load the saved preference on first *@
+@* render so the table paints at the correct density immediately. See JIM.Web/CLAUDE.md "Row density". *@
+<MudTooltip Text="@(Dense ? "Normal row spacing" : "Compact row spacing")" Arrow="true" Placement="Placement.Top">
+    <MudIconButton Icon="@(Dense ? Icons.Material.Filled.DensitySmall : Icons.Material.Filled.DensityMedium)"
+                   Variant="Variant.Filled" Color="Color.Default" Size="Size.Small" OnClick="ToggleAsync" />
+</MudTooltip>
+
+@code {
+    /// <summary>
+    /// Whether the associated table is currently in compact (dense) row mode. Two-way bindable.
+    /// </summary>
+    [Parameter]
+    public bool Dense { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> DenseChanged { get; set; }
+
+    private async Task ToggleAsync()
+    {
+        var dense = !Dense;
+        await PreferenceService.SetTableDenseAsync(dense);
+        await DenseChanged.InvokeAsync(dense);
+    }
+}

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1128,6 +1128,19 @@ html[lang] .mud-alert-position {
     white-space: nowrap;
 }
 
+/* The schema change table sits inside an outlined alert that carries a subtle
+   semantic-colour tint (see the theme .mud-alert-outlined-info rules). A table's
+   default opaque surface fill coincides with that tint in dark mode but clashes
+   with it in light mode (a 6% tint reads as off-white against the table's pure
+   white surface). Make the table transparent so it inherits the alert's tint in
+   every theme and both modes; the row borders still provide structure.
+   html[lang] gives (0,2,2) to beat MudBlazor's .mud-table surface fill. */
+html[lang] .jim-schema-change-table,
+html[lang] .jim-schema-change-table th,
+html[lang] .jim-schema-change-table td {
+    background-color: transparent !important;
+}
+
 /* Table group header rows - subtle background tint for category emphasis */
 .mud-table-cell-custom-group {
     background-color: var(--mud-palette-background-grey) !important;

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1119,6 +1119,12 @@ html[lang] .mud-alert-position {
     margin: 0 !important;
 }
 
+/* Schema refresh change table - keep the Change Type column on a single line */
+.jim-schema-change-table th:first-child,
+.jim-schema-change-table td:first-child {
+    white-space: nowrap;
+}
+
 /* Table group header rows - subtle background tint for category emphasis */
 .mud-table-cell-custom-group {
     background-color: var(--mud-palette-background-grey) !important;

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -514,8 +514,11 @@ html[lang] .mud-tabs-tabbar.mud-tabs-border-top {
     font-weight: 300;
 }
 
+/* !important is required so the monospace font and size win over MudBlazor's
+   table cell typography rules (e.g. .mud-table-root .mud-table-body .mud-table-cell
+   and .mud-simple-table table * tr>td), which are more specific than a single class. */
 .jim-text-code {
-    font-family: "IBM Plex Mono", "Lucida Console", "Courier New", monospace;
+    font-family: "IBM Plex Mono", "Lucida Console", "Courier New", monospace !important;
     font-size: 0.9em !important;
 }
 


### PR DESCRIPTION
## Summary
- Extract the copy-pasted compact-row toggle (12 files, with drifted markup: `MudButton` vs `MudIconButton`, a missing tooltip arrow) into a shared `<TableDensityToggle>` component, and the two ad-hoc dimmed-hyphen forms (`span` and `MudText`, 9 files) into `<EmptyValue>`.
- Add the compact-row toggle and empty-value formatting to the Connected Systems and Connectors tables, which previously had neither.
- Fix the Activity list Outcomes column so the empty-cell hyphen is left-aligned (matching the header and left-aligned stats chips) instead of horizontally centred.
- Earlier schema-refresh commits on this branch: refine the schema refresh results panel, use monospace styling for the details column, force `jim-text-code` monospace over MudBlazor table styles, and make the schema change table transparent inside its alert.
- Document JIM.Web UI conventions in a new `src/JIM.Web/CLAUDE.md` (auto-loads under `JIM.Web`); migrate the UI rules out of `src/CLAUDE.md` leaving a pointer; add the doc to the folder-CLAUDE.md index in the root `CLAUDE.md`.

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors)
- [ ] `dotnet test JIM.sln` — not applicable (UI-only Razor/CSS/docs; no UI tests per CLAUDE.md)
- [ ] Manual: density toggle + empty-value hyphens render on Connected Systems / Connectors; Activity Outcomes dash now left-aligned (not yet verified in the running app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)