### PR TITLE
fix: asserted-null guard + honest errors in MVO/CSO change tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 A completed example data generation Activity no longer shows a stale "Persisting to database..." progress line; the transient progress message is cleared when the Activity completes.
+- 🐛 Recording a Metaverse Object change for an asserted-null attribute value (a positively-asserted "no value" from a priority source) no longer crashes. The portal-driven change-tracking path was missing the asserted-null guard the synchronisation engine already had, so such markers fell through to an error; they are now correctly skipped, and genuinely corrupt or unconfigured attribute values now fail with an accurate error instead of a misleading "not yet supported" one.
 - 🐛 A factory reset no longer strips the built-in "Users & Groups" example data template of its attributes. The reset's bulk wipe removed them as a side effect (they share a foreign-key graph with Connected System schema), so generating example data after a reset produced objects with no attribute values. The built-in template is now restored as part of the reset, and repaired on startup if a previous reset left it incomplete, keeping the out-of-box configuration intact.
 
 ## [0.12.0] - 2026-06-23

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -1042,7 +1042,7 @@ public class ConnectedSystemServer
         else if (connectedSystem.ConnectorDefinition.Name == Connectors.ConnectorConstants.FileConnectorName)
             results.AddRange(new FileConnector().ValidateSettingValues(connectedSystem.SettingValues, Log.Logger));
         else
-            throw new NotImplementedException("Support for that connector definition has not been implemented yet."); // todo: support custom connectors.
+            throw new NotImplementedException("Support for that connector definition has not been implemented yet."); // todo (#875): centralise connector dispatch / support additional connector definitions.
 
         return results;
     }
@@ -1447,7 +1447,7 @@ public class ConnectedSystemServer
             partitions = await CreateConfiguredLdapConnector().GetPartitionsAsync(connectedSystem.SettingValues, Log.Logger);
             if (partitions.Count == 0)
             {
-                // todo: report to the user we attempted to retrieve partitions, but got none back
+                // todo (#876): report to the user we attempted to retrieve partitions, but got none back
             }
         }
         else
@@ -1508,7 +1508,7 @@ public class ConnectedSystemServer
             partitions = await CreateConfiguredLdapConnector().GetPartitionsAsync(connectedSystem.SettingValues, Log.Logger);
             if (partitions.Count == 0)
             {
-                // todo: report to the user we attempted to retrieve partitions, but got none back
+                // todo (#876): report to the user we attempted to retrieve partitions, but got none back
             }
         }
         else

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -3572,8 +3572,20 @@ public class ConnectedSystemServer
                 attributeChange.ValueChanges.Add(new ConnectedSystemObjectChangeAttributeValue(attributeChange, valueChangeType, connectedSystemObjectAttributeValue.UnresolvedReferenceValue));
                 break;
             case AttributeDataType.NotSet:
+                // The attribute has no data type configured; we cannot record a typed value change for it.
+                throw new InvalidDataException(
+                    $"AddChangeAttributeValueObject: attribute '{connectedSystemObjectAttributeValue.Attribute.Name}' has no data type configured (NotSet); cannot record a Connected System Object change for it.");
             default:
-                throw new InvalidDataException($"AddChangeAttributeValueObject:  Invalid removal attribute '{connectedSystemObjectAttributeValue.Attribute.Name}' of type '{connectedSystemObjectAttributeValue.Attribute.Type}' or null attribute value.");
+                // Reached when a *known*, switch-handled data type's value holder was unexpectedly null (a corrupt
+                // attribute value), or when the AttributeDataType enum has gained a member this switch does not yet
+                // handle. The message distinguishes the two; the exception type is deliberately kept uniform
+                // (InvalidDataException) because the deletion path's CaptureDeletedCsoAttributeValues catch filters
+                // on InvalidOperationException/InvalidDataException to degrade gracefully.
+                throw Enum.IsDefined(connectedSystemObjectAttributeValue.Attribute.Type)
+                    ? new InvalidDataException(
+                        $"AddChangeAttributeValueObject: attribute '{connectedSystemObjectAttributeValue.Attribute.Name}' of type '{connectedSystemObjectAttributeValue.Attribute.Type}' has no value; the Connected System Object attribute value is corrupt.")
+                    : new InvalidDataException(
+                        $"AddChangeAttributeValueObject: attribute '{connectedSystemObjectAttributeValue.Attribute.Name}' has an unhandled data type '{connectedSystemObjectAttributeValue.Attribute.Type}' for Connected System Object change tracking.");
         }
     }
 

--- a/src/JIM.Application/Servers/ExampleDataServer.cs
+++ b/src/JIM.Application/Servers/ExampleDataServer.cs
@@ -744,7 +744,7 @@ public class ExampleDataServer
         //if (dataGenerationTemplateAttribute.BoolTrueDistribution.HasValue)
         //{
         // a certain number of true values are required over the total number of objects created
-        // TODO: implement true value distribution logic
+        // TODO (#877): implement true value distribution logic
         //}
         //else
         //{

