### PR TITLE
feat(powershell): persist SSO auth + provision initial admin via CLI/API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ✨ The PowerShell module now persists your interactive SSO sign-in across terminal sessions: after `Connect-JIM`, opening a new terminal reconnects silently without a browser. Only the refresh token is stored, in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux), with no extra password beyond your normal OS sign-in. Use `Connect-JIM -NoPersist` to opt out for a session, `-Force` to re-authenticate and overwrite the stored token, and `Disconnect-JIM -ClearCache` / `-Url` / `-All` to remove stored tokens. Headless Linux without a keyring falls back to in-memory tokens and points you to `-ApiKey`.
+- ✨ The PowerShell module now persists your interactive SSO sign-in across terminal sessions: after `Connect-JIM`, opening a new terminal reconnects silently without a browser. Only the refresh token is stored, in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux), with no extra password beyond your normal OS sign-in. Use `Connect-JIM -NoPersist` to opt out for a session, `-Force` to re-authenticate and overwrite the stored token, and `Disconnect-JIM` to remove the stored token for the current instance (`-Url` for a specific instance, `-All` for every instance). Headless Linux without a keyring falls back to in-memory tokens and points you to `-ApiKey`.
 - ✨ Factory reset is now available in the portal: a new Administration danger area (`/admin/factory-reset`) with a backup warning, type-to-confirm, and an optional "delete administrators" path.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ✨ The PowerShell module now persists your interactive SSO sign-in across terminal sessions: after `Connect-JIM`, opening a new terminal reconnects silently without a browser. Only the refresh token is stored, in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux), with no extra password beyond your normal OS sign-in. Use `Connect-JIM -NoPersist` to opt out for a session, `-Force` to re-authenticate and overwrite the stored token, and `Disconnect-JIM` to remove the stored token for the current instance (`-Url` for a specific instance, `-All` for every instance). Headless Linux without a keyring falls back to in-memory tokens and points you to `-ApiKey`.
 - ✨ Factory reset is now available in the portal: a new Administration danger area (`/admin/factory-reset`) with a backup warning, type-to-confirm, and an optional "delete administrators" path.
+- ✨ The initial administrator can now be provisioned on first contact via the PowerShell module or REST API, not just the web portal. On a fresh deployment, the configured initial admin's first authenticated call (CLI or portal) just-in-time creates their identity and grants the Administrator role, so an edge or air-gapped instance can be administered entirely from the command line without ever opening the portal. Profile attributes from a CLI-only bootstrap are backfilled on a later portal sign-in.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ The PowerShell module now persists your interactive SSO sign-in across terminal sessions: after `Connect-JIM`, opening a new terminal reconnects silently without a browser. Only the refresh token is stored, in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux), with no extra password beyond your normal OS sign-in. Use `Connect-JIM -NoPersist` to opt out for a session, `-Force` to re-authenticate and overwrite the stored token, and `Disconnect-JIM -ClearCache` / `-Url` / `-All` to remove stored tokens. Headless Linux without a keyring falls back to in-memory tokens and points you to `-ApiKey`.
+
+### Changed
+
+- 🔄 JIM now requests the `offline_access` scope during interactive authentication so the identity provider issues a refresh token. This enables reliable in-session token renewal and the new PowerShell token persistence. Existing SSO deployments should ensure `offline_access` is permitted on the interactive/public client; see the updated SSO setup guide.
+
 ## [0.11.0] - 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔄 JIM now requests the `offline_access` scope during interactive authentication so the identity provider issues a refresh token. This enables reliable in-session token renewal and the new PowerShell token persistence. Existing SSO deployments should ensure `offline_access` is permitted on the interactive/public client; see the updated SSO setup guide.
 - 🔄 Factory reset now **preserves administrator users by default** (so you are not locked out) and always records a Reset activity attributed to whoever initiated it. The previous behaviour of also removing administrators is available via the new `-IncludeAdministrators` switch on `Reset-JIMSystem` (and `includeAdministrators` on `POST /api/v1/system/reset`), guarded against lockout when no initial administrator is configured.
 - 🔄 The reconnection overlay now shows live attempt progress (for example, "Attempt 2 of 5...") while JIM re-establishes a dropped connection.
+- 🔄 Running a PowerShell cmdlet before connecting now shows a clear one-line message telling you to run `Connect-JIM -Url <your JIM URL>`, instead of a raw error referencing the module's internals; the not-connected state is non-terminating by default and can be made fatal in scripts with `-ErrorAction Stop`.
 
 ### Fixed
 

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -123,6 +123,9 @@ Because the web and PowerShell platforms share the same **Application (client) I
 !!! note
     Entra ID requires exact redirect URI matching. If port 8400 is busy, the module will try ports 8401--8409. You may need to add additional redirect URIs if you encounter port conflicts.
 
+!!! note "Refresh tokens"
+    Setting **Allow public client flows** to **Yes** (step 8 above) is what lets Entra ID return a refresh token to the module. JIM requests the `offline_access` scope at runtime; it is a standard OIDC scope and does not need to be added as an API permission. The refresh token enables silent in-session renewal and optional cross-session token persistence.
+
 ### Step 6: Configure JIM Environment Variables
 
 Add these to your `.env` file:
@@ -226,6 +229,7 @@ This step creates the API configuration for JWT Bearer token validation.
     - `openid`
     - `profile`
     - `email`
+    - `offline_access` (required for refresh-token issuance; enables PowerShell silent renewal and token persistence)
 10. Click **Next** and then **Close**
 
 ### Step 6: Generate a Client Secret
@@ -387,6 +391,7 @@ The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based
 9. Go to the **Client scopes** tab
 10. Click **Add client scope**
 11. Select `jim-api` and add as **Optional**
+12. Confirm `offline_access` is listed (Keycloak adds it as a default optional scope on new clients). If it is missing, click **Add client scope**, select `offline_access`, and add it as **Optional**. This lets the module receive a refresh token for silent renewal and token persistence.
 
 !!! note
     The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). If port 8400 is busy, the module will try ports 8401--8409. Add the corresponding redirect URIs (e.g. `http://localhost:8401/callback/` through `http://localhost:8409/callback/`) if port conflicts are likely in your environment.
@@ -461,9 +466,12 @@ The JIM server exposes `/api/v1/auth/config`, an unauthenticated discovery endpo
 
 - `authority`: the OIDC authority URL — `JIM_SSO_PUBLIC_AUTHORITY` if set, else `JIM_SSO_AUTHORITY`
 - `clientId`: the client ID for public/PKCE flows — `JIM_SSO_PUBLIC_CLIENT_ID` if set, else `JIM_SSO_CLIENT_ID`
-- `scopes`: the OAuth scopes to request, including `JIM_SSO_API_SCOPE`
+- `scopes`: the OAuth scopes to request: `openid`, `profile`, `offline_access`, and (when set) `JIM_SSO_API_SCOPE`
 
 Backend token validation (the JWT bearer middleware that protects `/api/**` endpoints) always uses `JIM_SSO_AUTHORITY` for issuer and JWKS, and `JIM_SSO_API_SCOPE` for the audience, regardless of which public client issued the token. As long as the public and confidential clients belong to the same realm/tenant and both request the same API scope, tokens from either are valid.
+
+!!! info "Why `offline_access`?"
+    JIM requests the `offline_access` scope so the identity provider issues a **refresh token**. The PowerShell module uses this for two things: silent in-session token renewal (so long-running sessions don't expire mid-task), and optional cross-session token persistence (so opening a new terminal doesn't require re-authenticating in the browser). The refresh token is the only credential persisted, and it is stored in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux); never in plain text. Your public client must be permitted to receive `offline_access`. Most identity providers grant it to public clients by default; the per-provider steps above note where it must be enabled explicitly.
 
 ---
 

--- a/docs/developer/powershell-module.md
+++ b/docs/developer/powershell-module.md
@@ -33,6 +33,63 @@ Remove-Module JIM
 Import-Module ./src/JIM.PowerShell/JIM.psd1
 ```
 
+## Testing a branch on your host machine
+
+Some module behaviour cannot be exercised from inside the devcontainer and must be tested from a PowerShell session on your **host** machine:
+
+- **OS credential-store persistence**: the refresh-token store writes to Windows Credential Manager, the macOS login Keychain, or Linux libsecret. The devcontainer has no usable keyring, so persistence always falls back to in-memory.
+- **Silent reconnect across sessions**: verifying that a brand-new terminal reconnects without a browser only makes sense where the token actually persists.
+- **Interactive browser-based SSO**: as noted under [Connecting to local JIM](#connecting-to-local-jim), the browser flow only works on the host.
+
+To test the branch's module on your host, copy the source tree into your user module path under the name `JIM` so a new terminal autoloads it. Importing straight from the repo path works for a single session, but copying into the module path is what lets a fresh terminal pick it up, which is exactly what the silent-reconnect tests need.
+
+=== "macOS / Linux"
+
+    ```powershell
+    $dest = "$HOME/.local/share/powershell/Modules/JIM"
+    Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+    Copy-Item <repo>/src/JIM.PowerShell $dest -Recurse
+    Import-Module JIM -Force
+    ```
+
+=== "Windows"
+
+    ```powershell
+    $dest = "$env:USERPROFILE\Documents\PowerShell\Modules\JIM"
+    Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+    Copy-Item <repo>\src\JIM.PowerShell $dest -Recurse
+    Import-Module JIM -Force
+    ```
+
+Replace `<repo>` with your host checkout path. Confirm the loaded copy is the one you just placed, not a gallery copy elsewhere on the path:
+
+```powershell
+(Get-Module JIM).Path
+```
+
+!!! warning "The copied folder shadows the gallery version"
+    While the dev folder sits in your module path it takes precedence over any gallery-installed `JIM`, and both report the same `ModuleVersion` (the branch does not bump it). `Get-Module JIM` alone cannot tell them apart; use `(Get-Module JIM).Path` to be sure which one is loaded. After editing module source on the branch, re-run the `Copy-Item` step before `Import-Module JIM -Force`, since `-Force` reloads from the copied location, not the repo.
+
+### Reverting to the gallery version
+
+When finished, remove the dev copy and restore the published module. Deleting the folder matters: `Remove-Module` only unloads it from the current session, so a new terminal would silently reload the dev build while the folder remains on the path.
+
+=== "macOS / Linux"
+
+    ```powershell
+    Remove-Module JIM -Force -ErrorAction SilentlyContinue
+    Remove-Item "$HOME/.local/share/powershell/Modules/JIM" -Recurse -Force
+    Install-Module JIM        # or Update-Module JIM if previously installed
+    ```
+
+=== "Windows"
+
+    ```powershell
+    Remove-Module JIM -Force -ErrorAction SilentlyContinue
+    Remove-Item "$env:USERPROFILE\Documents\PowerShell\Modules\JIM" -Recurse -Force
+    Install-Module JIM        # or Update-Module JIM if previously installed
+    ```
+
 ## Connecting to local JIM
 
 Start the Docker stack first:

--- a/docs/powershell/connection.md
+++ b/docs/powershell/connection.md
@@ -94,12 +94,12 @@ Connect-JIM "https://jim.example.com" "jim_ak_7f3e..."
 
 ## Disconnect-JIM
 
-Disconnects from the current JIM instance and clears session state.
+Disconnects from a JIM instance and forgets its persisted credentials.
 
 ### Syntax
 
 ```powershell
-Disconnect-JIM [-Url <string>] [-ClearCache]
+Disconnect-JIM [-Url <string>]
 Disconnect-JIM -All
 ```
 
@@ -107,9 +107,8 @@ Disconnect-JIM -All
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `ClearCache` | `switch` | No | `$false` | Also remove the persisted refresh token from the OS credential store. Without `-Url`, targets the currently connected instance |
-| `Url` | `string` | No | | Remove the persisted refresh token for a specific instance. Implies `-ClearCache`; works even when not connected |
-| `All` | `switch` | No | `$false` | Remove every persisted JIM refresh token from this machine |
+| `Url` | `string` | No | currently connected instance | The instance to disconnect and forget. Works even when not connected to it |
+| `All` | `switch` | No | `$false` | Remove every persisted JIM refresh token from this machine, across all instances |
 
 ### Output
 
@@ -117,16 +116,12 @@ None. Writes informational messages to the host confirming disconnection.
 
 ### Examples
 
-```powershell title="Disconnect from JIM (persisted token kept)"
+```powershell title="Disconnect and forget the connected instance"
 Disconnect-JIM
 ```
 
-```powershell title="Disconnect and forget the persisted token for this instance"
-Disconnect-JIM -ClearCache
-```
-
-```powershell title="Remove a specific instance's persisted token (even if not connected)"
-Disconnect-JIM -Url "https://jim.example.com" -ClearCache
+```powershell title="Forget a specific instance's persisted token (even if not connected)"
+Disconnect-JIM -Url "https://jim.example.com"
 ```
 
 ```powershell title="Remove every persisted JIM token from this machine"
@@ -135,9 +130,9 @@ Disconnect-JIM -All
 
 ### Notes
 
