### PR TITLE
fix: reject duplicate JSON properties; reconnect progress UI

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-merge
-description: Take a feature branch through to a clean squash-merge — rebase on origin/main, build/test, open PR, resolve code-quality bot feedback, queue auto-merge, then clean up local + remote refs.
+description: Take a feature branch through to a clean squash-merge — merge origin/main, build/test, open PR, resolve code-quality bot feedback, queue auto-merge, then clean up local + remote refs.
 argument-hint: "[optional PR title — under 70 chars; if omitted, derive one from the commit log]"
 ---
 
@@ -42,6 +42,8 @@ If `$ARGUMENTS` is non-empty, treat it as the proposed PR title (still under 70 
 
 This is the step previously missed. Strict mode means it has to happen *before* the PR exists, otherwise the PR is born BEHIND and `--auto` is blocked.
 
+**Merge, don't rebase.** Because the PR lands as a squash, the feature branch's pre-merge history is discarded on merge. Rebasing therefore buys linear history that is immediately thrown away, while costing per-commit conflict resolution (the same conflict re-surfaces once per replayed commit) and a force-push (which the harness gates). A merge resolves each conflict once, needs only a plain `git push`, and satisfies strict-mode "up to date" identically; it is exactly what GitHub's own "Update branch" button does. See CLAUDE.md → "Bringing a feature branch up to date with `main`".
+
 1. **Update local `main`:**
    ```
    git checkout main
@@ -54,17 +56,18 @@ This is the step previously missed. Strict mode means it has to happen *before* 
    git log --oneline HEAD..origin/main
    ```
    - If empty, the branch is already current — skip to the build/test step.
-   - If non-empty, rebase onto `origin/main`:
+   - If non-empty, merge `origin/main` into the branch:
      ```
-     git rebase origin/main
+     git merge origin/main
      ```
-   - **If the rebase produces conflicts**, stop and surface them to the user. Do NOT auto-resolve; the user has to decide.
-   - After a successful rebase, force-push with lease:
+   - `CHANGELOG.md` carries a `merge=union` driver (`.gitattributes`), so concurrent `[Unreleased]` entries combine automatically rather than conflicting. After the merge, eyeball the `[Unreleased]` section for duplicated `###` headers or bullets and tidy if needed.
+   - **If the merge produces other (non-CHANGELOG) conflicts**, stop and surface them to the user. Do NOT auto-resolve; the user has to decide.
+   - Push normally (no force needed):
      ```
-     git push --force-with-lease
+     git push
      ```
 
-   Fallback: if for some reason the rebase route is unavailable (e.g. user has explicitly asked not to rewrite history), create the PR first and then `gh pr update-branch <n>` immediately. This produces a merge commit on the feature branch, but the squash-merge collapses it away.
+   Opt-in rebase: only if the user explicitly wants linear pre-squash history. Then `git rebase origin/main` followed by `git push --force-with-lease`. Note the merge backend can report a misleading "local changes would be overwritten" on a clean tree; `git -c rebase.backend=apply rebase origin/main` gets past it.
 
 ## Build and test
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,11 @@
 *.css text eol=lf
 *.md text eol=lf
 
+# CHANGELOG: union-merge concurrent [Unreleased] entries so parallel branches and
+# releases combine automatically instead of conflicting on every merge/rebase.
+# Caveat: may leave duplicate section headers or bullets; tidy at release time.
+CHANGELOG.md merge=union
+
 # Binary files
 *.png binary
 *.jpg binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - 🔒 A factory reset now invalidates every existing portal sign-in session, so no stale access or privileges survive the wipe; users must re-authenticate. API key access is unaffected.
+- 🔒 The REST API now rejects request bodies containing duplicate JSON property names, removing an ambiguous-parsing and request-smuggling vector.
 
 ## [0.11.0] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 🔄 Factory reset now **preserves administrator users by default** (so you are not locked out) and always records a Reset activity attributed to whoever initiated it. The previous behaviour of also removing administrators is available via the new `-IncludeAdministrators` switch on `Reset-JIMSystem` (and `includeAdministrators` on `POST /api/v1/system/reset`), guarded against lockout when no initial administrator is configured.
+- 🔄 The reconnection overlay now shows live attempt progress (for example, "Attempt 2 of 5...") while JIM re-establishes a dropped connection.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,18 @@ For new features or significant changes:
 - Before filing a new GitHub issue, ALWAYS search existing open and closed issues for duplicates: `gh issue list --state all --search "<keywords>"`. Surface any close matches to the user before creating a new one.
 - Dependabot does not auto-rebase PRs when they fall behind `main`. After merging any PR in a batch, comment `@dependabot rebase` on each remaining open Dependabot PR via `gh pr comment <num> --body '@dependabot rebase'`.
 
+### Bringing a feature branch up to date with `main`
+
+**Merge, don't rebase.** `main` squash-merges, so a feature branch's pre-merge history is discarded on landing. Rebasing therefore buys linear history that is immediately thrown away, while costing per-commit conflict resolution (the same conflict re-surfaces once per replayed commit) and a force-push (which the harness gates). A merge resolves each conflict once, needs only a plain `git push`, and satisfies the strict-mode "up to date" check identically; it is exactly what GitHub's own "Update branch" button does.
+
+```bash
+git fetch origin --prune
+git merge origin/main      # then git push (no force needed)
+```
+
+- `CHANGELOG.md` carries a `merge=union` driver (`.gitattributes`), so concurrent `[Unreleased]` entries combine automatically rather than conflicting. After merging, eyeball that section for duplicated `###` headers or bullets and tidy if needed.
+- Only rebase when the user explicitly wants linear pre-squash history. If you do, and the merge backend reports a misleading "local changes would be overwritten" on a clean tree, `git -c rebase.backend=apply rebase origin/main` gets past it.
+
 ### Merging via gh CLI
 
 `main` is protected by a ruleset that requires eight status checks to pass before a merge is allowed: `build-and-test`, `discover-base-images`, `scan-base-images-summary`, the three CodeQL analyses (`Analyze (actions)`, `Analyze (csharp)`, `Analyze (javascript-typescript)`), `claude-review`, and `changelog-lint`. Strict mode is on, so the PR must be up to date with `main`. Zero approvals are required, but unresolved review threads block the merge.

--- a/src/JIM.Web/ApiJsonConfiguration.cs
+++ b/src/JIM.Web/ApiJsonConfiguration.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JIM.Web;
+
+/// <summary>
+/// Central configuration for the JSON serialiser used by the REST API controllers.
+/// Kept in one place (rather than inline in Program.cs) so the policy can be unit-tested
+/// without booting the web host.
+/// </summary>
+public static class ApiJsonConfiguration
+{
+    /// <summary>
+    /// Applies JIM's API JSON serialisation policy to the supplied options.
+    /// </summary>
+    /// <param name="options">The serialiser options to configure (typically the MVC input/output options).</param>
+    public static void Configure(JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Serialise enums as their string names rather than numeric values.
+        options.Converters.Add(new JsonStringEnumConverter());
+
+        // Reject payloads containing duplicate JSON property names. The JSON specification
+        // does not define which value wins, so duplicates are ambiguous and are a known
+        // request-smuggling vector when an upstream proxy and the application parser disagree
+        // on which value to honour. Fail fast at the API boundary instead. (System.Text.Json,
+        // .NET 10+; the default is permissive for backwards compatibility.)
+        options.AllowDuplicateProperties = false;
+    }
+}

--- a/src/JIM.Web/Pages/_Layout.cshtml
+++ b/src/JIM.Web/Pages/_Layout.cshtml
@@ -30,7 +30,7 @@
         <div class="jim-reconnect-content">
             <div class="jim-reconnect-spinner"></div>
             <p class="jim-reconnect-message">Attempting to reconnect to JIM...</p>
-            <p class="jim-reconnect-retry"></p>
+            <p class="jim-reconnect-retry" aria-live="polite"></p>
         </div>
     </div>
 
@@ -50,6 +50,12 @@
         // the old Blazor circuit no longer exists. Rather than spinning on "Attempting
         // to reconnect" forever, reload the page after a few failed attempts so the
         // browser gets a fresh circuit from the new server.
+        //
+        // Supplying a custom reconnectionHandler replaces Blazor's
+        // DefaultReconnectionHandler, so the framework never applies the
+        // components-reconnect-* CSS classes or populates its attempt counters; we
+        // show the modal and the attempt indicator ourselves below.
+        var jimReconnectInterval = null;
         Blazor.start({
             reconnectionOptions: {
                 maxRetries: 5,
@@ -60,18 +66,27 @@
                     var modal = document.getElementById('components-reconnect-modal');
                     if (modal) modal.style.display = 'flex';
 
+                    var retryText = document.querySelector('.jim-reconnect-retry');
+
+                    // Guard against overlapping loops if the connection drops repeatedly.
+                    if (jimReconnectInterval) clearInterval(jimReconnectInterval);
+
                     var retries = 0;
-                    var interval = setInterval(async function () {
+                    jimReconnectInterval = setInterval(async function () {
                         retries++;
                         if (retries > options.maxRetries) {
-                            clearInterval(interval);
+                            clearInterval(jimReconnectInterval);
+                            jimReconnectInterval = null;
+                            if (retryText) retryText.textContent = 'Reloading...';
                             location.reload();
                             return;
                         }
+                        if (retryText) retryText.textContent = 'Attempt ' + retries + ' of ' + options.maxRetries + '...';
                         try {
                             var result = await Blazor.reconnect();
                             if (result) {
-                                clearInterval(interval);
+                                clearInterval(jimReconnectInterval);
+                                jimReconnectInterval = null;
                                 location.reload();
                             }
                         } catch (_e) {
@@ -80,6 +95,10 @@
                     }, options.retryIntervalMilliseconds);
                 },
                 onConnectionUp: function () {
+                    if (jimReconnectInterval) {
+                        clearInterval(jimReconnectInterval);
+                        jimReconnectInterval = null;
+                    }
                     var modal = document.getElementById('components-reconnect-modal');
                     if (modal) modal.style.display = 'none';
                 }

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -347,12 +347,10 @@ try
     builder.Services.AddRazorPages();
     builder.Services.AddServerSideBlazor();
 
-    // Add API controller support with JSON serialization configured to use string enums
+    // Add API controller support with JSON serialisation policy centralised in
+    // ApiJsonConfiguration (see that class for the rationale and for unit tests).
     builder.Services.AddControllers()
-        .AddJsonOptions(options =>
-        {
-            options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
-        });
+        .AddJsonOptions(options => JIM.Web.ApiJsonConfiguration.Configure(options.JsonSerializerOptions));
     builder.Services.AddEndpointsApiExplorer();
 
     // Increase MaxDepth for the HTTP JSON options used by the OpenAPI schema generator.

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -1500,11 +1500,10 @@ html[lang] .jim-schema-change-table td {
     align-items: center;
 }
 
-#components-reconnect-modal.components-reconnect-show,
-#components-reconnect-modal.components-reconnect-failed,
-#components-reconnect-modal.components-reconnect-rejected {
-    display: flex;
-}
+/* Visibility is toggled inline (display: flex) by the custom reconnectionHandler
+   in _Layout.cshtml. Supplying a custom handler replaces Blazor's
+   DefaultReconnectionHandler, so the framework never applies the
+   components-reconnect-* classes; do not key styles off them here. */
 
 .jim-reconnect-content {
     background-color: var(--mud-palette-surface);
@@ -1542,18 +1541,7 @@ html[lang] .jim-schema-change-table td {
     font-size: 0.875rem;
     margin: 0;
     color: var(--mud-palette-text-secondary);
-}
-
-/* Failed state */
-#components-reconnect-modal.components-reconnect-failed .jim-reconnect-spinner,
-#components-reconnect-modal.components-reconnect-rejected .jim-reconnect-spinner {
-    border-top-color: var(--mud-palette-error);
-    animation: none;
-}
-
-#components-reconnect-modal.components-reconnect-failed .jim-reconnect-message::after,
-#components-reconnect-modal.components-reconnect-rejected .jim-reconnect-message::after {
-    content: " Reload the page to try again.";
+    min-height: 1.25rem;
 }
 
 /* Audit info chips - compact label that expands on hover */

--- a/test/JIM.Web.Api.Tests/ApiJsonConfigurationTests.cs
+++ b/test/JIM.Web.Api.Tests/ApiJsonConfigurationTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Text.Json;
+using JIM.Web;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for the API JSON serialisation policy applied by <see cref="ApiJsonConfiguration"/>.
+/// Duplicate JSON property names are ambiguous (the JSON spec does not define which value wins)
+/// and are a known request-smuggling vector when different parsers disagree; the API must reject
+/// them at the boundary rather than silently pick one.
+/// </summary>
+[TestFixture]
+public class ApiJsonConfigurationTests
+{
+    [Test]
+    public void Configure_DisallowsDuplicateJsonProperties()
+    {
+        var options = new JsonSerializerOptions();
+
+        ApiJsonConfiguration.Configure(options);
+
+        Assert.That(options.AllowDuplicateProperties, Is.False);
+    }
+
+    [Test]
+    public void ConfiguredOptions_RejectDuplicatePropertyNames_WhenDeserialising()
+    {
+        var options = new JsonSerializerOptions();
+        ApiJsonConfiguration.Configure(options);
+        const string jsonWithDuplicateKey = "{\"Name\":\"first\",\"Name\":\"second\"}";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DuplicateProbe>(jsonWithDuplicateKey, options));
+    }
+
+    private sealed record DuplicateProbe(string Name);
+}


### PR DESCRIPTION
## Summary

- 🔒 **Reject duplicate JSON property names at the REST API boundary.** Duplicate keys are ambiguous (the JSON spec does not define a winner) and are a known request-smuggling vector when a proxy and the app parser disagree. `ApiJsonConfiguration.Configure` now sets `JsonSerializerOptions.AllowDuplicateProperties = false`; the policy is extracted so it can be unit-tested without booting the host.
- 🔄 **Reconnection overlay now shows live attempt progress** (e.g. "Attempt 2 of 5...") while a dropped connection re-establishes. Also removed the dead `components-reconnect-*` CSS rules that the custom Blazor reconnection handler never triggers.
- 🛠 **Dev tooling (no user-facing impact):** feature-branch updates now merge `origin/main` by default instead of rebase + force-push (CLAUDE.md + `pr-merge` skill), and `CHANGELOG.md` carries a `merge=union` driver so concurrent `[Unreleased]` entries stop conflicting.

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors)
- [x] `dotnet test JIM.sln` clean (2666 passed, 8 skipped, 0 failed across 6 projects)
- [x] Duplicate-JSON verified end-to-end against a live JIM.Web instance: `POST /api/v1/synchronisation/test-expression` with a duplicated `Expression` key returns **400** (duplicate-property ProblemDetails); the de-duplicated control body returns **200**; unauthenticated returns **401**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)