--- a/src/JIM.Application/Servers/ExampleDataServer.cs
+++ b/src/JIM.Application/Servers/ExampleDataServer.cs
@@ -671,7 +671,6 @@ public class ExampleDataServer
         Random random,
         ExampleDataValueTrackerStore trackerStore)
     {
-        // todo: make use of data gen value trackers to get next highest value
         if (dataGenerationTemplateAttribute.MetaverseAttribute == null)
             throw new ArgumentNullException(nameof(dataGenerationTemplateAttribute));
 
@@ -689,7 +688,6 @@ public class ExampleDataServer
         Random random,
         ExampleDataValueTrackerStore trackerStore)
     {
-        // todo: make use of data gen value trackers to get next highest value
         if (dataGenerationTemplateAttribute.MetaverseAttribute == null)
             throw new ArgumentNullException(nameof(dataGenerationTemplateAttribute));
 

--- a/src/JIM.Application/Servers/ExportEvaluationServer.cs
+++ b/src/JIM.Application/Servers/ExportEvaluationServer.cs
@@ -1462,7 +1462,7 @@ public class ExportEvaluationServer
                     // For Update operations with expressions, we need to check if any source attributes changed
                     // For simplicity, always include expression results for Create, but for Update we include them
                     // because expression results may depend on the changed attributes
-                    // TODO: Consider optimising by tracking which MVO attributes the expression depends on
+                    // TODO (#880): Consider optimising by tracking which MVO attributes the expression depends on
 
                     // Build expression context with MVO attributes (lazy initialization - only build once)
                     mvAttributeDictionary ??= BuildAttributeDictionary(mvo);

--- a/src/JIM.Application/Servers/MetaverseServer.cs
+++ b/src/JIM.Application/Servers/MetaverseServer.cs
@@ -546,6 +546,12 @@ public class MetaverseServer
         MetaverseObjectAttributeValue metaverseObjectAttributeValue,
         ValueChangeType valueChangeType)
     {
+        // Asserted-null markers (#91) carry no value; their addition/removal is an internal representation of
+        // "asserted null", not a tracked value. The meaningful change (the real value being cleared) is recorded
+        // via the removal of the real value, so skip the marker itself here. Mirrors SyncTaskProcessorBase.
+        if (metaverseObjectAttributeValue.NullValue)
+            return;
+
         var attributeChange = metaverseObjectChange.AttributeChanges.SingleOrDefault(
             ac => ac.Attribute!.Id == metaverseObjectAttributeValue.Attribute.Id);
 
@@ -614,9 +620,22 @@ public class MetaverseServer
             case AttributeDataType.Reference:
                 // Reference attribute with no resolved or unresolved value — nothing to track
                 break;
+            case AttributeDataType.NotSet:
+                // The attribute has no data type configured; we cannot record a typed value change for it.
+                throw new InvalidOperationException(
+                    $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) has no data type configured (NotSet); cannot record a Metaverse Object change for it.");
             default:
-                throw new NotImplementedException(
-                    $"Attribute data type {metaverseObjectAttributeValue.Attribute.Type} is not yet supported for MVO change tracking.");
+                // Reached only when a *known*, switch-handled data type's value holder was unexpectedly null on a
+                // row that is not an asserted-null marker (data corruption; the NullValue guard above already
+                // returned for legitimate asserted nulls), or when the AttributeDataType enum has gained a member
+                // this switch does not yet handle. Distinguish the two so the failure is honest.
+                throw Enum.IsDefined(metaverseObjectAttributeValue.Attribute.Type)
+                    ? new InvalidOperationException(
+                        $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) of type {metaverseObjectAttributeValue.Attribute.Type} has no value but is not an asserted-null marker; the Metaverse Object Attribute Value is corrupt.")
+                    : new ArgumentOutOfRangeException(
+                        nameof(metaverseObjectAttributeValue),
+                        metaverseObjectAttributeValue.Attribute.Type,
+                        "Unhandled attribute data type for Metaverse Object change tracking.");
         }
     }
 

--- a/src/JIM.Application/Servers/MetaverseServer.cs
+++ b/src/JIM.Application/Servers/MetaverseServer.cs
@@ -522,121 +522,19 @@ public class MetaverseServer
             ChangeInitiatorType = effectiveChangeInitiatorType
         };
 
-        // Create attribute change records (reuse helper from sync processor pattern)
+        // Create attribute change records
         foreach (var addition in additions)
         {
-            AddMvoChangeAttributeValueObject(change, addition, ValueChangeType.Add);
+            change.AddAttributeValueChange(addition, ValueChangeType.Add);
         }
 
         foreach (var removal in removals)
         {
-            AddMvoChangeAttributeValueObject(change, removal, ValueChangeType.Remove);
+            change.AddAttributeValueChange(removal, ValueChangeType.Remove);
         }
 
         // Add to MVO's Changes collection
         metaverseObject.Changes.Add(change);
