### PR TITLE
fix(worker): bump cifs-utils apt pin to restore Docker builds

### DIFF
--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libldap-common=2.6.10+dfsg-0ubuntu0.24.04.1 \
         libldap2=2.6.10+dfsg-0ubuntu0.24.04.1 \
-        cifs-utils=2:7.0-2ubuntu0.2 \
+        cifs-utils=2:7.0-2ubuntu0.3 \
         libgssapi-krb5-2=1.20.1-6ubuntu2.6 \
     && rm -rf /var/lib/apt/lists/* \
     # Symlink for System.DirectoryServices.Protocols compatibility


### PR DESCRIPTION
## Problem

Every Docker build (\`jim-build\`, \`jim-stack\`, integration tests, CI) is currently failing at the \`jim.worker\` image's apt layer:

\`\`\`
E: Version '2:7.0-2ubuntu0.2' for 'cifs-utils' was not found
\`\`\`

Ubuntu Noble keeps only the latest point release of each package in its archive. \`cifs-utils\` was updated from \`2:7.0-2ubuntu0.2\` to the security release \`2:7.0-2ubuntu0.3\` (noble-updates / noble-security), and the old version was withdrawn, so the pinned \`apt-get install\` 404s. This is upstream bit-rot, not a code change; the .NET solution compiles cleanly.

## Fix

Bump the single pin in \`src/JIM.Worker/Dockerfile\` to \`cifs-utils=2:7.0-2ubuntu0.3\`. The pin stays in place (per the dependency-pinning policy); it just tracks the current security release. The other three apt pins (\`libldap-common\`, \`libldap2\`, \`libgssapi-krb5-2\`) are still available and unchanged. It is the only Dockerfile pinning \`cifs-utils\`.

## Verification

Ran the full \`jim-build\` Docker build locally: **jim.web, jim.worker and jim.scheduler all build (exit 0)**.

Docs: n/a - build-infrastructure fix (apt pin), no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)