### PR TITLE
test(powershell): cover cached-reconnect and refresh write-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔄 Factory reset now **preserves administrator users by default** (so you are not locked out) and always records a Reset activity attributed to whoever initiated it. The previous behaviour of also removing administrators is available via the new `-IncludeAdministrators` switch on `Reset-JIMSystem` (and `includeAdministrators` on `POST /api/v1/system/reset`), guarded against lockout when no initial administrator is configured.
 - 🔄 The reconnection overlay now shows live attempt progress (for example, "Attempt 2 of 5...") while JIM re-establishes a dropped connection.
 - 🔄 Running a PowerShell cmdlet before connecting now shows a clear one-line message telling you to run `Connect-JIM -Url <your JIM URL>`, instead of a raw error referencing the module's internals; the not-connected state is non-terminating by default and can be made fatal in scripts with `-ErrorAction Stop`.
+- 🔄 The "not authorised" message shown when an authenticated user lacks a JIM identity now explains that identities arrive via synchronisation or administrator provisioning, rather than directing users to sign in to the web portal first (which no longer reflects how identities are created).
 
 ### Fixed
 

--- a/src/JIM.PowerShell/Private/Invoke-JIMApi.ps1
+++ b/src/JIM.PowerShell/Private/Invoke-JIMApi.ps1
@@ -215,7 +215,7 @@ function Invoke-JIMApiRequest {
                 }
             }
             403 {
-                throw "Access denied. You are authenticated but not authorised to perform this operation. This usually means your identity has not been provisioned in JIM. Sign in to the JIM web portal first, then run Connect-JIM again."
+                throw "Access denied. You are authenticated but not authorised to perform this operation. This usually means your identity has not been provisioned in JIM. Identities are created when you are synchronised into JIM from a connected system, or provisioned by an administrator. Contact your JIM administrator if this is unexpected."
             }
             404 {
                 throw "Resource not found: $errorMessage"

--- a/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Connect-JIM.Tests.ps1
@@ -372,3 +372,151 @@ Describe 'Invoke-JIMApi when not connected' {
         }
     }
 }