-    }
-
-    /// <summary>
-    /// Helper method to create attribute change records for MVO changes.
-    /// Mirrors the pattern used in SyncTaskProcessorBase for consistency.
-    /// </summary>
-    internal static void AddMvoChangeAttributeValueObject(
-        MetaverseObjectChange metaverseObjectChange,
-        MetaverseObjectAttributeValue metaverseObjectAttributeValue,
-        ValueChangeType valueChangeType)
-    {
-        // Asserted-null markers (#91) carry no value; their addition/removal is an internal representation of
-        // "asserted null", not a tracked value. The meaningful change (the real value being cleared) is recorded
-        // via the removal of the real value, so skip the marker itself here. Mirrors SyncTaskProcessorBase.
-        if (metaverseObjectAttributeValue.NullValue)
-            return;
-
-        var attributeChange = metaverseObjectChange.AttributeChanges.SingleOrDefault(
-            ac => ac.Attribute!.Id == metaverseObjectAttributeValue.Attribute.Id);
-
-        if (attributeChange == null)
-        {
-            attributeChange = new MetaverseObjectChangeAttribute
-            {
-                Attribute = metaverseObjectAttributeValue.Attribute,
-                AttributeName = metaverseObjectAttributeValue.Attribute.Name,
-                AttributeType = metaverseObjectAttributeValue.Attribute.Type,
-                MetaverseObjectChange = metaverseObjectChange
-            };
-            metaverseObjectChange.AttributeChanges.Add(attributeChange);
-        }
-
-        switch (metaverseObjectAttributeValue.Attribute.Type)
-        {
-            case AttributeDataType.Text when metaverseObjectAttributeValue.StringValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, metaverseObjectAttributeValue.StringValue));
-                break;
-            case AttributeDataType.Number when metaverseObjectAttributeValue.IntValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, (int)metaverseObjectAttributeValue.IntValue));
-                break;
-            case AttributeDataType.LongNumber when metaverseObjectAttributeValue.LongValue != null:
-                // TODO: MetaverseObjectChangeAttributeValue needs LongValue support
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, (int)metaverseObjectAttributeValue.LongValue.Value));
-                break;
-            case AttributeDataType.Guid when metaverseObjectAttributeValue.GuidValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, (Guid)metaverseObjectAttributeValue.GuidValue));
-                break;
-            case AttributeDataType.Boolean when metaverseObjectAttributeValue.BoolValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, (bool)metaverseObjectAttributeValue.BoolValue));
-                break;
-            case AttributeDataType.DateTime when metaverseObjectAttributeValue.DateTimeValue.HasValue:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, metaverseObjectAttributeValue.DateTimeValue.Value));
-                break;
-            case AttributeDataType.Binary when metaverseObjectAttributeValue.ByteValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, true, metaverseObjectAttributeValue.ByteValue.Length));
-                break;
-            case AttributeDataType.Reference when metaverseObjectAttributeValue.ReferenceValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
-                    attributeChange, valueChangeType, metaverseObjectAttributeValue.ReferenceValue));
-                break;
-            case AttributeDataType.Reference when metaverseObjectAttributeValue.ReferenceValueId.HasValue:
-                // Navigation property not loaded but FK is set — record the FK directly on the
-                // change record so the ReferenceValue navigation can be materialised later via
-                // .Include. Happens during MVO deletion (referenced MVOs not in change tracker)
-                // and during projection (reference values populated via direct SQL).
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue
-                {
-                    MetaverseObjectChangeAttribute = attributeChange,
-                    ValueChangeType = valueChangeType,
-                    ReferenceValueId = metaverseObjectAttributeValue.ReferenceValueId.Value
-                });
-                break;
-            case AttributeDataType.Reference when metaverseObjectAttributeValue.UnresolvedReferenceValue != null:
-                // Don't track unresolved references
-                break;
-            case AttributeDataType.Reference:
-                // Reference attribute with no resolved or unresolved value — nothing to track
-                break;
-            case AttributeDataType.NotSet:
-                // The attribute has no data type configured; we cannot record a typed value change for it.
-                throw new InvalidOperationException(
-                    $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) has no data type configured (NotSet); cannot record a Metaverse Object change for it.");
-            default:
-                // Reached only when a *known*, switch-handled data type's value holder was unexpectedly null on a
-                // row that is not an asserted-null marker (data corruption; the NullValue guard above already
-                // returned for legitimate asserted nulls), or when the AttributeDataType enum has gained a member
-                // this switch does not yet handle. Distinguish the two so the failure is honest.
-                throw Enum.IsDefined(metaverseObjectAttributeValue.Attribute.Type)
-                    ? new InvalidOperationException(
-                        $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) of type {metaverseObjectAttributeValue.Attribute.Type} has no value but is not an asserted-null marker; the Metaverse Object Attribute Value is corrupt.")
-                    : new ArgumentOutOfRangeException(
-                        nameof(metaverseObjectAttributeValue),
-                        metaverseObjectAttributeValue.Attribute.Type,
-                        "Unhandled attribute data type for Metaverse Object change tracking.");
-        }
     }
 
     public async Task<MetaverseObject?> GetMetaverseObjectByTypeAndAttributeAsync(MetaverseObjectType metaverseObjectType, MetaverseAttribute metaverseAttribute, string attributeValue)
@@ -779,7 +677,7 @@ public class MetaverseServer
             // record preserves the final state of the object for audit purposes.
             foreach (var attributeValue in attributesToCapture)
             {
-                AddMvoChangeAttributeValueObject(change, attributeValue, ValueChangeType.Remove);
+                change.AddAttributeValueChange(attributeValue, ValueChangeType.Remove);
             }
 
             // Delete the MVO first, then save the change record afterwards.

--- a/src/JIM.Application/Servers/SyncServer.cs
+++ b/src/JIM.Application/Servers/SyncServer.cs
@@ -151,7 +151,7 @@ public class SyncServer : ISyncServer
             };
 
             foreach (var attributeValue in attributesToCapture)
-                MetaverseServer.AddMvoChangeAttributeValueObject(change, attributeValue, ValueChangeType.Remove);
+                change.AddAttributeValueChange(attributeValue, ValueChangeType.Remove);
 
             await _syncRepo.DeleteMetaverseObjectAsync(metaverseObject);
             await _syncRepo.CreateMetaverseObjectChangeDirectAsync(change);

--- a/src/JIM.Application/Utilities/ExportChangeHistoryBuilder.cs
+++ b/src/JIM.Application/Utilities/ExportChangeHistoryBuilder.cs
@@ -6,6 +6,8 @@ using JIM.Models.Core;
 using JIM.Models.Enums;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
+using JIM.Utilities;
+using Serilog;
 
 namespace JIM.Application.Utilities;
 
@@ -224,8 +226,13 @@ public static class ExportChangeHistoryBuilder
                 // RemoveAll changes may have null values — record the attribute change without a value
                 break;
             default:
