### PR TITLE
fix(connected-system): reliable, atomic Connected System deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- 🐛 Deleting a Connected System no longer fails with a database error (`column ... does not exist`); the bulk-deletion SQL referenced sync-rule-mapping columns that were removed in an earlier schema change.
+- 🐛 Deleting a Connected System no longer fails with a database error. The bulk-deletion SQL referenced sync-rule-mapping columns removed in an earlier schema change (`column ... does not exist`), and did not remove the system's object matching rules before the sync rules and object types they reference (foreign key violation). Both are fixed, and the deletion is covered by new database-backed tests.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🔄 Factory reset now **preserves administrator users by default** (so you are not locked out) and always records a Reset activity attributed to whoever initiated it. The previous behaviour of also removing administrators is available via the new `-IncludeAdministrators` switch on `Reset-JIMSystem` (and `includeAdministrators` on `POST /api/v1/system/reset`), guarded against lockout when no initial administrator is configured.
 
+### Fixed
+
+- 🐛 Deleting a Connected System no longer fails with a database error (`column ... does not exist`); the bulk-deletion SQL referenced sync-rule-mapping columns that were removed in an earlier schema change.
+
 ### Security
 
 - 🔒 A factory reset now invalidates every existing portal sign-in session, so no stale access or privileges survive the wipe; users must re-authenticate. API key access is unaffected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 Deleting a Connected System no longer fails with a database error. The bulk-deletion SQL referenced sync-rule-mapping columns removed in an earlier schema change (`column ... does not exist`), and did not remove the system's object matching rules before the sync rules and object types they reference (foreign key violation). Both are fixed, and the deletion is covered by new database-backed tests.
+- 🐛 Deleting a Connected System that has been synchronised no longer fails with a foreign-key database error, and the deletion is now atomic: it either completes fully or rolls back, rather than leaving the system behind with its objects already removed. Run profiles, partitions, activities, metaverse change history, and metaverse attribute values contributed by the system are now removed or detached in the correct order. Metaverse attribute values contributed by the deleted system are retained with their contributor link cleared (attribute recall remains a synchronisation-time behaviour).
 
 ### Security
 

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -4482,6 +4482,16 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
               WHERE ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
+        // 9b. Delete Object Matching Rules for this system before the Sync Rules and Object Types they
+        //     reference (those foreign keys do not cascade). Their Sources and source parameter values
+        //     are removed automatically via ON DELETE CASCADE. An OMR belongs to this system when it is
+        //     scoped to one of its object types or one of its sync rules.
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"DELETE FROM ""ObjectMatchingRules""
+              WHERE ""ConnectedSystemObjectTypeId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjectTypes"" WHERE ""ConnectedSystemId"" = {0})
+                 OR ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
+            connectedSystemId);
+
         // 10. Delete Sync Rules
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0}",

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -4446,23 +4446,16 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             @"DELETE FROM ""ConnectedSystemRunProfiles"" WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
 
-        // 5. Delete SyncRuleMappingSourceParamValues (child of SyncRuleMappingSource)
-        await Repository.Database.Database.ExecuteSqlRawAsync(
-            @"DELETE FROM ""SyncRuleMappingSourceParamValues""
-              WHERE ""SyncRuleMappingSourceId"" IN (
-                SELECT sms.""Id"" FROM ""SyncRuleMappingSources"" sms
-                INNER JOIN ""SyncRuleMappings"" srm ON sms.""SyncRuleMappingId"" = srm.""Id""
-                INNER JOIN ""SyncRules"" sr ON srm.""AttributeFlowSynchronisationRuleId"" = sr.""Id""
-                WHERE sr.""ConnectedSystemId"" = {0}
-              )",
-            connectedSystemId);
+        // 5. (SyncRuleMappingSourceParamValues are intentionally not deleted here: the table has no
+        //    foreign key to SyncRuleMappingSource in the current schema and is not populated anywhere
+        //    in the application, so there is nothing to scope to this connected system.)
 
         // 6. Delete SyncRuleMappingSources (child of SyncRuleMapping)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRuleMappingSources""
               WHERE ""SyncRuleMappingId"" IN (
                 SELECT srm.""Id"" FROM ""SyncRuleMappings"" srm
-                INNER JOIN ""SyncRules"" sr ON srm.""AttributeFlowSynchronisationRuleId"" = sr.""Id""
+                INNER JOIN ""SyncRules"" sr ON srm.""SyncRuleId"" = sr.""Id""
                 WHERE sr.""ConnectedSystemId"" = {0}
               )",
             connectedSystemId);
@@ -4470,8 +4463,7 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         // 7. Delete SyncRuleMappings (attribute flow rules)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRuleMappings""
-              WHERE ""AttributeFlowSynchronisationRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})
-                 OR ""ObjectMatchingSynchronisationRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
+              WHERE ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
         // 8. Delete SyncRuleScopingCriteria (child of SyncRuleScopingCriteriaGroup)

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -4337,6 +4337,13 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         var csoCount = await Repository.Database.ConnectedSystemObjects
             .CountAsync(cso => cso.ConnectedSystemId == connectedSystemId);
 
+        // Wrap the multi-statement deletion in a transaction so a failure rolls back cleanly rather than leaving
+        // a half-deleted system (fast/hard failure over corrupted state). When called from DeleteConnectedSystemAsync
+        // the ambient transaction is reused; when called standalone (clearing connected system objects) this method
+        // owns and commits its own transaction. Npgsql does not support nested transactions, hence the ownership check.
+        var ownsTransaction = Repository.Database.Database.CurrentTransaction == null;
+        await using var transaction = ownsTransaction ? await Repository.Database.Database.BeginTransactionAsync() : null;
+
         // 1. Delete PendingExportAttributeValueChanges (child of PendingExport)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""PendingExportAttributeValueChanges""
