### PR TITLE
fix: correct Admin breadcrumb link on admin sub-pages

### DIFF
--- a/src/JIM.Web/Pages/Admin/ApiKeyDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyDetail.razor
@@ -232,7 +232,7 @@ else if (!_loading)
         _breadcrumbs = new List<BreadcrumbItem>
         {
             new("Home", href: "/", icon: Icons.Material.Filled.Home),
-            new("Admin", href: "/admin/operations"),
+            new("Admin", href: "/admin"),
             new("API Keys", href: "/admin/apikeys"),
             new(_apiKey?.Name ?? "Not Found", href: null, disabled: true)
         };

--- a/src/JIM.Web/Pages/Admin/ApiKeyList.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyList.razor
@@ -283,7 +283,7 @@
     private readonly List<BreadcrumbItem> _breadcrumbs = new()
     {
         new("Home", href: "/", icon: Icons.Material.Filled.Home),
-        new("Admin", href: "/admin/operations"),
+        new("Admin", href: "/admin"),
         new("API Keys", href: null, disabled: true)
     };
 

--- a/src/JIM.Web/Pages/Admin/CertificateList.razor
+++ b/src/JIM.Web/Pages/Admin/CertificateList.razor
@@ -301,7 +301,7 @@
     private readonly List<BreadcrumbItem> _breadcrumbs = new()
 {
 new("Home", href: "/", icon: Icons.Material.Filled.Home),
-new("Admin", href: "/admin/operations"),
+new("Admin", href: "/admin"),
 new("Certificates", href: null, disabled: true)
 };
 

--- a/src/JIM.Web/Pages/Admin/DeletedObjects.razor
+++ b/src/JIM.Web/Pages/Admin/DeletedObjects.razor
@@ -299,7 +299,7 @@
     private readonly List<BreadcrumbItem> _breadcrumbs = new()
     {
         new("Home", href: "/", icon: Icons.Material.Filled.Home),
-        new("Admin", href: "/admin/operations"),
+        new("Admin", href: "/admin"),
         new("Deleted Objects", href: null, disabled: true)
     };
 

--- a/src/JIM.Web/Pages/Admin/Logs.razor
+++ b/src/JIM.Web/Pages/Admin/Logs.razor
@@ -280,7 +280,7 @@
     private readonly List<BreadcrumbItem> _breadcrumbs =
     [
         new("Home", href: "/", icon: Icons.Material.Filled.Home),
-        new("Admin", href: "/admin/operations"),
+        new("Admin", href: "/admin"),
         new("Logs", href: null, disabled: true)
     ];
 


### PR DESCRIPTION
## Summary
- Five admin pages had their "Admin" breadcrumb incorrectly linking to `/admin/operations` instead of `/admin`
- Affected pages: Deleted Objects, API Key List, API Key Detail, Logs, Certificate List
- Loading Preview was already correct; it was the only page not affected

## Test plan
- [x] `dotnet build JIM.sln` clean
- [x] Navigate to `/admin/deleted-objects` — "Admin" breadcrumb now links to `/admin`
- [x] Verified all five affected pages corrected in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)