-                // Skip unrecognised types rather than throwing — export change history
-                // is an audit feature, not a sync-critical path
+                // Skip unrecognised types rather than throwing — export change history is an audit feature, not a
+                // sync-critical path. Log it though: every real data type is handled above, so reaching here means an
+                // unconfigured (NotSet) attribute or a new AttributeDataType that this builder has not been taught.
+                Log.Warning(
+                    "ExportChangeHistoryBuilder.AddValueChange: skipped attribute '{AttributeName}' with unhandled data type {AttributeType}; no export change value recorded.",
+                    LogSanitiser.Sanitise(peChange.Attribute.Name),
+                    attrType);
                 break;
         }
     }

--- a/src/JIM.Connectors/File/FileConnector.cs
+++ b/src/JIM.Connectors/File/FileConnector.cs
@@ -474,7 +474,6 @@ public class FileConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     {
         logger.Verbose("ImportAsync() called");
 
-        // todo: see about changing this so it returns a ConnectedSystemImportResult with an error on it
         if (string.IsNullOrEmpty(runProfile.FilePath))
             throw new InvalidDataException($"ImportAsync: FilePath is missing or empty!");
 

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -390,7 +390,6 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     public Task<ConnectedSystemImportResult> ImportAsync(ConnectedSystem connectedSystem, ConnectedSystemRunProfile runProfile, List<ConnectedSystemPaginationToken> paginationTokens, string? persistedConnectorData, ILogger logger, CancellationToken cancellationToken)
     {
         logger.Verbose("ImportAsync() called");
-        // todo: wrap this in a task to eliminate the compiler warning. still needs to propagate exceptions and return values.
 
         if (_connection == null)
             throw new InvalidOperationException("Must call OpenImportConnection() before ImportAsync()!");

--- a/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
@@ -1538,7 +1538,7 @@ internal class LdapConnectorImport
 
         var importObjects = new List<ConnectedSystemImportObject>();
 
-        // todo: experiment with parallel foreach to see if we can speed up processing
+        // todo (#497): experiment with parallel foreach to see if we can speed up processing
         foreach (SearchResultEntry searchResult in searchResults)
         {
             if (_cancellationToken.IsCancellationRequested)

--- a/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
@@ -499,8 +499,8 @@ internal class LdapConnectorImport
     /// </summary>
     private int? QueryDirectoryForLastChangeNumber(int lastChangeNumber)
     {
-        // TODO: this needs optimising. If we pass in zero, do we really want to have to enumerate all changes to get the last change number?
-        // TODO: make sure this works with a range of directory implementations.
+        // TODO (#878): this needs optimising. If we pass in zero, do we really want to have to enumerate all changes to get the last change number?
+        // TODO (#878): make sure this works with a range of directory implementations.
 
         var ldapFilter = $"(&(!(cn=changelog))(changeNumber>={lastChangeNumber}))";
         var ldapRequest = new SearchRequest("cn=changelog", ldapFilter, SearchScope.Subtree);
@@ -804,7 +804,7 @@ internal class LdapConnectorImport
         }
 
         var stopwatch = Stopwatch.StartNew();
-        var ldapFilter = $"(objectClass={connectedSystemObjectType.Name})"; // todo: add in implicit support for returning containers/organisational units?
+        var ldapFilter = $"(objectClass={connectedSystemObjectType.Name})";
 
         // add user selected attributes
         var attributes = connectedSystemObjectType.Attributes.Where(a => a.Selected).Select(a => a.Name).ToList();

--- a/src/JIM.Connectors/LDAP/LdapConnectorSchema.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorSchema.cs
@@ -129,7 +129,7 @@ internal class LdapConnectorSchema
         foreach (var objectClassEntry in objectClassEntries)
             GetObjectClassAttributesRecursively(objectClassEntry, objectType);
 
-        // todo: it's possible there's some duplication of attributes going on due to attributes being specified on structural and auxiliary classes, so de-dupe before we return
+        // todo (#492): it's possible there's some duplication of attributes going on due to attributes being specified on structural and auxiliary classes, so de-dupe before we return
         objectType.Attributes = objectType.Attributes.OrderBy(q => q.Name).ToList();
 
         return true;

--- a/src/JIM.Models/Activities/Activity.cs
+++ b/src/JIM.Models/Activities/Activity.cs
@@ -308,14 +308,6 @@ public class Activity
     /// </summary>
     public List<ActivityRunProfileExecutionItem> RunProfileExecutionItems { get; init; } = new();
 
-    // -----------------------------------------------------------------------------------------------------------------
-    // object changes (created/update/delete)
-    // this would apply to all object types, i.e. Metaverse Object, Synchronisation Rules, Connected Systems, etc.
-    // todo:
-    // - json blob that contains object changes (might regret this later, but it seems quicker to get going this way)
-    // - some kind of access control for sensitive attribute values being logged, i.e. should someone reviewing the
-    //   audit log be able to see sensitive attribute values?
-
     public ActivityRunProfileExecutionItem AddRunProfileExecutionItem()
     {
         var activityRunProfileExecutionItem = PrepareRunProfileExecutionItem();

--- a/src/JIM.Models/Core/MetaverseObjectChange.cs
+++ b/src/JIM.Models/Core/MetaverseObjectChange.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using System.Linq;
 using JIM.Models.Activities;
 using JIM.Models.Enums;
 using JIM.Models.Logic;
@@ -105,4 +106,113 @@ public class MetaverseObjectChange
     /// If the object was deleted, the display name is preserved here for UI display in the deleted objects browser.
     /// </summary>
     public string? DeletedObjectDisplayName { get; set; }
+
+    /// <summary>
+    /// Records an attribute value change on this change record: finds (or creates) the
+    /// <see cref="MetaverseObjectChangeAttribute"/> for the value's attribute, then appends a typed
+    /// <see cref="MetaverseObjectChangeAttributeValue"/> describing the addition or removal. This is the single
+    /// source of truth for building a change record's attribute graph; both the synchronisation engine and the
+    /// portal-driven Metaverse Object operations route through it.
+    /// </summary>
+    /// <param name="value">The Metaverse Object attribute value being added or removed.</param>
+    /// <param name="valueChangeType">Whether the value is being added or removed.</param>
+    /// <exception cref="InvalidOperationException">
+    /// The attribute has no data type configured (<see cref="AttributeDataType.NotSet"/>), or a known data type's
+    /// value holder is null on a row that is not an asserted-null marker (a corrupt Metaverse Object Attribute Value).
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">The attribute's data type is not handled by this method.</exception>
+    public void AddAttributeValueChange(MetaverseObjectAttributeValue value, ValueChangeType valueChangeType)
+    {
+        // Asserted-null markers (#91) carry no value; their addition/removal is an internal representation of
+        // "asserted null", not a tracked value. The meaningful change (the real value being cleared) is recorded
+        // via the removal of the real value, so skip the marker itself here. Richer asserted-null history is the
+        // SyncOutcome surface (#363), not the attribute value-change log.
+        if (value.NullValue)
+            return;
+
+        var attributeChange = AttributeChanges.SingleOrDefault(ac => ac.Attribute!.Id == value.Attribute.Id);
+        if (attributeChange == null)
+        {
+            attributeChange = new MetaverseObjectChangeAttribute
+            {
+                Attribute = value.Attribute,
+                AttributeName = value.Attribute.Name,
+                AttributeType = value.Attribute.Type,
+                MetaverseObjectChange = this
+            };
+            AttributeChanges.Add(attributeChange);
+        }
+
+        switch (value.Attribute.Type)
+        {
+            case AttributeDataType.Text when value.StringValue != null:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, value.StringValue));
+                break;
+            case AttributeDataType.Number when value.IntValue != null:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, (int)value.IntValue));
+                break;
+            case AttributeDataType.LongNumber when value.LongValue != null:
+                // #871: MetaverseObjectChangeAttributeValue has no long storage; this narrows to int and can
+                // truncate values outside Int32 range. Tracked for an end-to-end Int64 audit.
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, (int)value.LongValue.Value));
+                break;
+            case AttributeDataType.Guid when value.GuidValue != null:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, (Guid)value.GuidValue));
+                break;
+            case AttributeDataType.Boolean when value.BoolValue != null:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, (bool)value.BoolValue));
+                break;
+            case AttributeDataType.DateTime when value.DateTimeValue.HasValue:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, value.DateTimeValue.Value));
+                break;
+            case AttributeDataType.Binary when value.ByteValue != null:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, true, value.ByteValue.Length));
+                break;
+            case AttributeDataType.Reference when value.ReferenceValue != null:
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(
+                    attributeChange, valueChangeType, value.ReferenceValue));
+                break;
+            case AttributeDataType.Reference when value.ReferenceValueId.HasValue:
+                // Navigation property not loaded but FK is set — record the FK directly on the
+                // change record so the ReferenceValue navigation can be materialised later via
+                // .Include. Happens during MVO deletion (referenced MVOs not in change tracker)
+                // and during projection (reference values populated via direct SQL).
+                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue
+                {
+                    MetaverseObjectChangeAttribute = attributeChange,
+                    ValueChangeType = valueChangeType,
+                    ReferenceValueId = value.ReferenceValueId.Value
+                });
+                break;
+            case AttributeDataType.Reference when value.UnresolvedReferenceValue != null:
+                // Don't track unresolved references
+                break;
+            case AttributeDataType.Reference:
+                // Reference attribute with no resolved or unresolved value — nothing to track
+                break;
+            case AttributeDataType.NotSet:
+                // The attribute has no data type configured; we cannot record a typed value change for it.
+                throw new InvalidOperationException(
+                    $"Attribute '{value.Attribute.Name}' (id {value.Attribute.Id}) has no data type configured (NotSet); cannot record a Metaverse Object change for it.");
+            default:
+                // Reached only when a *known*, switch-handled data type's value holder was unexpectedly null on a
+                // row that is not an asserted-null marker (data corruption; the NullValue guard above already
+                // returned for legitimate asserted nulls), or when the AttributeDataType enum has gained a member
+                // this switch does not yet handle. Distinguish the two so the failure is honest.
+                throw Enum.IsDefined(value.Attribute.Type)
+                    ? new InvalidOperationException(
+                        $"Attribute '{value.Attribute.Name}' (id {value.Attribute.Id}) of type {value.Attribute.Type} has no value but is not an asserted-null marker; the Metaverse Object Attribute Value is corrupt.")
+                    : new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value.Attribute.Type,
+                        "Unhandled attribute data type for Metaverse Object change tracking.");
+        }
+    }
 }

