### PR TITLE
fix(deps): pin Microsoft.OpenApi to 2.7.5 (clears high-severity advisory breaking all builds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- 🐛 Updated the bundled Microsoft.OpenApi library to a patched release (2.7.5), clearing a high-severity advisory (GHSA-v5pm-xwqc-g5wc: circular schema references could terminate OpenAPI document parsing) present in JIM's API documentation generation.
 - 🐛 A Connected System hierarchy refresh that retrieves no partitions no longer wipes the configured hierarchy. Previously, if the connector returned zero partitions (typically a transient connection, authentication, or scope problem rather than a genuinely empty directory), every existing partition and container, including selected ones, was treated as removed and deleted. JIM now leaves the existing hierarchy untouched in that case and records a warning on the Activity so the cause can be investigated.
 - 🐛 A completed example data generation Activity no longer shows a stale "Persisting to database..." progress line; the transient progress message is cleared when the Activity completes.
 - 🐛 Recording a Metaverse Object change for an asserted-null attribute value (a positively-asserted "no value" from a priority source) no longer crashes. The portal-driven change-tracking path was missing the asserted-null guard the synchronisation engine already had, so such markers fell through to an error; they are now correctly skipped, and genuinely corrupt or unconfigured attribute values now fail with an accurate error instead of a misleading "not yet supported" one.

--- a/src/JIM.Web/JIM.Web.csproj
+++ b/src/JIM.Web/JIM.Web.csproj
@@ -24,6 +24,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Direct pin to override the vulnerable Microsoft.OpenApi 2.0.0 pulled in transitively by
+         Microsoft.AspNetCore.OpenApi 10.0.9. 2.7.5 is the first patched release for GHSA-v5pm-xwqc-g5wc
+         ("Circular schema references may terminate OpenAPI parsing", high). Remove once the parent
+         package references a patched version. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.6" />
     <PackageReference Include="MudBlazor" Version="9.6.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes the repo-wide build break from a freshly-published high-severity advisory on the transitive `Microsoft.OpenApi 2.0.0` ([GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc), "Circular schema references may terminate OpenAPI parsing").

`Microsoft.AspNetCore.OpenApi 10.0.9` pulls in `Microsoft.OpenApi 2.0.0`, which is in the vulnerable range (`>= 2.0.0-preview11, <= 2.7.4`). With `TreatWarningsAsErrors`, the NU1903 audit warning fails every build on `main`. This pins a direct reference to `2.7.5` (the first patched release, Microsoft-maintained, same major version) to override the transitive version. Remove once the parent package references a patched Microsoft.OpenApi.

- Build: `dotnet build JIM.sln` clean, audit on (0/0).
- Tests: full suite green (1738 passed, 0 failed, 29 skipped).

Docs: n/a - dependency security patch, no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)