@@ -4358,13 +4365,10 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             @"UPDATE ""ConnectedSystemObjects"" SET ""MetaverseObjectId"" = NULL WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
 
-        // 5. Delete CSO attribute values
-        await Repository.Database.Database.ExecuteSqlRawAsync(
-            @"DELETE FROM ""ConnectedSystemObjectAttributeValues""
-              WHERE ""ConnectedSystemObjectId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjects"" WHERE ""ConnectedSystemId"" = {0})",
-            connectedSystemId);
-
-        // 6. Handle ConnectedSystemObjectChanges based on deleteChangeHistory flag
+        // 5. Handle ConnectedSystemObjectChanges before deleting CSO attribute values and CSOs below. The change rows
+        //    carry non-cascading FKs (DeletedObjectExternalIdAttributeValueId -> a CSO attribute value; ConnectedSystemObjectId
+        //    -> a CSO), so they must be removed (delete-history path) or have those FKs nulled (preserve-history path)
+        //    first, otherwise the attribute-value and CSO deletes are blocked.
         if (deleteChangeHistory)
         {
             // Delete change attribute values first (child records)
@@ -4392,12 +4396,20 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         }
         else
         {
-            // Null CSO FK on ConnectedSystemObjectChanges (preserve audit trail)
+            // Preserve the audit trail: null the change FKs that point at the CSO attribute values and CSOs deleted
+            // below (DeletedObjectExternalIdAttributeValueId and ConnectedSystemObjectId are both non-cascading).
             await Repository.Database.Database.ExecuteSqlRawAsync(
-                @"UPDATE ""ConnectedSystemObjectChanges"" SET ""ConnectedSystemObjectId"" = NULL
-                  WHERE ""ConnectedSystemObjectId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjects"" WHERE ""ConnectedSystemId"" = {0})",
+                @"UPDATE ""ConnectedSystemObjectChanges""
+                  SET ""DeletedObjectExternalIdAttributeValueId"" = NULL, ""ConnectedSystemObjectId"" = NULL
+                  WHERE ""ConnectedSystemId"" = {0}",
                 connectedSystemId);
         }
+
+        // 6. Delete CSO attribute values
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"DELETE FROM ""ConnectedSystemObjectAttributeValues""
+              WHERE ""ConnectedSystemObjectId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjects"" WHERE ""ConnectedSystemId"" = {0})",
+            connectedSystemId);
 
         // 7. Null CSO FK on ActivityRunProfileExecutionItems
         await Repository.Database.Database.ExecuteSqlRawAsync(
@@ -4405,10 +4417,21 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
               WHERE ""ConnectedSystemObjectId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjects"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
+        // 7b. Null the staged unresolved reference held by metaverse attribute values that point at a CSO in this
+        //     system. This FK does not cascade, so it would otherwise block the CSO delete below. The metaverse
+        //     object and its attribute values are retained; only the now-unresolvable reference is cleared.
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""MetaverseObjectAttributeValues"" SET ""UnresolvedReferenceValueId"" = NULL
+              WHERE ""UnresolvedReferenceValueId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjects"" WHERE ""ConnectedSystemId"" = {0})",
+            connectedSystemId);
+
         // 8. Delete CSOs
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystemObjects"" WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
+
+        if (ownsTransaction)
+            await transaction!.CommitAsync();
 
         Log.Information("DeleteAllConnectedSystemObjectsAndDependenciesAsync: Completed for Connected System {Id}. Removed {PendingExports} pending exports, {Csos} CSOs",
             connectedSystemId, pendingExportCount, csoCount);
