### PR TITLE
feat(release): add GitHub Discussions announcement step to /release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -342,6 +342,34 @@ Provide the Actions URL for monitoring:
 https://github.com/TetronIO/JIM/actions
 ```
 
+## Step 9: Long-form Release Announcement (GitHub Discussions)
+
+The curated `CHANGELOG.md` / GitHub Release notes are intentionally terse and customer-facing. The detail that does NOT belong there (performance work, test-coverage expansion, internal hardening) has a home here instead: a long-form announcement in GitHub Discussions, written for an interested-but-external reader. This is where the entries the Changelog Validation step removed can resurface, reframed as outcomes.
+
+**Prerequisites:** Discussions enabled on the repo with an **Announcements** category (maintainer-post-only, which suits release notes), and `gh` authenticated with permission to create discussions. If Discussions is disabled or the user does not want an announcement for this release, skip this step; it is additive.
+
+1. **Draft the announcement.** You write it (you have the full context at release time). Synthesise it from the curated `[<version>]` changelog section, the full commit range (`git log <previous-tag>..v<version> --no-merges`), and the merged PR titles/bodies in that range. Write it in the JIM product-team voice, more expansive than the changelog, with sections roughly like:
+   - a one-paragraph headline ("what's in v<version>");
+   - **What's new** — the customer-facing features, each expanded with why it matters and a short example where useful;
+   - **Fixes** — notable corrected behaviour;
+   - **Under the hood** — the engineering, performance, quality, and testing improvements that were (rightly) kept out of the changelog, reframed as outcomes ("X is now faster / more robust") rather than internal method names;
+   - **Upgrade notes** — anything an operator must know (e.g. a licence change, a config change);
+   - links to the GitHub Release and the full changelog.
+   Write it to `/tmp/release-discussion-v<version>.md` (outside the repo; do NOT commit it).
+
+2. **Human review is mandatory.** This is public, customer-facing, AI-drafted content. Present the draft path to the user and ask them to review and edit `/tmp/release-discussion-v<version>.md` before anything is posted. Do NOT post unreviewed; there is no "draft" state in GitHub Discussions, so review happens before publishing, not after.
+
+3. **Post it once approved:**
+   ```
+   # Dry run first to confirm the repository and Announcements category resolve:
+   pwsh -File ./scripts/Publish-ReleaseDiscussion.ps1 -Title "JIM v<version>" -BodyFile /tmp/release-discussion-v<version>.md -WhatIf
+   # Then post:
+   pwsh -File ./scripts/Publish-ReleaseDiscussion.ps1 -Title "JIM v<version>" -BodyFile /tmp/release-discussion-v<version>.md
+   ```
+   The script resolves the category and prints the published discussion URL.
+
+4. **Cross-link** (optional): append the discussion URL to the GitHub Release notes (`gh release edit v<version>`) so readers can find the long-form write-up, and report the URL to the user.
+
 ## Recovery: PR rejected after release commit was made
 
 If you created the release commit and tried to push directly to `main` (e.g. with `git push origin main --tags`), the tag will push but `main` will be rejected by branch protection. To recover:

--- a/scripts/Publish-ReleaseDiscussion.ps1
+++ b/scripts/Publish-ReleaseDiscussion.ps1
@@ -1,0 +1,92 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Publishes a long-form release announcement to GitHub Discussions.
+
+.DESCRIPTION
+    Creates a discussion in the target category (default: Announcements) from a
+    reviewed markdown body file, using the GitHub GraphQL API (createDiscussion).
+
+    This is the mechanical "post the approved file" step. It does NOT write the
+    announcement: the /release skill drafts the body, a human reviews and edits
+    it, and only then is this script run. It performs no confirmation of its own
+    beyond -WhatIf, so callers must ensure the body has been approved first.
+
+    Requires gh to be authenticated with permission to create discussions, and
+    Discussions to be enabled on the repository with the target category present.
+
+.PARAMETER Title
+    The discussion title (e.g. "JIM v0.11.0").
+
+.PARAMETER BodyFile
+    Path to the reviewed markdown body for the announcement.
+
+.PARAMETER Category
+    Discussion category name. Defaults to "Announcements".
+
+.PARAMETER Owner
+    Repository owner. Defaults to "TetronIO".
+
+.PARAMETER Repo
+    Repository name. Defaults to "JIM".
+
+.EXAMPLE
+    ./scripts/Publish-ReleaseDiscussion.ps1 -Title "JIM v0.11.0" -BodyFile /tmp/release-discussion-v0.11.0.md
+
+.EXAMPLE
+    ./scripts/Publish-ReleaseDiscussion.ps1 -Title "JIM v0.11.0" -BodyFile /tmp/body.md -WhatIf
+    Resolves the repository and category IDs and validates inputs without posting.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)][string]$Title,
+    [Parameter(Mandatory)][string]$BodyFile,
+    [string]$Category = 'Announcements',
+    [string]$Owner = 'TetronIO',
+    [string]$Repo = 'JIM'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Fail([string]$Message, [int]$Code = 1) {
+    [Console]::Error.WriteLine("ERROR: $Message")
+    exit $Code
+}
+
+if (-not (Test-Path -LiteralPath $BodyFile)) { Fail "Body file not found: $BodyFile" 2 }
+$body = Get-Content -Raw -LiteralPath $BodyFile
+if ([string]::IsNullOrWhiteSpace($body)) { Fail "Body file is empty: $BodyFile" 2 }
+
+# Resolve the repository node ID and the target category ID.
+$query = 'query($owner:String!,$repo:String!){repository(owner:$owner,name:$repo){id discussionCategories(first:25){nodes{id name}}}}'
+$lookupJson = gh api graphql -f "query=$query" -f "owner=$Owner" -f "repo=$Repo"
+if ($LASTEXITCODE -ne 0) { Fail "Failed to query repository discussion categories (gh exit $LASTEXITCODE)." }
+$lookup = $lookupJson | ConvertFrom-Json
+
+$repoId = $lookup.data.repository.id
+if (-not $repoId) { Fail "Could not resolve repository $Owner/$Repo." }
+
+$categoryNode = $lookup.data.repository.discussionCategories.nodes | Where-Object { $_.name -eq $Category } | Select-Object -First 1
+if (-not $categoryNode) {
+    $available = ($lookup.data.repository.discussionCategories.nodes.name) -join ', '
+    Fail "Discussion category '$Category' not found. Available: $available"
+}
+$categoryId = $categoryNode.id
+
+if (-not $PSCmdlet.ShouldProcess("$Owner/$Repo discussions [$Category]", "Create discussion '$Title'")) {
+    Write-Host "WhatIf: would create discussion '$Title' in '$Category' (repoId=$repoId, categoryId=$categoryId)."
+    return
+}
+
+# Create the discussion.
+$mutation = 'mutation($repositoryId:ID!,$categoryId:ID!,$title:String!,$body:String!){createDiscussion(input:{repositoryId:$repositoryId,categoryId:$categoryId,title:$title,body:$body}){discussion{url}}}'
+$resultJson = gh api graphql -f "query=$mutation" -f "repositoryId=$repoId" -f "categoryId=$categoryId" -f "title=$Title" -f "body=$body"
+if ($LASTEXITCODE -ne 0) { Fail "Failed to create discussion (gh exit $LASTEXITCODE)." }
+$result = $resultJson | ConvertFrom-Json
+
+$url = $result.data.createDiscussion.discussion.url
+if (-not $url) { Fail "Discussion creation returned no URL. Response: $($result | ConvertTo-Json -Depth 8)" }
+
+Write-Host "Discussion published: $url"


### PR DESCRIPTION
## Summary

Adds a long-form release announcement to the release flow, posted to the **Announcements** discussion category. This gives the comprehensive detail that is (rightly) kept out of the terse customer changelog a proper home, reframed as outcomes rather than internal notes — closing the loop with the changelog-pruning work in #797.

- **`scripts/Publish-ReleaseDiscussion.ps1`** — resolves the repository + target category and creates a discussion via the GraphQL `createDiscussion` mutation from a reviewed markdown body file. Supports `-WhatIf` (resolve + validate, no post); clean stderr errors with distinct exit codes.
- **`.claude/skills/release/SKILL.md`** — new **Step 9**: the release agent drafts the announcement (it has full context at release time), the human reviews and edits it (mandatory — the content is public and AI-drafted), and only then is it posted. Step is additive/skippable.

## Design notes

- **Who writes it:** the release agent, synthesising from the curated changelog + `git log <prev-tag>..<tag>` + merged PRs, in the JIM product voice with a "Under the hood" section for the engineering/perf/test detail.
- **Review before publish:** GitHub Discussions has no draft state, so the gate is draft → approve → post, never blind auto-post.

## Test plan

- [x] Scripts/docs only — `dotnet build`/`test` not required per the CLAUDE.md exception list
- [x] `-WhatIf` resolves the repo + Announcements category via GraphQL and short-circuits without posting (exit 0)
- [x] Error paths verified: missing body file (exit 2), unknown category (exit 1, lists available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)