+
+Describe 'Invoke-TokenRefresh write-back (issue #305)' {
+
+    # Most identity providers rotate the refresh token on every use. The persisted
+    # copy must therefore be re-saved after each successful refresh, or cross-session
+    # persistence works exactly once. These tests pin that write-back contract.
+
+    It 'Persists the rotated refresh token after a successful refresh when the session is persisted' {
+        InModuleScope JIM {
+            $script:JIMConnection = [PSCustomObject]@{
+                Url            = 'https://jim.example.com'
+                AuthMethod     = 'OAuth'
+                AccessToken    = 'old-at'
+                RefreshToken   = 'old-rt'
+                TokenExpiresAt = $null
+                Persisted      = $true
+                OAuthConfig    = @{ TokenEndpoint = 'https://idp/token'; ClientId = 'jim'; Scopes = @('openid', 'offline_access') }
+            }
+            Mock Invoke-OAuthTokenRefresh { [PSCustomObject]@{ AccessToken = 'new-at'; RefreshToken = 'rotated-rt'; ExpiresAt = (Get-Date).AddHours(1) } }
+            Mock Save-JIMToken { $true }
+
+            Invoke-TokenRefresh
+
+            Should -Invoke Save-JIMToken -Times 1 -ParameterFilter {
+                $BaseUrl -eq 'https://jim.example.com' -and $RefreshToken -eq 'rotated-rt'
+            }
+            $script:JIMConnection.RefreshToken | Should -Be 'rotated-rt'
+            $script:JIMConnection.AccessToken | Should -Be 'new-at'
+        }
+    }
+
+    It 'Does not write to the credential store when the session is not persisted (-NoPersist)' {
+        InModuleScope JIM {
+            $script:JIMConnection = [PSCustomObject]@{
+                Url            = 'https://jim.example.com'
+                AuthMethod     = 'OAuth'
+                AccessToken    = 'old-at'
+                RefreshToken   = 'old-rt'
+                TokenExpiresAt = $null
+                Persisted      = $false
+                OAuthConfig    = @{ TokenEndpoint = 'https://idp/token'; ClientId = 'jim'; Scopes = @('openid') }
+            }
+            Mock Invoke-OAuthTokenRefresh { [PSCustomObject]@{ AccessToken = 'new-at'; RefreshToken = 'rotated-rt'; ExpiresAt = (Get-Date).AddHours(1) } }
+            Mock Save-JIMToken { $true }
+
+            Invoke-TokenRefresh
+
+            Should -Invoke Save-JIMToken -Times 0
+            # The in-memory token is still rotated; only the on-disk copy is skipped.
+            $script:JIMConnection.RefreshToken | Should -Be 'rotated-rt'
+        }
+    }
+
+    It 'A failed save does not surface as a terminating error (refresh still succeeds)' {
+        InModuleScope JIM {
+            $script:JIMConnection = [PSCustomObject]@{
+                Url            = 'https://jim.example.com'
+                AuthMethod     = 'OAuth'
+                AccessToken    = 'old-at'
+                RefreshToken   = 'old-rt'
+                TokenExpiresAt = $null
+                Persisted      = $true
+                OAuthConfig    = @{ TokenEndpoint = 'https://idp/token'; ClientId = 'jim'; Scopes = @('openid', 'offline_access') }
+            }
+            Mock Invoke-OAuthTokenRefresh { [PSCustomObject]@{ AccessToken = 'new-at'; RefreshToken = 'rotated-rt'; ExpiresAt = (Get-Date).AddHours(1) } }
+            Mock Save-JIMToken { throw 'keyring exploded' }
+
+            { Invoke-TokenRefresh } | Should -Not -Throw
+            $script:JIMConnection.AccessToken | Should -Be 'new-at'
+        }
+    }
+}
+
+Describe 'Connect-JIMInteractive cached reconnect (issue #305)' {
+
+    # The headline feature: a persisted refresh token lets a new terminal reconnect
+    # silently, with no browser round-trip, and re-persists the rotated token.
+
+    It 'Reconnects silently with a cached token and never opens a browser' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            Mock Invoke-RestMethod { [PSCustomObject]@{ authority = 'https://idp/'; clientId = 'jim'; scopes = @('openid', 'offline_access') } }
+            Mock Get-OidcDiscoveryDocument { [PSCustomObject]@{ TokenEndpoint = 'https://idp/token'; AuthorizeEndpoint = 'https://idp/authorize' } }
+            Mock Test-JIMTokenPersistenceAvailable { $true }
+            Mock Invoke-JIMApi { [PSCustomObject]@{ status = 'Healthy' } }
+            Mock Get-JIMServerVersion { '1.2.3' }
+            Mock Show-JIMBanner { }
+            Mock Test-JIMAuthorisation { [PSCustomObject]@{ authorised = $true } }
+            Mock Save-JIMToken { $true }
+            Mock Get-JIMPersistedToken { 'cached-rt' }
+            Mock Invoke-OAuthTokenRefresh { [PSCustomObject]@{ AccessToken = 'at'; RefreshToken = 'rotated-rt'; ExpiresAt = (Get-Date).AddHours(1) } }
+            Mock Invoke-OAuthBrowserFlow { throw 'Browser flow must not run on a cached reconnect' }
+
+            $result = Connect-JIMInteractive -BaseUrl 'https://jim.example.com'
+
+            $result.Status | Should -Be 'Connected (cached)'
+            $result.Connected | Should -BeTrue
+            Should -Invoke Invoke-OAuthBrowserFlow -Times 0
+            Should -Invoke Save-JIMToken -Times 1 -ParameterFilter { $RefreshToken -eq 'rotated-rt' }
+        }
+    }
+
+    It 'Falls back to the browser and clears the stale token when the cached refresh is rejected' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            Mock Invoke-RestMethod { [PSCustomObject]@{ authority = 'https://idp/'; clientId = 'jim'; scopes = @('openid', 'offline_access') } }
+            Mock Get-OidcDiscoveryDocument { [PSCustomObject]@{ TokenEndpoint = 'https://idp/token'; AuthorizeEndpoint = 'https://idp/authorize' } }
+            Mock Test-JIMTokenPersistenceAvailable { $true }
+            Mock Invoke-JIMApi { [PSCustomObject]@{ status = 'Healthy' } }
+            Mock Get-JIMServerVersion { '1.2.3' }
+            Mock Show-JIMBanner { }
+            Mock Test-JIMAuthorisation { [PSCustomObject]@{ authorised = $true } }
+            Mock Save-JIMToken { $true }
+            Mock Get-JIMPersistedToken { 'stale-rt' }
+            Mock Invoke-OAuthTokenRefresh { throw 'invalid_grant' }
+            Mock Remove-JIMToken { 1 }
+            Mock Invoke-OAuthBrowserFlow { [PSCustomObject]@{ AccessToken = 'at'; RefreshToken = 'fresh-rt'; ExpiresAt = (Get-Date).AddHours(1) } }
+
+            $result = Connect-JIMInteractive -BaseUrl 'https://jim.example.com'
+
+            Should -Invoke Remove-JIMToken -Times 1 -ParameterFilter { $BaseUrl -eq 'https://jim.example.com' }
+            Should -Invoke Invoke-OAuthBrowserFlow -Times 1
+            Should -Invoke Save-JIMToken -Times 1 -ParameterFilter { $RefreshToken -eq 'fresh-rt' }
+            $result.Connected | Should -BeTrue
+        }
+    }
+
+    It 'Skips the cached-token path entirely when -Force is set' {
+        InModuleScope JIM {
+            $script:JIMConnection = $null
+            Mock Invoke-RestMethod { [PSCustomObject]@{ authority = 'https://idp/'; clientId = 'jim'; scopes = @('openid', 'offline_access') } }
+            Mock Get-OidcDiscoveryDocument { [PSCustomObject]@{ TokenEndpoint = 'https://idp/token'; AuthorizeEndpoint = 'https://idp/authorize' } }
+            Mock Test-JIMTokenPersistenceAvailable { $true }
+            Mock Invoke-JIMApi { [PSCustomObject]@{ status = 'Healthy' } }
+            Mock Get-JIMServerVersion { '1.2.3' }
+            Mock Show-JIMBanner { }
+            Mock Test-JIMAuthorisation { [PSCustomObject]@{ authorised = $true } }
+            Mock Save-JIMToken { $true }
+            Mock Get-JIMPersistedToken { 'cached-rt' }
+            Mock Invoke-OAuthBrowserFlow { [PSCustomObject]@{ AccessToken = 'at'; RefreshToken = 'fresh-rt'; ExpiresAt = (Get-Date).AddHours(1) } }
+
+            $null = Connect-JIMInteractive -BaseUrl 'https://jim.example.com' -Force
+
+            Should -Invoke Get-JIMPersistedToken -Times 0
+            Should -Invoke Invoke-OAuthBrowserFlow -Times 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the two Pester behaviours the #305 checklist called for but that were missing from the merged feature (#814): the silent **cached-token reconnect** path in `Connect-JIMInteractive` (no browser, re-persists the rotated token, falls back and clears a stale token on `invalid_grant`, and is skipped under `-Force`) and the **refresh write-back** in `Invoke-TokenRefresh` (persists on rotation when the session is persisted, skips under `-NoPersist`, and a failing save does not break the refresh).
- Tidies the last stale "sign in to the web portal first" message (the 403 path in `Invoke-JIMApiRequest`) to match the synchronisation/admin-provisioning wording shipped in #814, with a changelog note.
- Test-only plus one CLI error-message string; no behavioural code change.

## Test plan
- [x] PS-only change (`.ps1` + `.md`); the `dotnet build`/`test` gate does not apply per the CLAUDE.md exception list
- [x] Full PowerShell module Pester suite green: 711 passed, 0 failed
- [x] New tests: cached silent reconnect, stale-token fallback/clear, `-Force` bypass, write-back on rotation, `-NoPersist` skip, failing-save resilience

🤖 Generated with [Claude Code](https://claude.com/claude-code)