### PR TITLE
ci: rename APT_PIN_BOT_* secrets to JIM_AUTOMATION_*

### DIFF
--- a/.github/workflows/apt-pin-check.yml
+++ b/.github/workflows/apt-pin-check.yml
@@ -20,8 +20,8 @@
 #     2. A PR opened with the default GITHUB_TOKEN does NOT trigger the CI /
 #        required-check workflows, so it could never satisfy branch protection.
 #        App-authored events DO trigger them, so the bump PR runs CI and can merge.
-#   The App's credentials live in two secrets, APT_PIN_BOT_APP_ID and
-#   APT_PIN_BOT_PRIVATE_KEY. The workflow mints a short-lived (1 hour) installation
+#   The jim-automation App's credentials live in two secrets, JIM_AUTOMATION_APP_ID
+#   and JIM_AUTOMATION_PRIVATE_KEY. The workflow mints a short-lived (1 hour) installation
 #   token from them per run; nothing personal is stored or used.
 
 name: apt-pin-check
@@ -63,8 +63,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.APT_PIN_BOT_APP_ID }}
-          private-key: ${{ secrets.APT_PIN_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.JIM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.JIM_AUTOMATION_PRIVATE_KEY }}
 
       - name: Open or update bump PR
         if: steps.check.outputs.has_updates == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,7 +515,7 @@ jobs:
   #
   # Auth: the cross-repo dispatch cannot use the default GITHUB_TOKEN (scoped to
   # this repo only). We mint a short-lived installation token for the
-  # jim-automation GitHub App, whose credentials are stored in the APT_PIN_BOT_*
+  # jim-automation GitHub App, whose credentials are stored in the JIM_AUTOMATION_*
   # secrets (shared automation account; also installed on TetronIO/junctional.io
   # with Contents: write). The token is scoped to junctional.io alone.
   notify-site:
@@ -533,8 +533,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.APT_PIN_BOT_APP_ID }}
-          private-key: ${{ secrets.APT_PIN_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.JIM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.JIM_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: junctional.io
 

--- a/.github/workflows/tooling-pin-check.yml
+++ b/.github/workflows/tooling-pin-check.yml
@@ -15,15 +15,15 @@
 # signed-commit PR opener, also used by apt-pin-check).
 #
 # Identity / token choice is identical to apt-pin-check: the PR is opened by the
-# APT_PIN_BOT GitHub App, not the default GITHUB_TOKEN. Two reasons:
+# jim-automation GitHub App, not the default GITHUB_TOKEN. Two reasons:
 #   1. `main` requires signed commits; commits created via the GitHub API (the
 #      GraphQL createCommitOnBranch mutation in open-pin-pr.ps1) are signed by
 #      GitHub, and an App installation token authorises them.
 #   2. A PR opened with GITHUB_TOKEN does NOT trigger the required-check
 #      workflows, so it could never satisfy branch protection. App-authored
 #      events DO trigger them, so the bump PR runs CI and can merge.
-# The App's credentials are reused from apt-pin-check (APT_PIN_BOT_APP_ID /
-# APT_PIN_BOT_PRIVATE_KEY); the App is already scoped to Contents and Pull
+# The App's credentials are reused from apt-pin-check (JIM_AUTOMATION_APP_ID /
+# JIM_AUTOMATION_PRIVATE_KEY); the App is already scoped to Contents and Pull
 # requests (read/write) on this repository, which is all this workflow needs.
 
 name: tooling-pin-check
@@ -64,8 +64,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.APT_PIN_BOT_APP_ID }}
-          private-key: ${{ secrets.APT_PIN_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.JIM_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.JIM_AUTOMATION_PRIVATE_KEY }}
 
       - name: Open or update bump PR
         if: steps.check.outputs.has_updates == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,14 @@ No glazing. Do not call an idea "great", "brilliant", or "smart" without concret
 
 If the answer is "no" or "this will not work", say so in the first sentence. The more certain I sound, the more I need pushback.
 
+**Response style:** Optimise for my reading time. I care about outputs, not your reasoning.
+
+- Lead with the result: is it done, does it work, what is the verdict. First sentence, every time.
+- Cut the thought process, the options you did not take, and anything restating what I already know. Do not narrate how you got there; give me the outcome.
+- Be brief. If a point does not change what I think or do, drop it. Prefer a tight paragraph or a few bullets over a wall of text.
+- If you need anything from me, collect it into an **`Over to you:`** bullet list at the very end of the response; never bury an ask mid-text. If you need nothing, do not add the section.
+- For any non-trivial response, open with a one-line summary I can read in isolation: did it work, do I need to act.
+
 ## Synchronisation Integrity
 
 **SYNCHRONISATION INTEGRITY IS PARAMOUNT.** Sync operations are the core of JIM; customers depend on it not corrupting their data.


### PR DESCRIPTION
## Summary
- The GitHub App is named `jim-automation`, but its credentials were stored in secrets named `APT_PIN_BOT_*` (a holdover from when apt-pin-check was its only job). Renames the secret references to `JIM_AUTOMATION_*` across all three workflows that use the app: `apt-pin-check.yml`, `tooling-pin-check.yml`, and the `notify-site` job in `release.yml`.
- Corrects comments that referred to the app as "APT_PIN_BOT".
- Adds a **Response style** rule to root `CLAUDE.md` (lead with the result, cut the reasoning, put any ask in an `Over to you:` list at the end).

## Notes
- The `JIM_AUTOMATION_APP_ID` / `JIM_AUTOMATION_PRIVATE_KEY` secrets are already created (same app, same key). The old `APT_PIN_BOT_*` secrets will be deleted after this merges and the next pin-check run stays green.

## Test plan
- [x] All three workflows parse as valid YAML; no `APT_PIN_BOT` references remain
- [x] New secrets exist in the repo
- [ ] CI/docs-only change: `dotnet build`/`test` not applicable per CLAUDE.md exception list

🤖 Generated with [Claude Code](https://claude.com/claude-code)