### PR TITLE
ci: changelog-lint on all PRs + fix .claude gitignore footgun

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -18,6 +18,9 @@ permissions:
 
 jobs:
   lint:
+    # Explicit job name so the required-check context is the stable, descriptive
+    # "changelog-lint" rather than the bare job id "lint".
+    name: changelog-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1

--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -1,17 +1,17 @@
 name: changelog-lint
 
 # Mechanical backstop for the changelog quality rules in engineering/CLAUDE.md.
-# Runs on PRs that touch CHANGELOG.md and hard-fails when an entry in the
-# [Unreleased] section does not lead with a canonical emoji (the tell for a
-# non-customer-facing entry). Verbose/internal-looking entries are surfaced as
-# warnings for the author to confirm or remove.
+# Hard-fails when an entry in the [Unreleased] section does not lead with a
+# canonical emoji (the tell for a non-customer-facing entry); verbose/internal-
+# looking entries are surfaced as warnings for the author to confirm or remove.
+#
+# Runs on every PR (no path filter) so it always reports a status and can safely
+# be a required check: a path-filtered required check never reports on PRs that
+# do not match, which blocks the merge indefinitely. Linting an empty or clean
+# [Unreleased] is cheap and passes.
 
 on:
   pull_request:
-    paths:
-      - 'CHANGELOG.md'
-      - 'scripts/Lint-Changelog.ps1'
-      - '.github/workflows/changelog-lint.yml'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -451,10 +451,15 @@ db.local.yml
 *.exe
 env
 
-# Claude Code configuration (ignore all except commands and skills)
-.claude/*
+# Claude Code configuration: ignore local state, keep tracked commands and skills.
+# Re-include the directories AND their contents (the `/**` lines), otherwise git's
+# working-tree operations (add, rebase) mishandle the tracked files under a parent
+# that the glob excluded.
+.claude/**
 !.claude/commands/
+!.claude/commands/**
 !.claude/skills/
+!.claude/skills/**
 
 # Integration test artifacts
 test/integration/results/


### PR DESCRIPTION
## Summary

Prep so `changelog-lint` can become a required check, plus a fix for the gitignore footgun that forced two earlier PRs to merge instead of rebase.

- **`.github/workflows/changelog-lint.yml`** — drop the `paths:` filter so the lint runs on **every** PR. A path-filtered required check never reports on PRs that do not match its paths, which blocks the merge indefinitely; running always (and reporting a `changelog-lint` status every time) makes it safe to require. Linting a clean/empty `[Unreleased]` is cheap.
- **`.gitignore`** — replace the `.claude/*` glob (which left tracked files under `.claude/skills` in a state where `git add`/`git rebase` reported spurious "local changes would be overwritten") with the canonical `.claude/**` + explicit content re-includes. The two local-state files (`settings.local.json`, `scheduled_tasks.lock`) stay ignored; `commands/` and `skills/` stay fully tracked.

After this merges, `changelog-lint` will be added to the "Protect Main" ruleset's required checks.

## Test plan

- [x] CI/config only — `dotnet build`/`test` not required per the CLAUDE.md exception list
- [x] gitignore verified: local-state files still ignored; skill files not ignored; modifying + `git add`-ing a skill file no longer warns "ignored"
- [x] workflow YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)