--- a/src/JIM.Models/Security/Role.cs
+++ b/src/JIM.Models/Security/Role.cs
@@ -73,7 +73,7 @@ public class Role : IAuditable
     /// </summary>
     public List<MetaverseObject> StaticMembers { get; set; } = new();
 
-    // todo: resource scope
-    // todo: permissions
-    // todo: dynamic membership
+    // todo (#622): resource scope
+    // todo (#622): permissions
+    // todo (#622): dynamic membership
 }

--- a/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
+++ b/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
@@ -957,7 +957,7 @@ public class MetaverseRepository : IMetaverseRepository
                 // More err...
             }
 
-            // todo: handle group nesting as well
+            // todo (#850): handle group nesting as well
         }
 
         // Apply search filter - searches across all attribute values

--- a/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
+++ b/src/JIM.PostgresData/Repositories/MetaverseRepository.cs
@@ -850,7 +850,7 @@ public class MetaverseRepository : IMetaverseRepository
                 objects = objects.OrderByDescending(q => q.Created);
                 break;
 
-            // todo: support more ways of sorting, i.e. by attribute value
+            // todo (#813): support more ways of sorting, i.e. by attribute value
         }
 
         // now just retrieve a page's worth of images from the results

--- a/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
@@ -348,7 +348,7 @@ public class SyncImportTaskProcessor
 
                 // Progress is now initialised inside ProcessImportObjectsAsync
 
