### PR TITLE
docs: update required-check count in CLAUDE.md (7 -> 8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ For new features or significant changes:
 
 ### Merging via gh CLI
 
-`main` is protected by a ruleset that requires seven status checks to pass before a merge is allowed: `build-and-test`, `discover-base-images`, `scan-base-images-summary`, the three CodeQL analyses (`Analyze (actions)`, `Analyze (csharp)`, `Analyze (javascript-typescript)`), and `claude-review`. Strict mode is on, so the PR must be up to date with `main`. Zero approvals are required, but unresolved review threads block the merge.
+`main` is protected by a ruleset that requires eight status checks to pass before a merge is allowed: `build-and-test`, `discover-base-images`, `scan-base-images-summary`, the three CodeQL analyses (`Analyze (actions)`, `Analyze (csharp)`, `Analyze (javascript-typescript)`), `claude-review`, and `changelog-lint`. Strict mode is on, so the PR must be up to date with `main`. Zero approvals are required, but unresolved review threads block the merge.
 
 - Default merge command: `gh pr merge <n> --squash --delete-branch --auto`. The `--auto` flag queues the merge so it lands the moment all required checks go green.
 - An immediate `gh pr merge` failure right after `gh pr create` is **expected**, not a blocker. The checks haven't started yet. Don't escalate it; just use `--auto`.


### PR DESCRIPTION
## Summary

`changelog-lint` was added to the "Protect Main" ruleset's required checks, so the count in CLAUDE.md's "Merging via gh CLI" section is now stale. Update it from seven to eight and add `changelog-lint` to the list, so future sessions have the correct gate count.

## Test plan

- [x] Docs-only — `dotnet build`/`test` not required per the CLAUDE.md exception list

🤖 Generated with [Claude Code](https://claude.com/claude-code)