### PR TITLE
chore(devcontainer): stable PowerShell via .NET global tool

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,16 @@ RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && /tmp/dotnet-install.sh --version 10.0.203 --install-dir /usr/share/dotnet --no-path \
     && rm /tmp/dotnet-install.sh
 
+# Remove the PowerShell bundled in the base image. The
+# mcr.microsoft.com/devcontainers/dotnet:1-10.0-noble image was built during the
+# .NET 10 RC window and ships PowerShell 7.6.0-preview.4 (the only build targeting
+# .NET 10 at the time) at /usr/share/powershell, symlinked from /usr/bin/pwsh.
+# We standardise on a stable PowerShell installed as a .NET global tool in
+# setup.sh; removing the base copy leaves that as the single, unambiguous `pwsh`
+# on PATH instead of letting the preview shadow it (/usr/bin precedes
+# ~/.dotnet/tools). Re-evaluate when the base image ships a stable PowerShell.
+RUN rm -rf /usr/share/powershell /usr/bin/pwsh /usr/local/bin/pwsh
+
 # Remove stale Yarn apt repo that breaks feature installs (expired GPG key)
 RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null; \
     rm -f /etc/apt/keyrings/yarn.gpg 2>/dev/null; \

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -14,11 +14,6 @@
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
       "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
-    },
-    "ghcr.io/devcontainers/features/powershell:1.5.1": {
-      "version": "1.5.1",
-      "resolved": "ghcr.io/devcontainers/features/powershell@sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18",
-      "integrity": "sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,11 +50,12 @@
     // GitHub CLI
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "latest"
-    },
-    // PowerShell - standard scripting platform
-    "ghcr.io/devcontainers/features/powershell:1.5.1": {
-      "version": "latest"
     }
+    // PowerShell is NOT a Feature. The base image already bundles PowerShell
+    // (a preview, 7.6.0-preview.4 - see the Dockerfile, which strips it), so the
+    // Feature was redundant. PowerShell is installed instead as a .NET global
+    // tool in setup.sh, which resolves the latest *stable* release by default
+    // and is architecture-independent.
   },
   // VS Code customizations
   "customizations": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -160,30 +160,29 @@ else
     print_warning "postgres-tune.sh not found - skipping auto-tuning"
 fi
 
-# 5. Install PowerShell Pester module for testing (socat is in the Dockerfile)
+# 5. Install PowerShell (.NET global tool)
+# PowerShell is installed as a NuGet global tool under ~/.dotnet/tools (added to
+# PATH after the EF tools install above) rather than relying on the copy bundled
+# in the base image, which is a preview (7.6.0-preview.4) and is stripped by the
+# Dockerfile. `dotnet tool install`/`update` resolves the latest *stable* release
+# by default (prereleases need an explicit --prerelease flag) and is
+# architecture-independent. The current stable (7.6.x) targets .NET 10, matching
+# the SDK in the Dockerfile; it stays runtime-compatible as long as it targets the
+# SDK's .NET major. Update a running container in place with:
+#   dotnet tool update --global PowerShell
+print_step "Installing PowerShell (.NET global tool)..."
+if dotnet tool install --global PowerShell 2>/dev/null || dotnet tool update --global PowerShell 2>/dev/null; then
+    print_success "PowerShell installed ($(pwsh -NoProfile -Command '$PSVersionTable.PSVersion.ToString()' 2>/dev/null))"
+else
+    print_warning "PowerShell installation failed - install manually: dotnet tool install --global PowerShell"
+fi
+
+# 5a. Install PowerShell Pester module for testing (socat is in the Dockerfile)
 print_step "Installing PowerShell Pester module..."
 if pwsh -NoProfile -Command 'Set-PSRepository PSGallery -InstallationPolicy Trusted; Install-Module -Name Pester -MinimumVersion 5.0 -Force -Scope CurrentUser' 2>/dev/null; then
     print_success "Pester module installed"
 else
     print_warning "Pester installation failed - you can install manually: Install-Module -Name Pester -MinimumVersion 5.0 -Force"