-                // todo: simplify externalIdsImported. objects are unnecessarily complex
+                // todo (#879): simplify externalIdsImported. objects are unnecessarily complex
                 // add the external ids from the results to our external id collection for later deletion calculation
                 AddExternalIdsToCollection(result, externalIdsImported);
 
@@ -1129,7 +1129,7 @@ public class SyncImportTaskProcessor
                     activityRunProfileExecutionItem.ErrorType = ActivityRunProfileExecutionItemErrorType.DuplicateImportedAttributes;
                     activityRunProfileExecutionItem.ErrorMessage = $"The imported object has one or more duplicate attributes: {string.Join(", ", duplicateAttributeNames)}. Please de-duplicate and try again.";
 
-                    // todo: include a serialised snapshot of the imported object that is also presented to sync admin when viewing sync errors
+                    // todo (#874): include a serialised snapshot of the imported object that is also presented to sync admin when viewing sync errors
                     continue;
                 }
 
@@ -2027,7 +2027,7 @@ public class SyncImportTaskProcessor
                         // there will be only a single value for a bool. is it the same or different?
                         // if different, remove the old value, add the new one
                         // observation: removing and adding SVA values is costlier than just updating a row. it also results in increased primary key usage, i.e. constantly generating new values
-                        // todo: consider having the ability to update values instead of replacing.
+                        // todo (#872): consider having the ability to update values instead of replacing.
                         var csoBooleanAttributeValue = connectedSystemObject.AttributeValues.SingleOrDefault(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id);
                         if (csoBooleanAttributeValue == null)
                         {
@@ -2339,7 +2339,7 @@ public class SyncImportTaskProcessor
                 else
                 {
                     // reference not found. referenced object probably out of container scope!
-                    // todo: make it a per-Connected System setting whether to raise an error, or ignore. sometimes this is desirable.
+                    // todo (#873): make it a per-Connected System setting whether to raise an error, or ignore. sometimes this is desirable.
                     rpeiLookup.TryGetValue(cso, out var activityRunProfileExecutionItem);
                     if (activityRunProfileExecutionItem != null && (activityRunProfileExecutionItem.ErrorType == null || activityRunProfileExecutionItem.ErrorType == ActivityRunProfileExecutionItemErrorType.NotSet))
                     {

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -2688,8 +2688,22 @@ public abstract class SyncTaskProcessorBase
             case AttributeDataType.Reference:
                 // Reference attribute with no resolved or unresolved value — nothing to track
                 break;
+            case AttributeDataType.NotSet:
+                // The attribute has no data type configured; we cannot record a typed value change for it.
+                throw new InvalidOperationException(
+                    $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) has no data type configured (NotSet); cannot record a Metaverse Object change for it.");
             default:
-                throw new NotImplementedException($"Attribute data type {metaverseObjectAttributeValue.Attribute.Type} is not yet supported for MVO change tracking.");
+                // Reached only when a *known*, switch-handled data type's value holder was unexpectedly null on a
+                // row that is not an asserted-null marker (data corruption; the NullValue guard above already
+                // returned for legitimate asserted nulls), or when the AttributeDataType enum has gained a member
+                // this switch does not yet handle. Distinguish the two so the failure is honest.
+                throw Enum.IsDefined(metaverseObjectAttributeValue.Attribute.Type)
+                    ? new InvalidOperationException(
+                        $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) of type {metaverseObjectAttributeValue.Attribute.Type} has no value but is not an asserted-null marker; the Metaverse Object Attribute Value is corrupt.")
+                    : new ArgumentOutOfRangeException(
+                        nameof(metaverseObjectAttributeValue),
+                        metaverseObjectAttributeValue.Attribute.Type,
+                        "Unhandled attribute data type for Metaverse Object change tracking.");
         }
     }
 

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -2574,13 +2574,13 @@ public abstract class SyncTaskProcessorBase
             // Create attribute change records for additions
             foreach (var addition in additions)
             {
-                AddMvoChangeAttributeValueObject(change, addition, ValueChangeType.Add);
+                change.AddAttributeValueChange(addition, ValueChangeType.Add);
             }
 
             // Create attribute change records for removals
             foreach (var removal in removals)
             {
-                AddMvoChangeAttributeValueObject(change, removal, ValueChangeType.Remove);
+                change.AddAttributeValueChange(removal, ValueChangeType.Remove);
             }
 
             // Route to the appropriate persistence queue based on whether the parent
@@ -2613,99 +2613,6 @@ public abstract class SyncTaskProcessorBase
         _pendingMvoChangeAttributesToPersist.Clear();
     }
 