@@ -4422,35 +4445,94 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
 
     public async Task DeleteConnectedSystemAsync(int connectedSystemId, bool deleteChangeHistory = false)
     {
-        // Use raw SQL for bulk deletion - much faster than EF Core tracking
-        // Delete order follows dependency graph from design doc
+        // Use raw SQL for bulk deletion - much faster than EF Core tracking. The whole operation runs in one
+        // transaction so a mid-sequence failure rolls back rather than leaving a half-deleted system (fast/hard
+        // failure over corrupted state). Delete order follows the dependency graph; foreign keys from retained
+        // audit/history rows are nulled before their targets are removed.
         Log.Information("DeleteConnectedSystemAsync: Starting bulk deletion for Connected System {Id}, deleteChangeHistory={DeleteHistory}",
             connectedSystemId, deleteChangeHistory);
 
-        // 1. Delete all CSOs and their dependencies
+        // Large systems delete many rows under one transaction; raise the command timeout to match the bulk-insert
+        // paths, restoring it after a successful commit.
+        var previousTimeout = Repository.Database.Database.GetCommandTimeout();
+        Repository.Database.Database.SetCommandTimeout(PostgresDataRepository.BulkOperationCommandTimeoutSeconds);
+
+        // This method owns the transaction; the CSO-deletion helper below detects the ambient transaction and
+        // enrols in it rather than starting its own (Npgsql does not support nested transactions).
+        var ownsTransaction = Repository.Database.Database.CurrentTransaction == null;
+        await using var transaction = ownsTransaction ? await Repository.Database.Database.BeginTransactionAsync() : null;
+
+        // 1. Delete all CSOs and their dependencies (also nulls the unresolved-reference and, on the preserve-history
+        //    path, the change FKs that point at CSOs / CSO attribute values).
         await DeleteAllConnectedSystemObjectsAndDependenciesAsync(connectedSystemId, deleteChangeHistory);
 
-        // 2. Delete Containers (child of Partition)
+        // 2. Sever audit and history foreign keys that reference rows deleted below. These rows are retained for
+        //    audit; only the now-dead foreign key is nulled. They must be nulled before their targets are deleted.
+
+        // 2a. Activities referencing this system, its run profiles, or its sync rules.
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""Activities"" SET ""ConnectedSystemRunProfileId"" = NULL
+              WHERE ""ConnectedSystemRunProfileId"" IN (SELECT ""Id"" FROM ""ConnectedSystemRunProfiles"" WHERE ""ConnectedSystemId"" = {0})",
+            connectedSystemId);
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""Activities"" SET ""SyncRuleId"" = NULL
+              WHERE ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
+            connectedSystemId);
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""Activities"" SET ""ConnectedSystemId"" = NULL WHERE ""ConnectedSystemId"" = {0}",
+            connectedSystemId);
+
+        // 2b. Metaverse object changes referencing this system's sync rules.
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""MetaverseObjectChanges"" SET ""SyncRuleId"" = NULL
+              WHERE ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
+            connectedSystemId);
+
+        // 2c. Metaverse attribute values contributed by this system: keep the value, null the contributor.
+        //     Attribute recall (removing the values and re-evaluating precedence) is deliberately out of scope here;
+        //     it is a sync-engine concern handled on CSO obsoletion, not bulk system deletion.
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""MetaverseObjectAttributeValues"" SET ""ContributedBySystemId"" = NULL WHERE ""ContributedBySystemId"" = {0}",
+            connectedSystemId);
+
+        // 2d. Example-data template attributes referencing this system's schema attributes.
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"UPDATE ""ExampleDataTemplateAttributes"" SET ""ConnectedSystemObjectTypeAttributeId"" = NULL
+              WHERE ""ConnectedSystemObjectTypeAttributeId"" IN (
+                SELECT ""Id"" FROM ""ConnectedSystemAttributes""
+                WHERE ""ConnectedSystemObjectTypeId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjectTypes"" WHERE ""ConnectedSystemId"" = {0})
+              )",
+            connectedSystemId);
+
+        // 2e. On the preserve-history path, retained ConnectedSystemObjectChanges reference the object types deleted
+        //     in step 11; null that FK first. (On the delete-history path those change rows have already been removed.)
+        if (!deleteChangeHistory)
+            await Repository.Database.Database.ExecuteSqlRawAsync(
+                @"UPDATE ""ConnectedSystemObjectChanges"" SET ""DeletedObjectTypeId"" = NULL WHERE ""ConnectedSystemId"" = {0}",
+                connectedSystemId);
+
+        // 3. Delete Containers (child of Partition)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystemContainers""
               WHERE ""PartitionId"" IN (SELECT ""Id"" FROM ""ConnectedSystemPartitions"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
-        // 3. Delete Partitions
-        await Repository.Database.Database.ExecuteSqlRawAsync(
-            @"DELETE FROM ""ConnectedSystemPartitions"" WHERE ""ConnectedSystemId"" = {0}",
-            connectedSystemId);
-
-        // 4. Delete Run Profiles
+        // 4. Delete Run Profiles. Must be before Partitions: ConnectedSystemRunProfiles.PartitionId is a
+        //    non-cascading FK to ConnectedSystemPartitions, so partitions cannot be deleted while run profiles
+        //    still reference them.
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystemRunProfiles"" WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
 
-        // 5. (SyncRuleMappingSourceParamValues are intentionally not deleted here: the table has no
-        //    foreign key to SyncRuleMappingSource in the current schema and is not populated anywhere
-        //    in the application, so there is nothing to scope to this connected system.)
+        // 5. Delete Partitions
+        await Repository.Database.Database.ExecuteSqlRawAsync(
+            @"DELETE FROM ""ConnectedSystemPartitions"" WHERE ""ConnectedSystemId"" = {0}",
+            connectedSystemId);
 
-        // 6. Delete SyncRuleMappingSources (child of SyncRuleMapping)
+        // 6. (SyncRuleMappingSourceParamValues are intentionally not deleted here: the table is not populated
+        //    anywhere in the application, so there is nothing to scope to this connected system.)
+
+        // 7. Delete SyncRuleMappingSources (child of SyncRuleMapping)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRuleMappingSources""
               WHERE ""SyncRuleMappingId"" IN (
@@ -4460,13 +4542,13 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
               )",
             connectedSystemId);
 
-        // 7. Delete SyncRuleMappings (attribute flow rules)
+        // 8. Delete SyncRuleMappings (attribute flow rules)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRuleMappings""
               WHERE ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
-        // 8. Delete SyncRuleScopingCriteria (child of SyncRuleScopingCriteriaGroup)
+        // 9. Delete SyncRuleScopingCriteria (child of SyncRuleScopingCriteriaGroup)
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRuleScopingCriteria""
               WHERE ""SyncRuleScopingCriteriaGroupId"" IN (
@@ -4476,52 +4558,52 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
               )",
             connectedSystemId);
 
-        // 9. Delete SyncRuleScopingCriteriaGroups
+        // 10. Delete SyncRuleScopingCriteriaGroups
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRuleScopingCriteriaGroups""
               WHERE ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
