### PR TITLE
ci(release): notify junctional.io to rebuild on stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,3 +502,49 @@ jobs:
             ./docker-compose.yml \
             ./docker-compose.production.yml \
             ./.env.example
+
+  # Job 6: Notify the junctional.io marketing site to rebuild.
+  # The site fetches the current JIM version from GitHub at build time, so a
+  # rebuild is needed after each release for the displayed version to update.
+  # We send a repository_dispatch event; junctional.io's deploy workflow listens
+  # for type 'jim-release' on its default branch.
+  #
+  # Gated to stable releases only (same `!contains(github.ref, '-')` condition the
+  # Docker `latest` tag uses) so a prerelease tag does not push an alpha version
+  # onto the public site.
+  #
+  # Auth: the cross-repo dispatch cannot use the default GITHUB_TOKEN (scoped to
+  # this repo only). We mint a short-lived installation token for the
+  # jim-automation GitHub App, whose credentials are stored in the APT_PIN_BOT_*
+  # secrets (shared automation account; also installed on TetronIO/junctional.io
+  # with Contents: write). The token is scoped to junctional.io alone.
+  notify-site:
+    name: Notify junctional.io
+    runs-on: ubuntu-latest
+    needs: create-release
+    if: ${{ !contains(github.ref, '-') }}
+
+    # This job authenticates with the app installation token, not GITHUB_TOKEN.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Mint junctional.io-scoped token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APT_PIN_BOT_APP_ID }}
+          private-key: ${{ secrets.APT_PIN_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: junctional.io
+
+      # Non-fatal: the release itself has already published by this point, so a
+      # transient dispatch failure must not mark the release run as failed. The
+      # step still surfaces a red annotation if it fails.
+      - name: Dispatch rebuild to junctional.io
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.repository_owner }}/junctional.io
+          event-type: jim-release


### PR DESCRIPTION
## Summary
- Adds a `notify-site` job to the release workflow that sends a `repository_dispatch` event (type `jim-release`) to `TetronIO/junctional.io` after the GitHub Release is created, so the marketing site rebuilds and picks up the new version (it fetches the current JIM version from GitHub at build time).
- Gated to stable releases only (`!contains(github.ref, '-')`), matching the existing Docker `latest` tag condition, so a prerelease tag does not push an alpha version onto the public site.
- Cross-repo dispatch authenticates via a short-lived installation token for the `jim-automation` GitHub App (credentials in the `APT_PIN_BOT_*` secrets; the app is installed on `junctional.io` with Contents: write), scoped to `junctional.io` alone. The default `GITHUB_TOKEN` cannot dispatch cross-repo.
- Dispatch step is non-fatal (`continue-on-error`) so a transient notify failure cannot mark an already-published release as failed.

## Notes
- The receiver half is already live on `junctional.io`'s `main` (`repository_dispatch: types: [jim-release]` in its deploy workflow).
- Follow-up (separate branch): rename the `APT_PIN_BOT_*` secrets to `JIM_AUTOMATION_*` so they describe the now-general automation app, and refresh the app description.

## Test plan
- [x] `release.yml` parses as valid YAML; `notify-site` job wired with `needs: create-release` and stable-only `if`
- [x] Actions pinned to commit SHAs (`create-github-app-token`, `peter-evans/repository-dispatch`) per repo policy
- [x] Receiver trigger confirmed present on `junctional.io` default branch
- [ ] CI/CD-only change: `dotnet build`/`test` not applicable per CLAUDE.md exception list
- [ ] End-to-end dispatch only provable on the next real stable `v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)