### PR TITLE
chore(deps): bump .NET base images to patch CVE-2026-45447

### DIFF
--- a/src/JIM.Scheduler/Dockerfile
+++ b/src/JIM.Scheduler/Dockerfile
@@ -7,7 +7,7 @@
 
 ARG VERSION=dev
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:d399699ebc8a27ab34665707ae6dc8f77ae478bd319444841a33a2b3840c5c9a AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:58318ab0733b63d3ac0d7609c46f2718244e623a176f45991ee01fad46fbf880 AS base
 ARG VERSION
 
 LABEL org.opencontainers.image.title="JIM Scheduler"
@@ -27,7 +27,7 @@ RUN mkdir -p /data/keys /var/log/jim \
 # Run as non-root for security (built-in 'app' user, UID 1654)
 USER app
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:c0790639332692a0d56cdd81ed581cfd24d040d9839764c138994866df89a3b6 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "./"]
 COPY ["VERSION", "./"]

--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -11,7 +11,7 @@ ARG VERSION=dev
 # to skip the expensive generation step in local dev builds.
 ARG OPENAPI_STAGE=openapi-gen
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:8c0b6857eab7b2aa57884c839bf4678414606bd7d17370f18a842ac5cf414711 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS base
 ARG VERSION
 
 LABEL org.opencontainers.image.title="JIM Web"
@@ -87,7 +87,7 @@ RUN dotnet publish "JIM.Web.csproj" -c Release -o /app/publish /p:UseAppHost=fal
 #
 # The output is written under /app/publish so that the final stage can pull
 # from either openapi-gen or publish using the same path.
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:8c0b6857eab7b2aa57884c839bf4678414606bd7d17370f18a842ac5cf414711 AS openapi-gen
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS openapi-gen
 WORKDIR /app/publish
 COPY --from=publish /app/publish .
 ENV JIM_OPENAPI_GENERATE=true \

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -7,7 +7,7 @@
 
 ARG VERSION=dev
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:d399699ebc8a27ab34665707ae6dc8f77ae478bd319444841a33a2b3840c5c9a AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:58318ab0733b63d3ac0d7609c46f2718244e623a176f45991ee01fad46fbf880 AS base
 ARG VERSION
 
 LABEL org.opencontainers.image.title="JIM Worker"
@@ -43,7 +43,7 @@ RUN mkdir -p /data/keys /var/log/jim /connector-files \
 # Run as non-root for security (built-in 'app' user, UID 1654)
 USER app
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:c0790639332692a0d56cdd81ed581cfd24d040d9839764c138994866df89a3b6 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "./"]
 COPY ["VERSION", "./"]


### PR DESCRIPTION
## Summary

Consolidates Dependabot PRs #816, #817, #818, #819, #820 into a single change that bumps all three .NET base image families across all three service Dockerfiles at once.

## Why one PR instead of merging the five individually

`scan-base-images` scans **every** Dockerfile's base image in the tree, not just the one a given PR changes. **CVE-2026-45447** (CVSS 8.0, HIGH, fixable) landed in the Trivy DB for the older `aspnet`/`runtime`/`sdk` digests. Each Dependabot PR only bumps one image, so once rebased onto `main` it still leaves the *other* services on vulnerable digests and trips the scan. The five PRs are mutually deadlocked: none can go green on its own. (#821 merged earlier only because its scan ran minutes before the CVE entered the Trivy DB.)

Bumping all three families together clears the CVE across the whole tree in a single pass, so the scan passes.

## Changes

| Image | Old | New | Services |
|-------|-----|-----|----------|
| `aspnet:10.0-noble` | `8c0b685` | `ddcf70a` | JIM.Web |
| `runtime:10.0-noble` | `d399699` | `58318ab` | JIM.Worker, JIM.Scheduler |
| `sdk:10.0-noble` | `c079063` | `548d93f` | JIM.Worker, JIM.Scheduler (JIM.Web already on it via #821) |

## Verification

- All pinned apt packages (`libldap-common`, `libldap2`, `cifs-utils`, `libgssapi-krb5-2`) confirmed to resolve at their exact pinned versions on the new `runtime` and `aspnet` digests.
- Each new digest has already passed `scan-base-images` post-CVE in CI on its respective Dependabot PR, confirming the fix.
- All within `10.0-noble`, Microsoft-published.

Supersedes #816, #817, #818, #819, #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)