-        // 9b. Delete Object Matching Rules for this system before the Sync Rules and Object Types they
-        //     reference (those foreign keys do not cascade). Their Sources and source parameter values
-        //     are removed automatically via ON DELETE CASCADE. An OMR belongs to this system when it is
-        //     scoped to one of its object types or one of its sync rules.
+        // 11. Delete Object Matching Rules for this system before the Sync Rules and Object Types they reference
+        //     (those foreign keys do not cascade). Their Sources and source parameter values are removed
+        //     automatically via ON DELETE CASCADE. An OMR belongs to this system when it is scoped to one of its
+        //     object types or one of its sync rules.
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ObjectMatchingRules""
               WHERE ""ConnectedSystemObjectTypeId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjectTypes"" WHERE ""ConnectedSystemId"" = {0})
                  OR ""SyncRuleId"" IN (SELECT ""Id"" FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
-        // 10. Delete Sync Rules
+        // 12. Delete Sync Rules
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""SyncRules"" WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
 
-        // 11. Delete Object Type Attributes
+        // 13. Delete Object Type Attributes
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystemAttributes""
               WHERE ""ConnectedSystemObjectTypeId"" IN (SELECT ""Id"" FROM ""ConnectedSystemObjectTypes"" WHERE ""ConnectedSystemId"" = {0})",
             connectedSystemId);
 
-        // 12. Delete Object Types
+        // 14. Delete Object Types
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystemObjectTypes"" WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
 
-        // 13. Delete Setting Values
+        // 15. Delete Setting Values
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystemSettingValues"" WHERE ""ConnectedSystemId"" = {0}",
             connectedSystemId);
 
-        // 14. Null Activity FKs (preserve audit trail)
-        await Repository.Database.Database.ExecuteSqlRawAsync(
-            @"UPDATE ""Activities"" SET ""ConnectedSystemId"" = NULL WHERE ""ConnectedSystemId"" = {0}",
-            connectedSystemId);
-
-        // 15. Finally, delete the Connected System itself
+        // 16. Finally, delete the Connected System itself
         await Repository.Database.Database.ExecuteSqlRawAsync(
             @"DELETE FROM ""ConnectedSystems"" WHERE ""Id"" = {0}",
             connectedSystemId);
+
+        if (ownsTransaction)
+            await transaction!.CommitAsync();
+
+        Repository.Database.Database.SetCommandTimeout(previousTimeout);
 
         Log.Information("DeleteConnectedSystemAsync: Completed bulk deletion for Connected System {Id}", connectedSystemId);
     }

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
 using JIM.Models.Logic;
 using JIM.Models.Staging;
 using JIM.PostgresData;
@@ -195,5 +198,252 @@ public class ConnectedSystemDeletionDatabaseTests
         Assert.That(await verify.ObjectMatchingRules.AnyAsync(), Is.False, "Object matching rules should be removed.");
         Assert.That(await verify.ObjectMatchingRuleSources.AnyAsync(), Is.False, "Object matching rule sources should be removed.");
         Assert.That(await verify.ObjectMatchingRuleSourceParamValues.AnyAsync(), Is.False, "Object matching rule source parameter values should be removed.");