-    /// <summary>
-    /// Creates the necessary attribute change audit item for when an MVO is updated or deleted, and adds it to the change object.
-    /// </summary>
-    /// <param name="metaverseObjectChange">The MetaverseObjectChange being built.</param>
-    /// <param name="metaverseObjectAttributeValue">The attribute and value pair for the change.</param>
-    /// <param name="valueChangeType">The type of change (Add or Remove).</param>
-    private static void AddMvoChangeAttributeValueObject(MetaverseObjectChange metaverseObjectChange, MetaverseObjectAttributeValue metaverseObjectAttributeValue, ValueChangeType valueChangeType)
-    {
-        // Asserted-null markers (#91) carry no value; their addition/removal is an internal representation of
-        // "asserted null", not a tracked value. The meaningful change (the real value being cleared) is recorded via
-        // the removal of the real value, so skip the marker itself here. Richer asserted-null history is the
-        // SyncOutcome surface (#363), not the attribute value-change log.
-        if (metaverseObjectAttributeValue.NullValue)
-            return;
-
-        var attributeChange = metaverseObjectChange.AttributeChanges.SingleOrDefault(ac => ac.Attribute!.Id == metaverseObjectAttributeValue.Attribute.Id);
-        if (attributeChange == null)
-        {
-            // Create the attribute change object that provides an audit trail of changes to an MVO's attributes
-            attributeChange = new MetaverseObjectChangeAttribute
-            {
-                Attribute = metaverseObjectAttributeValue.Attribute,
-                AttributeName = metaverseObjectAttributeValue.Attribute.Name,
-                AttributeType = metaverseObjectAttributeValue.Attribute.Type,
-                MetaverseObjectChange = metaverseObjectChange
-            };
-            metaverseObjectChange.AttributeChanges.Add(attributeChange);
-        }
-
-        switch (metaverseObjectAttributeValue.Attribute.Type)
-        {
-            case AttributeDataType.Text when metaverseObjectAttributeValue.StringValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, metaverseObjectAttributeValue.StringValue));
-                break;
-            case AttributeDataType.Number when metaverseObjectAttributeValue.IntValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, (int)metaverseObjectAttributeValue.IntValue));
-                break;
-            case AttributeDataType.LongNumber when metaverseObjectAttributeValue.LongValue != null:
-                // TODO: MetaverseObjectChangeAttributeValue model needs LongValue property and constructor
-                // For now, cast to int (may lose precision for very large longs)
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, (int)metaverseObjectAttributeValue.LongValue.Value));
-                break;
-            case AttributeDataType.Guid when metaverseObjectAttributeValue.GuidValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, (Guid)metaverseObjectAttributeValue.GuidValue));
-                break;
-            case AttributeDataType.Boolean when metaverseObjectAttributeValue.BoolValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, (bool)metaverseObjectAttributeValue.BoolValue));
-                break;
-            case AttributeDataType.DateTime when metaverseObjectAttributeValue.DateTimeValue.HasValue:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, metaverseObjectAttributeValue.DateTimeValue.Value));
-                break;
-            case AttributeDataType.Binary when metaverseObjectAttributeValue.ByteValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, true, metaverseObjectAttributeValue.ByteValue.Length));
-                break;
-            case AttributeDataType.Reference when metaverseObjectAttributeValue.ReferenceValue != null:
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue(attributeChange, valueChangeType, metaverseObjectAttributeValue.ReferenceValue));
-                break;
-            case AttributeDataType.Reference when metaverseObjectAttributeValue.ReferenceValueId.HasValue:
-                // Navigation property not loaded but FK is set — record the FK directly on the
-                // change record so the ReferenceValue navigation can be materialised later via
-                // .Include. Happens when ReferenceValue navigations aren't loaded via EF Include
-                // (replaced by direct SQL PopulateReferenceValuesAsync on the CSO side).
-                attributeChange.ValueChanges.Add(new MetaverseObjectChangeAttributeValue
-                {
-                    MetaverseObjectChangeAttribute = attributeChange,
-                    ValueChangeType = valueChangeType,
-                    ReferenceValueId = metaverseObjectAttributeValue.ReferenceValueId.Value
-                });
-                break;
-            case AttributeDataType.Reference when metaverseObjectAttributeValue.UnresolvedReferenceValue != null:
-                // We do not log changes for unresolved references. Only resolved references get change tracked.
-                break;
-            case AttributeDataType.Reference:
-                // Reference attribute with no resolved or unresolved value — nothing to track
-                break;
-            case AttributeDataType.NotSet:
-                // The attribute has no data type configured; we cannot record a typed value change for it.
-                throw new InvalidOperationException(
-                    $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) has no data type configured (NotSet); cannot record a Metaverse Object change for it.");
-            default:
-                // Reached only when a *known*, switch-handled data type's value holder was unexpectedly null on a
-                // row that is not an asserted-null marker (data corruption; the NullValue guard above already
-                // returned for legitimate asserted nulls), or when the AttributeDataType enum has gained a member
-                // this switch does not yet handle. Distinguish the two so the failure is honest.
-                throw Enum.IsDefined(metaverseObjectAttributeValue.Attribute.Type)
-                    ? new InvalidOperationException(
-                        $"Attribute '{metaverseObjectAttributeValue.Attribute.Name}' (id {metaverseObjectAttributeValue.Attribute.Id}) of type {metaverseObjectAttributeValue.Attribute.Type} has no value but is not an asserted-null marker; the Metaverse Object Attribute Value is corrupt.")
-                    : new ArgumentOutOfRangeException(
-                        nameof(metaverseObjectAttributeValue),
-                        metaverseObjectAttributeValue.Attribute.Type,
-                        "Unhandled attribute data type for Metaverse Object change tracking.");
-        }
-    }
 
     /// <summary>
     /// Attempts to find a Metaverse Object that matches the CSO using Object Matching Rules on any applicable Synchronisation Rules for this system and object type.

--- a/test/JIM.Worker.Tests/Servers/MetaverseServerChangeTrackingTests.cs
+++ b/test/JIM.Worker.Tests/Servers/MetaverseServerChangeTrackingTests.cs
@@ -733,4 +733,62 @@ public class MetaverseServerChangeTrackingTests
     }
 
     #endregion