-fi
-
-# 5a. Make the nested pwsh binary executable for non-root users.
-# The `pwsh` shim at /usr/bin/pwsh works for all users, but PowerShell's own Start-Process
-# resolves to the real binary at /usr/share/powershell/.store/.../pwsh, which ships with
-# 0744 permissions (only root can exec). That blocks any PowerShell script from spawning
-# a pwsh subprocess (e.g. the integration runner's docker-stats capture), with a confusing
-# "Permission denied" error. A single chmod +x on the real binary fixes it permanently.
-print_step "Fixing nested pwsh binary permissions..."
-nested_pwsh=$(find /usr/share/powershell/.store -name 'pwsh' -type f 2>/dev/null | head -1)
-if [ -n "$nested_pwsh" ] && [ ! -x "$nested_pwsh" ]; then
-    if sudo chmod +x "$nested_pwsh" 2>/dev/null; then
-        print_success "Made $nested_pwsh executable for all users"
-    else
-        print_warning "Could not chmod $nested_pwsh; pwsh subprocess spawning may fail"
-    fi
-else
-    print_success "Nested pwsh binary already executable (or not found)"
 fi
 
 # 6. Install MkDocs Material for documentation preview

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -2854,16 +2854,14 @@ if ($metricsStreamingEnabled) {
 # Start docker stats capture as a detached pwsh process so we can correlate per-container
 # memory and CPU with the scenario phases. Uses Start-Process rather than Start-Job
 # because Start-Job's runspace adds unnecessary overhead for a fire-and-forget script.
-# The explicit /usr/bin/pwsh path is the distro shim; bare "pwsh" resolves Start-Process
-# to a nested .store binary whose permissions can cause "Permission denied" on some
-# devcontainer images (see .devcontainer/setup.sh for the complementary chmod fix).
+# "pwsh" resolves via PATH to the .NET global-tool install (the devcontainer's only
+# PowerShell; see .devcontainer/setup.sh), whose apphost spawns cleanly via Start-Process.
 $dockerStatsProcess = $null
 $dockerStatsPath = $null
 if (Get-Command docker -ErrorAction SilentlyContinue) {
     $dockerStatsPath = Join-Path $scriptRoot "results" "docker-stats-$Scenario-$Template-$(Get-Date -Format 'yyyy-MM-dd_HHmmss').csv"
     Write-Step "Starting docker stats capture -> $dockerStatsPath"
-    $pwshPath = if (Test-Path '/usr/bin/pwsh') { '/usr/bin/pwsh' } else { 'pwsh' }
-    $dockerStatsProcess = Start-Process -FilePath $pwshPath -ArgumentList @(
+    $dockerStatsProcess = Start-Process -FilePath 'pwsh' -ArgumentList @(
         "-NoProfile", "-File", "$scriptRoot/Capture-DockerStats.ps1",
         "-OutputPath", $dockerStatsPath, "-IntervalSeconds", "2"
     ) -PassThru -RedirectStandardOutput "$dockerStatsPath.stdout.log" -RedirectStandardError "$dockerStatsPath.stderr.log"


### PR DESCRIPTION
## Summary
- The devcontainer shipped PowerShell `7.6.0-preview.4`. Root cause: the base image (`mcr.microsoft.com/devcontainers/dotnet:1-10.0-noble`) bundles it (built during the .NET 10 RC window, when the only PowerShell targeting .NET 10 was a preview). The devcontainers `powershell` Feature we also declared was redundant and not the source.
- **Dockerfile**: strip the base image's bundled PowerShell (`/usr/share/powershell` + `/usr/bin/pwsh`) so it can't shadow the stable install (`/usr/bin` precedes `~/.dotnet/tools` on PATH).
- **setup.sh**: install PowerShell via `dotnet tool install/update --global PowerShell`, which resolves the latest *stable* release by default (prereleases need an explicit `--prerelease` flag) and is architecture-independent. Stable 7.6.x targets .NET 10, matching the SDK.
- **devcontainer.json + lock**: drop the now-redundant `powershell` Feature.
- **setup.sh**: drop the nested-pwsh `chmod` workaround; the global-tool apphost on PATH is world-executable, so `pwsh`-spawns-`pwsh` works without it.
- **Run-IntegrationTests.ps1**: drop the `/usr/bin/pwsh` preference in the docker-stats capture (it dodged the same nested-binary quirk and referenced the removed `chmod` fix); bare `pwsh` now spawns cleanly via `Start-Process`.
- Enables in-place updates without a rebuild: `dotnet tool update --global PowerShell`.

## Test plan
- [x] Build/test gate not applicable: diff is `.devcontainer/*` config + `.sh`/`.ps1` scripts only (CLAUDE.md exception list)
- [x] Verified on a clean container rebuild: `pwsh --version` reports `7.6.2` with empty prerelease label (stable); `which -a pwsh` lists only `~/.dotnet/tools/pwsh`; `/usr/bin/pwsh` and `/usr/share/powershell` removed
- [x] Pester `5.7.1` installs against the global tool; `Start-Process pwsh` subprocess returns expected exit code
- [x] `Run-IntegrationTests.ps1` parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)