+    }
+
+    /// <summary>
+    /// Identifiers captured from <see cref="SeedFullGraphAsync"/> so the deletion tests can assert both removal
+    /// of the connected-system graph and foreign-key null-out on retained audit rows.
+    /// </summary>
+    private sealed class FullGraphIds
+    {
+        public int SystemId { get; init; }
+        public Guid ContributedMvavId { get; init; }
+        public Guid UnresolvedMvavId { get; init; }
+        public Guid MvoChangeId { get; init; }
+        public Guid CsoChangeId { get; init; }
+        public Guid ActivityId { get; init; }
+    }
+
+    /// <summary>
+    /// Seeds a complete connected-system dependency graph: partition, container, run profile, object type and
+    /// attribute, sync rule (+ mapping + source), a CSO (+ attribute value), a metaverse object with one attribute
+    /// value contributed by the system and one unresolved reference to a CSO, a metaverse object change, a
+    /// connected-system object change (+ attribute + value) and an activity. Every inbound foreign key the deletion
+    /// must null or reorder is populated, so the fixture exercises the full delete path an empty or sync-rules-only
+    /// seed cannot reach. This is the graph that reproduces the partition / run-profile FK violation and the
+    /// metaverse-contribution FK violations from issue context.
+    /// </summary>
+    private async Task<FullGraphIds> SeedFullGraphAsync()
+    {
+        await using var seed = NewContext();
+
+        // --- Phase 1: connected system, schema, partition, container, sync rule graph ---
+        var connectorDefinition = new ConnectorDefinition { Name = "Test Connector", BuiltIn = true };
+        var system = new ConnectedSystem { Name = "Full Graph System", ConnectorDefinition = connectorDefinition };
+        var csType = new ConnectedSystemObjectType { Name = "USER", ConnectedSystem = system, Selected = true };
+        var csAttr = new ConnectedSystemObjectTypeAttribute
+        {
+            Name = "accountName", ConnectedSystemObjectType = csType, Type = AttributeDataType.Text, Selected = true, IsExternalId = true
+        };
+        csType.Attributes.Add(csAttr);
+
+        var mvType = new MetaverseObjectType { Name = "User", PluralName = "Users", BuiltIn = true };
+        var mvTextAttr = new MetaverseAttribute { Name = "accountName", Type = AttributeDataType.Text, AttributePlurality = AttributePlurality.SingleValued, BuiltIn = true };
+        var mvRefAttr = new MetaverseAttribute { Name = "manager", Type = AttributeDataType.Reference, AttributePlurality = AttributePlurality.SingleValued, BuiltIn = true };
+
+        var partition = new ConnectedSystemPartition { ConnectedSystem = system, Name = "DC=test", ExternalId = "DC=test", Selected = true };
+        var container = new ConnectedSystemContainer { Partition = partition, Name = "OU=Users", ExternalId = "OU=Users,DC=test", Selected = true };
+
+        var rule = new SyncRule
+        {
+            Name = "Import Rule",
+            ConnectedSystem = system,
+            ConnectedSystemObjectType = csType,
+            MetaverseObjectType = mvType,
+            Direction = SyncRuleDirection.Import,
+            Enabled = true
+        };
+        var mapping = new SyncRuleMapping { SyncRule = rule };
+        mapping.Sources.Add(new SyncRuleMappingSource { Order = 0, Expression = "\"literal\"" });
+
+        seed.AddRange(connectorDefinition, system, csType, mvType, mvTextAttr, mvRefAttr, partition, container, rule, mapping);
+        await seed.SaveChangesAsync();
+
+        // --- Phase 2: run profile, CSO graph, metaverse object + values, change records ---
+        var runProfile = new ConnectedSystemRunProfile
+        {
+            Name = "Full Import",
+            ConnectedSystemId = system.Id,
+            Partition = partition,
+            RunType = ConnectedSystemRunType.FullImport
+        };
+
+        var cso = new ConnectedSystemObject
+        {
+            Type = csType,
+            ConnectedSystem = system,
+            Partition = partition,
+            ExternalIdAttributeId = csAttr.Id,
+            Status = ConnectedSystemObjectStatus.Normal
+        };
+        var csoAttrValue = new ConnectedSystemObjectAttributeValue { Attribute = csAttr, StringValue = "jdoe", ConnectedSystemObject = cso };
+        cso.AttributeValues.Add(csoAttrValue);
+
+        var mvo = new MetaverseObject { Type = mvType };
+        var contributedMvav = new MetaverseObjectAttributeValue { Attribute = mvTextAttr, StringValue = "jdoe", MetaverseObject = mvo, ContributedBySystem = system };
+        var unresolvedMvav = new MetaverseObjectAttributeValue { Attribute = mvRefAttr, MetaverseObject = mvo, UnresolvedReferenceValue = cso };
+        mvo.AttributeValues.Add(contributedMvav);
+        mvo.AttributeValues.Add(unresolvedMvav);
+
+        var mvoChange = new MetaverseObjectChange
+        {
+            MetaverseObject = mvo,
+            ChangeTime = DateTime.UtcNow,
+            ChangeInitiatorType = MetaverseObjectChangeInitiatorType.SynchronisationRule,
+            ChangeType = ObjectChangeType.Updated,
+            SyncRule = rule,
+            SyncRuleName = rule.Name
+        };
+
+        var csoChange = new ConnectedSystemObjectChange
+        {
+            ConnectedSystemId = system.Id,
+            ChangeTime = DateTime.UtcNow,
+            ChangeType = ObjectChangeType.Updated,
+            DeletedObjectType = csType,
+            DeletedObjectExternalIdAttributeValue = csoAttrValue,
+            ConnectedSystemObject = cso
+        };
+        var csoChangeAttr = new ConnectedSystemObjectChangeAttribute
+        {
+            ConnectedSystemChange = csoChange,
+            Attribute = csAttr,
+            AttributeName = "accountName",
+            AttributeType = AttributeDataType.Text
+        };
+        csoChangeAttr.ValueChanges.Add(new ConnectedSystemObjectChangeAttributeValue
+        {
+            ConnectedSystemObjectChangeAttribute = csoChangeAttr,
+            ValueChangeType = ValueChangeType.Add,
+            StringValue = "jdoe",
+            ReferenceValue = cso
+        });
+        csoChange.AttributeChanges.Add(csoChangeAttr);
+
+        seed.AddRange(runProfile, cso, mvo, mvoChange, csoChange);
+        await seed.SaveChangesAsync();
+
+        // --- Phase 3: activity referencing the now-persisted run profile and sync rule (scalar FKs) ---
+        var activity = new Activity
+        {
+            TargetType = ActivityTargetType.ConnectedSystem,
+            TargetOperationType = ActivityTargetOperationType.Delete,
+            TargetName = system.Name,
+            Status = ActivityStatus.Complete,
+            Executed = DateTime.UtcNow,
+            InitiatedByType = ActivityInitiatorType.System,
+            ConnectedSystemId = system.Id,
+            ConnectedSystemRunProfileId = runProfile.Id,
+            SyncRuleId = rule.Id
+        };
+        seed.Add(activity);
+        await seed.SaveChangesAsync();
+
+        return new FullGraphIds
+        {
+            SystemId = system.Id,
+            ContributedMvavId = contributedMvav.Id,
+            UnresolvedMvavId = unresolvedMvav.Id,
+            MvoChangeId = mvoChange.Id,
+            CsoChangeId = csoChange.Id,
+            ActivityId = activity.Id
+        };
+    }
+
+    [Test]
+    public async Task DeleteConnectedSystemAsync_FullGraph_DeleteChangeHistory_RemovesSystemAndNullsAuditFksAsync()
+    {
+        var ids = await SeedFullGraphAsync();
+
+        await using (var ctx = NewContext())
+        {
+            var repository = new PostgresDataRepository(ctx);
+            // Before the fix this throws PostgresException 23503 (foreign key violation): deleting the CSO breaches
+            // MetaverseObjectAttributeValues.UnresolvedReferenceValueId, and deleting partitions breaches
+            // ConnectedSystemRunProfiles.PartitionId.
+            await repository.ConnectedSystems.DeleteConnectedSystemAsync(ids.SystemId, deleteChangeHistory: true);
+        }
+
+        await using var verify = NewContext();
+
+        // Connected-system graph fully removed.
+        Assert.That(await verify.ConnectedSystems.AnyAsync(), Is.False, "Connected system should be removed.");
+        Assert.That(await verify.SyncRules.AnyAsync(), Is.False, "Sync rules should be removed.");
+        Assert.That(await verify.ConnectedSystemRunProfiles.AnyAsync(), Is.False, "Run profiles should be removed.");
+        Assert.That(await verify.ConnectedSystemPartitions.AnyAsync(), Is.False, "Partitions should be removed.");
+        Assert.That(await verify.ConnectedSystemObjects.AnyAsync(), Is.False, "CSOs should be removed.");
+        Assert.That(await verify.ConnectedSystemObjectChanges.AnyAsync(), Is.False, "Change history should be removed when deleteChangeHistory is true.");
+
+        // Retained audit rows survive with their now-dead foreign keys nulled.
+        var activity = await verify.Activities.SingleAsync(a => a.Id == ids.ActivityId);
+        Assert.That(activity.ConnectedSystemId, Is.Null, "Activity ConnectedSystemId should be nulled.");
+        Assert.That(activity.ConnectedSystemRunProfileId, Is.Null, "Activity ConnectedSystemRunProfileId should be nulled.");
+        Assert.That(activity.SyncRuleId, Is.Null, "Activity SyncRuleId should be nulled.");
+
+        Assert.That(await verify.MetaverseObjects.AnyAsync(), Is.True, "Surviving metaverse object should be retained.");
+        var contributedMvav = await verify.MetaverseObjectAttributeValues.SingleAsync(av => av.Id == ids.ContributedMvavId);
+        Assert.That(contributedMvav.ContributedBySystemId, Is.Null, "Contributed metaverse attribute value should keep the value but null the contributor.");
+        var unresolvedMvav = await verify.MetaverseObjectAttributeValues.SingleAsync(av => av.Id == ids.UnresolvedMvavId);
+        Assert.That(unresolvedMvav.UnresolvedReferenceValueId, Is.Null, "Unresolved reference to a deleted CSO should be nulled.");
+
+        var mvoChange = await verify.MetaverseObjectChanges.SingleAsync(c => c.Id == ids.MvoChangeId);
+        Assert.That(mvoChange.SyncRuleId, Is.Null, "Metaverse object change should keep the record but null the deleted sync rule FK.");
+    }
+
+    [Test]
+    public async Task DeleteConnectedSystemAsync_FullGraph_PreserveChangeHistory_RetainsChangesWithNulledFksAsync()
+    {
+        var ids = await SeedFullGraphAsync();
+
+        await using (var ctx = NewContext())
+        {
+            var repository = new PostgresDataRepository(ctx);
+            await repository.ConnectedSystems.DeleteConnectedSystemAsync(ids.SystemId, deleteChangeHistory: false);
+        }
+
+        await using var verify = NewContext();
+
+        Assert.That(await verify.ConnectedSystems.AnyAsync(), Is.False, "Connected system should be removed.");
+        Assert.That(await verify.SyncRules.AnyAsync(), Is.False, "Sync rules should be removed.");
+        Assert.That(await verify.ConnectedSystemObjects.AnyAsync(), Is.False, "CSOs should be removed.");
+        Assert.That(await verify.ConnectedSystemObjectTypes.AnyAsync(), Is.False, "Object types should be removed.");
+
+        // Change history is retained, with foreign keys to the now-deleted schema/objects nulled.
+        // DeletedObjectTypeId / DeletedObjectExternalIdAttributeValueId / AttributeId / ReferenceValueId are shadow
+        // FKs (no CLR property), so they are read via EF.Property projections which work under NoTracking.
+        Assert.That(await verify.ConnectedSystemObjectChanges.AnyAsync(c => c.Id == ids.CsoChangeId), Is.True,
+            "Change history should be retained when deleteChangeHistory is false.");
+
+        var deletedObjectTypeId = await verify.ConnectedSystemObjectChanges
+            .Where(c => c.Id == ids.CsoChangeId)
+            .Select(c => EF.Property<int?>(c, "DeletedObjectTypeId"))
+            .SingleAsync();
+        Assert.That(deletedObjectTypeId, Is.Null, "Retained change should null its deleted-object-type FK.");
+
+        var deletedExternalIdAttributeValueId = await verify.ConnectedSystemObjectChanges
+            .Where(c => c.Id == ids.CsoChangeId)
+            .Select(c => EF.Property<Guid?>(c, "DeletedObjectExternalIdAttributeValueId"))
+            .SingleAsync();
+        Assert.That(deletedExternalIdAttributeValueId, Is.Null, "Retained change should null its deleted-attribute-value FK.");
+
+        var csoChange = await verify.ConnectedSystemObjectChanges.SingleAsync(c => c.Id == ids.CsoChangeId);
+        Assert.That(csoChange.ConnectedSystemObjectId, Is.Null, "Retained change should null its CSO FK (SetNull cascade).");
+
+        var changeAttributeFk = await verify.ConnectedSystemObjectChangeAttributes
+            .Select(a => EF.Property<int?>(a, "AttributeId"))
+            .SingleAsync();
+        Assert.That(changeAttributeFk, Is.Null, "Retained change attribute should null its attribute FK (SetNull cascade).");
+
+        var changeValueReferenceFk = await verify.ConnectedSystemObjectChangeAttributeValues
+            .Select(v => EF.Property<Guid?>(v, "ReferenceValueId"))
+            .SingleAsync();
+        Assert.That(changeValueReferenceFk, Is.Null, "Retained change value should null its CSO reference FK (SetNull cascade).");
+
+        // Same audit-preservation behaviour as the delete-history path.
+        var activity = await verify.Activities.SingleAsync(a => a.Id == ids.ActivityId);
+        Assert.That(activity.ConnectedSystemRunProfileId, Is.Null, "Activity ConnectedSystemRunProfileId should be nulled.");
+        Assert.That(activity.SyncRuleId, Is.Null, "Activity SyncRuleId should be nulled.");
+        var contributedMvav = await verify.MetaverseObjectAttributeValues.SingleAsync(av => av.Id == ids.ContributedMvavId);
+        Assert.That(contributedMvav.ContributedBySystemId, Is.Null, "Contributed metaverse attribute value should null the contributor.");
     }
 }

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
@@ -138,4 +138,62 @@ public class ConnectedSystemDeletionDatabaseTests
         Assert.That(await verify.SyncRuleMappings.AnyAsync(), Is.False, "Sync rule mappings should be removed.");
         Assert.That(await verify.SyncRuleMappingSources.AnyAsync(), Is.False, "Sync rule mapping sources should be removed.");
     }