-- Clears access tokens and refresh tokens from memory.
-- By default the **persisted** refresh token in the OS credential store is left intact, so a later `Connect-JIM` can still reconnect silently. Use `-ClearCache` (or `-Url`, or `-All`) to remove it.
-- `-ClearCache`, `-Url`, and `-All` work even when there is no active connection, since clearing the credential store is a maintenance operation independent of session state.
+- Clears the in-memory session (access and refresh tokens) **and** removes the persisted refresh token for the targeted instance from the OS credential store, so a later `Connect-JIM` must authenticate again. By default the targeted instance is the connected one; use `-Url` for a specific instance or `-All` for every instance.
+- Removal is **auth-agnostic**: a stored refresh token for the instance is removed even if the cleared session authenticated with an API key. API keys themselves are never persisted by the module, so for an API-key-only session there is simply nothing in the store to remove.
+- `-Url` and `-All` work even when there is no active connection, since clearing the credential store is a maintenance operation independent of session state. A bare `Disconnect-JIM` while not connected has no instance to target and does nothing.
 - Does **not** sign you out of your identity provider. If you authenticated via SSO, your identity provider session remains active.
 - After disconnecting, you must call [Connect-JIM](#connect-jim) again before using other JIM cmdlets.
 

--- a/docs/powershell/connection.md
+++ b/docs/powershell/connection.md
@@ -16,7 +16,7 @@ Establishes a connection to a JIM instance. This must be called before using any
 
 ```powershell
 # Interactive SSO (default)
-Connect-JIM -Url <string> [-Force] [-TimeoutSeconds <int>]
+Connect-JIM -Url <string> [-Force] [-NoPersist] [-TimeoutSeconds <int>]
 
 # API Key
 Connect-JIM -Url <string> -ApiKey <string>
@@ -28,7 +28,8 @@ Connect-JIM -Url <string> -ApiKey <string>
 |------|------|----------|---------|-------------|
 | `Url` | `string` | Yes (Position 0) | | Base URL of the JIM instance, e.g. `https://jim.example.com` |
 | `ApiKey` | `string` | Yes for ApiKey set (Position 1) | | API key for non-interactive authentication |
-| `Force` | `switch` | No (Interactive only) | `$false` | Forces re-authentication even if a valid session already exists |
+| `Force` | `switch` | No (Interactive only) | `$false` | Forces re-authentication even if a valid session already exists. Ignores and overwrites any persisted refresh token |
+| `NoPersist` | `switch` | No (Interactive only) | `$false` | Authenticates for this session only, without reading from or writing to the OS credential store |
 | `TimeoutSeconds` | `int` | No (Interactive only) | `300` | How long (in seconds) to wait for interactive authentication to complete. Valid range: 30 to 600. |
 
 ### Output
@@ -60,6 +61,10 @@ Connect-JIM -Url "https://jim.example.com" -Force
 Connect-JIM -Url "https://jim.example.com" -TimeoutSeconds 60
 ```
 
+```powershell title="Interactive SSO without persisting the token (shared machine)"
+Connect-JIM -Url "https://jim.example.com" -NoPersist
+```
+
 ```powershell title="API key authentication for automation"
 Connect-JIM -Url "https://jim.example.com" -ApiKey "jim_ak_7f3e..."
 ```
@@ -74,6 +79,15 @@ Connect-JIM "https://jim.example.com" "jim_ak_7f3e..."
 - **API key authentication** is recommended for automation, CI/CD pipelines, and headless environments where a browser is not available.
 - OAuth sessions are cached locally; tokens are refreshed automatically when they approach expiry.
 - If a valid session already exists, `Connect-JIM` reuses it unless `-Force` is specified.
+- **Token persistence (interactive SSO):** after an interactive sign-in, the OAuth refresh token is saved to the operating system's credential store so that a new terminal can reconnect silently without opening a browser. The next `Connect-JIM` to the same URL prints `Connected to JIM using cached credentials` and skips the browser. Only the refresh token is stored, never the access token (a fresh access token is obtained from it on demand). The store used per platform is:
+
+    | Platform | Credential store |
+    |----------|------------------|
+    | Windows | Credential Manager (DPAPI, per-user) |
+    | macOS | login Keychain |
+    | Linux | libsecret (`secret-tool`), when present |
+
+    No password is required to unlock these stores beyond your normal OS sign-in. On systems with no usable store (typically headless Linux or SSH sessions without a keyring), persistence is skipped and the module prints a notice; use `-ApiKey` for unattended scenarios. Use `-NoPersist` to opt out of persistence for a session, and `-Force` to ignore and overwrite a persisted token. Persistence requires the identity provider to issue a refresh token, which depends on the `offline_access` scope being permitted on the public client (see [SSO Setup](../administration/sso-setup.md)).
 - To disconnect, use [Disconnect-JIM](#disconnect-jim). To verify your session, use [Test-JIMConnection](#test-jimconnection).
 
 ---
@@ -85,12 +99,17 @@ Disconnects from the current JIM instance and clears session state.
 ### Syntax
 
 ```powershell
-Disconnect-JIM
+Disconnect-JIM [-Url <string>] [-ClearCache]
+Disconnect-JIM -All
 ```
 
 ### Parameters
 
-None.
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `ClearCache` | `switch` | No | `$false` | Also remove the persisted refresh token from the OS credential store. Without `-Url`, targets the currently connected instance |
+| `Url` | `string` | No | | Remove the persisted refresh token for a specific instance. Implies `-ClearCache`; works even when not connected |
+| `All` | `switch` | No | `$false` | Remove every persisted JIM refresh token from this machine |
 
 ### Output
 
@@ -98,19 +117,27 @@ None. Writes informational messages to the host confirming disconnection.
 
 ### Examples
 
-```powershell title="Disconnect from JIM"
+```powershell title="Disconnect from JIM (persisted token kept)"
 Disconnect-JIM
 ```
 
-```powershell title="Connect, perform work, then disconnect"
-Connect-JIM -Url "https://jim.example.com"
-# ... perform administrative tasks ...
-Disconnect-JIM
+```powershell title="Disconnect and forget the persisted token for this instance"
+Disconnect-JIM -ClearCache
+```
+
+```powershell title="Remove a specific instance's persisted token (even if not connected)"
+Disconnect-JIM -Url "https://jim.example.com" -ClearCache
+```
+
+```powershell title="Remove every persisted JIM token from this machine"
+Disconnect-JIM -All
 ```
 
 ### Notes
 
 - Clears access tokens and refresh tokens from memory.
+- By default the **persisted** refresh token in the OS credential store is left intact, so a later `Connect-JIM` can still reconnect silently. Use `-ClearCache` (or `-Url`, or `-All`) to remove it.
+- `-ClearCache`, `-Url`, and `-All` work even when there is no active connection, since clearing the credential store is a maintenance operation independent of session state.
 - Does **not** sign you out of your identity provider. If you authenticated via SSO, your identity provider session remains active.
 - After disconnecting, you must call [Connect-JIM](#connect-jim) again before using other JIM cmdlets.
 

--- a/docs/powershell/connection.md
+++ b/docs/powershell/connection.md
@@ -6,6 +6,15 @@ title: Connection
 
 The connection cmdlets manage authentication and session state with a JIM instance. You must establish a connection with [Connect-JIM](#connect-jim) before using any other JIM cmdlets. Use [Test-JIMConnection](#test-jimconnection) to verify your session is active, and [Disconnect-JIM](#disconnect-jim) to clean up when finished.
 
+!!! info "Running a cmdlet before connecting"
+    If you run any JIM cmdlet before `Connect-JIM`, it produces no output and reports a clear, non-terminating error telling you to connect first, for example:
+
+    ```
+    Get-JIMConnectedSystem: You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again.
+    ```
+
+    Because the error is non-terminating, a script continues by default. Add `-ErrorAction Stop` to the cmdlet (or set `$ErrorActionPreference = 'Stop'`) when you want the not-connected state to halt the script or be caught by `try/catch`.
+
 ---
 
 ## Connect-JIM

--- a/docs/powershell/run-profiles.md
+++ b/docs/powershell/run-profiles.md
@@ -281,7 +281,7 @@ Get-JIMRunProfile -ConnectedSystemId 1 |
 
 ```powershell title="Automation with error handling"
 try {
-    Start-JIMRunProfile -RunProfileId 42 -Wait -Timeout 600 -PassThru
+    Start-JIMRunProfile -RunProfileId 42 -Wait -Timeout 600 -PassThru -ErrorAction Stop
 } catch {
     Write-Error "Run profile execution failed or timed out: $_"
 }

--- a/engineering/testing/MANUAL_TEST_PS_INTERACTIVE_AUTH.md
+++ b/engineering/testing/MANUAL_TEST_PS_INTERACTIVE_AUTH.md
@@ -1,344 +1,394 @@
 # Manual Test: PowerShell Module Interactive Authentication
 
-This guide walks through testing the interactive browser-based authentication for the JIM PowerShell module.
+This guide is a manual regression script for the JIM PowerShell module's interactive
+(browser-based SSO) authentication, refresh-token persistence, and disconnect
+behaviour. It complements the automated Pester suite (`src/JIM.PowerShell/Tests/`),
+which cannot exercise a real browser, a real OS credential store, or new-terminal
+behaviour.
 
 ## Prerequisites
 
-1. **JIM stack running** with SSO configured (see [SSO_SETUP_GUIDE.md](../SSO_SETUP_GUIDE.md))
-2. **Identity provider configured** for PowerShell module (Step 4a in SSO guide):
-   - Entra ID: Loopback redirect URI + public client flows enabled
-   - AD FS: Native application with loopback redirect
-   - Keycloak: Public client with loopback redirect
-3. **PowerShell 7.0+** installed
-4. **Web browser** available (Chrome, Edge, Firefox, etc.)
+1. **JIM stack running** with SSO configured (see [SSO_SETUP_GUIDE.md](../../docs/administration/sso-setup.md)).
+2. **Identity provider configured** for the PowerShell public client with a loopback redirect URI:
+   - Keycloak (bundled dev realm): public client `jim-powershell` with `http://localhost:8400/callback/` (and `8401-8409` as fallback ports).
+   - Entra ID: loopback redirect URI plus public client flows enabled.
+   - AD FS: native application with loopback redirect.
+3. **PowerShell 7.0+**.
+4. **A web browser** on the same machine as the PowerShell session.
 
-> **Note for devcontainer users:** The default JIM URL is `http://localhost:5200` when running with `jim-stack`.
+> **Run these tests on your host machine, not inside the devcontainer.** Interactive
+> SSO needs a browser and host-reachable IdP endpoints; the devcontainer has neither,
+> so the browser flow only works from a host PowerShell session. See
+> [PowerShell Module (developer guide)](../../docs/developer/powershell-module.md) for
+> the host-install workflow and the reasoning. API-key auth (Test A4) is the only part
+> that also works inside the devcontainer.
 
 ## Test Environment Setup
 
+Install the branch's module into your host module path so a new terminal autoloads it
+(this matters for the persistence tests, which open fresh terminals). On macOS/Linux:
+
 ```powershell
-# Import the module from the local development path
-Import-Module ./src/JIM.PowerShell -Force
+$dest = "$HOME/.local/share/powershell/Modules/JIM"
+Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item <repo>/src/JIM.PowerShell $dest -Recurse
+Import-Module JIM -Force
 
-# Verify the module loaded
-Get-Module JIM
-
-# Expected output:
-# ModuleType Version    Name
-# ---------- -------    ----
-# Script     0.2.0      JIM
+# Confirm you loaded the copy you just placed, and its version
+(Get-Module JIM).Path
+(Get-Module JIM).Version    # expect 0.11.0 (or current)
 ```
 
-## Test Cases
+On Windows use `"$env:USERPROFILE\Documents\PowerShell\Modules\JIM"` as `$dest`.
 
-### Test 1: Basic Interactive Authentication
+Throughout, the bundled dev URL is `http://localhost:5200`. Replace it with your
+instance URL where appropriate.
 
-**Steps:**
-1. Ensure you're disconnected from any previous session:
+### Inspecting the credential store
+
+Several tests verify whether a refresh token is persisted. The cache key is the
+normalised base URL, `scheme://host:port` (for example `http://localhost:5200`).
+
+| Platform | Check whether a token is stored |
+|----------|---------------------------------|
+| macOS | `security find-generic-password -s JIM -w` (prints the token, or errors if none) |
+| Linux (libsecret) | `secret-tool lookup service JIM url http://localhost:5200` |
+| Windows | `cmdkey /list \| Select-String 'JIM:'` (shows the target if present) |
+
+A non-empty result means a token is persisted for that instance; an error or empty
+result means none is.
+
+---
+
+## Part A: Authentication basics
+
+### Test A1: Basic interactive authentication
+
+1. Start from a clean slate (clears session and any stored token for this instance):
    ```powershell
-   Disconnect-JIM
+   Disconnect-JIM -Url "http://localhost:5200"
    ```
-
-2. Initiate interactive authentication:
+2. Authenticate:
    ```powershell
    Connect-JIM -Url "http://localhost:5200"
    ```
-
 3. **Expected behaviour:**
-   - Console displays: `Opening browser for authentication...`
-   - Console displays: `Waiting for authentication (timeout: 300 seconds)...`
-   - Default browser opens to your identity provider's login page
-   - After successful login, browser shows a success message
-   - Console displays: `Successfully connected to JIM at http://localhost:5200`
-
-4. Verify the connection:
+   - Console shows `Starting interactive authentication with JIM...`, then
+     `Opening browser for authentication...` and `Waiting for authentication to complete...`.
+   - The default browser opens to your IdP's login page; after sign-in the page shows a success message.
+   - Console shows the banner `Connected to JIM server v<version> at http://localhost:5200`.
+4. Verify:
    ```powershell
    Test-JIMConnection
    ```
+   Expected: `Connected = True`, `AuthMethod = OAuth`, a future `TokenExpiresAt`.
 
-5. **Expected output:**
-   ```
-   Connected      : True
-   Url            : http://localhost:5200
-   AuthMethod     : OAuth
-   Status         : Healthy
-   Message        : Connection successful
-   TokenExpiresAt : <future date/time>
-   ```
-
-**Pass criteria:** Browser opens, authentication completes, `AuthMethod` shows `OAuth`
+**Pass criteria:** browser opens, sign-in completes, `AuthMethod` is `OAuth`.
 
 ---
 
-### Test 2: Quiet Mode Connection Test
+### Test A2: API call after authentication
 
-**Steps:**
-1. After connecting (Test 1), test quiet mode:
-   ```powershell
-   Test-JIMConnection -Quiet
-   ```
-
-2. **Expected output:** `True` (just a boolean, no object)
-
-**Pass criteria:** Returns `True` with no additional output
-
----
-
-### Test 3: API Call After Authentication
-
-**Steps:**
-1. After connecting (Test 1), make an API call:
+1. While connected from A1:
    ```powershell
    Get-JIMConnectedSystem
-   ```
-
-2. **Expected behaviour:**
-   - Returns list of connected systems (may be empty if none configured)
-   - No authentication errors
-
-3. Try another cmdlet:
-   ```powershell
    Get-JIMMetaverseObjectType
    ```
+2. **Expected:** both return data (possibly empty lists) with no authentication errors or re-prompts.
 
-4. **Expected behaviour:**
-   - Returns list of MVO types (Person, Group, etc.)
-   - No authentication errors
-
-**Pass criteria:** API calls succeed without re-authentication prompts
+**Pass criteria:** API calls succeed without re-authenticating.
 
 ---
 
-### Test 4: Disconnect and Reconnect
+### Test A3: Force re-authentication
 
-**Steps:**
-1. Disconnect:
-   ```powershell
-   Disconnect-JIM
-   ```
-
-2. Verify disconnected:
-   ```powershell
-   Test-JIMConnection
-   ```
-
-3. **Expected output:**
-   ```
-   Connected      : False
-   Url            :
-   AuthMethod     :
-   Status         :
-   Message        : Not connected. Use Connect-JIM to establish a connection.
-   TokenExpiresAt :
-   ```
-
-4. Reconnect:
-   ```powershell
-   Connect-JIM -Url "http://localhost:5200"
-   ```
-
-5. **Expected behaviour:** Browser opens again for re-authentication
-
-**Pass criteria:** Disconnect clears session, reconnect requires new browser auth
-
----
-
-### Test 5: Force Re-authentication
-
-**Steps:**
-1. Connect if not already connected:
-   ```powershell
-   Connect-JIM -Url "http://localhost:5200"
-   ```
-
-2. Force re-authentication (without disconnecting first):
+1. While connected, force a fresh sign-in without disconnecting:
    ```powershell
    Connect-JIM -Url "http://localhost:5200" -Force
    ```
+2. **Expected:** the browser opens again even though a valid session exists; a new token is obtained and the stored token is overwritten.
 
-3. **Expected behaviour:**
-   - Browser opens for authentication even though already connected
-   - New token obtained
-
-**Pass criteria:** `-Force` triggers new browser authentication flow
+**Pass criteria:** `-Force` always triggers a new browser flow.
 
 ---
 
-### Test 6: Custom Timeout
+### Test A4: API key authentication (works in the devcontainer too)
 
-**Steps:**
-1. Disconnect first:
+1. Obtain an API key (JIM UI under **Admin > API Keys**, or the dev infrastructure key from `.env`).
+2. Disconnect, then connect with the key:
    ```powershell
    Disconnect-JIM
+   Connect-JIM -Url "http://localhost:5200" -ApiKey "jim_ak_xxxxxxxx"
    ```
-
-2. Connect with short timeout:
+3. **Expected:** no browser opens; immediate connection. `Test-JIMConnection` shows `AuthMethod = ApiKey` and an empty `TokenExpiresAt`.
+4. Confirm API keys are never persisted:
    ```powershell
-   Connect-JIM -Url "http://localhost:5200" -TimeoutSeconds 30
+   # macOS example; nothing should be stored for an API-key-only session
+   Disconnect-JIM
+   security find-generic-password -s JIM -w
    ```
 
-3. **Expected behaviour:**
-   - Console shows: `Waiting for authentication (timeout: 30 seconds)...`
-   - If you don't complete auth within 30 seconds, it should timeout
-
-4. To test timeout, start the command and wait without completing browser auth:
-   ```powershell
-   Connect-JIM -Url "http://localhost:5200" -TimeoutSeconds 10
-   # Don't complete the browser authentication
-   ```
-
-5. **Expected behaviour after timeout:**
-   - Error message about authentication timeout
-   - Connection not established
-
-**Pass criteria:** Timeout respected, error displayed when exceeded
+**Pass criteria:** `AuthMethod` is `ApiKey`; no token is written to the credential store.
 
 ---
 
-### Test 7: Invalid URL Handling
+### Test A5: Invalid and unreachable URLs
 
-**Steps:**
-1. Try connecting with invalid URL:
+1. Invalid format:
    ```powershell
    Connect-JIM -Url "not-a-url"
    ```
-
-2. **Expected behaviour:**
-   - Error: `Invalid URL format...`
-   - No browser opened
-
-3. Try with unreachable URL:
+   **Expected:** `Invalid URL format...`, no browser opens.
+2. Unreachable host:
    ```powershell
    Connect-JIM -Url "https://invalid.example.com"
    ```
+   **Expected:** an error fetching the OAuth/OIDC configuration; no connection established.
 
-4. **Expected behaviour:**
-   - Error about failing to fetch OIDC discovery document
-   - No browser opened (or browser shows error)
-
-**Pass criteria:** Invalid URLs rejected with helpful error messages
+**Pass criteria:** bad URLs are rejected with helpful errors.
 
 ---
 
-### Test 8: Browser Cancellation
+### Test A6: Timeout and browser cancellation
 
-**Steps:**
-1. Disconnect:
+1. Short timeout, do not complete sign-in:
+   ```powershell
+   Disconnect-JIM
+   Connect-JIM -Url "http://localhost:5200" -TimeoutSeconds 30
+   # Leave the browser sign-in incomplete
+   ```
+   **Expected:** after ~30 seconds, an authentication timeout error; no connection.
+2. Cancellation: start `Connect-JIM` again and close the browser tab without signing in.
+   **Expected:** PowerShell reports an authentication failure/timeout; no connection.
+
+**Pass criteria:** timeout is respected and cancellation is handled gracefully.
+
+---
+
+## Part B: Refresh-token persistence and silent reconnect
+
+This is the headline feature: an interactive sign-in persists the refresh token in the
+OS credential store so a new terminal reconnects without a browser.
+
+### Test B1: First sign-in persists the token
+
+1. Clean slate, then sign in interactively:
+   ```powershell
+   Disconnect-JIM -Url "http://localhost:5200"
+   Connect-JIM -Url "http://localhost:5200"
+   ```
+2. Verify a token was stored (see [Inspecting the credential store](#inspecting-the-credential-store)):
+   ```powershell
+   security find-generic-password -s JIM -w   # macOS; should print a token
+   ```
+
+**Pass criteria:** after an interactive sign-in, a refresh token is present in the store.
+
+---
+
+### Test B2: Silent reconnect in a new terminal (key test)
+
+1. **Close the terminal entirely** and open a **new** one (this clears the in-memory session, forcing the persisted-token path).
+2. Reconnect:
+   ```powershell
+   Import-Module JIM
+   Connect-JIM -Url "http://localhost:5200" -Verbose
+   ```
+3. **Expected behaviour:**
+   - `-Verbose` shows `Found a persisted refresh token; attempting silent reconnect...`.
+   - **No browser opens.**
+   - Green message: `Connected to JIM using cached credentials (no browser sign-in required).`
+   - `Test-JIMConnection` shows `Connected = True`, `AuthMethod = OAuth`.
+
+**Pass criteria:** a fresh terminal reconnects with no browser.
+
+---
+
+### Test B3: In-session reconnect uses the cached access token
+
+1. In the same session as B2, run again:
+   ```powershell
+   Connect-JIM -Url "http://localhost:5200" -Verbose
+   ```
+2. **Expected:** instant return with status `Connected (cached)` from the in-memory access token; no call to the IdP and no credential-store read (the valid access token short-circuits, with a 5-minute expiry buffer).
+
+**Pass criteria:** repeated connects in one session do not hit the IdP.
+
+---
+
+### Test B4: `-NoPersist` does not write to the store
+
+1. Clear any stored token, then connect without persisting:
+   ```powershell
+   Disconnect-JIM -Url "http://localhost:5200"
+   Connect-JIM -Url "http://localhost:5200" -NoPersist
+   ```
+2. Confirm nothing was stored:
+   ```powershell
+   security find-generic-password -s JIM -w   # macOS; should error / be empty
+   ```
+3. Close the terminal, open a new one, and reconnect:
+   ```powershell
+   Import-Module JIM
+   Connect-JIM -Url "http://localhost:5200"
+   ```
+   **Expected:** a browser opens (nothing was persisted to reconnect silently).
+
+**Pass criteria:** `-NoPersist` leaves the store untouched; a new session must sign in again.
+
+---
+
+### Test B5: Headless / no-keyring fallback (Linux without libsecret only)
+
+1. On a headless Linux host with no `secret-tool`, connect interactively (where feasible) or inspect the notice path.
+2. **Expected:** a grey notice that token persistence is unavailable and a pointer to use `-ApiKey` for unattended use; the session still works in-memory.
+
+**Pass criteria:** persistence degrades gracefully with a clear notice; no error.
+
+---
+
+## Part C: Disconnect-and-forget semantics
+
+`Disconnect-JIM` clears the session **and** removes the persisted token for the
+targeted instance. Removal is auth-agnostic.
+
+### Test C1: Default forgets the connected instance
+
+1. With a persisted token present (from B1/B2) and connected:
    ```powershell
    Disconnect-JIM
    ```
-
-2. Start authentication:
+   **Expected:** `Disconnected from JIM at http://localhost:5200`, then
+   `Removed persisted credentials for http://localhost:5200 from the OS credential store.`
+2. Confirm the token is gone, and that a new terminal now needs a browser:
    ```powershell
-   Connect-JIM -Url "http://localhost:5200"
+   security find-generic-password -s JIM -w   # macOS; should error / be empty
    ```
 
-3. When browser opens, close the browser tab/window without completing authentication
-
-4. **Expected behaviour:**
-   - After a moment, PowerShell shows error about authentication failure or timeout
-   - Connection not established
-
-**Pass criteria:** Graceful handling of user cancellation
+**Pass criteria:** the default disconnect removes the connected instance's stored token.
 
 ---
 
-### Test 9: API Key Authentication (Comparison)
+### Test C2: `-Url` forgets a specific instance while not connected
 
-**Steps:**
-1. Create an API key in JIM UI (Settings > API Keys)
+1. Disconnect fully, then target a specific instance by URL:
+   ```powershell
+   Disconnect-JIM
+   Disconnect-JIM -Url "http://localhost:5200"
+   ```
+   **Expected:** removes the stored token for that instance even though there is no active session. If nothing was stored, it is a quiet no-op.
 
-2. Disconnect OAuth session:
+**Pass criteria:** `-Url` removes a specific instance's token without requiring a connection.
+
+---
+
+### Test C3: `-All` forgets every instance
+
+1. Persist tokens for two or more instances (if available), then:
+   ```powershell
+   Disconnect-JIM -All
+   ```
+   **Expected:** `Removed N persisted JIM credential(s) from the OS credential store.` where N matches the number of instances stored.
+
+**Pass criteria:** `-All` clears every JIM token on the machine.
+
+---
+
+### Test C4: Auth-agnostic removal during an API-key session
+
+1. Ensure an SSO token exists for the instance (B1), then connect to the **same** instance with an API key and disconnect:
+   ```powershell
+   Connect-JIM -Url "http://localhost:5200" -ApiKey "jim_ak_xxxxxxxx"
+   Disconnect-JIM
+   security find-generic-password -s JIM -w   # macOS; the SSO token should be gone
+   ```
+2. **Expected:** the in-memory API-key session is cleared and the previously stored SSO token for that instance is removed too (disconnect forgets the instance regardless of how the current session authenticated).
+
+**Pass criteria:** disconnect removes the instance's stored token even from an API-key session.
+
+---
+
+### Test C5: Bare disconnect while not connected is a no-op
+
+1. With no active session and no stored token:
    ```powershell
    Disconnect-JIM
    ```
+   **Expected:** no error and no store change (a verbose message only). Safe to call as a reset.
 
-3. Connect with API key:
-   ```powershell
-   Connect-JIM -Url "http://localhost:5200" -ApiKey "your-api-key"
-   ```
-
-4. **Expected behaviour:**
-   - No browser opened
-   - Immediate connection
-
-5. Verify:
-   ```powershell
-   Test-JIMConnection
-   ```
-
-6. **Expected output:**
-   ```
-   Connected      : True
-   Url            : http://localhost:5200
-   AuthMethod     : ApiKey
-   Status         : Healthy
-   Message        : Connection successful
-   TokenExpiresAt :
-   ```
-
-**Pass criteria:** `AuthMethod` shows `ApiKey`, no `TokenExpiresAt` (API keys don't expire in the same way)
+**Pass criteria:** idempotent, no error.
 
 ---
 
-### Test 10: Token Refresh (Advanced)
+## Part D: Token renewal and stale-token fallback
 
-**Steps:**
-1. Connect with OAuth:
+### Test D1: Automatic in-session refresh
+
+1. Connect interactively and note the expiry:
    ```powershell
    Connect-JIM -Url "http://localhost:5200"
-   ```
-
-2. Note the `TokenExpiresAt` value:
-   ```powershell
-   $conn = Test-JIMConnection
-   $conn.TokenExpiresAt
-   ```
-
-3. Wait for token to approach expiry (or configure short token lifetime in IDP for testing)
-
-4. Make an API call:
-   ```powershell
-   Get-JIMConnectedSystem
-   ```
-
-5. **Expected behaviour:**
-   - If token expired but refresh token valid, silent refresh occurs
-   - API call succeeds
-   - New `TokenExpiresAt` if refreshed
-
-6. Check new expiry:
-   ```powershell
    (Test-JIMConnection).TokenExpiresAt
    ```
+2. Let the access token approach expiry (or set a short access-token lifetime in the IdP), then make a call:
+   ```powershell
+   Get-JIMConnectedSystem
+   (Test-JIMConnection).TokenExpiresAt   # should be later if a refresh occurred
+   ```
 
-**Pass criteria:** Token refresh happens automatically without requiring re-authentication
+**Pass criteria:** an expiring access token is refreshed silently; the API call succeeds.
+
+---
+
+### Test D2: Revoked refresh token falls back to the browser
+
+This verifies that a dead persisted token does not wedge the user out: the silent
+reconnect fails and the module falls back to a browser sign-in, dropping the stale
+token.
+
+1. With a persisted token (B1) and **not** in an in-memory session, revoke the refresh
+   token at the IdP. For the bundled Keycloak dev realm the refresh token is an
+   **offline** token, so revoke the offline session (a plain user logout does not):
+   - Keycloak admin console: **Users > (your user) > Sessions**, or delete the offline
+     session via the admin REST API. The session must be removed with the offline flag,
+     for example `DELETE /admin/realms/jim/sessions/{sessionId}?isOffline=true`.
+   - Quick proxy if you cannot revoke: corrupt the stored value, for example on macOS
+     `security add-generic-password -a "http://localhost:5200" -s JIM -U -w "garbage"`.
+2. In a **new** terminal, attempt reconnect:
+   ```powershell
+   Import-Module JIM
+   Connect-JIM -Url "http://localhost:5200" -Verbose
+   ```
+3. **Expected behaviour:**
+   - `-Verbose` shows `Found a persisted refresh token; attempting silent reconnect...`
+     then `Silent reconnect with persisted token failed, falling back to browser sign-in`.
+   - The browser opens for a fresh sign-in.
+   - The stale token is removed from the store. Verify **after** the fallback but
+     **before** completing the new sign-in (a successful sign-in writes a fresh token):
+     ```powershell
+     security find-generic-password -s JIM -w   # macOS; should error / be empty
+     ```
+
+**Pass criteria:** a revoked token triggers a clean browser fallback and the stale token is dropped (no repeated retries against the dead token).
 
 ---
 
 ## Troubleshooting
 
-### Browser doesn't open
-- Check if a default browser is configured
-- Try running PowerShell as a regular user (not elevated)
-- Check firewall isn't blocking localhost ports
+### Browser does not open
+- Confirm a default browser is configured and you are not running elevated.
+- Confirm the loopback callback port (8400, falling back to 8401-8409) is not blocked.
 
-### Authentication fails after browser login
-- Verify loopback redirect URI is configured in IDP:
-  - **Entra ID**: `http://localhost:8400/callback/` (exact match required)
-  - **AD FS**: `http://localhost:8400/callback/` (exact match recommended)
-  - **Keycloak**: `http://localhost:8400/callback/` (exact match recommended)
-- If port 8400 is busy, add additional URIs for ports 8401-8409
-- Check IDP allows public client flows (Entra ID) or is a public client (Keycloak)
-- Look for errors in browser developer console
+### Authentication fails after browser sign-in
+- Verify the loopback redirect URI on the public client: `http://localhost:8400/callback/` (exact match; add `8401-8409` if 8400 is busy).
+- Confirm the IdP client is public / allows public client flows.
 
-### "Discovery document" errors
-- Verify `SSO_AUTHORITY` is correct and accessible
-- Test: `curl https://login.microsoftonline.com/{tenant-id}/v2.0/.well-known/openid-configuration`
+### Silent reconnect always opens a browser
+- Confirm a token is actually stored (see the inspection table). `-NoPersist` or a headless no-keyring host both result in nothing being stored.
+- Confirm you opened a **new** terminal; the same session short-circuits on the in-memory access token (Test B3), which is expected.
 
-### Token refresh fails
-- Ensure `offline_access` scope is requested and allowed
-- Check refresh token lifetime in IDP settings
+### Token refresh / silent reconnect fails unexpectedly
+- Ensure the `offline_access` scope is permitted on the public client, so the IdP issues a refresh token.
+- Check the refresh-token (offline session) lifetime in the IdP.
 
 ---
 
@@ -346,18 +396,26 @@ Get-Module JIM
 
 | Test | Description | Pass/Fail | Notes |
 |------|-------------|-----------|-------|
-| 1 | Basic Interactive Auth | | |
-| 2 | Quiet Mode | | |
-| 3 | API Call After Auth | | |
-| 4 | Disconnect/Reconnect | | |
-| 5 | Force Re-auth | | |
-| 6 | Custom Timeout | | |
-| 7 | Invalid URL | | |
-| 8 | Browser Cancellation | | |
-| 9 | API Key Comparison | | |
-| 10 | Token Refresh | | |
+| A1 | Basic interactive auth | | |
+| A2 | API call after auth | | |
+| A3 | Force re-auth | | |
+| A4 | API key auth (no persistence) | | |
+| A5 | Invalid / unreachable URL | | |
+| A6 | Timeout / cancellation | | |
+| B1 | First sign-in persists token | | |
+| B2 | Silent reconnect (new terminal) | | |
+| B3 | In-session cached reconnect | | |
+| B4 | `-NoPersist` writes nothing | | |
+| B5 | Headless no-keyring fallback | | |
+| C1 | Disconnect forgets connected instance | | |
+| C2 | `-Url` forgets specific instance | | |
+| C3 | `-All` forgets every instance | | |
+| C4 | Auth-agnostic removal (API-key session) | | |
+| C5 | Bare disconnect no-op | | |
+| D1 | Automatic in-session refresh | | |
+| D2 | Revoked token browser fallback | | |
 
 **Tested by:** _______________
 **Date:** _______________
-**JIM Version:** 0.2.0
-**IDP:** _______________
+**JIM Version:** _______________
+**IdP:** _______________

--- a/src/JIM.Application/JimApplication.cs
+++ b/src/JIM.Application/JimApplication.cs
@@ -38,6 +38,7 @@ public class JimApplication : IDisposable
 
     internal SeedingServer Seeding { get; }
     public ActivityServer Activities { get; }
+    public AuthServer Auth { get; }
     public CertificateServer Certificates { get; }
     public ChangeHistoryServer ChangeHistory { get; }
     public ConnectedSystemServer ConnectedSystems { get; }
@@ -59,6 +60,7 @@ public class JimApplication : IDisposable
     public JimApplication(IRepository dataRepository, IMemoryCache? cache = null, ISyncRepository? syncRepository = null)
     {
         Activities = new ActivityServer(this);
+        Auth = new AuthServer(this);
         Certificates = new CertificateServer(this);
         ChangeHistory = new ChangeHistoryServer(this);
         ConnectedSystems = new ConnectedSystemServer(this);

--- a/src/JIM.Application/Servers/AuthServer.cs
+++ b/src/JIM.Application/Servers/AuthServer.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Security;
+using Serilog;
+
+namespace JIM.Application.Servers;
+
+/// <summary>
+/// Resolves authenticated SSO identities to JIM MetaverseObjects, and bootstraps the
+/// initial administrator just-in-time on first contact.
+///
+/// This logic is auth-scheme agnostic: it operates on an <see cref="SsoIdentity"/> DTO,
+/// so the same provisioning runs whether the user arrives via the interactive browser
+/// (cookie/OIDC) flow or via a bearer token (the PowerShell module / REST API). That is
+/// what allows a fresh deployment to be administered entirely from the CLI without ever
+/// signing in to the web portal.
+///
+/// Only the configured initial administrator (<c>JIM_SSO_INITIAL_ADMIN</c>) is created
+/// just-in-time. Every other user must be provisioned through synchronisation.
+/// </summary>
+public class AuthServer
+{
+    private JimApplication Application { get; }
+
+    internal AuthServer(JimApplication application)
+    {
+        Application = application;
+    }
+
+    /// <summary>
+    /// Resolves an authenticated SSO identity to its MetaverseObject, creating the initial
+    /// administrator just-in-time if this is their first contact, and supplementing any
+    /// missing profile attributes from the identity. Returns <c>null</c> when the identity
+    /// cannot be matched and is not the initial administrator (such users are provisioned
+    /// via synchronisation, not from a token).
+    /// </summary>
+    /// <param name="identity">The provider-agnostic identity built from the validated token.</param>
+    public async Task<MetaverseObject?> ResolveOrProvisionSsoIdentityAsync(SsoIdentity identity)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+
+        if (string.IsNullOrEmpty(identity.UniqueId))
+        {
+            Log.Warning("AuthServer: SSO identity has no unique id; cannot resolve a JIM user.");
+            return null;
+        }
+
+        var serviceSettings = await Application.ServiceSettings.GetServiceSettingsAsync() ??
+            throw new InvalidOperationException("ServiceSettings was null. Cannot resolve SSO identity.");
+
+        if (serviceSettings.SSOUniqueIdentifierMetaverseAttribute == null)
+            throw new InvalidOperationException("ServiceSettings.SSOUniqueIdentifierMetaverseAttribute is null.");
+
+        var userType = await Application.Metaverse.GetMetaverseObjectTypeAsync(Constants.BuiltInObjectTypes.User, false) ??
+            throw new InvalidOperationException("Could not retrieve the User object type.");
+
+        var user = await Application.Metaverse.GetMetaverseObjectByTypeAndAttributeAsync(
+            userType, serviceSettings.SSOUniqueIdentifierMetaverseAttribute, identity.UniqueId);
+
+        var initialAdminId = Environment.GetEnvironmentVariable(Constants.Config.SsoInitialAdmin);
+        var isInitialAdmin = !string.IsNullOrEmpty(initialAdminId) && identity.UniqueId == initialAdminId;
+
+        // Bootstrap the initial admin just-in-time on first contact (web or API/CLI).
+        if (user == null && isInitialAdmin)
+            user = await CreateInitialAdminUserAsync(userType, serviceSettings.SSOUniqueIdentifierMetaverseAttribute, identity);
+
+        // Unknown user who isn't the initial admin: they must be provisioned via synchronisation.
+        if (user == null)
+            return null;
+
+        // The initial admin always retains the Administrator role, even if they already existed.
+        if (isInitialAdmin && !await Application.Security.IsObjectInRoleAsync(user, Constants.BuiltInRoles.Administrator))
+            await Application.Security.AddObjectToRoleAsync(user, Constants.BuiltInRoles.Administrator);
+
+        // Supplement any missing profile attributes from the identity. This is a no-op for a
+        // freshly created user (attributes were set during creation) and for an existing user
+        // whose attributes are already populated.
+        await SupplementUserAttributesAsync(user, identity);
+
+        return user;
+    }
+
+    /// <summary>
+    /// Creates the initial admin user just-in-time on their first sign-in, with all available
+    /// identity values populated in a single operation (producing one "Created" change event),
+    /// and assigns the Administrator role. Both steps are recorded as Activities.
+    /// </summary>
+    private async Task<MetaverseObject> CreateInitialAdminUserAsync(
+        MetaverseObjectType userType,
+        MetaverseAttribute uniqueIdentifierAttribute,
+        SsoIdentity identity)
+    {
+        Log.Information("AuthServer: Creating initial admin user just-in-time ({UniqueId}).", identity.UniqueId);
+
+        var activity = new Activity
+        {
+            TargetType = ActivityTargetType.MetaverseObject,
+            TargetOperationType = ActivityTargetOperationType.Create,
+            Message = "Creating initial administrator user on first sign-in"
+        };
+        await Application.Activities.CreateSystemActivityAsync(activity);
+
+        try
+        {
+            // Set Origin to Internal to protect the admin from automatic deletion rules.
+            var user = new MetaverseObject
+            {
+                Type = userType,
+                Origin = MetaverseObjectOrigin.Internal
+            };
+
+            // unique identifier attribute (required)
+            user.AttributeValues.Add(new MetaverseObjectAttributeValue
+            {
+                MetaverseObject = user,
+                Attribute = uniqueIdentifierAttribute,
+                StringValue = identity.UniqueId
+            });
+
+            // Type attribute (required)
+            var typeAttribute = await Application.Metaverse.GetMetaverseAttributeAsync(Constants.BuiltInAttributes.Type) ??
+                throw new InvalidOperationException($"Couldn't get essential attribute: {Constants.BuiltInAttributes.Type}");
+            user.AttributeValues.Add(new MetaverseObjectAttributeValue
+            {
+                MetaverseObject = user,
+                Attribute = typeAttribute,
+                StringValue = "PersonEntity"
+            });
+
+            // populate optional attributes from the identity so everything is set in one go
+            await AddAttributeFromValueAsync(user, identity.DisplayName, Constants.BuiltInAttributes.DisplayName);
+            await AddAttributeFromValueAsync(user, identity.FirstName, Constants.BuiltInAttributes.FirstName);
+            await AddAttributeFromValueAsync(user, identity.LastName, Constants.BuiltInAttributes.LastName);
+            await AddAttributeFromValueAsync(user, identity.UserPrincipalName, Constants.BuiltInAttributes.UserPrincipalName);
+
+            await Application.Metaverse.CreateMetaverseObjectAsync(
+                user,
+                changeInitiatorType: MetaverseObjectChangeInitiatorType.System);
+
+            // update the parent activity with the user's details now that the MVO exists
+            activity.TargetName = user.DisplayName;
+            activity.MetaverseObjectId = user.Id;
+
+            // assign the Administrator role as a child activity
+            var roleActivity = new Activity
+            {
+                ParentActivityId = activity.Id,
+                TargetType = ActivityTargetType.MetaverseObject,
+                TargetOperationType = ActivityTargetOperationType.Update,
+                TargetName = user.DisplayName,
+                MetaverseObjectId = user.Id,
+                Message = $"Assigning {Constants.BuiltInRoles.Administrator} role to initial administrator"
+            };
+            await Application.Activities.CreateSystemActivityAsync(roleActivity);
+
+            try
+            {
+                await Application.Security.AddObjectToRoleAsync(user, Constants.BuiltInRoles.Administrator);
+                roleActivity.Message = $"Assigned {Constants.BuiltInRoles.Administrator} role to initial administrator";
+                await Application.Activities.CompleteActivityAsync(roleActivity);
+            }
+            catch (Exception ex)
+            {
+                // Record the failure against the audit activity before propagating; any failure
+                // mode (persistence, role lookup) must mark the activity failed and rethrow.
+                await Application.Activities.FailActivityWithErrorAsync(roleActivity, ex);
+                throw;
+            }
+
+            activity.Message = $"Created initial administrator '{user.DisplayName}'";
+            await Application.Activities.CompleteActivityAsync(activity);
+
+            Log.Information("AuthServer: Initial admin user created and assigned {Role} role.", Constants.BuiltInRoles.Administrator);
+            return user;
+        }
+        catch (Exception ex)
+        {
+            await Application.Activities.FailActivityWithErrorAsync(activity, ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Adds an attribute value to a MetaverseObject during creation, if a value is present.
+    /// </summary>
+    private async Task AddAttributeFromValueAsync(MetaverseObject user, string? value, string metaverseAttributeName)
+    {
+        if (string.IsNullOrEmpty(value))
+            return;
+
+        var attribute = await Application.Metaverse.GetMetaverseAttributeAsync(metaverseAttributeName);
+        if (attribute == null)
+            return;
+
+        user.AttributeValues.Add(new MetaverseObjectAttributeValue
+        {
+            MetaverseObject = user,
+            Attribute = attribute,
+            StringValue = value
+        });
+        Log.Verbose("AuthServer: Added {Attribute} from identity.", metaverseAttributeName);
+    }
+
+    /// <summary>
+    /// Supplements an existing user's missing profile attributes from the identity, persisting
+    /// only the additions. Attributes already present are left untouched.
+    /// </summary>
+    private async Task SupplementUserAttributesAsync(MetaverseObject user, SsoIdentity identity)
+    {
+        var additions = new List<MetaverseObjectAttributeValue>();
+
+        await AddMissingAttributeAsync(user, additions, identity.DisplayName, Constants.BuiltInAttributes.DisplayName);
+        await AddMissingAttributeAsync(user, additions, identity.FirstName, Constants.BuiltInAttributes.FirstName);
+        await AddMissingAttributeAsync(user, additions, identity.LastName, Constants.BuiltInAttributes.LastName);
+        await AddMissingAttributeAsync(user, additions, identity.UserPrincipalName, Constants.BuiltInAttributes.UserPrincipalName);
+
+        if (additions.Count > 0)
+        {
+            await Application.Metaverse.UpdateMetaverseObjectAsync(
+                user,
+                additions: additions,
+                changeInitiatorType: MetaverseObjectChangeInitiatorType.System);
+            Log.Debug("AuthServer: Supplemented {Count} attribute value(s) on user {UserId} from the SSO identity.", additions.Count, user.Id);
+        }
+    }
+
+    /// <summary>
+    /// Stages an attribute addition when the value is present and the user does not already
+    /// have a value for that attribute.
+    /// </summary>
+    private async Task AddMissingAttributeAsync(
+        MetaverseObject user,
+        List<MetaverseObjectAttributeValue> additions,
+        string? value,
+        string metaverseAttributeName)
+    {
+        if (string.IsNullOrEmpty(value))
+            return;
+
+        if (user.HasAttributeValue(metaverseAttributeName))
+            return;
+
+        var attribute = await Application.Metaverse.GetMetaverseAttributeAsync(metaverseAttributeName);
+        if (attribute == null)
+            return;
+
+        var attributeValue = new MetaverseObjectAttributeValue
+        {
+            Attribute = attribute,
+            StringValue = value
+        };
+        user.AttributeValues.Add(attributeValue);
+        additions.Add(attributeValue);
+    }
+}

--- a/src/JIM.Models/Security/SsoIdentity.cs
+++ b/src/JIM.Models/Security/SsoIdentity.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Security;
+
+/// <summary>
+/// A provider-agnostic view of an authenticated SSO identity, carrying only the claim
+/// values JIM needs to resolve or provision a MetaverseObject. This decouples the
+/// application layer from the web layer's ClaimsPrincipal plumbing: the presentation
+/// layer extracts the relevant claims and hands over this DTO.
+/// </summary>
+public record SsoIdentity
+{
+    /// <summary>
+    /// The immutable unique identifier for the user, taken from the configured SSO unique-id
+    /// claim (for example the <c>sub</c> claim). Required; without it the user cannot be matched.
+    /// </summary>
+    public required string UniqueId { get; init; }
+
+    /// <summary>Optional display name (OIDC <c>name</c> claim).</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Optional first/given name (OIDC <c>given_name</c> claim).</summary>
+    public string? FirstName { get; init; }
+
+    /// <summary>Optional last/family name (OIDC <c>family_name</c> claim).</summary>
+    public string? LastName { get; init; }
+
+    /// <summary>Optional user principal name (OIDC <c>preferred_username</c> claim).</summary>
+    public string? UserPrincipalName { get; init; }
+}

--- a/src/JIM.PowerShell/Private/Invoke-JIMApi.ps1
+++ b/src/JIM.PowerShell/Private/Invoke-JIMApi.ps1
@@ -90,6 +90,18 @@ function Invoke-TokenRefresh {
             $script:JIMConnection.RefreshToken = $tokens.RefreshToken
             $script:JIMConnection.TokenExpiresAt = $tokens.ExpiresAt
             Write-Verbose "Successfully refreshed access token"
+
+            # Write the rotated refresh token back to the credential store so the
+            # persisted copy stays usable in future sessions (most IdPs rotate
+            # refresh tokens on each use).
+            if ($script:JIMConnection.Persisted) {
+                try {
+                    Save-JIMToken -BaseUrl $script:JIMConnection.Url -RefreshToken $tokens.RefreshToken | Out-Null
+                }
+                catch {
+                    Write-Verbose "Failed to persist refreshed token: $_"
+                }
+            }
         }
         catch {
             throw "Access token expired and refresh failed. Please run Connect-JIM again to re-authenticate. Error: $_"

--- a/src/JIM.PowerShell/Private/Invoke-JIMApi.ps1
+++ b/src/JIM.PowerShell/Private/Invoke-JIMApi.ps1
@@ -49,9 +49,14 @@ function Invoke-JIMApi {
         [string]$ContentType = 'application/json'
     )
 
-    # Check connection
+    # Not connected is an expected precondition, not a failure. Report it as a
+    # non-terminating error (matching every other cmdlet's guard) and return
+    # nothing, rather than throwing: a raw throw makes ConciseView render this
+    # helper's internal file and line, which reads like a crash. Callers can opt
+    # into terminating behaviour with -ErrorAction Stop.
     if (-not $script:JIMConnection) {
-        throw "Not connected to JIM. Use Connect-JIM first."
+        Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+        return
     }
 
     # Proactive token refresh: check before the request if token is near expiry

--- a/src/JIM.PowerShell/Private/JIMTokenStore.ps1
+++ b/src/JIM.PowerShell/Private/JIMTokenStore.ps1
@@ -479,7 +479,7 @@ function Remove-JIMToken {
     #>
     # ShouldProcess is intentionally not implemented: this is a private helper, and
     # the user-facing destructive intent is expressed through Disconnect-JIM
-    # (-ClearCache / -Url / -All), which is where any confirmation would belong.
+    # (its default, -Url, or -All), which is where any confirmation would belong.
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding(DefaultParameterSetName = 'Single')]
     [OutputType([int])]

--- a/src/JIM.PowerShell/Private/JIMTokenStore.ps1
+++ b/src/JIM.PowerShell/Private/JIMTokenStore.ps1
@@ -1,0 +1,579 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+    Persistent refresh-token storage for the JIM PowerShell module (issue #305).
+
+    Only the OAuth refresh token is persisted, never the access token. The refresh
+    token is stored in the operating system's native credential store so it is
+    encrypted at rest and unlocked automatically as part of the user's OS logon:
+
+      - Windows : Credential Manager (DPAPI, per-user) via advapi32 Cred* APIs
+      - macOS   : login Keychain via the 'security' CLI
+      - Linux   : libsecret via 'secret-tool' when present
+
+    On a system with no usable store (typically headless/SSH Linux without a
+    keyring), persistence is unavailable and callers fall back to in-memory
+    storage. No bespoke encrypted file is ever written.
+
+    To use a cached token in a new session the module re-fetches the OAuth
+    configuration (/api/v1/auth/config + OIDC discovery) and performs a
+    refresh_token grant, so nothing beyond the refresh token needs to be stored.
+#>
+
+# Service / target naming. The cache key (a normalised base URL) is appended so
+# multiple JIM instances can be cached independently.
+$script:JIMTokenStoreService = 'JIM'
+$script:JIMTokenStoreTargetPrefix = 'JIM:'
+
+function Get-JIMTokenCacheKey {
+    <#
+    .SYNOPSIS
+        Derives a stable cache key from a JIM base URL.
+
+    .DESCRIPTION
+        Normalises the URL to "scheme://host:port" with a lower-cased scheme and
+        host and an explicit port. This collapses incidental differences (trailing
+        slash, default-port presence, host casing) so the same instance always maps
+        to the same key, while keeping distinct schemes, hosts, and ports separate.
+
+    .PARAMETER BaseUrl
+        The JIM base URL, e.g. 'https://jim.company.com' or 'http://localhost:5200'.
+
+    .OUTPUTS
+        The normalised cache key string.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BaseUrl
+    )
+
+    $uri = [Uri]$BaseUrl
+    # [Uri].Port always returns the effective port (default if unspecified), so the
+    # key is explicit regardless of whether the caller included the port.
+    return "$($uri.Scheme.ToLowerInvariant())://$($uri.Host.ToLowerInvariant()):$($uri.Port)"
+}
+
+function Get-JIMTokenStoreProvider {
+    <#
+    .SYNOPSIS
+        Determines which credential-store provider is available on this system.
+
+    .OUTPUTS
+        One of 'Windows', 'MacOS', 'LibSecret', or 'None'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    if ($IsWindows -or $env:OS -match 'Windows') {
+        return 'Windows'
+    }
+
+    if ($IsMacOS) {
+        return 'MacOS'
+    }
+
+    # Linux (or any other platform): persistence requires libsecret's secret-tool.
+    # When it is absent (typical on headless servers / SSH with no keyring), there
+    # is no password-free store, so report None and let the caller fall back to
+    # in-memory storage.
+    if (Get-Command 'secret-tool' -ErrorAction SilentlyContinue) {
+        return 'LibSecret'
+    }
+
+    return 'None'
+}
+
+function Test-JIMTokenPersistenceAvailable {
+    <#
+    .SYNOPSIS
+        Returns $true when a usable credential store is available on this system.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    return (Get-JIMTokenStoreProvider) -ne 'None'
+}
+
+function Initialize-JIMWindowsCredentialStore {
+    <#
+    .SYNOPSIS
+        Compiles the Windows Credential Manager interop helper once per session.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ('JIMCredentialStore' -as [type]) {
+        return
+    }
+
+    $source = @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class JIMCredentialStore
+{
+    private const uint CRED_TYPE_GENERIC = 1;
+    private const uint CRED_PERSIST_LOCAL_MACHINE = 2;
+    private const int ERROR_NOT_FOUND = 1168;
+    // CRED_MAX_CREDENTIAL_BLOB_SIZE = 5 * 512.
+    private const int MaxBlobBytes = 2560;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct CREDENTIAL
+    {
+        public uint Flags;
+        public uint Type;
+        public string TargetName;
+        public string Comment;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+        public uint CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public uint Persist;
+        public uint AttributeCount;
+        public IntPtr Attributes;
+        public string TargetAlias;
+        public string UserName;
+    }
+
+    [DllImport("advapi32", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CredWriteW")]
+    private static extern bool CredWrite(ref CREDENTIAL userCredential, uint flags);
+
+    [DllImport("advapi32", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CredReadW")]
+    private static extern bool CredRead(string target, uint type, uint flags, out IntPtr credentialPtr);
+
+    [DllImport("advapi32", SetLastError = true, EntryPoint = "CredFree")]
+    private static extern void CredFree(IntPtr cred);
+
+    [DllImport("advapi32", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CredDeleteW")]
+    private static extern bool CredDelete(string target, uint type, uint flags);
+
+    [DllImport("advapi32", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CredEnumerateW")]
+    private static extern bool CredEnumerate(string filter, uint flags, out uint count, out IntPtr pCredentials);
+
+    public static void Write(string target, string userName, string secret)
+    {
+        byte[] blob = Encoding.Unicode.GetBytes(secret);
+        if (blob.Length > MaxBlobBytes)
+        {
+            throw new ArgumentException("Secret exceeds the Windows Credential Manager blob size limit of " + MaxBlobBytes + " bytes.");
+        }
+
+        IntPtr blobPtr = Marshal.AllocHGlobal(blob.Length);
+        try
+        {
+            Marshal.Copy(blob, 0, blobPtr, blob.Length);
+            CREDENTIAL cred = new CREDENTIAL();
+            cred.Type = CRED_TYPE_GENERIC;
+            cred.TargetName = target;
+            cred.CredentialBlobSize = (uint)blob.Length;
+            cred.CredentialBlob = blobPtr;
+            cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+            cred.UserName = userName;
+            if (!CredWrite(ref cred, 0))
+            {
+                throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(blobPtr);
+        }
+    }
+
+    public static string Read(string target)
+    {
+        IntPtr credPtr;
+        if (!CredRead(target, CRED_TYPE_GENERIC, 0, out credPtr))
+        {
+            int err = Marshal.GetLastWin32Error();
+            if (err == ERROR_NOT_FOUND)
+            {
+                return null;
+            }
+            throw new System.ComponentModel.Win32Exception(err);
+        }
+
+        try
+        {
+            CREDENTIAL cred = (CREDENTIAL)Marshal.PtrToStructure(credPtr, typeof(CREDENTIAL));
+            if (cred.CredentialBlobSize == 0)
+            {
+                return string.Empty;
+            }
+            byte[] blob = new byte[cred.CredentialBlobSize];
+            Marshal.Copy(cred.CredentialBlob, blob, 0, (int)cred.CredentialBlobSize);
+            return Encoding.Unicode.GetString(blob);
+        }
+        finally
+        {
+            CredFree(credPtr);
+        }
+    }
+
+    public static bool Delete(string target)
+    {
+        if (!CredDelete(target, CRED_TYPE_GENERIC, 0))
+        {
+            int err = Marshal.GetLastWin32Error();
+            if (err == ERROR_NOT_FOUND)
+            {
+                return false;
+            }
+            throw new System.ComponentModel.Win32Exception(err);
+        }
+        return true;
+    }
+
+    public static string[] List(string filter)
+    {
+        uint count;
+        IntPtr pCreds;
+        if (!CredEnumerate(filter, 0, out count, out pCreds))
+        {
+            int err = Marshal.GetLastWin32Error();
+            if (err == ERROR_NOT_FOUND)
+            {
+                return new string[0];
+            }
+            throw new System.ComponentModel.Win32Exception(err);
+        }
+
+        try
+        {
+            string[] names = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                IntPtr credPtr = Marshal.ReadIntPtr(pCreds, i * IntPtr.Size);
+                CREDENTIAL cred = (CREDENTIAL)Marshal.PtrToStructure(credPtr, typeof(CREDENTIAL));
+                names[i] = cred.TargetName;
+            }
+            return names;
+        }
+        finally
+        {
+            CredFree(pCreds);
+        }
+    }
+}
+'@
+
+    Add-Type -TypeDefinition $source -Language CSharp
+}
+
+function Invoke-JIMStoreProcess {
+    <#
+    .SYNOPSIS
+        Runs an external credential-store binary, optionally piping a secret to its
+        standard input without appending a newline.
+
+    .DESCRIPTION
+        Uses System.Diagnostics.Process with ArgumentList so arguments are passed
+        without shell interpretation (no injection, no quoting issues). Writing the
+        secret via stdin (rather than as an argument) keeps it off the process
+        command line where the platform store supports it (libsecret does; the macOS
+        'security' CLI requires the secret as an argument and is handled separately).
+
+    .OUTPUTS
+        A PSCustomObject with ExitCode, StdOut, and StdErr.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FilePath,
+
+        [string[]]$Arguments = @(),
+
+        [string]$StdinData
+    )
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $FilePath
+    foreach ($argument in $Arguments) {
+        $psi.ArgumentList.Add($argument)
+    }
+    $hasStdin = $PSBoundParameters.ContainsKey('StdinData')
+    $psi.RedirectStandardInput = $hasStdin
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+
+    $process = [System.Diagnostics.Process]::Start($psi)
+    if ($hasStdin) {
+        # Write the exact secret bytes with no trailing newline so the stored value
+        # matches the token precisely.
+        $process.StandardInput.Write($StdinData)
+        $process.StandardInput.Close()
+    }
+    $stdOut = $process.StandardOutput.ReadToEnd()
+    $stdErr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+
+    return [PSCustomObject]@{
+        ExitCode = $process.ExitCode
+        StdOut   = $stdOut
+        StdErr   = $stdErr
+    }
+}
+
+function Save-JIMToken {
+    <#
+    .SYNOPSIS
+        Persists a refresh token for a JIM instance in the OS credential store.
+
+    .DESCRIPTION
+        No-op (returns $false) when no credential store is available. Returns $true
+        when the token was stored successfully.
+
+    .PARAMETER BaseUrl
+        The JIM base URL the token belongs to.
+
+    .PARAMETER RefreshToken
+        The OAuth refresh token to persist.
+
+    .OUTPUTS
+        [bool] indicating whether the token was persisted.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BaseUrl,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$RefreshToken
+    )
+
+    $key = Get-JIMTokenCacheKey -BaseUrl $BaseUrl
+    $provider = Get-JIMTokenStoreProvider
+
+    switch ($provider) {
+        'Windows' {
+            Initialize-JIMWindowsCredentialStore
+            [JIMCredentialStore]::Write("$script:JIMTokenStoreTargetPrefix$key", $key, $RefreshToken)
+            Write-Verbose "Persisted refresh token to Windows Credential Manager for $key"
+            return $true
+        }
+        'MacOS' {
+            # The macOS 'security' CLI takes the secret as an argument (-w). This is
+            # the documented interface; argv is visible only to the same user's
+            # processes. -U updates the item if it already exists.
+            $result = Invoke-JIMStoreProcess -FilePath 'security' -Arguments @(
+                'add-generic-password',
+                '-a', $key,
+                '-s', $script:JIMTokenStoreService,
+                '-U',
+                '-w', $RefreshToken
+            )
+            if ($result.ExitCode -ne 0) {
+                throw "Failed to store token in macOS Keychain (exit $($result.ExitCode)): $($result.StdErr.Trim())"
+            }
+            Write-Verbose "Persisted refresh token to macOS Keychain for $key"
+            return $true
+        }
+        'LibSecret' {
+            $result = Invoke-JIMStoreProcess -FilePath 'secret-tool' -Arguments @(
+                'store',
+                '--label', "JIM refresh token ($key)",
+                'service', $script:JIMTokenStoreService,
+                'url', $key
+            ) -StdinData $RefreshToken
+            if ($result.ExitCode -ne 0) {
+                throw "Failed to store token via libsecret (exit $($result.ExitCode)): $($result.StdErr.Trim())"
+            }
+            Write-Verbose "Persisted refresh token to libsecret for $key"
+            return $true
+        }
+        default {
+            Write-Verbose "No credential store available; refresh token not persisted"
+            return $false
+        }
+    }
+}
+
+function Get-JIMPersistedToken {
+    <#
+    .SYNOPSIS
+        Retrieves a persisted refresh token for a JIM instance, or $null if none.
+
+    .PARAMETER BaseUrl
+        The JIM base URL whose token should be retrieved.
+
+    .OUTPUTS
+        The refresh token string, or $null when none is stored / no store exists.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BaseUrl
+    )
+
+    $key = Get-JIMTokenCacheKey -BaseUrl $BaseUrl
+    $provider = Get-JIMTokenStoreProvider
+
+    switch ($provider) {
+        'Windows' {
+            Initialize-JIMWindowsCredentialStore
+            $token = [JIMCredentialStore]::Read("$script:JIMTokenStoreTargetPrefix$key")
+            if ([string]::IsNullOrEmpty($token)) { return $null }
+            return $token
+        }
+        'MacOS' {
+            $result = Invoke-JIMStoreProcess -FilePath 'security' -Arguments @(
+                'find-generic-password',
+                '-a', $key,
+                '-s', $script:JIMTokenStoreService,
+                '-w'
+            )
+            if ($result.ExitCode -ne 0) { return $null }
+            # 'security -w' prints the secret followed by a newline.
+            $token = $result.StdOut.TrimEnd("`r", "`n")
+            if ([string]::IsNullOrEmpty($token)) { return $null }
+            return $token
+        }
+        'LibSecret' {
+            $result = Invoke-JIMStoreProcess -FilePath 'secret-tool' -Arguments @(
+                'lookup',
+                'service', $script:JIMTokenStoreService,
+                'url', $key
+            )
+            if ($result.ExitCode -ne 0) { return $null }
+            $token = $result.StdOut.TrimEnd("`r", "`n")
+            if ([string]::IsNullOrEmpty($token)) { return $null }
+            return $token
+        }
+        default {
+            return $null
+        }
+    }
+}
+
+function Remove-JIMToken {
+    <#
+    .SYNOPSIS
+        Removes persisted refresh token(s) from the OS credential store.
+
+    .DESCRIPTION
+        With -BaseUrl, removes the token for that instance. With -All, removes every
+        JIM token. No-op when no credential store is available.
+
+    .PARAMETER BaseUrl
+        The JIM base URL whose token should be removed.
+
+    .PARAMETER All
+        Remove all persisted JIM tokens.
+
+    .OUTPUTS
+        [int] the number of tokens removed.
+    #>
+    # ShouldProcess is intentionally not implemented: this is a private helper, and
+    # the user-facing destructive intent is expressed through Disconnect-JIM
+    # (-ClearCache / -Url / -All), which is where any confirmation would belong.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [CmdletBinding(DefaultParameterSetName = 'Single')]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Single')]
+        [ValidateNotNullOrEmpty()]
+        [string]$BaseUrl,
+
+        [Parameter(Mandatory, ParameterSetName = 'All')]
+        [switch]$All
+    )
+
+    $provider = Get-JIMTokenStoreProvider
+    if ($provider -eq 'None') {
+        Write-Verbose "No credential store available; nothing to remove"
+        return 0
+    }
+
+    if ($All) {
+        return Remove-JIMAllPersistedToken -Provider $provider
+    }
+
+    $key = Get-JIMTokenCacheKey -BaseUrl $BaseUrl
+
+    switch ($provider) {
+        'Windows' {
+            Initialize-JIMWindowsCredentialStore
+            $removed = [JIMCredentialStore]::Delete("$script:JIMTokenStoreTargetPrefix$key")
+            return [int]([bool]$removed)
+        }
+        'MacOS' {
+            $result = Invoke-JIMStoreProcess -FilePath 'security' -Arguments @(
+                'delete-generic-password',
+                '-a', $key,
+                '-s', $script:JIMTokenStoreService
+            )
+            return [int]($result.ExitCode -eq 0)
+        }
+        'LibSecret' {
+            $result = Invoke-JIMStoreProcess -FilePath 'secret-tool' -Arguments @(
+                'clear',
+                'service', $script:JIMTokenStoreService,
+                'url', $key
+            )
+            return [int]($result.ExitCode -eq 0)
+        }
+    }
+}
+
+function Remove-JIMAllPersistedToken {
+    <#
+    .SYNOPSIS
+        Removes every persisted JIM token for the given provider.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Provider
+    )
+
+    switch ($Provider) {
+        'Windows' {
+            Initialize-JIMWindowsCredentialStore
+            $targets = [JIMCredentialStore]::List("$script:JIMTokenStoreTargetPrefix*")
+            $count = 0
+            foreach ($target in $targets) {
+                if ([JIMCredentialStore]::Delete($target)) { $count++ }
+            }
+            return $count
+        }
+        'MacOS' {
+            # 'security' has no wildcard delete; remove items for our service one at a
+            # time until none remain (each delete removes a single matching item).
+            $count = 0
+            while ($true) {
+                $result = Invoke-JIMStoreProcess -FilePath 'security' -Arguments @(
+                    'delete-generic-password',
+                    '-s', $script:JIMTokenStoreService
+                )
+                if ($result.ExitCode -ne 0) { break }
+                $count++
+            }
+            return $count
+        }
+        'LibSecret' {
+            # 'secret-tool clear' removes all items matching the given attributes, so
+            # clearing by service alone removes every JIM token in one call.
+            $result = Invoke-JIMStoreProcess -FilePath 'secret-tool' -Arguments @(
+                'clear',
+                'service', $script:JIMTokenStoreService
+            )
+            return [int]($result.ExitCode -eq 0)
+        }
+    }
+}

--- a/src/JIM.PowerShell/Private/Show-JIMBanner.ps1
+++ b/src/JIM.PowerShell/Private/Show-JIMBanner.ps1
@@ -15,7 +15,10 @@ function Show-JIMBanner {
         [string]$ServerVersion,
 
         [Parameter()]
-        [string]$Url
+        [string]$Url,
+
+        [Parameter()]
+        [string[]]$StatusLine = @()
     )
 
     $cyan = [System.ConsoleColor]::Cyan
@@ -40,6 +43,12 @@ function Show-JIMBanner {
     }
     else {
         Write-Host "Successfully connected to JIM!" -ForegroundColor $green
+    }
+
+    # Additional green status lines sit directly under the connected line, with no
+    # blank line in between, so related confirmations read as one block.
+    foreach ($line in $StatusLine) {
+        Write-Host $line -ForegroundColor $green
     }
     Write-Host ""
 }

--- a/src/JIM.PowerShell/Private/Test-JIMAuthorisation.ps1
+++ b/src/JIM.PowerShell/Private/Test-JIMAuthorisation.ps1
@@ -29,8 +29,9 @@ function Test-JIMAuthorisation {
             Write-Host "WARNING: You are authenticated but not authorised to use JIM." -ForegroundColor Yellow
             Write-Host ""
             Write-Host "Your identity has not been provisioned in JIM yet." -ForegroundColor Yellow
-            Write-Host "Please sign in to the JIM web portal first to create your identity," -ForegroundColor Yellow
-            Write-Host "then reconnect with Connect-JIM." -ForegroundColor Yellow
+            Write-Host "Identities are created when you are synchronised into JIM from a" -ForegroundColor Yellow
+            Write-Host "connected system, or provisioned by an administrator." -ForegroundColor Yellow
+            Write-Host "Contact your JIM administrator if you believe this is in error." -ForegroundColor Yellow
             Write-Host ""
         }
 

--- a/src/JIM.PowerShell/Public/Activities/Get-JIMActivity.ps1
+++ b/src/JIM.PowerShell/Public/Activities/Get-JIMActivity.ps1
@@ -82,6 +82,12 @@ function Get-JIMActivity {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting Activity with ID: $Id"

--- a/src/JIM.PowerShell/Public/Activities/Get-JIMActivityChildren.ps1
+++ b/src/JIM.PowerShell/Public/Activities/Get-JIMActivityChildren.ps1
@@ -42,7 +42,7 @@ function Get-JIMActivityChildren {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Activities/Get-JIMActivityStats.ps1
+++ b/src/JIM.PowerShell/Public/Activities/Get-JIMActivityStats.ps1
@@ -47,6 +47,12 @@ function Get-JIMActivityStats {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         Write-Verbose "Getting execution statistics for Activity ID: $Id"
 
         try {

--- a/src/JIM.PowerShell/Public/ApiKeys/Get-JIMApiKey.ps1
+++ b/src/JIM.PowerShell/Public/ApiKeys/Get-JIMApiKey.ps1
@@ -52,6 +52,12 @@ function Get-JIMApiKey {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting API Key with ID: $Id"

--- a/src/JIM.PowerShell/Public/ApiKeys/New-JIMApiKey.ps1
+++ b/src/JIM.PowerShell/Public/ApiKeys/New-JIMApiKey.ps1
@@ -66,6 +66,12 @@ function New-JIMApiKey {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($PSCmdlet.ShouldProcess($Name, "Create API Key")) {
             Write-Verbose "Creating API Key: $Name"
 

--- a/src/JIM.PowerShell/Public/ApiKeys/Remove-JIMApiKey.ps1
+++ b/src/JIM.PowerShell/Public/ApiKeys/Remove-JIMApiKey.ps1
@@ -62,7 +62,7 @@ function Remove-JIMApiKey {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ApiKeys/Set-JIMApiKey.ps1
+++ b/src/JIM.PowerShell/Public/ApiKeys/Set-JIMApiKey.ps1
@@ -84,6 +84,12 @@ function Set-JIMApiKey {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($Enable -and $Disable) {
             Write-Error "Cannot specify both -Enable and -Disable"
             return

--- a/src/JIM.PowerShell/Public/Certificates/Add-JIMCertificate.ps1
+++ b/src/JIM.PowerShell/Public/Certificates/Add-JIMCertificate.ps1
@@ -76,6 +76,12 @@ function Add-JIMCertificate {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($PSCmdlet.ShouldProcess($Name, "Add Certificate")) {
             Write-Verbose "Adding certificate: $Name"
 

--- a/src/JIM.PowerShell/Public/Certificates/Export-JIMCertificate.ps1
+++ b/src/JIM.PowerShell/Public/Certificates/Export-JIMCertificate.ps1
@@ -68,7 +68,7 @@ function Export-JIMCertificate {
 
         # Check if connection exists
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Certificates/Get-JIMCertificate.ps1
+++ b/src/JIM.PowerShell/Public/Certificates/Get-JIMCertificate.ps1
@@ -80,6 +80,12 @@ function Get-JIMCertificate {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting certificate with ID: $Id"

--- a/src/JIM.PowerShell/Public/Certificates/Remove-JIMCertificate.ps1
+++ b/src/JIM.PowerShell/Public/Certificates/Remove-JIMCertificate.ps1
@@ -61,7 +61,7 @@ function Remove-JIMCertificate {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Certificates/Set-JIMCertificate.ps1
+++ b/src/JIM.PowerShell/Public/Certificates/Set-JIMCertificate.ps1
@@ -70,6 +70,12 @@ function Set-JIMCertificate {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($Enable -and $Disable) {
             Write-Error "Cannot specify both -Enable and -Disable"
             return

--- a/src/JIM.PowerShell/Public/Certificates/Test-JIMCertificate.ps1
+++ b/src/JIM.PowerShell/Public/Certificates/Test-JIMCertificate.ps1
@@ -43,6 +43,12 @@ function Test-JIMCertificate {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         Write-Verbose "Validating certificate: $Id"
 
         try {

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Clear-JIMConnectedSystem.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Clear-JIMConnectedSystem.ps1
@@ -75,6 +75,12 @@ function Clear-JIMConnectedSystem {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Get the ID from InputObject if provided
         $systemId = if ($PSCmdlet.ParameterSetName -eq 'ByInputObject') {
             $InputObject.id

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystem.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystem.ps1
@@ -80,6 +80,12 @@ function Get-JIMConnectedSystem {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting Connected System with ID: $Id"

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemDeletionPreview.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemDeletionPreview.ps1
@@ -43,7 +43,7 @@ function Get-JIMConnectedSystemDeletionPreview {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
@@ -122,6 +122,12 @@ function Get-JIMConnectedSystemObject {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'Count' {
                 Write-Verbose "Getting connector space count for Connected System $ConnectedSystemId"

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObjectAttributeValue.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObjectAttributeValue.ps1
@@ -89,7 +89,7 @@ function Get-JIMConnectedSystemObjectAttributeValue {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObjectChangeHistory.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObjectChangeHistory.ps1
@@ -78,7 +78,7 @@ function Get-JIMConnectedSystemObjectChangeHistory {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Run Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObjectType.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObjectType.ps1
@@ -45,7 +45,7 @@ function Get-JIMConnectedSystemObjectType {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemPartition.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemPartition.ps1
@@ -45,7 +45,7 @@ function Get-JIMConnectedSystemPartition {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemUnresolvedReferenceCount.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemUnresolvedReferenceCount.ps1
@@ -54,7 +54,7 @@ function Get-JIMConnectedSystemUnresolvedReferenceCount {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMPendingExport.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMPendingExport.ps1
@@ -137,6 +137,12 @@ function Get-JIMPendingExport {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'Count' {
                 Write-Verbose "Getting pending exports count for Connected System $ConnectedSystemId"

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Import-JIMConnectedSystemHierarchy.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Import-JIMConnectedSystemHierarchy.ps1
@@ -72,7 +72,7 @@ function Import-JIMConnectedSystemHierarchy {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Import-JIMConnectedSystemSchema.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Import-JIMConnectedSystemSchema.ps1
@@ -67,7 +67,7 @@ function Import-JIMConnectedSystemSchema {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/New-JIMConnectedSystem.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/New-JIMConnectedSystem.ps1
@@ -67,7 +67,7 @@ function New-JIMConnectedSystem {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Remove-JIMConnectedSystem.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Remove-JIMConnectedSystem.ps1
@@ -72,6 +72,12 @@ function Remove-JIMConnectedSystem {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Get the ID from InputObject if provided
         $systemId = if ($PSCmdlet.ParameterSetName -eq 'ByInputObject') {
             $InputObject.id

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystem.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystem.ps1
@@ -101,7 +101,7 @@ function Set-JIMConnectedSystem {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemAttribute.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemAttribute.ps1
@@ -126,7 +126,7 @@ function Set-JIMConnectedSystemAttribute {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemContainer.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemContainer.ps1
@@ -65,7 +65,7 @@ function Set-JIMConnectedSystemContainer {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemObjectType.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemObjectType.ps1
@@ -72,7 +72,7 @@ function Set-JIMConnectedSystemObjectType {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemPartition.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Set-JIMConnectedSystemPartition.ps1
@@ -70,7 +70,7 @@ function Set-JIMConnectedSystemPartition {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Connection/Connect-JIM.ps1
+++ b/src/JIM.PowerShell/Public/Connection/Connect-JIM.ps1
@@ -251,12 +251,15 @@ function Connect-JIMInteractive {
                     }
 
                     Write-Verbose "Successfully refreshed access token"
+                    $serverVersion = Get-JIMServerVersion
+                    Show-JIMBanner -ServerVersion $serverVersion -Url $script:JIMConnection.Url
                     return [PSCustomObject]@{
-                        Url        = $script:JIMConnection.Url
-                        AuthMethod = 'OAuth'
-                        Connected  = $true
-                        ExpiresAt  = $tokens.ExpiresAt
-                        Status     = 'Connected (refreshed)'
+                        Url           = $script:JIMConnection.Url
+                        AuthMethod    = 'OAuth'
+                        Connected     = $true
+                        ServerVersion = $serverVersion
+                        ExpiresAt     = $tokens.ExpiresAt
+                        Status        = 'Connected (refreshed)'
                     }
                 }
                 catch {
@@ -325,7 +328,7 @@ function Connect-JIMInteractive {
                 $script:JIMConnection.Connected = $true
 
                 $serverVersion = Get-JIMServerVersion
-                Show-JIMBanner -ServerVersion $serverVersion -Url $BaseUrl
+                Show-JIMBanner -ServerVersion $serverVersion -Url $BaseUrl -StatusLine "Connected to JIM using cached credentials (no browser sign-in required)."
                 $userInfo = Test-JIMAuthorisation
 
                 # Persist the (possibly rotated) refresh token.
@@ -335,8 +338,6 @@ function Connect-JIMInteractive {
                 catch {
                     Write-Verbose "Failed to persist refreshed token: $_"
                 }
-
-                Write-Host "Connected to JIM using cached credentials (no browser sign-in required)." -ForegroundColor Green
 
                 return [PSCustomObject]@{
                     Url           = $script:JIMConnection.Url
@@ -409,7 +410,13 @@ function Connect-JIMInteractive {
         # Fetch server version
         $serverVersion = Get-JIMServerVersion
 
-        Show-JIMBanner -ServerVersion $serverVersion -Url $BaseUrl
+        # When the user opted out of persistence, confirm it directly under the
+        # connected line so it is obvious a new terminal will need to sign in again.
+        $bannerStatus = @()
+        if ($NoPersist) {
+            $bannerStatus += "Auth persistence disabled (-NoPersist): a new terminal will require a fresh sign-in."
+        }
+        Show-JIMBanner -ServerVersion $serverVersion -Url $BaseUrl -StatusLine $bannerStatus
 
         # Verify the user is authorised to use JIM
         $userInfo = Test-JIMAuthorisation

--- a/src/JIM.PowerShell/Public/Connection/Connect-JIM.ps1
+++ b/src/JIM.PowerShell/Public/Connection/Connect-JIM.ps1
@@ -14,15 +14,28 @@ function Connect-JIM {
         1. Interactive browser-based SSO authentication (default for interactive sessions)
         2. API key authentication (for automation, CI/CD, and scripting)
 
+        For interactive (SSO) sign-ins, the refresh token is persisted in the operating
+        system's credential store (Credential Manager on Windows, login Keychain on macOS,
+        libsecret on Linux) so that opening a new terminal reconnects silently without a
+        browser. Only the refresh token is stored, never the access token. On systems with
+        no usable credential store (typically headless Linux without a keyring), the module
+        falls back to in-memory tokens for the session. Use -NoPersist to opt out.
+
     .PARAMETER Url
         The base URL of the JIM instance, e.g., 'https://jim.company.com' or 'http://localhost:5200'.
 
     .PARAMETER ApiKey
         The API key for authentication. API keys can be created in the JIM web interface
-        under Admin > API Keys. When specified, skips interactive authentication.
+        under Admin > API Keys. When specified, skips interactive authentication. API key
+        connections never read or write the credential store.
 
     .PARAMETER Force
-        Forces re-authentication even if a valid session exists.
+        Forces re-authentication even if a valid session exists. Ignores any persisted
+        refresh token and overwrites it with the newly obtained one.
+
+    .PARAMETER NoPersist
+        Authenticates for this session only, without reading from or writing to the
+        operating system credential store. Useful on shared machines.
 
     .PARAMETER TimeoutSeconds
         How long to wait for interactive authentication to complete. Defaults to 300 (5 minutes).
@@ -50,6 +63,12 @@ function Connect-JIM {
         Connect-JIM -Url "https://jim.company.com" -Force
 
         Forces re-authentication, ignoring any cached session.
+
+    .EXAMPLE
+        Connect-JIM -Url "https://jim.company.com" -NoPersist
+
+        Connects interactively without persisting the refresh token to the OS
+        credential store (in-memory for this session only).
 
     .NOTES
         Interactive authentication requires:
@@ -80,6 +99,9 @@ function Connect-JIM {
         [switch]$Force,
 
         [Parameter(ParameterSetName = 'Interactive')]
+        [switch]$NoPersist,
+
+        [Parameter(ParameterSetName = 'Interactive')]
         [ValidateRange(30, 600)]
         [int]$TimeoutSeconds = 300
     )
@@ -99,7 +121,7 @@ function Connect-JIM {
     }
 
     # Interactive authentication
-    return Connect-JIMInteractive -BaseUrl $baseUrl -Force:$Force -TimeoutSeconds $TimeoutSeconds
+    return Connect-JIMInteractive -BaseUrl $baseUrl -Force:$Force -NoPersist:$NoPersist -TimeoutSeconds $TimeoutSeconds
 }
 
 function Connect-JIMWithApiKey {
@@ -183,6 +205,8 @@ function Connect-JIMInteractive {
 
         [switch]$Force,
 
+        [switch]$NoPersist,
+
         [int]$TimeoutSeconds = 300
     )
 
@@ -214,6 +238,17 @@ function Connect-JIMInteractive {
                     $script:JIMConnection.AccessToken = $tokens.AccessToken
                     $script:JIMConnection.RefreshToken = $tokens.RefreshToken
                     $script:JIMConnection.TokenExpiresAt = $tokens.ExpiresAt
+
+                    # Write the rotated refresh token back to the credential store so the
+                    # persisted copy stays valid (most IdPs rotate refresh tokens on use).
+                    if ($script:JIMConnection.Persisted) {
+                        try {
+                            Save-JIMToken -BaseUrl $script:JIMConnection.Url -RefreshToken $tokens.RefreshToken | Out-Null
+                        }
+                        catch {
+                            Write-Verbose "Failed to persist refreshed token: $_"
+                        }
+                    }
 
                     Write-Verbose "Successfully refreshed access token"
                     return [PSCustomObject]@{
@@ -248,6 +283,91 @@ function Connect-JIMInteractive {
     Write-Verbose "Fetching OIDC discovery document from $($authConfig.authority)..."
     $discovery = Get-OidcDiscoveryDocument -Authority $authConfig.authority
 
+    # Determine whether persistent token storage is in play for this session.
+    # -NoPersist opts out; otherwise it depends on whether the OS has a usable
+    # credential store (Windows/macOS always; Linux only with libsecret present).
+    $persistenceAvailable = Test-JIMTokenPersistenceAvailable
+    $usePersistence = (-not $NoPersist) -and $persistenceAvailable
+
+    # Attempt a silent reconnect using a persisted refresh token before opening a
+    # browser. Skipped when -Force is set (force always re-authenticates and then
+    # overwrites the stored token).
+    if ($usePersistence -and -not $Force) {
+        $cachedRefreshToken = Get-JIMPersistedToken -BaseUrl $BaseUrl
+        if ($cachedRefreshToken) {
+            try {
+                Write-Verbose "Found a persisted refresh token; attempting silent reconnect..."
+                $tokens = Invoke-OAuthTokenRefresh `
+                    -TokenEndpoint $discovery.TokenEndpoint `
+                    -ClientId $authConfig.clientId `
+                    -RefreshToken $cachedRefreshToken `
+                    -Scopes $authConfig.scopes
+
+                $script:JIMConnection = [PSCustomObject]@{
+                    Url            = $BaseUrl
+                    ApiKey         = $null
+                    AccessToken    = $tokens.AccessToken
+                    RefreshToken   = $tokens.RefreshToken
+                    TokenExpiresAt = $tokens.ExpiresAt
+                    AuthMethod     = 'OAuth'
+                    Connected      = $false
+                    Persisted      = $true
+                    OAuthConfig    = @{
+                        Authority     = $authConfig.authority
+                        ClientId      = $authConfig.clientId
+                        Scopes        = $authConfig.scopes
+                        TokenEndpoint = $discovery.TokenEndpoint
+                    }
+                }
+
+                Write-Verbose "Testing connection to JIM with cached credentials..."
+                $health = Invoke-JIMApi -Endpoint '/api/v1/health'
+                $script:JIMConnection.Connected = $true
+
+                $serverVersion = Get-JIMServerVersion
+                Show-JIMBanner -ServerVersion $serverVersion -Url $BaseUrl
+                $userInfo = Test-JIMAuthorisation
+
+                # Persist the (possibly rotated) refresh token.
+                try {
+                    Save-JIMToken -BaseUrl $BaseUrl -RefreshToken $tokens.RefreshToken | Out-Null
+                }
+                catch {
+                    Write-Verbose "Failed to persist refreshed token: $_"
+                }
+
+                Write-Host "Connected to JIM using cached credentials (no browser sign-in required)." -ForegroundColor Green
+
+                return [PSCustomObject]@{
+                    Url           = $script:JIMConnection.Url
+                    AuthMethod    = 'OAuth'
+                    Connected     = $true
+                    ServerVersion = $serverVersion
+                    ExpiresAt     = $tokens.ExpiresAt
+                    Authorised    = $userInfo.authorised ?? $null
+                    Status        = 'Connected (cached)'
+                }
+            }
+            catch {
+                Write-Verbose "Silent reconnect with persisted token failed, falling back to browser sign-in: $_"
+                $script:JIMConnection = $null
+                # Drop the stale token so we don't keep retrying a dead refresh token.
+                try {
+                    Remove-JIMToken -BaseUrl $BaseUrl | Out-Null
+                }
+                catch {
+                    Write-Verbose "Failed to remove stale persisted token: $_"
+                }
+            }
+        }
+    }
+
+    # Tell the user when persistence was wanted but the platform has no usable store
+    # (typically headless/SSH Linux without a keyring), and point them at -ApiKey.
+    if (-not $NoPersist -and -not $persistenceAvailable) {
+        Write-Host "Token persistence is unavailable on this system (no OS keyring detected); you will need to re-authenticate in new sessions. For unattended or headless use, connect with -ApiKey instead." -ForegroundColor DarkGray
+    }
+
     # Perform browser-based authentication
     Write-Host ""
     Write-Host "Starting interactive authentication with JIM..." -ForegroundColor Cyan
@@ -270,6 +390,7 @@ function Connect-JIMInteractive {
         TokenExpiresAt = $tokens.ExpiresAt
         AuthMethod     = 'OAuth'
         Connected      = $false
+        Persisted      = $usePersistence
         OAuthConfig    = @{
             Authority     = $authConfig.authority
             ClientId      = $authConfig.clientId
@@ -292,6 +413,17 @@ function Connect-JIMInteractive {
 
         # Verify the user is authorised to use JIM
         $userInfo = Test-JIMAuthorisation
+
+        # Persist the refresh token so future sessions can reconnect without a browser.
+        if ($usePersistence -and $tokens.RefreshToken) {
+            try {
+                Save-JIMToken -BaseUrl $BaseUrl -RefreshToken $tokens.RefreshToken | Out-Null
+                Write-Verbose "Persisted refresh token for future sessions"
+            }
+            catch {
+                Write-Warning "Connected, but failed to persist the refresh token for future sessions: $_"
+            }
+        }
 
         [PSCustomObject]@{
             Url           = $script:JIMConnection.Url

--- a/src/JIM.PowerShell/Public/Connection/Disconnect-JIM.ps1
+++ b/src/JIM.PowerShell/Public/Connection/Disconnect-JIM.ps1
@@ -13,31 +13,103 @@ function Disconnect-JIM {
         For OAuth sessions, this clears the access token and refresh token from memory.
         Note: This does not sign you out of your identity provider.
 
+        By default the persisted refresh token in the operating system credential store
+        is left intact, so a later Connect-JIM can still reconnect silently. Use
+        -ClearCache to also remove the persisted refresh token. -ClearCache works even
+        when there is no active connection, since clearing the credential store is a
+        maintenance operation independent of session state.
+
+    .PARAMETER ClearCache
+        Also remove the persisted refresh token from the OS credential store. Without
+        -Url or -All, this targets the currently connected instance.
+
+    .PARAMETER Url
+        The JIM instance whose persisted refresh token should be removed from the
+        credential store. Implies -ClearCache. Useful when not currently connected.
+
+    .PARAMETER All
+        Remove every persisted JIM refresh token from the credential store.
+
     .OUTPUTS
         None.
 
     .EXAMPLE
         Disconnect-JIM
 
-        Disconnects from the current JIM instance.
+        Disconnects the current session. Any persisted refresh token is left in place.
+
+    .EXAMPLE
+        Disconnect-JIM -ClearCache
+
+        Disconnects and removes the persisted refresh token for the current instance.
+
+    .EXAMPLE
+        Disconnect-JIM -Url "https://jim.company.com" -ClearCache
+
+        Removes the persisted refresh token for a specific instance, even if not connected.
+
+    .EXAMPLE
+        Disconnect-JIM -All
+
+        Disconnects and removes every persisted JIM refresh token from this machine.
 
     .LINK
         Connect-JIM
         Test-JIMConnection
     #>
-    [CmdletBinding()]
-    param()
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param(
+        [Parameter(ParameterSetName = 'Default')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url,
 
+        [Parameter(ParameterSetName = 'Default')]
+        [switch]$ClearCache,
+
+        [Parameter(Mandatory, ParameterSetName = 'All')]
+        [switch]$All
+    )
+
+    # -All: clear every persisted token, plus any in-memory session.
+    if ($PSCmdlet.ParameterSetName -eq 'All') {
+        $script:JIMConnection = $null
+        try {
+            $removed = Remove-JIMToken -All
+            Write-Host "Removed $removed persisted JIM credential(s) from the OS credential store." -ForegroundColor Cyan
+        }
+        catch {
+            Write-Warning "Failed to clear persisted JIM credentials: $_"
+        }
+        return
+    }
+
+    # A -Url targets the credential store and so implies -ClearCache.
+    $shouldClearCache = $ClearCache -or $PSBoundParameters.ContainsKey('Url')
+
+    if ($PSBoundParameters.ContainsKey('Url') -and -not ($Url -match '^https?://')) {
+        throw "Invalid URL format. URL must start with http:// or https://"
+    }
+
+    # Determine which instance's persisted token to remove: an explicit -Url wins,
+    # otherwise the currently connected instance.
+    $targetUrl = if ($PSBoundParameters.ContainsKey('Url')) {
+        $Url
+    }
+    elseif ($script:JIMConnection) {
+        $script:JIMConnection.Url
+    }
+    else {
+        $null
+    }
+
+    # Clear the in-memory session.
     if ($script:JIMConnection) {
         $authMethod = $script:JIMConnection.AuthMethod ?? 'Unknown'
-        $url = $script:JIMConnection.Url
+        $sessionUrl = $script:JIMConnection.Url
 
-        Write-Verbose "Disconnecting from JIM at $url (auth method: $authMethod)"
-
-        # Clear all connection data
+        Write-Verbose "Disconnecting from JIM at $sessionUrl (auth method: $authMethod)"
         $script:JIMConnection = $null
-
-        Write-Host "Disconnected from JIM at $url" -ForegroundColor Cyan
+        Write-Host "Disconnected from JIM at $sessionUrl" -ForegroundColor Cyan
 
         if ($authMethod -eq 'OAuth') {
             Write-Verbose "OAuth tokens cleared from memory"
@@ -46,5 +118,26 @@ function Disconnect-JIM {
     }
     else {
         Write-Verbose "No active JIM connection to disconnect"
+    }
+
+    # Optionally remove the persisted refresh token.
+    if ($shouldClearCache) {
+        if ($targetUrl) {
+            try {
+                $removed = Remove-JIMToken -BaseUrl $targetUrl
+                if ($removed -gt 0) {
+                    Write-Host "Removed persisted credentials for $targetUrl from the OS credential store." -ForegroundColor Cyan
+                }
+                else {
+                    Write-Host "No persisted credentials found for $targetUrl." -ForegroundColor Gray
+                }
+            }
+            catch {
+                Write-Warning "Failed to remove persisted credentials for $targetUrl`: $_"
+            }
+        }
+        else {
+            Write-Warning "No URL specified and no active connection; nothing to clear from the credential store. Use -Url or -All."
+        }
     }
 }

--- a/src/JIM.PowerShell/Public/Connection/Disconnect-JIM.ps1
+++ b/src/JIM.PowerShell/Public/Connection/Disconnect-JIM.ps1
@@ -4,31 +4,35 @@
 function Disconnect-JIM {
     <#
     .SYNOPSIS
-        Disconnects from the current JIM instance.
+        Disconnects from a JIM instance and forgets its persisted credentials.
 
     .DESCRIPTION
-        Clears the connection state and removes stored credentials from the session.
-        After disconnecting, you must use Connect-JIM again before using other JIM cmdlets.
+        Clears the in-memory session and removes the persisted refresh token for the
+        instance from the operating system credential store, so a later Connect-JIM
+        must authenticate again.
 
-        For OAuth sessions, this clears the access token and refresh token from memory.
-        Note: This does not sign you out of your identity provider.
+        By default this targets the currently connected instance. Use -Url to target a
+        specific instance (which may or may not be the connected one, and need not be
+        connected at all), or -All to remove every persisted JIM credential on the
+        machine; the latter is useful when several JIM instances are in play.
 
-        By default the persisted refresh token in the operating system credential store
-        is left intact, so a later Connect-JIM can still reconnect silently. Use
-        -ClearCache to also remove the persisted refresh token. -ClearCache works even
-        when there is no active connection, since clearing the credential store is a
-        maintenance operation independent of session state.
+        Removal is auth-agnostic: a stored refresh token for the targeted instance is
+        removed even if the cleared session authenticated with an API key. (API keys
+        themselves are never persisted by the module; the caller supplies them on each
+        Connect-JIM.)
 
-    .PARAMETER ClearCache
-        Also remove the persisted refresh token from the OS credential store. Without
-        -Url or -All, this targets the currently connected instance.
+        For OAuth sessions this clears the access and refresh tokens from memory. Note
+        that it does not sign you out of your identity provider.
 
     .PARAMETER Url
-        The JIM instance whose persisted refresh token should be removed from the
-        credential store. Implies -ClearCache. Useful when not currently connected.
+        The JIM instance to disconnect and forget. Defaults to the currently connected
+        instance. An explicit -Url works even when there is no active connection, since
+        clearing the credential store is a maintenance operation independent of session
+        state.
 
     .PARAMETER All
-        Remove every persisted JIM refresh token from the credential store.
+        Remove every persisted JIM refresh token from the credential store, across all
+        instances, and clear any in-memory session.
 
     .OUTPUTS
         None.
@@ -36,17 +40,14 @@ function Disconnect-JIM {
     .EXAMPLE
         Disconnect-JIM
 
-        Disconnects the current session. Any persisted refresh token is left in place.
+        Disconnects the current session and removes the persisted refresh token for the
+        connected instance.
 
     .EXAMPLE
-        Disconnect-JIM -ClearCache
+        Disconnect-JIM -Url "https://jim.company.com"
 
-        Disconnects and removes the persisted refresh token for the current instance.
-
-    .EXAMPLE
-        Disconnect-JIM -Url "https://jim.company.com" -ClearCache
-
-        Removes the persisted refresh token for a specific instance, even if not connected.
+        Removes the persisted refresh token for a specific instance, even if not
+        currently connected to it.
 
     .EXAMPLE
         Disconnect-JIM -All
@@ -62,9 +63,6 @@ function Disconnect-JIM {
         [Parameter(ParameterSetName = 'Default')]
         [ValidateNotNullOrEmpty()]
         [string]$Url,
-
-        [Parameter(ParameterSetName = 'Default')]
-        [switch]$ClearCache,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch]$All
@@ -83,15 +81,12 @@ function Disconnect-JIM {
         return
     }
 
-    # A -Url targets the credential store and so implies -ClearCache.
-    $shouldClearCache = $ClearCache -or $PSBoundParameters.ContainsKey('Url')
-
     if ($PSBoundParameters.ContainsKey('Url') -and -not ($Url -match '^https?://')) {
         throw "Invalid URL format. URL must start with http:// or https://"
     }
 
-    # Determine which instance's persisted token to remove: an explicit -Url wins,
-    # otherwise the currently connected instance.
+    # Determine which instance to forget: an explicit -Url wins, otherwise the
+    # currently connected instance. Null means there is nothing to target.
     $targetUrl = if ($PSBoundParameters.ContainsKey('Url')) {
         $Url
     }
@@ -112,7 +107,6 @@ function Disconnect-JIM {
         Write-Host "Disconnected from JIM at $sessionUrl" -ForegroundColor Cyan
 
         if ($authMethod -eq 'OAuth') {
-            Write-Verbose "OAuth tokens cleared from memory"
             Write-Host "Note: You are still signed into your identity provider. To fully sign out, close your browser or sign out from your identity provider." -ForegroundColor Gray
         }
     }
@@ -120,24 +114,24 @@ function Disconnect-JIM {
         Write-Verbose "No active JIM connection to disconnect"
     }
 
-    # Optionally remove the persisted refresh token.
-    if ($shouldClearCache) {
-        if ($targetUrl) {
-            try {
-                $removed = Remove-JIMToken -BaseUrl $targetUrl
-                if ($removed -gt 0) {
-                    Write-Host "Removed persisted credentials for $targetUrl from the OS credential store." -ForegroundColor Cyan
-                }
-                else {
-                    Write-Host "No persisted credentials found for $targetUrl." -ForegroundColor Gray
-                }
+    # Remove the persisted refresh token for the targeted instance. Auth-agnostic: a
+    # stored token is removed even if the cleared session used an API key. A bare
+    # Disconnect-JIM while not connected has no target, so it is a quiet no-op.
+    if ($targetUrl) {
+        try {
+            $removed = Remove-JIMToken -BaseUrl $targetUrl
+            if ($removed -gt 0) {
+                Write-Host "Removed persisted credentials for $targetUrl from the OS credential store." -ForegroundColor Cyan
             }
-            catch {
-                Write-Warning "Failed to remove persisted credentials for $targetUrl`: $_"
+            else {
+                Write-Verbose "No persisted credentials found for $targetUrl."
             }
         }
-        else {
-            Write-Warning "No URL specified and no active connection; nothing to clear from the credential store. Use -Url or -All."
+        catch {
+            Write-Warning "Failed to remove persisted credentials for $targetUrl`: $_"
         }
+    }
+    else {
+        Write-Verbose "No active connection and no -Url specified; nothing to remove from the credential store. Use -Url or -All."
     }
 }

--- a/src/JIM.PowerShell/Public/ExampleData/Get-JIMExampleDataSet.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/Get-JIMExampleDataSet.ps1
@@ -44,6 +44,12 @@ function Get-JIMExampleDataSet {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         Write-Verbose "Getting example data sets"
 
         $queryParams = @(

--- a/src/JIM.PowerShell/Public/ExampleData/Get-JIMExampleDataTemplate.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/Get-JIMExampleDataTemplate.ps1
@@ -70,6 +70,12 @@ function Get-JIMExampleDataTemplate {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve name to ID if using ByName parameter set
         if ($PSCmdlet.ParameterSetName -eq 'ByName') {
             try {

--- a/src/JIM.PowerShell/Public/ExampleData/Invoke-JIMExampleDataTemplate.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/Invoke-JIMExampleDataTemplate.ps1
@@ -68,6 +68,12 @@ function Invoke-JIMExampleDataTemplate {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve name to ID if using ByName parameter set
         if ($PSCmdlet.ParameterSetName -eq 'ByName') {
             try {

--- a/src/JIM.PowerShell/Public/Expressions/Test-JIMExpression.ps1
+++ b/src/JIM.PowerShell/Public/Expressions/Test-JIMExpression.ps1
@@ -83,7 +83,7 @@ function Test-JIMExpression {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/History/Get-JIMDeletedObject.ps1
+++ b/src/JIM.PowerShell/Public/History/Get-JIMDeletedObject.ps1
@@ -113,6 +113,12 @@ function Get-JIMDeletedObject {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Build query string parameters
         $queryParams = @()
         $queryParams += "page=$Page"

--- a/src/JIM.PowerShell/Public/History/Get-JIMHistoryCount.ps1
+++ b/src/JIM.PowerShell/Public/History/Get-JIMHistoryCount.ps1
@@ -56,6 +56,12 @@ function Get-JIMHistoryCount {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # If using name, resolve to ID first
         if ($PSCmdlet.ParameterSetName -eq 'ByName') {
             Write-Verbose "Looking up Connected System by name: $ConnectedSystemName"

--- a/src/JIM.PowerShell/Public/History/Invoke-JIMHistoryCleanup.ps1
+++ b/src/JIM.PowerShell/Public/History/Invoke-JIMHistoryCleanup.ps1
@@ -68,6 +68,12 @@ function Invoke-JIMHistoryCleanup {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         Write-Verbose "Triggering manual history cleanup"
 
         try {

--- a/src/JIM.PowerShell/Public/MatchingRules/Get-JIMMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Get-JIMMatchingRule.ps1
@@ -54,7 +54,7 @@ function Get-JIMMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/Get-JIMSyncRuleMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Get-JIMSyncRuleMatchingRule.ps1
@@ -48,7 +48,7 @@ function Get-JIMSyncRuleMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/New-JIMMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/New-JIMMatchingRule.ps1
@@ -100,7 +100,7 @@ function New-JIMMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/New-JIMSyncRuleMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/New-JIMSyncRuleMatchingRule.ps1
@@ -83,7 +83,7 @@ function New-JIMSyncRuleMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/Remove-JIMMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Remove-JIMMatchingRule.ps1
@@ -56,7 +56,7 @@ function Remove-JIMMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/Remove-JIMSyncRuleMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Remove-JIMSyncRuleMatchingRule.ps1
@@ -56,7 +56,7 @@ function Remove-JIMSyncRuleMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/Set-JIMMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Set-JIMMatchingRule.ps1
@@ -97,7 +97,7 @@ function Set-JIMMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/Set-JIMSyncRuleMatchingRule.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Set-JIMSyncRuleMatchingRule.ps1
@@ -86,7 +86,7 @@ function Set-JIMSyncRuleMatchingRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/MatchingRules/Switch-JIMMatchingMode.ps1
+++ b/src/JIM.PowerShell/Public/MatchingRules/Switch-JIMMatchingMode.ps1
@@ -57,7 +57,7 @@ function Switch-JIMMatchingMode {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseAttribute.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseAttribute.ps1
@@ -64,6 +64,12 @@ function Get-JIMMetaverseAttribute {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve name to ID if using ByName parameter set
         if ($PSCmdlet.ParameterSetName -eq 'ByName') {
             try {

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObject.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObject.ps1
@@ -180,6 +180,12 @@ function Get-JIMMetaverseObject {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve ObjectTypeName to ObjectTypeId if provided
         if ($ObjectTypeName) {
             try {

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObjectChangeHistory.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObjectChangeHistory.ps1
@@ -78,7 +78,7 @@ function Get-JIMMetaverseObjectChangeHistory {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Run Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObjectType.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseObjectType.ps1
@@ -74,6 +74,12 @@ function Get-JIMMetaverseObjectType {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve name to ID if using ByName parameter set
         if ($PSCmdlet.ParameterSetName -eq 'ByName') {
             try {

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMPendingDeletion.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMPendingDeletion.ps1
@@ -80,7 +80,7 @@ function Get-JIMPendingDeletion {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Run Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/New-JIMMetaverseAttribute.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/New-JIMMetaverseAttribute.ps1
@@ -76,7 +76,7 @@ function New-JIMMetaverseAttribute {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/New-JIMMetaverseObjectType.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/New-JIMMetaverseObjectType.ps1
@@ -95,7 +95,7 @@ function New-JIMMetaverseObjectType {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/Remove-JIMMetaverseAttribute.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Remove-JIMMetaverseAttribute.ps1
@@ -56,7 +56,7 @@ function Remove-JIMMetaverseAttribute {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/Search-JIMMetaverseObject.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Search-JIMMetaverseObject.ps1
@@ -108,6 +108,12 @@ function Search-JIMMetaverseObject {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         Write-Verbose "Searching Metaverse Objects via predefined search: $PredefinedSearchUri"
 
         $encodedUri = [System.Uri]::EscapeDataString($PredefinedSearchUri)

--- a/src/JIM.PowerShell/Public/Metaverse/Set-JIMMetaverseAttribute.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Set-JIMMetaverseAttribute.ps1
@@ -88,7 +88,7 @@ function Set-JIMMetaverseAttribute {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Metaverse/Set-JIMMetaverseObjectType.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Set-JIMMetaverseObjectType.ps1
@@ -100,7 +100,7 @@ function Set-JIMMetaverseObjectType {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/RunProfiles/Get-JIMRunProfile.ps1
+++ b/src/JIM.PowerShell/Public/RunProfiles/Get-JIMRunProfile.ps1
@@ -65,6 +65,12 @@ function Get-JIMRunProfile {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve ConnectedSystemName to ConnectedSystemId if specified
         if ($PSBoundParameters.ContainsKey('ConnectedSystemName')) {
             $connectedSystem = Resolve-JIMConnectedSystem -Name $ConnectedSystemName

--- a/src/JIM.PowerShell/Public/RunProfiles/New-JIMRunProfile.ps1
+++ b/src/JIM.PowerShell/Public/RunProfiles/New-JIMRunProfile.ps1
@@ -104,7 +104,7 @@ function New-JIMRunProfile {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/RunProfiles/Remove-JIMRunProfile.ps1
+++ b/src/JIM.PowerShell/Public/RunProfiles/Remove-JIMRunProfile.ps1
@@ -80,7 +80,7 @@ function Remove-JIMRunProfile {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/RunProfiles/Set-JIMRunProfile.ps1
+++ b/src/JIM.PowerShell/Public/RunProfiles/Set-JIMRunProfile.ps1
@@ -102,7 +102,7 @@ function Set-JIMRunProfile {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/RunProfiles/Start-JIMRunProfile.ps1
+++ b/src/JIM.PowerShell/Public/RunProfiles/Start-JIMRunProfile.ps1
@@ -100,6 +100,12 @@ function Start-JIMRunProfile {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve ConnectedSystemName to ConnectedSystemId if specified
         if ($PSBoundParameters.ContainsKey('ConnectedSystemName')) {
             $connectedSystem = Resolve-JIMConnectedSystem -Name $ConnectedSystemName

--- a/src/JIM.PowerShell/Public/Schedules/Add-JIMScheduleStep.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Add-JIMScheduleStep.ps1
@@ -97,7 +97,7 @@ function Add-JIMScheduleStep {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Disable-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Disable-JIMSchedule.ps1
@@ -47,7 +47,7 @@ function Disable-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Enable-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Enable-JIMSchedule.ps1
@@ -47,7 +47,7 @@ function Enable-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Get-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Get-JIMSchedule.ps1
@@ -68,7 +68,7 @@ function Get-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Get-JIMScheduleExecution.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Get-JIMScheduleExecution.ps1
@@ -77,7 +77,7 @@ function Get-JIMScheduleExecution {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/New-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/New-JIMSchedule.ps1
@@ -138,7 +138,7 @@ function New-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Remove-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Remove-JIMSchedule.ps1
@@ -50,7 +50,7 @@ function Remove-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Remove-JIMScheduleStep.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Remove-JIMScheduleStep.ps1
@@ -58,7 +58,7 @@ function Remove-JIMScheduleStep {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Set-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Set-JIMSchedule.ps1
@@ -130,7 +130,7 @@ function Set-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Start-JIMSchedule.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Start-JIMSchedule.ps1
@@ -64,7 +64,7 @@ function Start-JIMSchedule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Schedules/Stop-JIMScheduleExecution.ps1
+++ b/src/JIM.PowerShell/Public/Schedules/Stop-JIMScheduleExecution.ps1
@@ -51,7 +51,7 @@ function Stop-JIMScheduleExecution {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ScopingCriteria/Get-JIMScopingCriteria.ps1
+++ b/src/JIM.PowerShell/Public/ScopingCriteria/Get-JIMScopingCriteria.ps1
@@ -48,7 +48,7 @@ function Get-JIMScopingCriteria {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ScopingCriteria/New-JIMScopingCriteriaGroup.ps1
+++ b/src/JIM.PowerShell/Public/ScopingCriteria/New-JIMScopingCriteriaGroup.ps1
@@ -69,7 +69,7 @@ function New-JIMScopingCriteriaGroup {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ScopingCriteria/New-JIMScopingCriterion.ps1
+++ b/src/JIM.PowerShell/Public/ScopingCriteria/New-JIMScopingCriterion.ps1
@@ -139,7 +139,7 @@ function New-JIMScopingCriterion {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ScopingCriteria/Remove-JIMScopingCriteriaGroup.ps1
+++ b/src/JIM.PowerShell/Public/ScopingCriteria/Remove-JIMScopingCriteriaGroup.ps1
@@ -44,7 +44,7 @@ function Remove-JIMScopingCriteriaGroup {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ScopingCriteria/Remove-JIMScopingCriterion.ps1
+++ b/src/JIM.PowerShell/Public/ScopingCriteria/Remove-JIMScopingCriterion.ps1
@@ -45,7 +45,7 @@ function Remove-JIMScopingCriterion {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ScopingCriteria/Set-JIMScopingCriteriaGroup.ps1
+++ b/src/JIM.PowerShell/Public/ScopingCriteria/Set-JIMScopingCriteriaGroup.ps1
@@ -64,7 +64,7 @@ function Set-JIMScopingCriteriaGroup {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Search/Get-JIMPredefinedSearch.ps1
+++ b/src/JIM.PowerShell/Public/Search/Get-JIMPredefinedSearch.ps1
@@ -66,7 +66,7 @@ function Get-JIMPredefinedSearch {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Search/Set-JIMPredefinedSearch.ps1
+++ b/src/JIM.PowerShell/Public/Search/Set-JIMPredefinedSearch.ps1
@@ -57,7 +57,7 @@ function Set-JIMPredefinedSearch {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Security/Add-JIMRoleMember.ps1
+++ b/src/JIM.PowerShell/Public/Security/Add-JIMRoleMember.ps1
@@ -59,7 +59,7 @@ function Add-JIMRoleMember {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Security/Get-JIMMetaverseObjectRole.ps1
+++ b/src/JIM.PowerShell/Public/Security/Get-JIMMetaverseObjectRole.ps1
@@ -41,7 +41,7 @@ function Get-JIMMetaverseObjectRole {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Security/Get-JIMRole.ps1
+++ b/src/JIM.PowerShell/Public/Security/Get-JIMRole.ps1
@@ -66,6 +66,12 @@ function Get-JIMRole {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($PSCmdlet.ParameterSetName -eq 'ById') {
             Write-Verbose "Getting role by ID: $Id"
             try {

--- a/src/JIM.PowerShell/Public/Security/Get-JIMRoleMember.ps1
+++ b/src/JIM.PowerShell/Public/Security/Get-JIMRoleMember.ps1
@@ -53,7 +53,7 @@ function Get-JIMRoleMember {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Security/Remove-JIMRoleMember.ps1
+++ b/src/JIM.PowerShell/Public/Security/Remove-JIMRoleMember.ps1
@@ -63,7 +63,7 @@ function Remove-JIMRoleMember {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/ServiceSettings/Get-JIMServiceSetting.ps1
+++ b/src/JIM.PowerShell/Public/ServiceSettings/Get-JIMServiceSetting.ps1
@@ -44,6 +44,12 @@ function Get-JIMServiceSetting {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ByKey' {
                 Write-Verbose "Getting service setting: $Key"

--- a/src/JIM.PowerShell/Public/ServiceSettings/Reset-JIMServiceSetting.ps1
+++ b/src/JIM.PowerShell/Public/ServiceSettings/Reset-JIMServiceSetting.ps1
@@ -47,6 +47,12 @@ function Reset-JIMServiceSetting {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($PSCmdlet.ShouldProcess($Key, "Revert service setting to default")) {
             Write-Verbose "Reverting service setting to default: $Key"
 

--- a/src/JIM.PowerShell/Public/ServiceSettings/Set-JIMServiceSetting.ps1
+++ b/src/JIM.PowerShell/Public/ServiceSettings/Set-JIMServiceSetting.ps1
@@ -53,6 +53,12 @@ function Set-JIMServiceSetting {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         if ($PSCmdlet.ShouldProcess($Key, "Update service setting to '$Value'")) {
             Write-Verbose "Updating service setting: $Key = $Value"
 

--- a/src/JIM.PowerShell/Public/SyncRuleMappings/Get-JIMSyncRuleMapping.ps1
+++ b/src/JIM.PowerShell/Public/SyncRuleMappings/Get-JIMSyncRuleMapping.ps1
@@ -51,7 +51,7 @@ function Get-JIMSyncRuleMapping {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/SyncRuleMappings/New-JIMSyncRuleMapping.ps1
+++ b/src/JIM.PowerShell/Public/SyncRuleMappings/New-JIMSyncRuleMapping.ps1
@@ -98,7 +98,7 @@ function New-JIMSyncRuleMapping {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/SyncRuleMappings/Remove-JIMSyncRuleMapping.ps1
+++ b/src/JIM.PowerShell/Public/SyncRuleMappings/Remove-JIMSyncRuleMapping.ps1
@@ -62,7 +62,7 @@ function Remove-JIMSyncRuleMapping {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/SyncRules/Get-JIMSyncRule.ps1
+++ b/src/JIM.PowerShell/Public/SyncRules/Get-JIMSyncRule.ps1
@@ -81,6 +81,12 @@ function Get-JIMSyncRule {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         # Resolve ConnectedSystemName to ConnectedSystemId if specified
         if ($PSBoundParameters.ContainsKey('ConnectedSystemName')) {
             $connectedSystem = Resolve-JIMConnectedSystem -Name $ConnectedSystemName

--- a/src/JIM.PowerShell/Public/SyncRules/New-JIMSyncRule.ps1
+++ b/src/JIM.PowerShell/Public/SyncRules/New-JIMSyncRule.ps1
@@ -100,7 +100,7 @@ function New-JIMSyncRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/SyncRules/Remove-JIMSyncRule.ps1
+++ b/src/JIM.PowerShell/Public/SyncRules/Remove-JIMSyncRule.ps1
@@ -61,7 +61,7 @@ function Remove-JIMSyncRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/SyncRules/Set-JIMSyncRule.ps1
+++ b/src/JIM.PowerShell/Public/SyncRules/Set-JIMSyncRule.ps1
@@ -121,7 +121,7 @@ function Set-JIMSyncRule {
     process {
         # Check connection first
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Public/Synchronisation/Get-JIMConnectorDefinition.ps1
+++ b/src/JIM.PowerShell/Public/Synchronisation/Get-JIMConnectorDefinition.ps1
@@ -50,6 +50,12 @@ function Get-JIMConnectorDefinition {
     )
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting connector definition with ID: $Id"

--- a/src/JIM.PowerShell/Public/System/Get-JIMUserInfo.ps1
+++ b/src/JIM.PowerShell/Public/System/Get-JIMUserInfo.ps1
@@ -30,6 +30,12 @@ function Get-JIMUserInfo {
     param()
 
     process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
         Write-Verbose "Getting current user info"
 
         $response = Invoke-JIMApi -Endpoint '/api/v1/userinfo'

--- a/src/JIM.PowerShell/Public/System/Reset-JIMSystem.ps1
+++ b/src/JIM.PowerShell/Public/System/Reset-JIMSystem.ps1
@@ -91,7 +91,7 @@ function Reset-JIMSystem {
 
     process {
         if (-not $script:JIMConnection) {
-            Write-Error "Not connected to JIM. Use Connect-JIM first."
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
             return
         }
 

--- a/src/JIM.PowerShell/Tests/Activities.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Activities.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Get-JIMActivity' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMActivity } | Should -Throw '*Connect-JIM*'
+            { Get-JIMActivity -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 
@@ -137,7 +137,7 @@ Describe 'Get-JIMActivityStats' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMActivityStats -Id ([guid]::NewGuid()) } | Should -Throw '*Connect-JIM*'
+            { Get-JIMActivityStats -Id ([guid]::NewGuid()) -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/ApiKeys.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/ApiKeys.Tests.ps1
@@ -59,7 +59,7 @@ Describe 'Get-JIMApiKey' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMApiKey } | Should -Throw '*Connect-JIM*'
+            { Get-JIMApiKey -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Certificates.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Certificates.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'Get-JIMCertificate' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMCertificate } | Should -Throw '*Connect-JIM*'
+            { Get-JIMCertificate -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
@@ -92,6 +92,18 @@ Describe 'Connect-JIM' {
             $timeoutParam.ParameterSets.Keys | Should -Contain 'Interactive'
             $timeoutParam.ParameterSets.Keys | Should -Not -Contain 'ApiKey'
         }
+
+        It 'Should have a NoPersist switch parameter' {
+            $command = Get-Command Connect-JIM
+            $command.Parameters['NoPersist'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'NoPersist should only be in Interactive parameter set' {
+            $command = Get-Command Connect-JIM
+            $noPersistParam = $command.Parameters['NoPersist']
+            $noPersistParam.ParameterSets.Keys | Should -Contain 'Interactive'
+            $noPersistParam.ParameterSets.Keys | Should -Not -Contain 'ApiKey'
+        }
     }
 
     Context 'Help Documentation' {
@@ -153,6 +165,61 @@ Describe 'Disconnect-JIM' {
         It 'Should have CmdletBinding' {
             $command = Get-Command Disconnect-JIM
             $command.CmdletBinding | Should -BeTrue
+        }
+    }
+
+    Context 'Cache-clearing parameters' {
+
+        It 'Should have a ClearCache switch parameter' {
+            (Get-Command Disconnect-JIM).Parameters['ClearCache'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should have a Url parameter' {
+            (Get-Command Disconnect-JIM).Parameters['Url'] | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have an All switch parameter' {
+            (Get-Command Disconnect-JIM).Parameters['All'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'All should be in its own parameter set, separate from Url' {
+            $command = Get-Command Disconnect-JIM
+            $command.Parameters['All'].ParameterSets.Keys | Should -Not -Contain 'Default'
+            $command.Parameters['Url'].ParameterSets.Keys | Should -Not -Contain 'All'
+        }
+
+        It 'Should reject an invalid Url' {
+            { Disconnect-JIM -Url 'not-a-url' -ClearCache } | Should -Throw '*Invalid URL*'
+        }
+    }
+
+    Context 'Cache-clearing behaviour' {
+
+        It 'Does not touch the credential store by default' {
+            InModuleScope JIM {
+                $script:JIMConnection = $null
+                Mock Remove-JIMToken { 0 }
+                Disconnect-JIM
+                Should -Invoke Remove-JIMToken -Times 0
+            }
+        }
+
+        It 'Removes the persisted token for an explicit -Url even when not connected' {
+            InModuleScope JIM {
+                $script:JIMConnection = $null
+                Mock Remove-JIMToken { 1 }
+                Disconnect-JIM -Url 'https://jim.example.com' -ClearCache
+                Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $BaseUrl -eq 'https://jim.example.com' }
+            }
+        }
+
+        It 'Removes all persisted tokens with -All' {
+            InModuleScope JIM {
+                $script:JIMConnection = $null
+                Mock Remove-JIMToken { 3 }
+                Disconnect-JIM -All
+                Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $All.IsPresent }
+            }
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
@@ -339,3 +339,36 @@ Describe 'Test-JIMConnection' {
         }
     }
 }
+
+Describe 'Invoke-JIMApi when not connected' {
+
+    It 'Does not throw by default (non-terminating error)' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            { Invoke-JIMApi -Endpoint '/api/v1/health' -ErrorAction SilentlyContinue } | Should -Not -Throw
+        }
+    }
+
+    It 'Writes an error that points the user at Connect-JIM -Url' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            Invoke-JIMApi -Endpoint '/api/v1/health' -ErrorVariable apiError -ErrorAction SilentlyContinue | Out-Null
+            ($apiError -join "`n") | Should -Match 'Connect-JIM -Url'
+        }
+    }
+
+    It 'Throws a catchable error with -ErrorAction Stop' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            { Invoke-JIMApi -Endpoint '/api/v1/health' -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    It 'Returns no output (caller emits nothing)' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            $result = Invoke-JIMApi -Endpoint '/api/v1/health' -ErrorAction SilentlyContinue
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
@@ -168,10 +168,10 @@ Describe 'Disconnect-JIM' {
         }
     }
 
-    Context 'Cache-clearing parameters' {
+    Context 'Parameters' {
 
-        It 'Should have a ClearCache switch parameter' {
-            (Get-Command Disconnect-JIM).Parameters['ClearCache'].SwitchParameter | Should -BeTrue
+        It 'Should not have a ClearCache parameter (retired)' {
+            (Get-Command Disconnect-JIM).Parameters.Keys | Should -Not -Contain 'ClearCache'
         }
 
         It 'Should have a Url parameter' {
@@ -189,18 +189,27 @@ Describe 'Disconnect-JIM' {
         }
 
         It 'Should reject an invalid Url' {
-            { Disconnect-JIM -Url 'not-a-url' -ClearCache } | Should -Throw '*Invalid URL*'
+            { Disconnect-JIM -Url 'not-a-url' } | Should -Throw '*Invalid URL*'
         }
     }
 
-    Context 'Cache-clearing behaviour' {
+    Context 'Disconnect-and-forget behaviour' {
 
-        It 'Does not touch the credential store by default' {
+        It 'Removes the persisted token for the currently connected instance by default' {
             InModuleScope JIM {
-                $script:JIMConnection = $null
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'OAuth' }
+                Mock Remove-JIMToken { 1 }
+                Disconnect-JIM
+                Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $BaseUrl -eq 'https://jim.example.com' }
+            }
+        }
+
+        It 'Removes the persisted token regardless of auth method (API key session)' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
                 Mock Remove-JIMToken { 0 }
                 Disconnect-JIM
-                Should -Invoke Remove-JIMToken -Times 0
+                Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $BaseUrl -eq 'https://jim.example.com' }
             }
         }
 
@@ -208,8 +217,17 @@ Describe 'Disconnect-JIM' {
             InModuleScope JIM {
                 $script:JIMConnection = $null
                 Mock Remove-JIMToken { 1 }
-                Disconnect-JIM -Url 'https://jim.example.com' -ClearCache
-                Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $BaseUrl -eq 'https://jim.example.com' }
+                Disconnect-JIM -Url 'https://other.example.com'
+                Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $BaseUrl -eq 'https://other.example.com' }
+            }
+        }
+
+        It 'Does not touch the credential store when not connected and no -Url' {
+            InModuleScope JIM {
+                $script:JIMConnection = $null
+                Mock Remove-JIMToken { 0 }
+                Disconnect-JIM
+                Should -Invoke Remove-JIMToken -Times 0
             }
         }
 

--- a/src/JIM.PowerShell/Tests/ExampleData.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/ExampleData.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Get-JIMExampleDataSet' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMExampleDataSet } | Should -Throw '*Connect-JIM*'
+            { Get-JIMExampleDataSet -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 
@@ -121,7 +121,7 @@ Describe 'Get-JIMExampleDataTemplate' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMExampleDataTemplate } | Should -Throw '*Connect-JIM*'
+            { Get-JIMExampleDataTemplate -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Get-JIMConnectedSystem.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Get-JIMConnectedSystem.Tests.ps1
@@ -75,11 +75,11 @@ Describe 'Get-JIMConnectedSystem' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMConnectedSystem } | Should -Throw '*Connect-JIM*'
+            { Get-JIMConnectedSystem -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
 
         It 'Should throw when getting by ID without connection' {
-            { Get-JIMConnectedSystem -Id 1 } | Should -Throw '*Connect-JIM*'
+            { Get-JIMConnectedSystem -Id 1 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Get-JIMConnectedSystemObject.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Get-JIMConnectedSystemObject.Tests.ps1
@@ -111,11 +111,11 @@ Describe 'Get-JIMConnectedSystemObject' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Id ([guid]::NewGuid()) } | Should -Throw '*Connect-JIM*'
+            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Id ([guid]::NewGuid()) -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
 
         It 'Should throw when not connected with Count' {
-            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count } | Should -Throw '*Connect-JIM*'
+            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Get-JIMPendingExport.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Get-JIMPendingExport.Tests.ps1
@@ -100,11 +100,11 @@ Describe 'Get-JIMPendingExport' {
         }
 
         It 'Should throw when listing without connection' {
-            { Get-JIMPendingExport -ConnectedSystemId 1 } | Should -Throw '*Connect-JIM*'
+            { Get-JIMPendingExport -ConnectedSystemId 1 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
 
         It 'Should throw when getting by ID without connection' {
-            { Get-JIMPendingExport -Id ([guid]::NewGuid()) } | Should -Throw '*Connect-JIM*'
+            { Get-JIMPendingExport -Id ([guid]::NewGuid()) -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Metaverse.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Metaverse.Tests.ps1
@@ -121,7 +121,7 @@ Describe 'Get-JIMMetaverseObject' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMMetaverseObject } | Should -Throw '*Connect-JIM*'
+            { Get-JIMMetaverseObject -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 
@@ -197,7 +197,7 @@ Describe 'Get-JIMMetaverseObjectType' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMMetaverseObjectType } | Should -Throw '*Connect-JIM*'
+            { Get-JIMMetaverseObjectType -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 
@@ -270,7 +270,7 @@ Describe 'Get-JIMMetaverseAttribute' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMMetaverseAttribute } | Should -Throw '*Connect-JIM*'
+            { Get-JIMMetaverseAttribute -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/RunProfiles.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/RunProfiles.Tests.ps1
@@ -53,7 +53,7 @@ Describe 'Get-JIMRunProfile' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMRunProfile -ConnectedSystemId 1 } | Should -Throw '*Connect-JIM*'
+            { Get-JIMRunProfile -ConnectedSystemId 1 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Security.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Security.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Get-JIMRole' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMRole } | Should -Throw '*Connect-JIM*'
+            { Get-JIMRole -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/SyncRules.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/SyncRules.Tests.ps1
@@ -63,7 +63,7 @@ Describe 'Get-JIMSyncRule' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMSyncRule } | Should -Throw '*Connect-JIM*'
+            { Get-JIMSyncRule -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/System.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/System.Tests.ps1
@@ -258,7 +258,7 @@ Describe 'Get-JIMUserInfo' {
         }
 
         It 'Should throw when not connected' {
-            { Get-JIMUserInfo } | Should -Throw '*Connect-JIM*'
+            { Get-JIMUserInfo -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/TokenStore.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/TokenStore.Tests.ps1
@@ -1,0 +1,193 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for the persistent refresh-token store (issue #305).
+
+.DESCRIPTION
+    Covers the pure cache-key derivation and the provider dispatch / argument
+    construction for Save-JIMToken, Get-JIMPersistedToken, and Remove-JIMToken.
+    Platform store calls are exercised via a mocked Invoke-JIMStoreProcess so the
+    tests are deterministic on any OS without needing a real keyring.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'JIM.psd1'
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $ModulePath -Force
+
+    # Dot-source the private token store so its functions are testable directly and
+    # internal calls can be mocked in this scope (same pattern as OAuth.Tests.ps1).
+    $ModuleRoot = Split-Path $ModulePath -Parent
+    . (Join-Path $ModuleRoot 'Private' 'JIMTokenStore.ps1')
+}
+
+AfterAll {
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+}
+
+Describe 'Get-JIMTokenCacheKey' {
+
+    It 'Normalises a trailing slash to the same key' {
+        $a = Get-JIMTokenCacheKey -BaseUrl 'https://jim.company.com'
+        $b = Get-JIMTokenCacheKey -BaseUrl 'https://jim.company.com/'
+        $a | Should -Be $b
+    }
+
+    It 'Includes the explicit default port for https' {
+        Get-JIMTokenCacheKey -BaseUrl 'https://jim.company.com' | Should -Be 'https://jim.company.com:443'
+    }
+
+    It 'Preserves a non-default port' {
+        Get-JIMTokenCacheKey -BaseUrl 'http://localhost:5200' | Should -Be 'http://localhost:5200'
+    }
+
+    It 'Lower-cases the host and scheme' {
+        Get-JIMTokenCacheKey -BaseUrl 'HTTPS://JIM.Company.COM' | Should -Be 'https://jim.company.com:443'
+    }
+
+    It 'Produces different keys for different schemes' {
+        $http = Get-JIMTokenCacheKey -BaseUrl 'http://jim.company.com'
+        $https = Get-JIMTokenCacheKey -BaseUrl 'https://jim.company.com'
+        $http | Should -Not -Be $https
+    }
+
+    It 'Produces different keys for different ports' {
+        $a = Get-JIMTokenCacheKey -BaseUrl 'http://localhost:5200'
+        $b = Get-JIMTokenCacheKey -BaseUrl 'http://localhost:5300'
+        $a | Should -Not -Be $b
+    }
+
+    It 'Produces different keys for different hosts' {
+        $a = Get-JIMTokenCacheKey -BaseUrl 'https://jim1.company.com'
+        $b = Get-JIMTokenCacheKey -BaseUrl 'https://jim2.company.com'
+        $a | Should -Not -Be $b
+    }
+}
+
+Describe 'Get-JIMTokenStoreProvider' {
+
+    It 'Returns LibSecret on Linux when secret-tool is available' -Skip:(-not $IsLinux) {
+        Mock Get-Command { [PSCustomObject]@{ Name = 'secret-tool' } } -ParameterFilter { $Name -eq 'secret-tool' }
+        Get-JIMTokenStoreProvider | Should -Be 'LibSecret'
+    }
+
+    It 'Returns None on Linux when secret-tool is absent' -Skip:(-not $IsLinux) {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'secret-tool' }
+        Get-JIMTokenStoreProvider | Should -Be 'None'
+    }
+
+    It 'Test-JIMTokenPersistenceAvailable is false when provider is None' {
+        Mock Get-JIMTokenStoreProvider { 'None' }
+        Test-JIMTokenPersistenceAvailable | Should -BeFalse
+    }
+
+    It 'Test-JIMTokenPersistenceAvailable is true when a provider exists' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Test-JIMTokenPersistenceAvailable | Should -BeTrue
+    }
+}
+
+Describe 'Save-JIMToken' {
+
+    It 'Returns false and does not call the store when no provider is available' {
+        Mock Get-JIMTokenStoreProvider { 'None' }
+        Mock Invoke-JIMStoreProcess { throw 'should not be called' }
+        $result = Save-JIMToken -BaseUrl 'https://jim.company.com' -RefreshToken 'rt-123'
+        $result | Should -BeFalse
+        Should -Invoke Invoke-JIMStoreProcess -Times 0
+    }
+
+    It 'Stores via libsecret with the token piped on stdin (not on the command line)' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 0; StdOut = ''; StdErr = '' } }
+
+        $result = Save-JIMToken -BaseUrl 'https://jim.company.com' -RefreshToken 'secret-refresh-token'
+
+        $result | Should -BeTrue
+        Should -Invoke Invoke-JIMStoreProcess -Times 1 -ParameterFilter {
+            $FilePath -eq 'secret-tool' -and
+            $Arguments -contains 'store' -and
+            $Arguments -contains 'https://jim.company.com:443' -and
+            $StdinData -eq 'secret-refresh-token'
+        }
+    }
+
+    It 'Throws a clear error when libsecret fails' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 1; StdOut = ''; StdErr = 'boom' } }
+        { Save-JIMToken -BaseUrl 'https://jim.company.com' -RefreshToken 'rt' } | Should -Throw '*libsecret*'
+    }
+
+    It 'Passes the secret as an argument with -U on macOS' {
+        Mock Get-JIMTokenStoreProvider { 'MacOS' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 0; StdOut = ''; StdErr = '' } }
+
+        Save-JIMToken -BaseUrl 'https://jim.company.com' -RefreshToken 'rt-mac' | Should -BeTrue
+
+        Should -Invoke Invoke-JIMStoreProcess -Times 1 -ParameterFilter {
+            $FilePath -eq 'security' -and
+            $Arguments -contains 'add-generic-password' -and
+            $Arguments -contains '-U' -and
+            $Arguments -contains 'rt-mac'
+        }
+    }
+}
+
+Describe 'Get-JIMPersistedToken' {
+
+    It 'Returns null when no provider is available' {
+        Mock Get-JIMTokenStoreProvider { 'None' }
+        Get-JIMPersistedToken -BaseUrl 'https://jim.company.com' | Should -BeNullOrEmpty
+    }
+
+    It 'Returns the trimmed token from libsecret' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 0; StdOut = "my-token`n"; StdErr = '' } }
+        Get-JIMPersistedToken -BaseUrl 'https://jim.company.com' | Should -Be 'my-token'
+    }
+
+    It 'Returns null when libsecret reports not found' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 1; StdOut = ''; StdErr = '' } }
+        Get-JIMPersistedToken -BaseUrl 'https://jim.company.com' | Should -BeNullOrEmpty
+    }
+
+    It 'Looks up by the normalised cache key' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 0; StdOut = 'tok'; StdErr = '' } }
+        Get-JIMPersistedToken -BaseUrl 'https://jim.company.com/' | Out-Null
+        Should -Invoke Invoke-JIMStoreProcess -Times 1 -ParameterFilter {
+            $Arguments -contains 'lookup' -and $Arguments -contains 'https://jim.company.com:443'
+        }
+    }
+}
+
+Describe 'Remove-JIMToken' {
+
+    It 'Returns 0 when no provider is available' {
+        Mock Get-JIMTokenStoreProvider { 'None' }
+        Remove-JIMToken -BaseUrl 'https://jim.company.com' | Should -Be 0
+    }
+
+    It 'Clears a single libsecret entry by url' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 0; StdOut = ''; StdErr = '' } }
+        Remove-JIMToken -BaseUrl 'https://jim.company.com' | Should -Be 1
+        Should -Invoke Invoke-JIMStoreProcess -Times 1 -ParameterFilter {
+            $Arguments -contains 'clear' -and $Arguments -contains 'url' -and $Arguments -contains 'https://jim.company.com:443'
+        }
+    }
+
+    It 'Clears all libsecret entries by service only when -All is used' {
+        Mock Get-JIMTokenStoreProvider { 'LibSecret' }
+        Mock Invoke-JIMStoreProcess { [PSCustomObject]@{ ExitCode = 0; StdOut = ''; StdErr = '' } }
+        Remove-JIMToken -All | Out-Null
+        Should -Invoke Invoke-JIMStoreProcess -Times 1 -ParameterFilter {
+            $Arguments -contains 'clear' -and ($Arguments -notcontains 'url')
+        }
+    }
+}

--- a/src/JIM.Web/Controllers/Api/AuthController.cs
+++ b/src/JIM.Web/Controllers/Api/AuthController.cs
@@ -58,8 +58,11 @@ public class AuthController : ControllerBase
             });
         }
 
-        // Build the scopes list
-        var scopes = new List<string> { "openid", "profile" };
+        // Build the scopes list. offline_access is requested so the IdP issues a refresh token;
+        // the PowerShell module persists that refresh token to the platform credential store for
+        // cross-session token caching (issue #305) and uses it for silent in-session refresh.
+        // Without offline_access, providers such as Entra ID issue no refresh token at all.
+        var scopes = new List<string> { "openid", "profile", "offline_access" };
         if (!string.IsNullOrEmpty(apiScope))
         {
             scopes.Add(apiScope);

--- a/src/JIM.Web/Controllers/Api/UserInfoController.cs
+++ b/src/JIM.Web/Controllers/Api/UserInfoController.cs
@@ -67,7 +67,7 @@ public class UserInfoController(ILogger<UserInfoController> logger, JimApplicati
                 authMethod,
                 metaverseObjectId = (Guid?)null,
                 roles = Array.Empty<string>(),
-                message = "You are authenticated but do not have a JIM identity. Please sign in to the JIM web portal first to create your identity, then retry."
+                message = "You are authenticated but do not have a JIM identity. Identities are created when you are synchronised into JIM from a connected system, or provisioned by an administrator. Contact your JIM administrator if you believe this is in error."
             }));
         }
 

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -13,7 +13,9 @@ using JIM.Web.Models;
 using JIM.Web.Services;
 using JIM.Models.Activities;
 using JIM.Models.Core;
+using JIM.Models.Security;
 using JIM.PostgresData;
+using JIM.Utilities;
 using JIM.Web.Middleware.Api;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
@@ -288,7 +290,7 @@ try
             // intercept the user login when a token is received and validate we can map them to a JIM user
             options.Events.OnTicketReceived = async ctx =>
             {
-                await AuthoriseAndUpdateUserAsync(ctx);
+                await ResolveAndAttachJimIdentityAsync(ctx.Principal, ctx.HttpContext);
             };
 
             // Prevent OIDC redirects for API requests - they should return 401 instead
@@ -337,6 +339,18 @@ try
             options.MapInboundClaims = false;
 
             options.TokenValidationParameters.RoleClaimType = Constants.BuiltInRoles.RoleClaimType;
+
+            // Resolve (and, for the initial admin, just-in-time provision) the JIM identity for
+            // bearer-token callers too, so the PowerShell module / REST API can administer a fresh
+            // deployment without anyone first signing in to the web portal. The resolved roles and
+            // MetaverseObject id are attached to this request's principal.
+            options.Events = new JwtBearerEvents
+            {
+                OnTokenValidated = async ctx =>
+                {
+                    await ResolveAndAttachJimIdentityAsync(ctx.Principal, ctx.HttpContext);
+                }
+            };
         });
 
     // setup authorisation policies
@@ -835,318 +849,78 @@ static async Task InitialiseInfrastructureApiKeyAsync(JimApplication jim)
         keyPrefix, apiKey.ExpiresAt);
 }
 
-static async Task AuthoriseAndUpdateUserAsync(TicketReceivedContext context)
+/// <summary>
+/// Resolves the authenticated SSO identity to a JIM MetaverseObject (bootstrapping the initial
+/// administrator just-in-time on first contact, via either the interactive browser or a bearer
+/// token), then attaches a JIM ClaimsIdentity carrying the user's roles and MetaverseObject id to
+/// the current principal. Without a successful mapping the principal gains no JIM roles and cannot
+/// access JIM. The provisioning decision itself lives in the application layer (jim.Auth); this
+/// method only bridges the web layer's ClaimsPrincipal to that logic and back.
+/// </summary>
+static async Task ResolveAndAttachJimIdentityAsync(ClaimsPrincipal? principal, HttpContext httpContext)
 {
-    // When a user signs in, we need to see if we can map the identity in the received token, to a user in the Metaverse.
-    // If we do, then the user's roles are retrieved and added to their identity, if not, they receive no roles and will
-    // not be able to access any part of JIM.
-    //
-    // If the user is the initial admin (matching JIM_SSO_INITIAL_ADMIN) and doesn't exist yet, they are created
-    // just-in-time with all available claims populated in a single operation.
-    //
-    // For existing users, any missing attributes are supplemented from claims on each sign-in.
-
-    Log.Verbose("AuthoriseAndUpdateUserAsync: Called.");
-
-    if (context.Principal?.Identity == null)
+    if (principal?.Identity == null)
     {
-        Log.Error($"AuthoriseAndUpdateUserAsync: User doesn't have a principal or identity");
+        Log.Error("ResolveAndAttachJimIdentityAsync: Request has no principal or identity.");
         return;
     }
 
-    // there's probably a better way to do this, i.e. getting JimApplication from Services somehow
-    var jim = new JimApplication(new PostgresDataRepository(new JimDbContext()));
-    var serviceSettings = await jim.ServiceSettings.GetServiceSettingsAsync() ??
-        throw new Exception("ServiceSettings was null. Cannot continue.");
+    var factory = httpContext.RequestServices.GetService<IJimApplicationFactory>();
+    if (factory == null)
+    {
+        Log.Error("ResolveAndAttachJimIdentityAsync: Could not resolve IJimApplicationFactory.");
+        return;
+    }
 
-    if (serviceSettings.SSOUniqueIdentifierMetaverseAttribute == null)
-        throw new Exception("ServiceSettings.SSOUniqueIdentifierMetaverseAttribute is null!");
+    using var jim = factory.Create();
+    var serviceSettings = await jim.ServiceSettings.GetServiceSettingsAsync() ??
+        throw new InvalidOperationException("ServiceSettings was null. Cannot authorise the user.");
 
     if (string.IsNullOrEmpty(serviceSettings.SSOUniqueIdentifierClaimType))
-        throw new Exception("ServiceSettings.SSOUniqueIdentifierClaimType is null or empty!");
-
-    var uniqueIdClaimValue = context.Principal.FindFirstValue(serviceSettings.SSOUniqueIdentifierClaimType);
-    if (string.IsNullOrEmpty(uniqueIdClaimValue))
     {
-        Log.Warning($"AuthoriseAndUpdateUserAsync: User '{context.Principal.Identity.Name}' doesn't have a '{serviceSettings.SSOUniqueIdentifierClaimType}' claim that's needed to identify the user.");
+        Log.Error("ResolveAndAttachJimIdentityAsync: ServiceSettings.SSOUniqueIdentifierClaimType is not configured.");
         return;
     }
 
-    Log.Debug($"AuthoriseAndUpdateUserAsync: User '{context.Principal.Identity.Name}' has a '{serviceSettings.SSOUniqueIdentifierClaimType}' claim value of '{uniqueIdClaimValue}'.");
-
-    // get the user using their unique id claim value
-    var userType = await jim.Metaverse.GetMetaverseObjectTypeAsync(Constants.BuiltInObjectTypes.User, false) ??
-        throw new Exception("Could not retrieve User object type");
-
-    var user = await jim.Metaverse.GetMetaverseObjectByTypeAndAttributeAsync(userType, serviceSettings.SSOUniqueIdentifierMetaverseAttribute, uniqueIdClaimValue);
-    var initialAdminClaimValue = Environment.GetEnvironmentVariable(Constants.Config.SsoInitialAdmin);
-    var isInitialAdmin = !string.IsNullOrEmpty(initialAdminClaimValue) && uniqueIdClaimValue == initialAdminClaimValue;
-
-    // if no matching user exists, check if this is the initial admin and create them just-in-time
-    if (user == null && isInitialAdmin)
+    var uniqueId = principal.FindFirstValue(serviceSettings.SSOUniqueIdentifierClaimType);
+    if (string.IsNullOrEmpty(uniqueId))
     {
-        user = await CreateInitialAdminUserAsync(jim, userType, serviceSettings.SSOUniqueIdentifierMetaverseAttribute, uniqueIdClaimValue, context.Principal);
+        Log.Warning("ResolveAndAttachJimIdentityAsync: User '{Name}' has no '{ClaimType}' claim; cannot identify them.",
+            LogSanitiser.Sanitise(principal.Identity.Name), serviceSettings.SSOUniqueIdentifierClaimType);
+        return;
     }
 
-    if (user != null)
+    // Hand a provider-agnostic identity to the application layer to resolve or provision.
+    var ssoIdentity = new SsoIdentity
     {
-        // we mapped a token user to a Metaverse user, now we need to create a new ASP.NET identity that represents an internal view
-        // of the user, with their roles claims. We have to create a new identity as we cannot modify the default ASP.NET one.
-        // This will do to start with. When we need a more developed RBAC system later, we might need to extend ClaimsIdentity to accomodate more complex roles.
-
-        // ensure the initial admin always has the Administrator role
-        if (isInitialAdmin && !await jim.Security.IsObjectInRoleAsync(user, Constants.BuiltInRoles.Administrator))
-        {
-            await jim.Security.AddObjectToRoleAsync(user, Constants.BuiltInRoles.Administrator);
-        }
-
-        // retrieve the existing JIM role assignments for this user.
-        var userRoles = await jim.Security.GetMetaverseObjectRolesAsync(user);
-
-        // convert their JIM role assignments to ASP.NET claims.
-        var userRoleClaims = userRoles.Select(role => new Claim(Constants.BuiltInRoles.RoleClaimType, role.Name)).ToList();
-
-        // add a virtual-role claim for user.
-        // this role provides basic access to JIM.Web. If we can't map a user, they don't get this role, and therefore they can't access much.
-        userRoleClaims.Add(new Claim(Constants.BuiltInRoles.RoleClaimType, Constants.BuiltInRoles.User));
-
-        // add their metaverse object id claim to the new identity as well.
-        // we'll use this to attribute user actions to the claims identity.
-        userRoleClaims.Add(new Claim(Constants.BuiltInClaims.MetaverseObjectId, user.Id.ToString()));
-
-        // the new JIM-specific identity is ready, now add it to the ASP.NET identity so it can be easily retrieved later.
-        var jimIdentity = new ClaimsIdentity(userRoleClaims, authenticationType: null, nameType: null, roleType: Constants.BuiltInRoles.RoleClaimType) { Label = "JIM.Web" };
-        context.Principal.AddIdentity(jimIdentity);
-
-        // now see if we can supplement the JIM identity with any supplied from the IdP to more fully populate the user.
-        await UpdateUserAttributesFromClaimsAsync(jim, user, context.Principal);
-    }
-
-    // we couldn't map the token user to a Metaverse user and they're not the initial admin. Quit.
-    // the user will have no roles added, so they won't be able to access JIM.Web
-}
-
-/// <summary>
-/// Creates the initial admin user just-in-time on their first sign-in, with all available
-/// OIDC claims populated in a single operation (producing one "Created" change event).
-/// </summary>
-static async Task<MetaverseObject> CreateInitialAdminUserAsync(
-    JimApplication jim,
-    MetaverseObjectType userType,
-    MetaverseAttribute uniqueIdentifierAttribute,
-    string uniqueIdClaimValue,
-    ClaimsPrincipal claimsPrincipal)
-{
-    Log.Information("CreateInitialAdminUserAsync: Creating initial admin user just-in-time ({UniqueId}).", uniqueIdClaimValue);
-
-    var activity = new Activity
-    {
-        TargetType = ActivityTargetType.MetaverseObject,
-        TargetOperationType = ActivityTargetOperationType.Create,
-        Message = "Creating initial administrator user on first sign-in"
+        UniqueId = uniqueId,
+        DisplayName = principal.FindFirstValue("name"),
+        FirstName = principal.FindFirstValue("given_name"),
+        LastName = principal.FindFirstValue("family_name"),
+        UserPrincipalName = principal.FindFirstValue("preferred_username")
     };
-    await jim.Activities.CreateSystemActivityAsync(activity);
 
-    try
+    var user = await jim.Auth.ResolveOrProvisionSsoIdentityAsync(ssoIdentity);
+    if (user == null)
     {
-        // Set Origin to Internal to protect admin from automatic deletion rules
-        var user = new MetaverseObject
-        {
-            Type = userType,
-            Origin = MetaverseObjectOrigin.Internal
-        };
-
-        // unique identifier attribute (required)
-        user.AttributeValues.Add(new MetaverseObjectAttributeValue
-        {
-            MetaverseObject = user,
-            Attribute = uniqueIdentifierAttribute,
-            StringValue = uniqueIdClaimValue
-        });
-
-        // Type attribute (required)
-        var typeAttribute = await jim.Metaverse.GetMetaverseAttributeAsync(Constants.BuiltInAttributes.Type) ??
-                            throw new Exception($"Couldn't get essential attribute: {Constants.BuiltInAttributes.Type}");
-        user.AttributeValues.Add(new MetaverseObjectAttributeValue
-        {
-            MetaverseObject = user,
-            Attribute = typeAttribute,
-            StringValue = "PersonEntity"
-        });
-
-        // populate optional attributes from OIDC claims so everything is set in one go
-        await AddAttributeFromClaimAsync(jim, user, claimsPrincipal, "name", Constants.BuiltInAttributes.DisplayName);
-        await AddAttributeFromClaimAsync(jim, user, claimsPrincipal, "given_name", Constants.BuiltInAttributes.FirstName);
-        await AddAttributeFromClaimAsync(jim, user, claimsPrincipal, "family_name", Constants.BuiltInAttributes.LastName);
-        await AddAttributeFromClaimAsync(jim, user, claimsPrincipal, "preferred_username", Constants.BuiltInAttributes.UserPrincipalName);
-
-        await jim.Metaverse.CreateMetaverseObjectAsync(
-            user,
-            changeInitiatorType: MetaverseObjectChangeInitiatorType.System);
-
-        // update the parent activity with the user's details now that the MVO exists
-        activity.TargetName = user.DisplayName;
-        activity.MetaverseObjectId = user.Id;
-
-        // assign the Administrator role as a child activity
-        var roleActivity = new Activity
-        {
-            ParentActivityId = activity.Id,
-            TargetType = ActivityTargetType.MetaverseObject,
-            TargetOperationType = ActivityTargetOperationType.Update,
-            TargetName = user.DisplayName,
-            MetaverseObjectId = user.Id,
-            Message = $"Assigning {Constants.BuiltInRoles.Administrator} role to initial administrator"
-        };
-        await jim.Activities.CreateSystemActivityAsync(roleActivity);
-
-        try
-        {
-            await jim.Security.AddObjectToRoleAsync(user, Constants.BuiltInRoles.Administrator);
-            roleActivity.Message = $"Assigned {Constants.BuiltInRoles.Administrator} role to initial administrator";
-            await jim.Activities.CompleteActivityAsync(roleActivity);
-        }
-        catch (Exception ex)
-        {
-            await jim.Activities.FailActivityWithErrorAsync(roleActivity, ex);
-            throw;
-        }
-
-        activity.Message = $"Created initial administrator '{user.DisplayName}'";
-        await jim.Activities.CompleteActivityAsync(activity);
-
-        Log.Information("CreateInitialAdminUserAsync: Initial admin user created and assigned {Role} role.", Constants.BuiltInRoles.Administrator);
-        return user;
-    }
-    catch (Exception ex)
-    {
-        await jim.Activities.FailActivityWithErrorAsync(activity, ex);
-        throw;
-    }
-}
-
-/// <summary>
-/// Adds an attribute value to a MetaverseObject from an OIDC claim, if the claim is present.
-/// </summary>
-static async Task AddAttributeFromClaimAsync(
-    JimApplication jim,
-    MetaverseObject user,
-    ClaimsPrincipal claimsPrincipal,
-    string claimType,
-    string metaverseAttributeName)
-{
-    var claim = claimsPrincipal.Claims.FirstOrDefault(q => q.Type == claimType);
-    if (claim == null) return;
-
-    var attribute = await jim.Metaverse.GetMetaverseAttributeAsync(metaverseAttributeName);
-    if (attribute == null) return;
-
-    user.AttributeValues.Add(new MetaverseObjectAttributeValue
-    {
-        MetaverseObject = user,
-        Attribute = attribute,
-        StringValue = claim.Value
-    });
-    Log.Verbose("CreateInitialAdminUserAsync: Added {Attribute} from claim {Claim}.", metaverseAttributeName, claimType);
-}
-
-static async Task UpdateUserAttributesFromClaimsAsync(JimApplication jim, MetaverseObject user, ClaimsPrincipal claimsPrincipal)
-{
-    Log.Verbose("UpdateUserAttributesFromClaimsAsync: Called.");
-    var additions = new List<MetaverseObjectAttributeValue>();
-
-    if (!user.HasAttributeValue(Constants.BuiltInAttributes.DisplayName))
-    {
-        var nameClaim = claimsPrincipal.Claims.FirstOrDefault(q => q.Type == "name");
-        if (nameClaim != null)
-        {
-            var displayNameAttribute = await jim.Metaverse.GetMetaverseAttributeAsync(Constants.BuiltInAttributes.DisplayName);
-            if (displayNameAttribute != null)
-            {
-                var attributeValue = new MetaverseObjectAttributeValue
-                {
-                    Attribute = displayNameAttribute,
-                    StringValue = nameClaim.Value
-                };
-                user.AttributeValues.Add(attributeValue);
-                additions.Add(attributeValue);
-                Log.Verbose("UpdateUserAttributesFromClaimsAsync: Added value from claim: " + nameClaim.Type);
-            }
-        }
+        // Not a known user and not the initial admin: no roles are added, so they cannot access JIM.
+        Log.Debug("ResolveAndAttachJimIdentityAsync: No JIM identity for '{ClaimType}'='{UniqueId}'.",
+            serviceSettings.SSOUniqueIdentifierClaimType, LogSanitiser.Sanitise(uniqueId));
+        return;
     }
 
-    // Map given_name claim (standard OIDC claim for first name)
-    if (!user.HasAttributeValue(Constants.BuiltInAttributes.FirstName))
-    {
-        var givenNameClaim = claimsPrincipal.Claims.FirstOrDefault(q => q.Type == "given_name");
-        if (givenNameClaim != null)
-        {
-            var firstNameAttribute = await jim.Metaverse.GetMetaverseAttributeAsync(Constants.BuiltInAttributes.FirstName);
-            if (firstNameAttribute != null)
-            {
-                var attributeValue = new MetaverseObjectAttributeValue
-                {
-                    Attribute = firstNameAttribute,
-                    StringValue = givenNameClaim.Value
-                };
-                user.AttributeValues.Add(attributeValue);
-                additions.Add(attributeValue);
-                Log.Verbose("UpdateUserAttributesFromClaimsAsync: Added value from claim: " + givenNameClaim.Type);
-            }
-        }
-    }
+    // Build a JIM-specific identity carrying the user's role claims and MetaverseObject id, and add it
+    // to the current principal so this request (and, for the cookie flow, the session) is authorised.
+    var roleClaims = (await jim.Security.GetMetaverseObjectRolesAsync(user))
+        .Select(role => new Claim(Constants.BuiltInRoles.RoleClaimType, role.Name))
+        .ToList();
 
-    // Map family_name claim (standard OIDC claim for last name)
-    if (!user.HasAttributeValue(Constants.BuiltInAttributes.LastName))
-    {
-        var familyNameClaim = claimsPrincipal.Claims.FirstOrDefault(q => q.Type == "family_name");
-        if (familyNameClaim != null)
-        {
-            var lastNameAttribute = await jim.Metaverse.GetMetaverseAttributeAsync(Constants.BuiltInAttributes.LastName);
-            if (lastNameAttribute != null)
-            {
-                var attributeValue = new MetaverseObjectAttributeValue
-                {
-                    Attribute = lastNameAttribute,
-                    StringValue = familyNameClaim.Value
-                };
-                user.AttributeValues.Add(attributeValue);
-                additions.Add(attributeValue);
-                Log.Verbose("UpdateUserAttributesFromClaimsAsync: Added value from claim: " + familyNameClaim.Type);
-            }
-        }
-    }
+    // Baseline role granting access to JIM.Web; a user without a JIM identity never receives it.
+    roleClaims.Add(new Claim(Constants.BuiltInRoles.RoleClaimType, Constants.BuiltInRoles.User));
+    roleClaims.Add(new Claim(Constants.BuiltInClaims.MetaverseObjectId, user.Id.ToString()));
 
-    // Map preferred_username claim (standard OIDC claim, often contains UPN for Entra ID)
-    if (!user.HasAttributeValue(Constants.BuiltInAttributes.UserPrincipalName))
-    {
-        var preferredUsernameClaim = claimsPrincipal.Claims.FirstOrDefault(q => q.Type == "preferred_username");
-        if (preferredUsernameClaim != null)
-        {
-            var upnAttribute = await jim.Metaverse.GetMetaverseAttributeAsync(Constants.BuiltInAttributes.UserPrincipalName);
-            if (upnAttribute != null)
-            {
-                var attributeValue = new MetaverseObjectAttributeValue
-                {
-                    Attribute = upnAttribute,
-                    StringValue = preferredUsernameClaim.Value
-                };
-                user.AttributeValues.Add(attributeValue);
-                additions.Add(attributeValue);
-                Log.Verbose("UpdateUserAttributesFromClaimsAsync: Added value from claim: " + preferredUsernameClaim.Type);
-            }
-        }
-    }
-
-    if (additions.Count > 0)
-    {
-        // update the user with the new attribute values (change tracking handled automatically)
-        await jim.Metaverse.UpdateMetaverseObjectAsync(
-            user,
-            additions: additions,
-            changeInitiatorType: MetaverseObjectChangeInitiatorType.System);
-        Log.Debug("UpdateUserAttributesFromClaimsAsync: Updated user with new attribute values from some claims");
-    }
+    var jimIdentity = new ClaimsIdentity(roleClaims, authenticationType: null, nameType: null, roleType: Constants.BuiltInRoles.RoleClaimType) { Label = "JIM" };
+    principal.AddIdentity(jimIdentity);
 }
 
 /// <summary>

--- a/test/JIM.Web.Api.Tests/AuthControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/AuthControllerTests.cs
@@ -164,7 +164,26 @@ public class AuthControllerTests
         Assert.That(config, Is.Not.Null);
         Assert.That(config!.Scopes, Contains.Item("openid"));
         Assert.That(config.Scopes, Contains.Item("profile"));
-        Assert.That(config.Scopes.Count, Is.EqualTo(2));
+        Assert.That(config.Scopes, Contains.Item("offline_access"));
+        Assert.That(config.Scopes.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void GetConfig_WhenSsoConfigured_IncludesOfflineAccessScope()
+    {
+        // Arrange - offline_access is required for the IdP to issue a refresh token, which the
+        // PowerShell module persists for cross-session token caching (issue #305). Without it,
+        // providers such as Entra ID issue no refresh token and silent reconnection is impossible.
+        Environment.SetEnvironmentVariable("JIM_SSO_AUTHORITY", "https://login.panoply.org");
+        Environment.SetEnvironmentVariable("JIM_SSO_CLIENT_ID", "test-client-id");
+
+        // Act
+        var result = _controller.GetConfig() as OkObjectResult;
+        var config = result?.Value as AuthConfigResponse;
+
+        // Assert
+        Assert.That(config, Is.Not.Null);
+        Assert.That(config!.Scopes, Contains.Item("offline_access"));
     }
 
     [Test]
@@ -184,8 +203,9 @@ public class AuthControllerTests
         Assert.That(config, Is.Not.Null);
         Assert.That(config!.Scopes, Contains.Item("openid"));
         Assert.That(config.Scopes, Contains.Item("profile"));
+        Assert.That(config.Scopes, Contains.Item("offline_access"));
         Assert.That(config.Scopes, Contains.Item(apiScope));
-        Assert.That(config.Scopes.Count, Is.EqualTo(3));
+        Assert.That(config.Scopes.Count, Is.EqualTo(4));
     }
 
     [Test]

--- a/test/JIM.Web.Api.Tests/AuthServerProvisioningTests.cs
+++ b/test/JIM.Web.Api.Tests/AuthServerProvisioningTests.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using JIM.Models.Security;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for <see cref="JIM.Application.Servers.AuthServer"/>, covering the just-in-time
+/// initial-admin bootstrap that now runs for any authenticated SSO identity (web or API/CLI).
+///
+/// The repository is mocked because the provisioning path crosses several servers and the
+/// underlying queries use Postgres-only operators (ILike) that the EF in-memory provider
+/// cannot translate. Mocking at the repository boundary keeps the test deterministic while
+/// still exercising AuthServer's real decision and orchestration logic.
+/// </summary>
+[TestFixture]
+public class AuthServerProvisioningTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IMetaverseRepository> _mockMetaverse = null!;
+    private Mock<ISecurityRepository> _mockSecurity = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettings = null!;
+    private Mock<IActivityRepository> _mockActivity = null!;
+    private JimApplication _application = null!;
+    private MetaverseAttribute _uniqueIdAttribute = null!;
+    private MetaverseObjectType _userType = null!;
+    private string? _originalInitialAdmin;
+
+    private const string AdminSub = "admin-sub-0001";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _originalInitialAdmin = Environment.GetEnvironmentVariable(Constants.Config.SsoInitialAdmin);
+
+        _mockRepository = new Mock<IRepository>();
+        _mockMetaverse = new Mock<IMetaverseRepository>();
+        _mockSecurity = new Mock<ISecurityRepository>();
+        _mockServiceSettings = new Mock<IServiceSettingsRepository>();
+        _mockActivity = new Mock<IActivityRepository>();
+
+        _mockRepository.Setup(r => r.Metaverse).Returns(_mockMetaverse.Object);
+        _mockRepository.Setup(r => r.Security).Returns(_mockSecurity.Object);
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettings.Object);
+        _mockRepository.Setup(r => r.Activity).Returns(_mockActivity.Object);
+
+        _uniqueIdAttribute = new MetaverseAttribute { Id = 1, Name = "Subject Identifier" };
+        _userType = new MetaverseObjectType { Id = 1, Name = Constants.BuiltInObjectTypes.User, PluralName = "Users" };
+
+        _mockServiceSettings.Setup(r => r.GetServiceSettingsAsync()).ReturnsAsync(new ServiceSettings
+        {
+            SSOUniqueIdentifierClaimType = "sub",
+            SSOUniqueIdentifierMetaverseAttribute = _uniqueIdAttribute
+        });
+
+        // Disable MVO change tracking so creation/update don't pull change-history into scope.
+        _mockServiceSettings.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ChangeTrackingMvoChangesEnabled))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ChangeTrackingMvoChangesEnabled,
+                DisplayName = "MVO change tracking",
+                ValueType = ServiceSettingValueType.Boolean,
+                Value = "false"
+            });
+
+        _mockMetaverse.Setup(r => r.GetMetaverseObjectTypeAsync(Constants.BuiltInObjectTypes.User, false))
+            .ReturnsAsync(_userType);
+
+        // Any built-in attribute requested by name resolves to a matching attribute.
+        _mockMetaverse.Setup(r => r.GetMetaverseAttributeAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((string name, bool _) => new MetaverseAttribute { Name = name });
+
+        // Persisting a new MVO assigns it an Id, mirroring the database.
+        _mockMetaverse.Setup(r => r.CreateMetaverseObjectAsync(It.IsAny<MetaverseObject>()))
+            .Callback<MetaverseObject>(m => m.Id = Guid.NewGuid())
+            .Returns(Task.CompletedTask);
+
+        // Stateful role membership, mirroring the database: once added, the object is in the
+        // role, so the "ensure admin role" guard does not re-add it.
+        var inAdminRole = false;
+        _mockSecurity.Setup(r => r.IsObjectInRoleAsync(It.IsAny<Guid>(), Constants.BuiltInRoles.Administrator))
+            .ReturnsAsync(() => inAdminRole);
+        _mockSecurity.Setup(r => r.AddObjectToRoleAsync(It.IsAny<Guid>(), Constants.BuiltInRoles.Administrator))
+            .Callback(() => inAdminRole = true)
+            .Returns(Task.CompletedTask);
+
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(Constants.Config.SsoInitialAdmin, _originalInitialAdmin);
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task ResolveOrProvisionSsoIdentityAsync_UnknownUserNotInitialAdmin_ReturnsNullAndCreatesNothingAsync()
+    {
+        Environment.SetEnvironmentVariable(Constants.Config.SsoInitialAdmin, AdminSub);
+        _mockMetaverse.Setup(r => r.GetMetaverseObjectByTypeAndAttributeAsync(_userType, _uniqueIdAttribute, It.IsAny<string>()))
+            .ReturnsAsync((MetaverseObject?)null);
+
+        var result = await _application.Auth.ResolveOrProvisionSsoIdentityAsync(
+            new SsoIdentity { UniqueId = "some-other-user" });
+
+        Assert.That(result, Is.Null);
+        _mockMetaverse.Verify(r => r.CreateMetaverseObjectAsync(It.IsAny<MetaverseObject>()), Times.Never);
+        _mockSecurity.Verify(r => r.AddObjectToRoleAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveOrProvisionSsoIdentityAsync_InitialAdminFirstContact_CreatesInternalUserWithAttributesAndAdminRoleAsync()
+    {
+        Environment.SetEnvironmentVariable(Constants.Config.SsoInitialAdmin, AdminSub);
+        _mockMetaverse.Setup(r => r.GetMetaverseObjectByTypeAndAttributeAsync(_userType, _uniqueIdAttribute, AdminSub))
+            .ReturnsAsync((MetaverseObject?)null);
+
+        MetaverseObject? created = null;
+        _mockMetaverse.Setup(r => r.CreateMetaverseObjectAsync(It.IsAny<MetaverseObject>()))
+            .Callback<MetaverseObject>(m => { m.Id = Guid.NewGuid(); created = m; })
+            .Returns(Task.CompletedTask);
+
+        var result = await _application.Auth.ResolveOrProvisionSsoIdentityAsync(new SsoIdentity
+        {
+            UniqueId = AdminSub,
+            DisplayName = "Jay Admin",
+            FirstName = "Jay",
+            LastName = "Admin"
+        });
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(created, Is.Not.Null);
+        Assert.That(created!.Origin, Is.EqualTo(MetaverseObjectOrigin.Internal), "Initial admin must be Internal-origin to survive deletion rules.");
+        Assert.That(created.AttributeValues.Single(av => av.Attribute!.Name == "Subject Identifier").StringValue, Is.EqualTo(AdminSub));
+        Assert.That(created.AttributeValues.Single(av => av.Attribute!.Name == Constants.BuiltInAttributes.DisplayName).StringValue, Is.EqualTo("Jay Admin"));
+        Assert.That(created.AttributeValues.Any(av => av.Attribute!.Name == Constants.BuiltInAttributes.Type), Is.True);
+        _mockSecurity.Verify(r => r.AddObjectToRoleAsync(created.Id, Constants.BuiltInRoles.Administrator), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveOrProvisionSsoIdentityAsync_ExistingNonAdminUser_SupplementsMissingAttributesAndDoesNotGrantAdminAsync()
+    {
+        Environment.SetEnvironmentVariable(Constants.Config.SsoInitialAdmin, AdminSub);
+
+        var existing = new MetaverseObject { Id = Guid.NewGuid(), Type = _userType, Origin = MetaverseObjectOrigin.Projected };
+        existing.AttributeValues.Add(new MetaverseObjectAttributeValue
+        {
+            MetaverseObject = existing,
+            Attribute = _uniqueIdAttribute,
+            StringValue = "synced-user-sub"
+        });
+        _mockMetaverse.Setup(r => r.GetMetaverseObjectByTypeAndAttributeAsync(_userType, _uniqueIdAttribute, "synced-user-sub"))
+            .ReturnsAsync(existing);
+
+        var result = await _application.Auth.ResolveOrProvisionSsoIdentityAsync(new SsoIdentity
+        {
+            UniqueId = "synced-user-sub",
+            DisplayName = "Synced User"
+        });
+
+        Assert.That(result, Is.SameAs(existing));
+        Assert.That(existing.AttributeValues.Single(av => av.Attribute!.Name == Constants.BuiltInAttributes.DisplayName).StringValue, Is.EqualTo("Synced User"));
+        _mockMetaverse.Verify(r => r.UpdateMetaverseObjectAsync(existing), Times.Once);
+        _mockMetaverse.Verify(r => r.CreateMetaverseObjectAsync(It.IsAny<MetaverseObject>()), Times.Never);
+        _mockSecurity.Verify(r => r.AddObjectToRoleAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveOrProvisionSsoIdentityAsync_ExistingInitialAdminMissingRole_EnsuresRoleWithoutRecreatingAsync()
+    {
+        Environment.SetEnvironmentVariable(Constants.Config.SsoInitialAdmin, AdminSub);
+
+        var existingAdmin = new MetaverseObject { Id = Guid.NewGuid(), Type = _userType, Origin = MetaverseObjectOrigin.Internal };
+        existingAdmin.AttributeValues.Add(new MetaverseObjectAttributeValue
+        {
+            MetaverseObject = existingAdmin,
+            Attribute = _uniqueIdAttribute,
+            StringValue = AdminSub
+        });
+        _mockMetaverse.Setup(r => r.GetMetaverseObjectByTypeAndAttributeAsync(_userType, _uniqueIdAttribute, AdminSub))
+            .ReturnsAsync(existingAdmin);
+
+        var result = await _application.Auth.ResolveOrProvisionSsoIdentityAsync(new SsoIdentity { UniqueId = AdminSub });
+
+        Assert.That(result, Is.SameAs(existingAdmin));
+        _mockMetaverse.Verify(r => r.CreateMetaverseObjectAsync(It.IsAny<MetaverseObject>()), Times.Never);
+        _mockSecurity.Verify(r => r.AddObjectToRoleAsync(existingAdmin.Id, Constants.BuiltInRoles.Administrator), Times.Once);
+    }
+}

--- a/test/JIM.Web.Api.Tests/UserInfoControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/UserInfoControllerTests.cs
@@ -327,7 +327,7 @@ public class UserInfoControllerTests
         var messageProperty = value!.GetType().GetProperty("message");
         var message = messageProperty?.GetValue(value) as string;
         Assert.That(message, Is.Not.Null.And.Not.Empty);
-        Assert.That(message, Does.Contain("sign in").IgnoreCase.Or.Contain("web portal").IgnoreCase);
+        Assert.That(message, Does.Contain("synchronised").IgnoreCase.Or.Contain("administrator").IgnoreCase);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- **Token persistence:** The PowerShell module now persists interactive SSO sign-in across terminal sessions via the OS credential store (Credential Manager / Keychain / libsecret). `Connect-JIM` reconnects silently in new terminals; `-NoPersist`, `-Force`, and a redesigned `Disconnect-JIM` (forget-by-default, `-Url`, `-All`; `-ClearCache` retired) control it. Requests the `offline_access` scope so the IdP issues a refresh token.
- **Initial-admin bootstrap via CLI/API:** The configured initial administrator can now be provisioned on first contact through the PowerShell module or REST API, not just the web portal, so an edge or air-gapped instance can be administered entirely from the command line. Provisioning logic was extracted from `JIM.Web/Program.cs` statics into a testable `JimApplication` `AuthServer`, decoupled from `ClaimsPrincipal` via a new `SsoIdentity` DTO, and shared by both the cookie and JWT bearer auth schemes.
- **Graceful not-connected / not-provisioned UX:** Running a cmdlet before `Connect-JIM` now shows a clear one-line message instead of a raw internal error (non-terminating by default). The not-provisioned message now correctly says identities arrive via synchronisation or admin provisioning, not portal sign-in.
- **Docs:** Host-machine branch-testing and gallery-revert workflow, updated connection/run-profile docs, and a rewritten PS interactive-auth manual regression script.

## Test plan
- [x] \`dotnet build JIM.sln\` clean (0 warnings, 0 errors)
- [x] \`dotnet test JIM.sln\` clean (2,711 passed, 8 skipped, 0 failed)
- [x] Manual interactive SSO auth + token-persistence + stale-token fallback verified end to end (issue #305 test plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)