+
+    #region Asserted-null and unsupported-type handling
+
+    [Test]
+    public void AddMvoChangeAttributeValueObject_AssertedNullMarker_IsSkipped()
+    {
+        // Arrange — an asserted-null marker (#91): every value holder is null but the row carries
+        // provenance via NullValue. This is legitimate data, not corruption, and must be skipped
+        // (mirroring SyncTaskProcessorBase) rather than falling through to the default case.
+        var change = new MetaverseObjectChange();
+        var attrValue = new MetaverseObjectAttributeValue
+        {
+            Attribute = _displayNameAttr,
+            StringValue = null,
+            NullValue = true
+        };
+
+        // Act & Assert — skipped without throwing, and no value change recorded
+        Assert.DoesNotThrow(() =>
+            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add));
+        Assert.That(change.AttributeChanges, Is.Empty);
+    }
+
+    [Test]
+    public void AddMvoChangeAttributeValueObject_NotSetType_ThrowsInvalidOperation()
+    {
+        // Arrange — an attribute with no data type configured (NotSet). This is a misconfiguration,
+        // not an unimplemented code path, so it must surface as InvalidOperationException.
+        var change = new MetaverseObjectChange();
+        var notSetAttr = new MetaverseAttribute { Id = 99, Name = "Misconfigured", Type = AttributeDataType.NotSet };
+        var attrValue = new MetaverseObjectAttributeValue { Attribute = notSetAttr, StringValue = "value" };
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() =>
+            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add));
+    }
+
+    [Test]
+    public void AddMvoChangeAttributeValueObject_KnownTypeWithNullValueHolder_ThrowsForCorruption()
+    {
+        // Arrange — a Text attribute whose StringValue is null but which is NOT an asserted-null marker.
+        // A real value row always populates its holder, so this is a corrupt Metaverse Object Attribute
+        // Value. It must hard-fail (synchronisation integrity) with an honest corruption error, not a
+        // misleading "Text is not yet supported".
+        var change = new MetaverseObjectChange();
+        var attrValue = new MetaverseObjectAttributeValue
+        {
+            Attribute = _displayNameAttr,
+            StringValue = null,
+            NullValue = false
+        };
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() =>
+            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add));
+    }
+
+    #endregion
 }

--- a/test/JIM.Worker.Tests/Servers/MetaverseServerChangeTrackingTests.cs
+++ b/test/JIM.Worker.Tests/Servers/MetaverseServerChangeTrackingTests.cs
@@ -672,7 +672,7 @@ public class MetaverseServerChangeTrackingTests
         };
 
         // Act
-        JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add);
+        change.AddAttributeValueChange(attrValue, ValueChangeType.Add);
 
         // Assert
         var attrChange = change.AttributeChanges.Single();
@@ -698,7 +698,7 @@ public class MetaverseServerChangeTrackingTests
         };
 
         // Act
-        JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Remove);
+        change.AddAttributeValueChange(attrValue, ValueChangeType.Remove);
 
         // Assert — FK recorded on the change record so the ReferenceValue navigation can be
         // loaded later via .Include; rendered as a linked MVO chip in the activity UI.
@@ -726,7 +726,7 @@ public class MetaverseServerChangeTrackingTests
 
         // Act & Assert — should not throw
         Assert.DoesNotThrow(() =>
-            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Remove));
+            change.AddAttributeValueChange(attrValue, ValueChangeType.Remove));
 
         // No value change recorded (nothing to track)
         Assert.That(change.AttributeChanges.Single().ValueChanges, Is.Empty);
@@ -752,7 +752,7 @@ public class MetaverseServerChangeTrackingTests
 
         // Act & Assert — skipped without throwing, and no value change recorded
         Assert.DoesNotThrow(() =>
-            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add));
+            change.AddAttributeValueChange(attrValue, ValueChangeType.Add));
         Assert.That(change.AttributeChanges, Is.Empty);
     }
 
@@ -767,7 +767,7 @@ public class MetaverseServerChangeTrackingTests
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() =>
-            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add));
+            change.AddAttributeValueChange(attrValue, ValueChangeType.Add));
     }
 
     [Test]
@@ -787,7 +787,7 @@ public class MetaverseServerChangeTrackingTests
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() =>
-            JIM.Application.Servers.MetaverseServer.AddMvoChangeAttributeValueObject(change, attrValue, ValueChangeType.Add));
+            change.AddAttributeValueChange(attrValue, ValueChangeType.Add));
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- **Fix:** `MetaverseServer` change-tracking was missing the asserted-null (#91) guard that the sync engine already had, so an asserted-null marker (all value holders null, `NullValue` set) fell through to the default case and threw on legitimate data. Added the guard so markers are skipped.
- **Honest errors (MVO):** replaced the misleading `NotImplementedException` default (which conflated three distinct conditions) with `InvalidOperationException` for `NotSet`/corrupt values and `ArgumentOutOfRangeException` for genuinely unhandled enum members.
- **Dedup:** consolidated the two byte-identical change-tracking builders into one domain method, `MetaverseObjectChange.AddAttributeValueChange(...)` in `JIM.Models`, and deleted both static copies. This duplication is what let the guard drift out of one copy.
- **Honest errors (CSO):** mirrored the cleanup on the Connected System Object builders, split `NotSet` from `default`, fixed the misleading "Invalid removal attribute" wording, and made `ExportChangeHistoryBuilder`'s default log instead of silently swallowing.
- **TODO triage:** cross-referenced tracked TODOs with their issues (#492/#497/#622/#850/#813), dropped stale/superseded ones, and filed #872-#881 for the live ones (milestoned, Size+Priority set; #875 parents the connector issues).

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings)
- [x] `dotnet test JIM.sln` clean (all projects pass; 14 pre-existing skips)
- [x] New tests cover the asserted-null skip, the `NotSet` case, and the corrupt-value case

🤖 Generated with [Claude Code](https://claude.com/claude-code)