+
+    [Test]
+    public async Task DeleteConnectedSystemAsync_WithObjectMatchingRule_RemovesTheWholeGraphAsync()
+    {
+        int systemId;
+        await using (var seed = NewContext())
+        {
+            var connectorDefinition = new ConnectorDefinition { Name = "Test Connector", BuiltIn = true };
+            var system = new ConnectedSystem { Name = "Matched System", ConnectorDefinition = connectorDefinition };
+            var csType = new ConnectedSystemObjectType { Name = "USER", ConnectedSystem = system };
+            var mvType = new JIM.Models.Core.MetaverseObjectType { Name = "User", PluralName = "Users", BuiltIn = true };
+
+            var rule = new SyncRule
+            {
+                Name = "Import Rule",
+                ConnectedSystem = system,
+                ConnectedSystemObjectType = csType,
+                MetaverseObjectType = mvType,
+                Direction = SyncRuleDirection.Import,
+                Enabled = true
+            };
+
+            // An object matching rule referencing both the system's object type and its sync rule, with a
+            // source and a source parameter value (the OMR source graph cascades from the rule).
+            var omr = new ObjectMatchingRule
+            {
+                Order = 0,
+                ConnectedSystemObjectType = csType,
+                SyncRule = rule,
+                MetaverseObjectType = mvType
+            };
+            var omrSource = new ObjectMatchingRuleSource { Order = 0, Expression = "\"literal\"" };
+            omrSource.ParameterValues.Add(new ObjectMatchingRuleSourceParamValue { Name = "p" });
+            omr.Sources.Add(omrSource);
+
+            seed.ConnectorDefinitions.Add(connectorDefinition);
+            seed.ConnectedSystems.Add(system);
+            seed.ConnectedSystemObjectTypes.Add(csType);
+            seed.MetaverseObjectTypes.Add(mvType);
+            seed.SyncRules.Add(rule);
+            seed.ObjectMatchingRules.Add(omr);
+            await seed.SaveChangesAsync();
+            systemId = system.Id;
+        }
+
+        await using (var ctx = NewContext())
+        {
+            var repository = new PostgresDataRepository(ctx);
+            await repository.ConnectedSystems.DeleteConnectedSystemAsync(systemId, deleteChangeHistory: true);
+        }
+
+        await using var verify = NewContext();
+        Assert.That(await verify.ConnectedSystems.AnyAsync(), Is.False, "Connected system should be removed.");
+        Assert.That(await verify.SyncRules.AnyAsync(), Is.False, "Sync rules should be removed.");
+        Assert.That(await verify.ObjectMatchingRules.AnyAsync(), Is.False, "Object matching rules should be removed.");
+        Assert.That(await verify.ObjectMatchingRuleSources.AnyAsync(), Is.False, "Object matching rule sources should be removed.");
+        Assert.That(await verify.ObjectMatchingRuleSourceParamValues.AnyAsync(), Is.False, "Object matching rule source parameter values should be removed.");
+    }
 }

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Logic;
+using JIM.Models.Staging;
+using JIM.PostgresData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Real-PostgreSQL verification of <see cref="JIM.PostgresData.Repositories.ConnectedSystemRepository.DeleteConnectedSystemAsync"/>.
+/// The deletion is raw SQL, so the EF Core in-memory provider cannot catch column-name regressions; this fixture
+/// runs it against a real database. Opt-in via the same <c>JIM_TEST_RESET_*</c> environment variables as
+/// <see cref="SystemResetDatabaseTests"/>; ignored when <c>JIM_TEST_RESET_DB</c> is absent.
+/// </summary>
+/// <remarks>
+/// Regression guard: the SyncRuleMapping schema consolidated onto a single <c>SyncRuleId</c> foreign key, but the
+/// deletion SQL still referenced the removed <c>AttributeFlowSynchronisationRuleId</c> /
+/// <c>ObjectMatchingSynchronisationRuleId</c> columns, throwing PostgreSQL 42703 (undefined column) for every
+/// connected-system deletion (the offending statement is parsed regardless of whether any sync rules exist).
+/// </remarks>
+[TestFixture]
+[Category("RequiresPostgres")]
+public class ConnectedSystemDeletionDatabaseTests
+{
+    private string _connectionString = null!;
+
+    private JimDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseNpgsql(_connectionString)
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new JimDbContext(options);
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var dbName = Environment.GetEnvironmentVariable("JIM_TEST_RESET_DB");
+        if (string.IsNullOrEmpty(dbName))
+            Assert.Ignore("JIM_TEST_RESET_DB not set; skipping real-PostgreSQL connected-system deletion tests.");
+
+        var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
+        var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
+        var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
+        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+
+        using var ctx = NewContext();
+        ctx.Database.Migrate();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(@"
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+                FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '__EFMigrationsHistory') LOOP
+                    EXECUTE 'TRUNCATE TABLE ""' || r.tablename || '"" RESTART IDENTITY CASCADE';
+                END LOOP;
+            END $$;");
+    }
+
+    [Test]
+    public async Task DeleteConnectedSystemAsync_WithNoSyncRules_RemovesTheSystemAsync()
+    {
+        int systemId;
+        await using (var seed = NewContext())
+        {
+            var connectorDefinition = new ConnectorDefinition { Name = "Test Connector", BuiltIn = true };
+            var system = new ConnectedSystem { Name = "Empty System", ConnectorDefinition = connectorDefinition };
+            seed.ConnectorDefinitions.Add(connectorDefinition);
+            seed.ConnectedSystems.Add(system);
+            await seed.SaveChangesAsync();
+            systemId = system.Id;
+        }
+
+        await using (var ctx = NewContext())
+        {
+            var repository = new PostgresDataRepository(ctx);
+            // Before the fix this throws PostgresException 42703 at the SyncRuleMappingSourceParamValues step.
+            await repository.ConnectedSystems.DeleteConnectedSystemAsync(systemId, deleteChangeHistory: true);
+        }
+
+        await using var verify = NewContext();
+        Assert.That(await verify.ConnectedSystems.AnyAsync(), Is.False);
+    }
+
+    [Test]
+    public async Task DeleteConnectedSystemAsync_WithSyncRuleAndMapping_RemovesTheWholeGraphAsync()
+    {
+        int systemId;
+        await using (var seed = NewContext())
+        {
+            var connectorDefinition = new ConnectorDefinition { Name = "Test Connector", BuiltIn = true };
+            var system = new ConnectedSystem { Name = "Mapped System", ConnectorDefinition = connectorDefinition };
+            var csType = new ConnectedSystemObjectType { Name = "USER", ConnectedSystem = system };
+            var mvType = new JIM.Models.Core.MetaverseObjectType { Name = "User", PluralName = "Users", BuiltIn = true };
+
+            var rule = new SyncRule
+            {
+                Name = "Import Rule",
+                ConnectedSystem = system,
+                ConnectedSystemObjectType = csType,
+                MetaverseObjectType = mvType,
+                Direction = SyncRuleDirection.Import,
+                Enabled = true
+            };
+            var mapping = new SyncRuleMapping { SyncRule = rule };
+            mapping.Sources.Add(new SyncRuleMappingSource { Order = 0, Expression = "\"literal\"" });
+
+            seed.ConnectorDefinitions.Add(connectorDefinition);
+            seed.ConnectedSystems.Add(system);
+            seed.ConnectedSystemObjectTypes.Add(csType);
+            seed.MetaverseObjectTypes.Add(mvType);
+            seed.SyncRules.Add(rule);
+            seed.Add(mapping);
+            await seed.SaveChangesAsync();
+            systemId = system.Id;
+        }
+
+        await using (var ctx = NewContext())
+        {
+            var repository = new PostgresDataRepository(ctx);
+            await repository.ConnectedSystems.DeleteConnectedSystemAsync(systemId, deleteChangeHistory: true);
+        }
+
+        await using var verify = NewContext();
+        Assert.That(await verify.ConnectedSystems.AnyAsync(), Is.False, "Connected system should be removed.");
+        Assert.That(await verify.SyncRules.AnyAsync(), Is.False, "Sync rules should be removed.");
+        Assert.That(await verify.SyncRuleMappings.AnyAsync(), Is.False, "Sync rule mappings should be removed.");
+        Assert.That(await verify.SyncRuleMappingSources.AnyAsync(), Is.False, "Sync rule mapping sources should be removed.");
+    }
+}


### PR DESCRIPTION
## Summary

- Makes deleting a Connected System **atomic**: the whole bulk delete now runs in a single transaction, so a mid-sequence failure rolls back instead of leaving a half-deleted system (objects gone, system row remaining). The shared CSO-deletion helper is transaction-aware, so the "clear objects" path becomes atomic too.
- Fixes the foreign-key violations that surface once a system has actually been synchronised: deletes run profiles before partitions (non-cascading `PartitionId` FK), and handles change-history rows before the CSO attribute values and CSOs they reference.
- Severs the inbound audit/history/metaverse foreign keys that the old code missed, before their targets are deleted, preserving the rows: `Activities` (run profile / sync rule / system), `MetaverseObjectChanges.SyncRuleId`, `MetaverseObjectAttributeValues.ContributedBySystemId` and `.UnresolvedReferenceValueId`, `ExampleDataTemplateAttributes`, and the retained-change FKs on the preserve-history path.
- Attribute recall for surviving metaverse objects is deliberately left to the synchronisation engine, not the bulk delete; tracked as #809.
- Also includes the two earlier fixes on this branch (stale sync-rule-mapping columns; delete object matching rules before the sync rules and object types they reference).

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors)
- [x] `dotnet test JIM.sln` clean (2712 passed, 0 failed)
- [x] New real-PostgreSQL tests seed the full dependency graph (partition, container, run profile, activity, sync rule, metaverse object + contributed/unresolved attribute values, metaverse change, CS object change) and assert correct deletion for both `deleteChangeHistory` paths; they fail with the FK violation before the fix and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)