### PR TITLE
API Endpoint Coverage Expansion: Worker Tasks, Example Data Sets, CSO list, FileSystem/Logs/Attribute Priority cmdlets (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ Example data generation templates can now construct a text attribute from an expression, using the same `mv["Attribute Name"]` syntax and function library as Synchronisation Rule Attribute Flows, so a generated value can be transformed from other attributes on the same object (for example an email domain derived from the assigned company). Referenced attributes are generated first, and circular references are detected up front.
 - ✨ Metaverse attributes contributed by more than one Connected System now resolve to a single winner by a configurable per-attribute priority order, so a higher-priority source is never overwritten by a lower-priority one. An advanced "Null is a value" option lets an authoritative source positively assert "no value", clearing the attribute downstream instead of falling through to a lower-priority source.
 
+#### API & PowerShell Coverage (#154)
+
+- ✨ Connected System Objects can now be listed and filtered via a paginated REST endpoint and the extended `Get-JIMConnectedSystemObject` cmdlet, rather than needing to be looked up one at a time.
+- ✨ Example Data Sets now support full create, update, and delete via the REST API and the new `New-`, `Set-`, and `Remove-JIMExampleDataSet` cmdlets, in addition to the existing read access.
+- ✨ Queued and in-progress background operations can now be listed, inspected, and cancelled remotely via a new Worker Tasks REST endpoint and the `Get-JIMWorkerTask` / `Stop-JIMWorkerTask` cmdlets.
+- ✨ File system browsing, log viewing, and Metaverse Attribute priority management (previously UI-only) are now available as PowerShell cmdlets, giving the module full parity with the REST API.
+
 ### Changed
 
 - 🔄 When more than one Connected System contributes to the same Metaverse attribute, JIM now resolves the value by attribute priority instead of by synchronisation timing (last-writer-wins). Single-source attributes are unaffected; existing multi-source attributes resolve deterministically until you set an explicit priority order.

--- a/docs/powershell/connected-systems.md
+++ b/docs/powershell/connected-systems.md
@@ -616,7 +616,16 @@ Retrieves connector space objects (CSOs) from a Connected System, with support f
 ### Syntax
 
 ```powershell
-# ById (default)
+# List (default)
+Get-JIMConnectedSystemObject -ConnectedSystemId <int> [-Search <string>] [-Status <string>]
+    [-ObjectTypeId <int>] [-JoinType <string>] [-SortBy <string>] [-Ascending]
+    [-Page <int>] [-PageSize <int>]
+
+# ListAll
+Get-JIMConnectedSystemObject -ConnectedSystemId <int> -All [-Search <string>] [-Status <string>]
+    [-ObjectTypeId <int>] [-JoinType <string>] [-SortBy <string>] [-Ascending] [-PageSize <int>]
+
+# ById
 Get-JIMConnectedSystemObject -ConnectedSystemId <int> -Id <guid>
 
 # AttributeValues
@@ -633,19 +642,37 @@ Get-JIMConnectedSystemObject -ConnectedSystemId <int> -Id <guid>
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `ConnectedSystemId` | `int` | Yes | | Connected System identifier |
-| `Id` | `guid` | Yes | | Connector space object identifier |
+| `Id` | `guid` | Yes (ById/AttributeValues sets) | | Connector space object identifier |
 | `AttributeName` | `string` | No | | Name of a multi-valued attribute to page through |
-| `Search` | `string` | No | | Filter attribute values by search term |
-| `Page` | `int` | No | `1` | Page number for attribute value results |
-| `PageSize` | `int` | No | `50` | Number of attribute values per page (maximum 100) |
-| `All` | `switch` | No | `$false` | Returns all attribute values without paging |
+| `Search` | `string` | No | | Filter attribute values, or filter the object list by display name/external ID |
+| `Status` | `string` | No | | Filter the object list by status: `Normal`, `Obsolete`, `PendingProvisioning` |
+| `ObjectTypeId` | `int` | No | | Filter the object list by Connected System Object Type |
+| `JoinType` | `string` | No | | Filter the object list by join type: `NotJoined`, `Projected`, `Provisioned`, `Joined` |
+| `SortBy` | `string` | No | | Property name to sort the object list by |
+| `Ascending` | `switch` | No | `$false` | Sort the object list ascending instead of the default descending |
+| `Page` | `int` | No | `1` | Page number for paginated results |
+| `PageSize` | `int` | No | `50` | Number of results per page (maximum 100) |
+| `All` | `switch` | No | `$false` | Returns all objects, or all attribute values, without paging |
 
 ### Output
 
+- **List / ListAll**: Lightweight headers for each Connected System Object matching the filters.
 - **ById**: A connector space object with its attributes and current values.
 - **AttributeValues / AttributeValuesAll**: Paged or complete list of values for the specified multi-valued attribute.
 
 ### Examples
+
+```powershell title="List objects in a Connected System"
+Get-JIMConnectedSystemObject -ConnectedSystemId 3
+```
+
+```powershell title="Find Obsolete objects matching a search term"
+Get-JIMConnectedSystemObject -ConnectedSystemId 3 -Search "smith" -Status Obsolete
+```
+
+```powershell title="Get every object in a Connected System"
+Get-JIMConnectedSystemObject -ConnectedSystemId 3 -All
+```
 
 ```powershell title="Get a specific connector space object"
 Get-JIMConnectedSystemObject -ConnectedSystemId 3 -Id "a1b2c3d4-e5f6-7890-abcd-ef1234567890"

--- a/docs/powershell/example-data.md
+++ b/docs/powershell/example-data.md
@@ -10,18 +10,23 @@ Cmdlets for generating sample identity data for testing and evaluation purposes.
 
 ## Get-JIMExampleDataSet
 
-Retrieves available example data sets. Each data set represents a collection of pre-generated identity objects that can be browsed or inspected.
+Retrieves available example data sets. Each data set is a named pool of string values (e.g. a list of cities, or first names) that Data Generation Templates can draw from.
 
 ### Syntax
 
 ```powershell
+# List (default)
 Get-JIMExampleDataSet [-Page <int>] [-PageSize <int>]
+
+# ById
+Get-JIMExampleDataSet -Id <int>
 ```
 
 ### Parameters
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
+| `Id` | `int` | Yes (ById set) | | The ID of a specific data set to retrieve, including its values. |
 | `Page` | `int` | No | `1` | Page number for paginated results. |
 | `PageSize` | `int` | No | `100` | Number of results per page (maximum 1000). |
 
@@ -35,12 +40,116 @@ Returns one or more `PSCustomObject` instances representing example data sets.
 Get-JIMExampleDataSet
 ```
 
+```powershell title="Get a specific data set, including its values"
+Get-JIMExampleDataSet -Id 5
+```
+
 ```powershell title="List data sets with pagination"
 Get-JIMExampleDataSet -Page 2 -PageSize 50
 ```
 
 ```powershell title="Select specific properties"
 Get-JIMExampleDataSet | Select-Object Name, Description, ObjectCount
+```
+
+---
+
+## New-JIMExampleDataSet
+
+Creates a new Example Data Set.
+
+### Syntax
+
+```powershell
+New-JIMExampleDataSet -Name <string> -Culture <string> [-Values <string[]>] [-PassThru]
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Name` | `string` | Yes | | The name for the data set. |
+| `Culture` | `string` | Yes | | The .NET culture the values are in, e.g. `en-GB`. |
+| `Values` | `string[]` | No | | The string values that make up this data set. |
+| `PassThru` | `switch` | No | `$false` | Returns the created data set object. |
+
+### Output
+
+If `-PassThru` is specified, returns the created Example Data Set object.
+
+### Examples
+
+```powershell title="Create a data set of UK city names"
+New-JIMExampleDataSet -Name "UK Cities" -Culture "en-GB" -Values "London", "Manchester", "Bristol" -PassThru
+```
+
+---
+
+## Set-JIMExampleDataSet
+
+Updates an existing Example Data Set. Built-in data sets cannot be updated.
+
+### Syntax
+
+```powershell
+Set-JIMExampleDataSet -Id <int> [-Name <string>] [-Culture <string>] [-Values <string[]>] [-PassThru]
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Id` | `int` | Yes | | The ID of the data set to update. Accepts pipeline input. |
+| `Name` | `string` | No | | A new name for the data set. |
+| `Culture` | `string` | No | | A new .NET culture for the values. |
+| `Values` | `string[]` | No | | When specified, replaces the entire set of values. |
+| `PassThru` | `switch` | No | `$false` | Returns the updated data set object. |
+
+### Output
+
+If `-PassThru` is specified, returns the updated Example Data Set object.
+
+### Examples
+
+```powershell title="Rename a data set"
+Set-JIMExampleDataSet -Id 5 -Name "UK Cities (Extended)"
+```
+
+```powershell title="Replace a data set's values"
+Set-JIMExampleDataSet -Id 5 -Values "London", "Manchester", "Bristol", "Leeds" -PassThru
+```
+
+---
+
+## Remove-JIMExampleDataSet
+
+Deletes an Example Data Set. Built-in data sets cannot be removed. This action cannot be undone.
+
+### Syntax
+
+```powershell
+Remove-JIMExampleDataSet -Id <int> [-Force]
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Id` | `int` | Yes | | The ID of the data set to remove. Accepts pipeline input. |
+| `Force` | `switch` | No | `$false` | Bypasses confirmation prompts. |
+
+### Output
+
+None.
+
+### Examples
+
+```powershell title="Remove a data set with confirmation"
+Remove-JIMExampleDataSet -Id 5
+```
+
+```powershell title="Remove a data set without confirmation"
+Remove-JIMExampleDataSet -Id 5 -Force
 ```
 
 ---

--- a/docs/powershell/file-system.md
+++ b/docs/powershell/file-system.md
@@ -1,0 +1,82 @@
+---
+title: File System
+---
+
+# File System
+
+File System cmdlets let you browse the JIM Container's file system, used when configuring file-based connectors (e.g. CSV) to select import/export paths. Only paths within the configured allowed mount points are accessible.
+
+---
+
+## Get-JIMFileSystemItem
+
+Lists files and directories within the JIM Container's allowed mount points.
+
+### Syntax
+
+```powershell
+# List (default)
+Get-JIMFileSystemItem [-Path <string>]
+
+# Roots
+Get-JIMFileSystemItem -Roots
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Path` | `string` | No | | The directory path to list. Omit to list the allowed root directories. |
+| `Roots` | `switch` | No | `$false` | Returns the allowed root directory paths instead of listing a directory. |
+
+### Output
+
+A directory listing (path, entries, parent path), or a list of allowed root paths.
+
+### Examples
+
+```powershell title="List the allowed root directories"
+Get-JIMFileSystemItem
+```
+
+```powershell title="List the contents of a directory"
+Get-JIMFileSystemItem -Path "/data/imports"
+```
+
+```powershell title="Get the allowed root paths explicitly"
+Get-JIMFileSystemItem -Roots
+```
+
+---
+
+## Test-JIMFileSystemPath
+
+Checks whether a file system path is within the JIM Container's allowed mount points.
+
+### Syntax
+
+```powershell
+Test-JIMFileSystemPath -Path <string>
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Path` | `string` | Yes | | The path to validate. Accepts pipeline input by property name. |
+
+### Output
+
+Boolean. `$true` if the path is within an allowed root, `$false` otherwise.
+
+### Examples
+
+```powershell title="Validate a path before configuring a connector"
+Test-JIMFileSystemPath -Path "/data/imports/users.csv"
+```
+
+---
+
+## See also
+
+- [Connected Systems](connected-systems.md): cmdlets for configuring file-based connectors that read paths validated here

--- a/docs/powershell/logs.md
+++ b/docs/powershell/logs.md
@@ -1,0 +1,90 @@
+---
+title: Logs
+---
+
+# Logs
+
+Log cmdlets provide read-only access to JIM's structured service logs (Web, Worker, Scheduler), with filtering by service, date, level, and search text. Useful for remote troubleshooting without needing container/host access.
+
+---
+
+## Get-JIMLogEntry
+
+Gets log entries, with optional filtering. Also exposes the available log level and service names, so you can discover valid `-Level`/`-Service` values.
+
+### Syntax
+
+```powershell
+# Entries (default)
+Get-JIMLogEntry [-Service <string>] [-Date <datetime>] [-Level <string[]>] [-Search <string>]
+    [-Limit <int>] [-Offset <int>]
+
+# Levels
+Get-JIMLogEntry -ListLevels
+
+# Services
+Get-JIMLogEntry -ListServices
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Service` | `string` | No | | Filter by service name (`web`, `worker`, `scheduler`). Omit for all services. |
+| `Date` | `datetime` | No | today (UTC) | The date to retrieve logs for. |
+| `Level` | `string[]` | No | | Specific log levels to include (`Verbose`, `Debug`, `Information`, `Warning`, `Error`, `Fatal`). Omit for all levels. |
+| `Search` | `string` | No | | Text to search for in the log message (case-insensitive). |
+| `Limit` | `int` | No | `500` | Maximum number of entries to return (maximum 5000). |
+| `Offset` | `int` | No | `0` | Number of entries to skip, for paging. |
+| `ListLevels` | `switch` | No | `$false` | Returns the available log level names instead of log entries. |
+| `ListServices` | `switch` | No | `$false` | Returns the available service names instead of log entries. |
+
+### Output
+
+Log entries (timestamp, level, message, service, and any structured properties), or a list of level/service names.
+
+### Examples
+
+```powershell title="Get today's log entries across all services"
+Get-JIMLogEntry
+```
+
+```powershell title="Search Warning and Error entries from the worker service"
+Get-JIMLogEntry -Service worker -Level Warning, Error -Search "timeout"
+```
+
+```powershell title="List the available log levels"
+Get-JIMLogEntry -ListLevels
+```
+
+---
+
+## Get-JIMLogFile
+
+Lists the log files JIM currently has on disk, across all services.
+
+### Syntax
+
+```powershell
+Get-JIMLogFile
+```
+
+### Output
+
+Log file metadata: service, date, and size.
+
+### Examples
+
+```powershell title="List all available log files"
+Get-JIMLogFile
+```
+
+```powershell title="List log files for the worker service only"
+Get-JIMLogFile | Where-Object Service -eq 'worker'
+```
+
+---
+
+## See also
+
+- [Activities](activities.md): the audit trail for synchronisation operations, complementary to raw service logs

--- a/docs/powershell/metaverse.md
+++ b/docs/powershell/metaverse.md
@@ -360,6 +360,116 @@ Get-JIMMetaverseAttribute -Name "Legacy Code" | Remove-JIMMetaverseAttribute -Fo
 
 ---
 
+### Get-JIMMetaverseAttributePriority
+
+Gets a metaverse attribute's import priority order: the ordered list of import contributions to the attribute for a given Metaverse Object Type, highest priority first. When more than one Connected System contributes to the same attribute, the highest-priority contributor still connected wins.
+
+#### Syntax
+
+```powershell
+Get-JIMMetaverseAttributePriority -AttributeId <int> -ObjectTypeId <int>
+```
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `AttributeId` | `int` | Yes | | The ID of the Metaverse Attribute |
+| `ObjectTypeId` | `int` | Yes | | The ID of the Metaverse Object Type that scopes the priority list |
+
+#### Output
+
+The attribute's priority order, including each contributing mapping's Synchronisation Rule, Connected System, and "Null is a value" flag.
+
+#### Examples
+
+```powershell title="Get the priority order for an attribute"
+Get-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1
+```
+
+```powershell title="List just the contributing mappings, in priority order"
+(Get-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1).Contributors
+```
+
+---
+
+### Set-JIMMetaverseAttributePriority
+
+Replaces a metaverse attribute's entire import priority order in one call. Every current contributing mapping must be listed exactly once, in the desired priority order.
+
+#### Syntax
+
+```powershell
+Set-JIMMetaverseAttributePriority -AttributeId <int> -ObjectTypeId <int> -MappingId <int[]>
+    [-NullIsValueMappingId <int[]>] [-PassThru]
+```
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `AttributeId` | `int` | Yes | | The ID of the Metaverse Attribute |
+| `ObjectTypeId` | `int` | Yes | | The ID of the Metaverse Object Type that scopes the priority list |
+| `MappingId` | `int[]` | Yes | | Every current contributing mapping ID, in the desired priority order (highest first) |
+| `NullIsValueMappingId` | `int[]` | No | | Mapping IDs (from `-MappingId`) that should have "Null is a value" enabled |
+| `PassThru` | `switch` | No | `$false` | Returns the resulting priority order |
+
+!!! info "ShouldProcess"
+    This cmdlet supports `ShouldProcess` with a **Medium** impact level. Use `-WhatIf` to preview changes or `-Confirm` to require confirmation.
+
+#### Output
+
+If `-PassThru` is specified, returns the resulting priority order.
+
+#### Examples
+
+```powershell title="Set the full priority order"
+Set-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 45, 12, 78
+```
+
+```powershell title="Set the order and flag a source as authoritative for 'no value'"
+Set-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 45, 12 -NullIsValueMappingId 45 -PassThru
+```
+
+---
+
+### Move-JIMMetaverseAttributePriority
+
+Repositions a single contributor within a metaverse attribute's priority order, without needing to restate the whole list.
+
+#### Syntax
+
+```powershell
+Move-JIMMetaverseAttributePriority -AttributeId <int> -ObjectTypeId <int> -MappingId <int>
+    -Position <int> [-NullIsValue] [-PassThru]
+```
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `AttributeId` | `int` | Yes | | The ID of the Metaverse Attribute |
+| `ObjectTypeId` | `int` | Yes | | The ID of the Metaverse Object Type that scopes the priority list |
+| `MappingId` | `int` | Yes | | The contributing mapping to move. Accepts pipeline input. |
+| `Position` | `int` | Yes | | The desired 1-based priority position (1 = highest priority) |
+| `NullIsValue` | `switch` | No | | When specified, also enables the moved mapping's "Null is a value" flag |
+| `PassThru` | `switch` | No | `$false` | Returns the resulting priority order |
+
+!!! info "ShouldProcess"
+    This cmdlet supports `ShouldProcess` with a **Medium** impact level. Use `-WhatIf` to preview changes or `-Confirm` to require confirmation.
+
+#### Output
+
+If `-PassThru` is specified, returns the resulting priority order.
+
+#### Examples
+
+```powershell title="Move a mapping to the highest priority"
+Move-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 78 -Position 1
+```
+
+---
+
 ## Objects
 
 ### Search-JIMMetaverseObject

--- a/docs/powershell/worker-tasks.md
+++ b/docs/powershell/worker-tasks.md
@@ -1,0 +1,88 @@
+---
+title: Worker Tasks
+---
+
+# Worker Tasks
+
+Worker Task cmdlets let you monitor and cancel queued and in-progress background operations (synchronisation runs, connector space clears, example data generation, and similar). Worker Tasks are ephemeral: once a task completes, its record is deleted and the associated [Activity](activities.md) becomes the durable audit record, so these cmdlets only ever return in-flight work.
+
+---
+
+## Get-JIMWorkerTask
+
+Gets currently queued, processing, or cancellation-requested Worker Tasks.
+
+### Syntax
+
+```powershell
+# List (default)
+Get-JIMWorkerTask [-Page <int>] [-PageSize <int>]
+
+# ById
+Get-JIMWorkerTask -Id <guid>
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Id` | `guid` | Yes (ById set) | | The ID of a specific Worker Task to retrieve. Accepts pipeline input. |
+| `Page` | `int` | No | `1` | Page number for paginated results. |
+| `PageSize` | `int` | No | `50` | Number of results per page (maximum 100). |
+
+### Output
+
+Returns one or more `PSCustomObject` instances representing Worker Task headers, including status, progress, and initiator.
+
+### Examples
+
+```powershell title="List in-flight Worker Tasks"
+Get-JIMWorkerTask
+```
+
+```powershell title="Get a specific Worker Task"
+Get-JIMWorkerTask -Id "12345678-1234-1234-1234-123456789012"
+```
+
+---
+
+## Stop-JIMWorkerTask
+
+Cancels a queued or in-progress Worker Task. Cancellation completes asynchronously: JIM returns as soon as the request has been accepted.
+
+### Syntax
+
+```powershell
+Stop-JIMWorkerTask -Id <guid> [-Force]
+```
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `Id` | `guid` | Yes | | The ID of the Worker Task to cancel. Accepts pipeline input. |
+| `Force` | `switch` | No | `$false` | Bypasses confirmation prompts. |
+
+!!! warning "ShouldProcess"
+    This cmdlet supports `ShouldProcess` with a **High** impact level. You will be prompted for confirmation unless `-Force` is specified.
+
+### Output
+
+None.
+
+### Examples
+
+```powershell title="Cancel a Worker Task with confirmation"
+Stop-JIMWorkerTask -Id "12345678-1234-1234-1234-123456789012"
+```
+
+```powershell title="Cancel every in-flight Worker Task without confirmation"
+Get-JIMWorkerTask | Stop-JIMWorkerTask -Force
+```
+
+---
+
+## See also
+
+- [Activities](activities.md): cmdlets for reviewing the durable audit record a Worker Task leaves behind
+- [Schedules](schedules.md): cmdlets for configuring the automated workflows that queue Worker Tasks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,9 @@ nav:
       - History: powershell/history.md
       - Example Data: powershell/example-data.md
       - Expressions: powershell/expressions.md
+      - Worker Tasks: powershell/worker-tasks.md
+      - File System: powershell/file-system.md
+      - Logs: powershell/logs.md
   - Developer Guide:
       - developer/index.md
       - Development Environment: developer/dev-environment.md

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -3175,6 +3175,17 @@ public class ConnectedSystemServer
     }
 
     /// <summary>
+    /// Returns the count of Connected System Objects for a particular Connected System, optionally filtered by Object Type and/or Partition.
+    /// </summary>
+    /// <param name="connectedSystemId">The unique identifier for the Connected System to find the object count for.</param>
+    /// <param name="objectTypeId">Optional Object Type ID to filter by.</param>
+    /// <param name="partitionId">Optional Partition ID to filter by.</param>
+    public async Task<int> GetConnectedSystemObjectCountAsync(int connectedSystemId, int? objectTypeId, int? partitionId)
+    {
+        return await Application.Repository.ConnectedSystems.GetConnectedSystemObjectCountAsync(connectedSystemId, objectTypeId, partitionId);
+    }
+
+    /// <summary>
     /// Returns the count of Connected System Objects joined to a specific Metaverse Object.
     /// Used to determine if an MVO has any remaining connectors before deletion.
     /// </summary>

--- a/src/JIM.PowerShell/JIM.psd1
+++ b/src/JIM.PowerShell/JIM.psd1
@@ -121,6 +121,9 @@
         'New-JIMMetaverseAttribute',
         'Set-JIMMetaverseAttribute',
         'Remove-JIMMetaverseAttribute',
+        'Get-JIMMetaverseAttributePriority',
+        'Set-JIMMetaverseAttributePriority',
+        'Move-JIMMetaverseAttributePriority',
 
         # API Keys
         'Get-JIMApiKey',
@@ -162,6 +165,14 @@
         # Worker Tasks
         'Get-JIMWorkerTask',
         'Stop-JIMWorkerTask',
+
+        # File System
+        'Get-JIMFileSystemItem',
+        'Test-JIMFileSystemPath',
+
+        # Logs
+        'Get-JIMLogEntry',
+        'Get-JIMLogFile',
 
         # Service Settings
         'Get-JIMServiceSetting',

--- a/src/JIM.PowerShell/JIM.psd1
+++ b/src/JIM.PowerShell/JIM.psd1
@@ -147,6 +147,9 @@
         'Get-JIMExampleDataSet',
         'Get-JIMExampleDataTemplate',
         'Invoke-JIMExampleDataTemplate',
+        'New-JIMExampleDataSet',
+        'Remove-JIMExampleDataSet',
+        'Set-JIMExampleDataSet',
 
         # Expressions
         'Test-JIMExpression',

--- a/src/JIM.PowerShell/JIM.psd1
+++ b/src/JIM.PowerShell/JIM.psd1
@@ -159,6 +159,10 @@
         'Get-JIMHistoryCount',
         'Invoke-JIMHistoryCleanup',
 
+        # Worker Tasks
+        'Get-JIMWorkerTask',
+        'Stop-JIMWorkerTask',
+
         # Service Settings
         'Get-JIMServiceSetting',
         'Set-JIMServiceSetting',

--- a/src/JIM.PowerShell/Private/Get-JIMConnectedSystemObjectListEndpoint.ps1
+++ b/src/JIM.PowerShell/Private/Get-JIMConnectedSystemObjectListEndpoint.ps1
@@ -1,0 +1,63 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Get-JIMConnectedSystemObjectListEndpoint {
+    <#
+    .SYNOPSIS
+        Builds the API endpoint for a paginated Connected System Object list request.
+
+    .DESCRIPTION
+        Internal helper shared by Get-JIMConnectedSystemObject's List and ListAll
+        parameter sets, so the query string is built identically for both.
+
+    .OUTPUTS
+        The relative API endpoint, including query string.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [int]$ConnectedSystemId,
+
+        [Parameter(Mandatory)]
+        [int]$Page,
+
+        [Parameter(Mandatory)]
+        [int]$PageSize,
+
+        [string]$Search,
+        [string]$Status,
+        [int]$ObjectTypeId,
+        [string]$JoinType,
+        [string]$SortBy,
+        [switch]$Ascending
+    )
+
+    $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/connector-space?page=$Page&pageSize=$PageSize"
+
+    if ($Search) {
+        $endpoint += "&search=$([System.Uri]::EscapeDataString($Search))"
+    }
+
+    if ($Status) {
+        $endpoint += "&status=$Status"
+    }
+
+    if ($ObjectTypeId -gt 0) {
+        $endpoint += "&objectTypeId=$ObjectTypeId"
+    }
+
+    if ($JoinType) {
+        $endpoint += "&joinType=$JoinType"
+    }
+
+    if ($SortBy) {
+        $endpoint += "&sortBy=$([System.Uri]::EscapeDataString($SortBy))"
+    }
+
+    if ($Ascending) {
+        $endpoint += "&sortDescending=false"
+    }
+
+    $endpoint
+}

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystemObject.ps1
@@ -72,17 +72,34 @@ function Get-JIMConnectedSystemObject {
 
         Gets the count of objects in partition 5 of Connected System 1.
 
+    .EXAMPLE
+        Get-JIMConnectedSystemObject -ConnectedSystemId 1
+
+        Gets the first page of Connected System Object headers for Connected System 1.
+
+    .EXAMPLE
+        Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Search "smith" -Status Obsolete
+
+        Gets Obsolete objects matching "smith" in Connected System 1.
+
+    .EXAMPLE
+        Get-JIMConnectedSystemObject -ConnectedSystemId 1 -All
+
+        Gets every Connected System Object header for Connected System 1 (auto-paginates).
+
     .LINK
         Get-JIMConnectedSystem
         Get-JIMPendingExport
     #>
-    [CmdletBinding(DefaultParameterSetName = 'ById')]
+    [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'AttributeValues', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'AttributeValuesAll', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'Count', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'List', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ListAll', ValueFromPipelineByPropertyName)]
         [int]$ConnectedSystemId,
 
         [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
@@ -97,28 +114,54 @@ function Get-JIMConnectedSystemObject {
 
         [Parameter(ParameterSetName = 'AttributeValues')]
         [Parameter(ParameterSetName = 'AttributeValuesAll')]
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
         [string]$Search,
 
         [Parameter(ParameterSetName = 'AttributeValues')]
+        [Parameter(ParameterSetName = 'List')]
         [ValidateRange(1, [int]::MaxValue)]
         [int]$Page = 1,
 
         [Parameter(ParameterSetName = 'AttributeValues')]
         [Parameter(ParameterSetName = 'AttributeValuesAll')]
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
         [ValidateRange(1, 100)]
         [int]$PageSize = 50,
 
         [Parameter(Mandatory, ParameterSetName = 'AttributeValuesAll')]
+        [Parameter(Mandatory, ParameterSetName = 'ListAll')]
         [switch]$All,
 
         [Parameter(Mandatory, ParameterSetName = 'Count')]
         [switch]$Count,
 
         [Parameter(ParameterSetName = 'Count')]
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
         [int]$ObjectTypeId,
 
         [Parameter(ParameterSetName = 'Count')]
-        [int]$PartitionId
+        [int]$PartitionId,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
+        [ValidateSet('Normal', 'Obsolete', 'PendingProvisioning')]
+        [string]$Status,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
+        [ValidateSet('NotJoined', 'Projected', 'Provisioned', 'Joined')]
+        [string]$JoinType,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
+        [string]$SortBy,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ListAll')]
+        [switch]$Ascending
     )
 
     process {
@@ -182,6 +225,36 @@ function Get-JIMConnectedSystemObject {
                     if ($Search) {
                         $endpoint += "&search=$([System.Uri]::EscapeDataString($Search))"
                     }
+
+                    $response = Invoke-JIMApi -Endpoint $endpoint
+                    foreach ($item in $response.items) {
+                        $item
+                    }
+
+                    $hasMore = $response.hasNextPage
+                    $currentPage++
+                }
+            }
+
+            'List' {
+                Write-Verbose "Getting Connected System Objects for Connected System $ConnectedSystemId (Page: $Page, PageSize: $PageSize)"
+                $endpoint = Get-JIMConnectedSystemObjectListEndpoint -ConnectedSystemId $ConnectedSystemId -Page $Page -PageSize $PageSize `
+                    -Search $Search -Status $Status -ObjectTypeId $ObjectTypeId -JoinType $JoinType -SortBy $SortBy -Ascending:$Ascending
+
+                $response = Invoke-JIMApi -Endpoint $endpoint
+                foreach ($item in $response.items) {
+                    $item
+                }
+            }
+
+            'ListAll' {
+                Write-Verbose "Getting all Connected System Objects for Connected System $ConnectedSystemId"
+                $currentPage = 1
+                $hasMore = $true
+
+                while ($hasMore) {
+                    $endpoint = Get-JIMConnectedSystemObjectListEndpoint -ConnectedSystemId $ConnectedSystemId -Page $currentPage -PageSize $PageSize `
+                        -Search $Search -Status $Status -ObjectTypeId $ObjectTypeId -JoinType $JoinType -SortBy $SortBy -Ascending:$Ascending
 
                     $response = Invoke-JIMApi -Endpoint $endpoint
                     foreach ($item in $response.items) {

--- a/src/JIM.PowerShell/Public/ExampleData/Get-JIMExampleDataSet.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/Get-JIMExampleDataSet.ps1
@@ -10,11 +10,14 @@ function Get-JIMExampleDataSet {
         Retrieves example data sets that can be used for testing and demonstration
         purposes. These contain pre-defined identity data.
 
+    .PARAMETER Id
+        The unique identifier of a specific Example Data Set to retrieve, including its values.
+
     .PARAMETER Page
-        Page number for paginated results. Defaults to 1.
+        Page number for paginated results. Defaults to 1. Not applicable when -Id is specified.
 
     .PARAMETER PageSize
-        Number of items per page. Defaults to 100.
+        Number of items per page. Defaults to 100. Not applicable when -Id is specified.
 
     .OUTPUTS
         PSCustomObject representing example data set(s).
@@ -25,20 +28,33 @@ function Get-JIMExampleDataSet {
         Gets all example data sets.
 
     .EXAMPLE
+        Get-JIMExampleDataSet -Id 5
+
+        Gets the Example Data Set with ID 5, including its values.
+
+    .EXAMPLE
         Get-JIMExampleDataSet | Select-Object Name, Description
 
         Gets all example data sets with specific properties.
 
     .LINK
+        New-JIMExampleDataSet
+        Set-JIMExampleDataSet
+        Remove-JIMExampleDataSet
         Get-JIMExampleDataTemplate
         Invoke-JIMExampleDataTemplate
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([PSCustomObject])]
     param(
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
+        [int]$Id,
+
+        [Parameter(ParameterSetName = 'List')]
         [ValidateRange(1, [int]::MaxValue)]
         [int]$Page = 1,
 
+        [Parameter(ParameterSetName = 'List')]
         [ValidateRange(1, 1000)]
         [int]$PageSize = 100
     )
@@ -47,6 +63,12 @@ function Get-JIMExampleDataSet {
         # Check connection first
         if (-not $script:JIMConnection) {
             Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            Write-Verbose "Getting example data set $Id"
+            Invoke-JIMApi -Endpoint "/api/v1/example-data/example-data-sets/$Id"
             return
         }
 

--- a/src/JIM.PowerShell/Public/ExampleData/New-JIMExampleDataSet.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/New-JIMExampleDataSet.ps1
@@ -1,0 +1,87 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function New-JIMExampleDataSet {
+    <#
+    .SYNOPSIS
+        Creates a new Example Data Set in JIM.
+
+    .DESCRIPTION
+        Creates a new Example Data Set: a named pool of string values (e.g. a list of
+        cities, or first names) that Data Generation Templates can draw from when
+        generating test identity data.
+
+    .PARAMETER Name
+        The name for the Example Data Set.
+
+    .PARAMETER Culture
+        The .NET culture the values are in, e.g. "en-GB".
+
+    .PARAMETER Values
+        The string values that make up this Example Data Set.
+
+    .PARAMETER PassThru
+        If specified, returns the created Example Data Set object.
+
+    .OUTPUTS
+        If -PassThru is specified, returns the created Example Data Set object.
+
+    .EXAMPLE
+        New-JIMExampleDataSet -Name "UK Cities" -Culture "en-GB" -Values "London", "Manchester", "Bristol" -PassThru
+
+        Creates a new Example Data Set of UK city names.
+
+    .LINK
+        Get-JIMExampleDataSet
+        Set-JIMExampleDataSet
+        Remove-JIMExampleDataSet
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Culture,
+
+        [Parameter()]
+        [string[]]$Values,
+
+        [switch]$PassThru
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ShouldProcess($Name, "Create Example Data Set")) {
+            Write-Verbose "Creating Example Data Set: $Name"
+
+            $body = @{
+                name    = $Name
+                culture = $Culture
+            }
+            if ($Values) {
+                $body.values = @($Values)
+            }
+
+            try {
+                $response = Invoke-JIMApi -Endpoint "/api/v1/example-data/example-data-sets" -Method 'POST' -Body $body
+                Write-Verbose "Created Example Data Set: $($response.id)"
+
+                if ($PassThru) {
+                    $response
+                }
+            }
+            catch {
+                Write-Error "Failed to create Example Data Set: $_"
+            }
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/ExampleData/Remove-JIMExampleDataSet.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/Remove-JIMExampleDataSet.ps1
@@ -1,0 +1,74 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Remove-JIMExampleDataSet {
+    <#
+    .SYNOPSIS
+        Removes an Example Data Set from JIM.
+
+    .DESCRIPTION
+        Deletes an Example Data Set. Built-in Example Data Sets cannot be removed.
+        This action cannot be undone.
+
+    .PARAMETER Id
+        The unique identifier of the Example Data Set to remove.
+
+    .PARAMETER Force
+        Bypasses confirmation prompts.
+
+    .OUTPUTS
+        None.
+
+    .EXAMPLE
+        Remove-JIMExampleDataSet -Id 5
+
+        Removes the specified Example Data Set (with confirmation).
+
+    .EXAMPLE
+        Remove-JIMExampleDataSet -Id 5 -Force
+
+        Removes the specified Example Data Set without confirmation.
+
+    .LINK
+        Get-JIMExampleDataSet
+        New-JIMExampleDataSet
+        Set-JIMExampleDataSet
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [int]$Id,
+
+        [switch]$Force
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        # Get data set name for confirmation message
+        $dataSetName = $Id
+        try {
+            $dataSet = Invoke-JIMApi -Endpoint "/api/v1/example-data/example-data-sets/$Id"
+            $dataSetName = $dataSet.name
+        }
+        catch {
+            # Continue with ID if we can't get the name
+        }
+
+        if ($Force -or $PSCmdlet.ShouldProcess($dataSetName, "Remove Example Data Set")) {
+            Write-Verbose "Removing Example Data Set: $Id ($dataSetName)"
+
+            try {
+                Invoke-JIMApi -Endpoint "/api/v1/example-data/example-data-sets/$Id" -Method 'DELETE'
+                Write-Verbose "Removed Example Data Set: $Id"
+            }
+            catch {
+                Write-Error "Failed to remove Example Data Set: $_"
+            }
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/ExampleData/Set-JIMExampleDataSet.ps1
+++ b/src/JIM.PowerShell/Public/ExampleData/Set-JIMExampleDataSet.ps1
@@ -1,0 +1,92 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Set-JIMExampleDataSet {
+    <#
+    .SYNOPSIS
+        Updates an Example Data Set in JIM.
+
+    .DESCRIPTION
+        Updates the name, culture, and/or values of an existing Example Data Set.
+        Built-in Example Data Sets cannot be updated.
+
+    .PARAMETER Id
+        The unique identifier of the Example Data Set to update.
+
+    .PARAMETER Name
+        The new name for the Example Data Set.
+
+    .PARAMETER Culture
+        The new .NET culture the values are in, e.g. "en-GB".
+
+    .PARAMETER Values
+        When specified, replaces the entire set of values.
+
+    .PARAMETER PassThru
+        If specified, returns the updated Example Data Set object.
+
+    .OUTPUTS
+        If -PassThru is specified, returns the updated Example Data Set object.
+
+    .EXAMPLE
+        Set-JIMExampleDataSet -Id 5 -Name "UK Cities (Extended)"
+
+        Renames the Example Data Set.
+
+    .EXAMPLE
+        Set-JIMExampleDataSet -Id 5 -Values "London", "Manchester", "Bristol", "Leeds" -PassThru
+
+        Replaces the values in the Example Data Set.
+
+    .LINK
+        Get-JIMExampleDataSet
+        New-JIMExampleDataSet
+        Remove-JIMExampleDataSet
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [int]$Id,
+
+        [Parameter()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$Culture,
+
+        [Parameter()]
+        [string[]]$Values,
+
+        [switch]$PassThru
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ShouldProcess($Id, "Update Example Data Set")) {
+            Write-Verbose "Updating Example Data Set: $Id"
+
+            $body = @{}
+            if ($Name) { $body.name = $Name }
+            if ($Culture) { $body.culture = $Culture }
+            if ($PSBoundParameters.ContainsKey('Values')) { $body.values = @($Values) }
+
+            try {
+                $response = Invoke-JIMApi -Endpoint "/api/v1/example-data/example-data-sets/$Id" -Method 'PUT' -Body $body
+                Write-Verbose "Updated Example Data Set: $Id"
+
+                if ($PassThru) {
+                    $response
+                }
+            }
+            catch {
+                Write-Error "Failed to update Example Data Set: $_"
+            }
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/FileSystem/Get-JIMFileSystemItem.ps1
+++ b/src/JIM.PowerShell/Public/FileSystem/Get-JIMFileSystemItem.ps1
@@ -1,0 +1,72 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Get-JIMFileSystemItem {
+    <#
+    .SYNOPSIS
+        Browses the JIM Container's file system.
+
+    .DESCRIPTION
+        Lists files and directories within the JIM Container's allowed mount points, used
+        when configuring file-based connectors (e.g. CSV) to select import/export paths.
+        Only paths within the configured allowed roots are accessible.
+
+    .PARAMETER Path
+        The directory path to list. Omit to list the allowed root directories.
+
+    .PARAMETER Roots
+        If specified, returns the allowed root directory paths instead of listing a directory.
+
+    .OUTPUTS
+        PSCustomObject representing a directory listing, or a list of allowed root paths.
+
+    .EXAMPLE
+        Get-JIMFileSystemItem
+
+        Lists the allowed root directories.
+
+    .EXAMPLE
+        Get-JIMFileSystemItem -Path "/data/imports"
+
+        Lists the contents of the given directory.
+
+    .EXAMPLE
+        Get-JIMFileSystemItem -Roots
+
+        Returns the allowed root directory paths.
+
+    .LINK
+        Test-JIMFileSystemPath
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'List')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(ParameterSetName = 'List')]
+        [string]$Path,
+
+        [Parameter(Mandatory, ParameterSetName = 'Roots')]
+        [switch]$Roots
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'Roots') {
+            Write-Verbose "Getting allowed file system roots"
+            Invoke-JIMApi -Endpoint "/api/v1/filesystem/roots"
+            return
+        }
+
+        Write-Verbose "Listing file system path: $(if ($Path) { $Path } else { '(root)' })"
+        $endpoint = "/api/v1/filesystem/list"
+        if ($Path) {
+            $endpoint += "?path=$([System.Uri]::EscapeDataString($Path))"
+        }
+
+        Invoke-JIMApi -Endpoint $endpoint
+    }
+}

--- a/src/JIM.PowerShell/Public/FileSystem/Test-JIMFileSystemPath.ps1
+++ b/src/JIM.PowerShell/Public/FileSystem/Test-JIMFileSystemPath.ps1
@@ -1,0 +1,45 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Test-JIMFileSystemPath {
+    <#
+    .SYNOPSIS
+        Checks whether a file system path is accessible to JIM.
+
+    .DESCRIPTION
+        Validates whether a given path falls within the JIM Container's allowed root
+        directories. Use this before configuring a connector with a file path.
+
+    .PARAMETER Path
+        The path to validate.
+
+    .OUTPUTS
+        Boolean. $true if the path is within an allowed root, $false otherwise.
+
+    .EXAMPLE
+        Test-JIMFileSystemPath -Path "/data/imports/users.csv"
+
+        Checks whether the given path is accessible.
+
+    .LINK
+        Get-JIMFileSystemItem
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
+        [string]$Path
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        Write-Verbose "Validating file system path: $Path"
+        $result = Invoke-JIMApi -Endpoint "/api/v1/filesystem/validate?path=$([System.Uri]::EscapeDataString($Path))"
+        $result.isAllowed
+    }
+}

--- a/src/JIM.PowerShell/Public/Logs/Get-JIMLogEntry.ps1
+++ b/src/JIM.PowerShell/Public/Logs/Get-JIMLogEntry.ps1
@@ -1,0 +1,132 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Get-JIMLogEntry {
+    <#
+    .SYNOPSIS
+        Gets JIM service log entries.
+
+    .DESCRIPTION
+        Retrieves log entries from JIM's services (Web, Worker, Scheduler), with optional
+        filtering by service, date, level, and search text. Also exposes the available
+        log levels and service names, so callers can discover valid -Level/-Service values.
+
+    .PARAMETER Service
+        Filter by service name (web, worker, scheduler). Omit for all services.
+
+    .PARAMETER Date
+        The date to retrieve logs for. Omit for today (UTC).
+
+    .PARAMETER Level
+        Specific log levels to include (Verbose, Debug, Information, Warning, Error, Fatal).
+        Omit for all levels.
+
+    .PARAMETER Search
+        Text to search for in the log message (case-insensitive).
+
+    .PARAMETER Limit
+        Maximum number of entries to return (1-5000). Defaults to 500.
+
+    .PARAMETER Offset
+        Number of entries to skip, for paging. Defaults to 0.
+
+    .PARAMETER ListLevels
+        If specified, returns the available log level names instead of log entries.
+
+    .PARAMETER ListServices
+        If specified, returns the available service names instead of log entries.
+
+    .OUTPUTS
+        PSCustomObject representing log entries, or a list of level/service names.
+
+    .EXAMPLE
+        Get-JIMLogEntry
+
+        Gets today's log entries across all services.
+
+    .EXAMPLE
+        Get-JIMLogEntry -Service worker -Level Warning, Error -Search "timeout"
+
+        Gets Warning and Error log entries from the worker service mentioning "timeout".
+
+    .EXAMPLE
+        Get-JIMLogEntry -ListLevels
+
+        Lists the available log level names.
+
+    .LINK
+        Get-JIMLogFile
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Entries')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(ParameterSetName = 'Entries')]
+        [string]$Service,
+
+        [Parameter(ParameterSetName = 'Entries')]
+        [datetime]$Date,
+
+        [Parameter(ParameterSetName = 'Entries')]
+        [string[]]$Level,
+
+        [Parameter(ParameterSetName = 'Entries')]
+        [string]$Search,
+
+        [Parameter(ParameterSetName = 'Entries')]
+        [ValidateRange(1, 5000)]
+        [int]$Limit = 500,
+
+        [Parameter(ParameterSetName = 'Entries')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$Offset = 0,
+
+        [Parameter(Mandatory, ParameterSetName = 'Levels')]
+        [switch]$ListLevels,
+
+        [Parameter(Mandatory, ParameterSetName = 'Services')]
+        [switch]$ListServices
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        switch ($PSCmdlet.ParameterSetName) {
+            'Levels' {
+                Write-Verbose "Getting available log levels"
+                Invoke-JIMApi -Endpoint "/api/v1/logs/levels"
+                return
+            }
+
+            'Services' {
+                Write-Verbose "Getting available log services"
+                Invoke-JIMApi -Endpoint "/api/v1/logs/services"
+                return
+            }
+        }
+
+        Write-Verbose "Getting log entries (Service: $Service, Limit: $Limit, Offset: $Offset)"
+
+        $queryParams = @(
+            "limit=$Limit",
+            "offset=$Offset"
+        )
+        if ($Service) { $queryParams += "service=$([System.Uri]::EscapeDataString($Service))" }
+        if ($Date) { $queryParams += "date=$($Date.ToString('o'))" }
+        if ($Search) { $queryParams += "search=$([System.Uri]::EscapeDataString($Search))" }
+        if ($Level) {
+            foreach ($l in $Level) {
+                $queryParams += "levels=$([System.Uri]::EscapeDataString($l))"
+            }
+        }
+
+        $endpoint = "/api/v1/logs?" + ($queryParams -join '&')
+        $response = Invoke-JIMApi -Endpoint $endpoint
+        foreach ($entry in $response) {
+            $entry
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/Logs/Get-JIMLogFile.ps1
+++ b/src/JIM.PowerShell/Public/Logs/Get-JIMLogFile.ps1
@@ -1,0 +1,46 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Get-JIMLogFile {
+    <#
+    .SYNOPSIS
+        Lists the JIM service log files available on the server.
+
+    .DESCRIPTION
+        Retrieves metadata (service, date, size) for every log file JIM currently has on
+        disk, across all services (Web, Worker, Scheduler).
+
+    .OUTPUTS
+        PSCustomObject representing log file metadata.
+
+    .EXAMPLE
+        Get-JIMLogFile
+
+        Lists all available log files.
+
+    .EXAMPLE
+        Get-JIMLogFile | Where-Object Service -eq 'worker'
+
+        Lists log files for the worker service only.
+
+    .LINK
+        Get-JIMLogEntry
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param()
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        Write-Verbose "Getting log files"
+        $response = Invoke-JIMApi -Endpoint "/api/v1/logs/files"
+        foreach ($file in $response) {
+            $file
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseAttributePriority.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Get-JIMMetaverseAttributePriority.ps1
@@ -1,0 +1,59 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Get-JIMMetaverseAttributePriority {
+    <#
+    .SYNOPSIS
+        Gets a Metaverse Attribute's import priority order.
+
+    .DESCRIPTION
+        Returns the ordered list of import contributions to a Metaverse Attribute for a given
+        Metaverse Object Type, highest priority first. When more than one Connected System
+        contributes to the same Metaverse Attribute, the highest-priority contributor still
+        connected wins. Disabled Synchronisation Rules are included; they hold position but
+        never contribute during resolution.
+
+    .PARAMETER AttributeId
+        The unique identifier of the Metaverse Attribute.
+
+    .PARAMETER ObjectTypeId
+        The unique identifier of the Metaverse Object Type that scopes the priority list.
+
+    .OUTPUTS
+        PSCustomObject representing the Attribute's priority order and contributors.
+
+    .EXAMPLE
+        Get-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1
+
+        Gets the priority order for Attribute 12 on Object Type 1.
+
+    .EXAMPLE
+        (Get-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1).Contributors
+
+        Lists just the contributing mappings, in priority order.
+
+    .LINK
+        Set-JIMMetaverseAttributePriority
+        Move-JIMMetaverseAttributePriority
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [int]$AttributeId,
+
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [int]$ObjectTypeId
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        Write-Verbose "Getting attribute priority order for attribute $AttributeId on object type $ObjectTypeId"
+        Invoke-JIMApi -Endpoint "/api/v1/metaverse/attributes/$AttributeId/priorities/$ObjectTypeId"
+    }
+}

--- a/src/JIM.PowerShell/Public/Metaverse/Move-JIMMetaverseAttributePriority.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Move-JIMMetaverseAttributePriority.ps1
@@ -1,0 +1,99 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Move-JIMMetaverseAttributePriority {
+    <#
+    .SYNOPSIS
+        Repositions a single contributor in a Metaverse Attribute's priority order.
+
+    .DESCRIPTION
+        Moves one contributing Synchronisation Rule Mapping to the given 1-based priority
+        position for a Metaverse Attribute on a Metaverse Object Type, shuffling the other
+        contributors to keep the list contiguous, then renumbering all affected rows in one
+        transaction. You state only the new position; JIM keeps the order gap-free and
+        duplicate-free. Optionally also updates the mapping's "Null is a value" flag.
+
+    .PARAMETER AttributeId
+        The unique identifier of the Metaverse Attribute.
+
+    .PARAMETER ObjectTypeId
+        The unique identifier of the Metaverse Object Type that scopes the priority list.
+
+    .PARAMETER MappingId
+        The contributing Synchronisation Rule Mapping to move.
+
+    .PARAMETER Position
+        The desired 1-based priority position (1 = highest priority).
+
+    .PARAMETER NullIsValue
+        When specified, also sets the moved mapping's "Null is a value" flag.
+
+    .PARAMETER PassThru
+        If specified, returns the resulting priority order.
+
+    .OUTPUTS
+        If -PassThru is specified, returns the resulting priority order.
+
+    .EXAMPLE
+        Move-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 78 -Position 1
+
+        Moves mapping 78 to the highest priority position.
+
+    .EXAMPLE
+        Move-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 78 -Position 2 -NullIsValue -PassThru
+
+        Moves mapping 78 to position 2 and enables "Null is a value" for it.
+
+    .LINK
+        Get-JIMMetaverseAttributePriority
+        Set-JIMMetaverseAttributePriority
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [int]$AttributeId,
+
+        [Parameter(Mandatory)]
+        [int]$ObjectTypeId,
+
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [int]$MappingId,
+
+        [Parameter(Mandatory)]
+        [int]$Position,
+
+        [switch]$NullIsValue,
+
+        [switch]$PassThru
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ShouldProcess("Mapping $MappingId", "Move to priority position $Position")) {
+            Write-Verbose "Moving mapping $MappingId to position $Position for attribute $AttributeId on object type $ObjectTypeId"
+
+            $body = @{ position = $Position }
+            if ($PSBoundParameters.ContainsKey('NullIsValue')) {
+                $body.nullIsValue = [bool]$NullIsValue
+            }
+
+            try {
+                $response = Invoke-JIMApi -Endpoint "/api/v1/metaverse/attributes/$AttributeId/priorities/$ObjectTypeId/mappings/$MappingId" -Method 'PUT' -Body $body
+                Write-Verbose "Moved mapping $MappingId to position $Position"
+
+                if ($PassThru) {
+                    $response
+                }
+            }
+            catch {
+                Write-Error "Failed to move mapping in attribute priority order: $_"
+            }
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/Metaverse/Set-JIMMetaverseAttributePriority.ps1
+++ b/src/JIM.PowerShell/Public/Metaverse/Set-JIMMetaverseAttributePriority.ps1
@@ -1,0 +1,98 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Set-JIMMetaverseAttributePriority {
+    <#
+    .SYNOPSIS
+        Replaces a Metaverse Attribute's import priority order.
+
+    .DESCRIPTION
+        Transactionally renumbers the priorities of all import contributions to a Metaverse
+        Attribute for a given Metaverse Object Type. -MappingId must list every current
+        contributing Synchronisation Rule Mapping for the Attribute exactly once, in the
+        desired priority order (highest first). To reposition a single mapping without
+        restating the whole list, use Move-JIMMetaverseAttributePriority instead.
+
+    .PARAMETER AttributeId
+        The unique identifier of the Metaverse Attribute.
+
+    .PARAMETER ObjectTypeId
+        The unique identifier of the Metaverse Object Type that scopes the priority list.
+
+    .PARAMETER MappingId
+        Every current contributing mapping ID, in the desired priority order (highest first).
+
+    .PARAMETER NullIsValueMappingId
+        Mapping IDs (from -MappingId) that should have their "Null is a value" flag set, so an
+        authoritative source can positively assert "no value" rather than falling through to
+        the next-priority source. Mappings not listed here have the flag cleared.
+
+    .PARAMETER PassThru
+        If specified, returns the resulting priority order.
+
+    .OUTPUTS
+        If -PassThru is specified, returns the resulting priority order.
+
+    .EXAMPLE
+        Set-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 45, 12, 78
+
+        Sets mapping 45 as highest priority, then 12, then 78.
+
+    .EXAMPLE
+        Set-JIMMetaverseAttributePriority -AttributeId 12 -ObjectTypeId 1 -MappingId 45, 12 -NullIsValueMappingId 45 -PassThru
+
+        Sets mapping 45 as highest priority with "Null is a value" enabled, then 12.
+
+    .LINK
+        Get-JIMMetaverseAttributePriority
+        Move-JIMMetaverseAttributePriority
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [int]$AttributeId,
+
+        [Parameter(Mandatory)]
+        [int]$ObjectTypeId,
+
+        [Parameter(Mandatory)]
+        [int[]]$MappingId,
+
+        [int[]]$NullIsValueMappingId,
+
+        [switch]$PassThru
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ShouldProcess("Attribute $AttributeId (Object Type $ObjectTypeId)", "Set priority order")) {
+            Write-Verbose "Setting attribute priority order for attribute $AttributeId on object type $ObjectTypeId"
+
+            $contributors = foreach ($id in $MappingId) {
+                @{
+                    mappingId   = $id
+                    nullIsValue = [bool]($NullIsValueMappingId -and $NullIsValueMappingId -contains $id)
+                }
+            }
+            $body = @{ contributors = @($contributors) }
+
+            try {
+                $response = Invoke-JIMApi -Endpoint "/api/v1/metaverse/attributes/$AttributeId/priorities/$ObjectTypeId" -Method 'PUT' -Body $body
+                Write-Verbose "Set attribute priority order for attribute $AttributeId"
+
+                if ($PassThru) {
+                    $response
+                }
+            }
+            catch {
+                Write-Error "Failed to set attribute priority order: $_"
+            }
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/WorkerTasks/Get-JIMWorkerTask.ps1
+++ b/src/JIM.PowerShell/Public/WorkerTasks/Get-JIMWorkerTask.ps1
@@ -1,0 +1,74 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Get-JIMWorkerTask {
+    <#
+    .SYNOPSIS
+        Gets Worker Tasks from JIM.
+
+    .DESCRIPTION
+        Retrieves currently queued, processing, or cancellation-requested Worker Tasks.
+        Worker Tasks are ephemeral: once a task completes, its record is deleted (the
+        associated Activity is the durable audit record), so this cmdlet only ever
+        returns in-flight work.
+
+    .PARAMETER Id
+        The unique identifier (GUID) of a specific Worker Task to retrieve.
+
+    .PARAMETER Page
+        Page number for paginated results. Defaults to 1. Not applicable when -Id is specified.
+
+    .PARAMETER PageSize
+        Number of items per page (1-100). Defaults to 50. Not applicable when -Id is specified.
+
+    .OUTPUTS
+        PSCustomObject representing Worker Task header(s).
+
+    .EXAMPLE
+        Get-JIMWorkerTask
+
+        Gets the first page of in-flight Worker Tasks.
+
+    .EXAMPLE
+        Get-JIMWorkerTask -Id "12345678-1234-1234-1234-123456789012"
+
+        Gets a specific Worker Task.
+
+    .LINK
+        Stop-JIMWorkerTask
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'List')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
+        [guid]$Id,
+
+        [Parameter(ParameterSetName = 'List')]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$Page = 1,
+
+        [Parameter(ParameterSetName = 'List')]
+        [ValidateRange(1, 100)]
+        [int]$PageSize = 50
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            Write-Verbose "Getting Worker Task $Id"
+            Invoke-JIMApi -Endpoint "/api/v1/worker-tasks/$Id"
+            return
+        }
+
+        Write-Verbose "Getting Worker Tasks (Page: $Page, PageSize: $PageSize)"
+        $response = Invoke-JIMApi -Endpoint "/api/v1/worker-tasks?page=$Page&pageSize=$PageSize"
+        foreach ($item in $response.items) {
+            $item
+        }
+    }
+}

--- a/src/JIM.PowerShell/Public/WorkerTasks/Stop-JIMWorkerTask.ps1
+++ b/src/JIM.PowerShell/Public/WorkerTasks/Stop-JIMWorkerTask.ps1
@@ -1,0 +1,65 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+function Stop-JIMWorkerTask {
+    <#
+    .SYNOPSIS
+        Cancels a Worker Task in JIM.
+
+    .DESCRIPTION
+        Requests cancellation of a queued or in-progress Worker Task. For a task actively
+        being processed, this signals the worker to stop and clean up gracefully; the task
+        remains visible with CancellationRequested status until the worker picks this up.
+        For a queued task, it is cancelled and removed immediately. Cancellation completes
+        asynchronously; JIM returns as soon as the request has been accepted.
+
+    .PARAMETER Id
+        The unique identifier (GUID) of the Worker Task to cancel.
+
+    .PARAMETER Force
+        Bypasses confirmation prompts.
+
+    .OUTPUTS
+        None.
+
+    .EXAMPLE
+        Stop-JIMWorkerTask -Id "12345678-1234-1234-1234-123456789012"
+
+        Requests cancellation of the specified Worker Task (with confirmation).
+
+    .EXAMPLE
+        Get-JIMWorkerTask | Stop-JIMWorkerTask -Force
+
+        Requests cancellation of every in-flight Worker Task without confirmation.
+
+    .LINK
+        Get-JIMWorkerTask
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [guid]$Id,
+
+        [switch]$Force
+    )
+
+    process {
+        # Check connection first
+        if (-not $script:JIMConnection) {
+            Write-Error "You are not connected to JIM. Run Connect-JIM -Url <your JIM URL> to authenticate, then try again."
+            return
+        }
+
+        if ($Force -or $PSCmdlet.ShouldProcess($Id, "Cancel Worker Task")) {
+            Write-Verbose "Requesting cancellation of Worker Task: $Id"
+
+            try {
+                Invoke-JIMApi -Endpoint "/api/v1/worker-tasks/$Id/cancel" -Method 'POST' | Out-Null
+                Write-Verbose "Requested cancellation of Worker Task: $Id"
+            }
+            catch {
+                Write-Error "Failed to cancel Worker Task: $_"
+            }
+        }
+    }
+}

--- a/src/JIM.PowerShell/Tests/ExampleData.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/ExampleData.Tests.ps1
@@ -20,6 +20,21 @@ AfterAll {
 
 Describe 'Get-JIMExampleDataSet' {
 
+    Context 'Parameter Sets' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMExampleDataSet
+        }
+
+        It 'Should have a List parameter set as default' {
+            $command.DefaultParameterSet | Should -Be 'List'
+        }
+
+        It 'Should have a ById parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'ById'
+        }
+    }
+
     Context 'Parameter Validation' {
 
         BeforeAll {
@@ -35,6 +50,12 @@ Describe 'Get-JIMExampleDataSet' {
             $param = $command.Parameters['PageSize']
             $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] } | Should -Not -BeNullOrEmpty
         }
+
+        It 'Should have Id as a mandatory int parameter in the ById set' {
+            $param = $command.Parameters['Id']
+            $param.ParameterType.Name | Should -Be 'Int32'
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
     }
 
     Context 'Requires Connection' {
@@ -46,12 +67,192 @@ Describe 'Get-JIMExampleDataSet' {
         It 'Should throw when not connected' {
             { Get-JIMExampleDataSet -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
+
+        It 'Should throw when not connected with Id' {
+            { Get-JIMExampleDataSet -Id 5 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
     }
 
     Context 'Help Documentation' {
 
         BeforeAll {
             $help = Get-Help Get-JIMExampleDataSet -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'New-JIMExampleDataSet' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command New-JIMExampleDataSet
+        }
+
+        It 'Should have a mandatory Name parameter' {
+            $param = $command.Parameters['Name']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have a mandatory Culture parameter' {
+            $param = $command.Parameters['Culture']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Values as a string array parameter' {
+            $command.Parameters['Values'].ParameterType.Name | Should -Be 'String[]'
+        }
+
+        It 'Should have PassThru switch parameter' {
+            $command.Parameters['PassThru'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should support ShouldProcess' {
+            $command.Parameters['WhatIf'] | Should -Not -BeNullOrEmpty
+            $command.Parameters['Confirm'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { New-JIMExampleDataSet -Name "Test" -Culture "en-GB" -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help New-JIMExampleDataSet -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Set-JIMExampleDataSet' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Set-JIMExampleDataSet
+        }
+
+        It 'Should have a mandatory Id parameter' {
+            $param = $command.Parameters['Id']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Id parameter that accepts pipeline by property name' {
+            $param = $command.Parameters['Id']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ValueFromPipelineByPropertyName } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have PassThru switch parameter' {
+            $command.Parameters['PassThru'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should support ShouldProcess' {
+            $command.Parameters['WhatIf'] | Should -Not -BeNullOrEmpty
+            $command.Parameters['Confirm'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Set-JIMExampleDataSet -Id 5 -Name "New Name" -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Set-JIMExampleDataSet -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Remove-JIMExampleDataSet' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Remove-JIMExampleDataSet
+        }
+
+        It 'Should have a mandatory Id parameter' {
+            $param = $command.Parameters['Id']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have a Force switch parameter' {
+            $command.Parameters['Force'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should support ShouldProcess' {
+            $command.Parameters['WhatIf'] | Should -Not -BeNullOrEmpty
+            $command.Parameters['Confirm'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Remove-JIMExampleDataSet -Id 5 -Force -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Remove-JIMExampleDataSet -Full
         }
 
         It 'Should have a synopsis' {

--- a/src/JIM.PowerShell/Tests/FileSystem.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/FileSystem.Tests.ps1
@@ -1,0 +1,136 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for File System browsing cmdlets.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'JIM.psd1'
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $ModulePath -Force
+}
+
+AfterAll {
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+}
+
+Describe 'Get-JIMFileSystemItem' {
+
+    Context 'Parameter Sets' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMFileSystemItem
+        }
+
+        It 'Should have a List parameter set as default' {
+            $command.DefaultParameterSet | Should -Be 'List'
+        }
+
+        It 'Should have a Roots parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'Roots'
+        }
+    }
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMFileSystemItem
+        }
+
+        It 'Should have Path as an optional string parameter' {
+            $command.Parameters['Path'].ParameterType.Name | Should -Be 'String'
+        }
+
+        It 'Should have Roots as a switch parameter' {
+            $command.Parameters['Roots'].SwitchParameter | Should -BeTrue
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Get-JIMFileSystemItem -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with Roots' {
+            { Get-JIMFileSystemItem -Roots -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Get-JIMFileSystemItem -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Test-JIMFileSystemPath' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Test-JIMFileSystemPath
+        }
+
+        It 'Should have a mandatory Path parameter' {
+            $param = $command.Parameters['Path']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Path parameter that accepts pipeline by property name' {
+            $param = $command.Parameters['Path']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ValueFromPipelineByPropertyName } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Test-JIMFileSystemPath -Path "/data" -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Test-JIMFileSystemPath -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/src/JIM.PowerShell/Tests/Get-JIMConnectedSystemObject.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Get-JIMConnectedSystemObject.Tests.ps1
@@ -26,8 +26,12 @@ Describe 'Get-JIMConnectedSystemObject' {
             $command = Get-Command Get-JIMConnectedSystemObject
         }
 
-        It 'Should have a ById parameter set as default' {
-            $command.DefaultParameterSet | Should -Be 'ById'
+        It 'Should have a List parameter set as default' {
+            $command.DefaultParameterSet | Should -Be 'List'
+        }
+
+        It 'Should have a ById parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'ById'
         }
 
         It 'Should have an AttributeValues parameter set' {
@@ -40,6 +44,10 @@ Describe 'Get-JIMConnectedSystemObject' {
 
         It 'Should have a Count parameter set' {
             $command.ParameterSets.Name | Should -Contain 'Count'
+        }
+
+        It 'Should have a ListAll parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'ListAll'
         }
     }
 
@@ -102,6 +110,28 @@ Describe 'Get-JIMConnectedSystemObject' {
         It 'Should have PartitionId as an optional int parameter' {
             $command.Parameters['PartitionId'].ParameterType.Name | Should -Be 'Int32'
         }
+
+        It 'Should have Status parameter with a ValidateSet' {
+            $param = $command.Parameters['Status']
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet | Should -Not -BeNullOrEmpty
+            $validateSet.ValidValues | Should -Contain 'Obsolete'
+        }
+
+        It 'Should have JoinType parameter with a ValidateSet' {
+            $param = $command.Parameters['JoinType']
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet | Should -Not -BeNullOrEmpty
+            $validateSet.ValidValues | Should -Contain 'NotJoined'
+        }
+
+        It 'Should have SortBy as an optional string parameter' {
+            $command.Parameters['SortBy'].ParameterType.Name | Should -Be 'String'
+        }
+
+        It 'Should have Ascending as a switch parameter' {
+            $command.Parameters['Ascending'].SwitchParameter | Should -BeTrue
+        }
     }
 
     Context 'Requires Connection' {
@@ -116,6 +146,14 @@ Describe 'Get-JIMConnectedSystemObject' {
 
         It 'Should throw when not connected with Count' {
             { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -Count -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with only ConnectedSystemId (List)' {
+            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with All (ListAll)' {
+            { Get-JIMConnectedSystemObject -ConnectedSystemId 1 -All -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
         }
     }
 

--- a/src/JIM.PowerShell/Tests/Logs.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Logs.Tests.ps1
@@ -1,0 +1,145 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for log viewing cmdlets.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'JIM.psd1'
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $ModulePath -Force
+}
+
+AfterAll {
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+}
+
+Describe 'Get-JIMLogEntry' {
+
+    Context 'Parameter Sets' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMLogEntry
+        }
+
+        It 'Should have an Entries parameter set as default' {
+            $command.DefaultParameterSet | Should -Be 'Entries'
+        }
+
+        It 'Should have a Levels parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'Levels'
+        }
+
+        It 'Should have a Services parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'Services'
+        }
+    }
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMLogEntry
+        }
+
+        It 'Should have Service as an optional string parameter' {
+            $command.Parameters['Service'].ParameterType.Name | Should -Be 'String'
+        }
+
+        It 'Should have Level as a string array parameter' {
+            $command.Parameters['Level'].ParameterType.Name | Should -Be 'String[]'
+        }
+
+        It 'Should have Limit parameter with ValidateRange' {
+            $param = $command.Parameters['Limit']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Offset parameter with ValidateRange' {
+            $param = $command.Parameters['Offset']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have ListLevels as a switch parameter' {
+            $command.Parameters['ListLevels'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should have ListServices as a switch parameter' {
+            $command.Parameters['ListServices'].SwitchParameter | Should -BeTrue
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Get-JIMLogEntry -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with ListLevels' {
+            { Get-JIMLogEntry -ListLevels -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with ListServices' {
+            { Get-JIMLogEntry -ListServices -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Get-JIMLogEntry -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Get-JIMLogFile' {
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Get-JIMLogFile -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Get-JIMLogFile -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/src/JIM.PowerShell/Tests/Metaverse.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Metaverse.Tests.ps1
@@ -289,3 +289,167 @@ Describe 'Get-JIMMetaverseAttribute' {
         }
     }
 }
+
+Describe 'Get-JIMMetaverseAttributePriority' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMMetaverseAttributePriority
+        }
+
+        It 'Should have a mandatory AttributeId parameter' {
+            $param = $command.Parameters['AttributeId']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have a mandatory ObjectTypeId parameter' {
+            $param = $command.Parameters['ObjectTypeId']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Get-JIMMetaverseAttributePriority -AttributeId 1 -ObjectTypeId 1 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Get-JIMMetaverseAttributePriority -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Set-JIMMetaverseAttributePriority' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Set-JIMMetaverseAttributePriority
+        }
+
+        It 'Should have a mandatory MappingId array parameter' {
+            $param = $command.Parameters['MappingId']
+            $param.ParameterType.Name | Should -Be 'Int32[]'
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have PassThru switch parameter' {
+            $command.Parameters['PassThru'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should support ShouldProcess' {
+            $command.Parameters['WhatIf'] | Should -Not -BeNullOrEmpty
+            $command.Parameters['Confirm'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Set-JIMMetaverseAttributePriority -AttributeId 1 -ObjectTypeId 1 -MappingId 1, 2 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Set-JIMMetaverseAttributePriority -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Move-JIMMetaverseAttributePriority' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Move-JIMMetaverseAttributePriority
+        }
+
+        It 'Should have a mandatory MappingId parameter' {
+            $param = $command.Parameters['MappingId']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have a mandatory Position parameter' {
+            $param = $command.Parameters['Position']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have NullIsValue as a switch parameter' {
+            $command.Parameters['NullIsValue'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should support ShouldProcess' {
+            $command.Parameters['WhatIf'] | Should -Not -BeNullOrEmpty
+            $command.Parameters['Confirm'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Move-JIMMetaverseAttributePriority -AttributeId 1 -ObjectTypeId 1 -MappingId 1 -Position 1 -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Move-JIMMetaverseAttributePriority -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/src/JIM.PowerShell/Tests/WorkerTasks.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/WorkerTasks.Tests.ps1
@@ -1,0 +1,156 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for Worker Task cmdlets.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'JIM.psd1'
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $ModulePath -Force
+}
+
+AfterAll {
+    Get-Module JIM -ErrorAction SilentlyContinue | Remove-Module -Force
+}
+
+Describe 'Get-JIMWorkerTask' {
+
+    Context 'Parameter Sets' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMWorkerTask
+        }
+
+        It 'Should have a List parameter set as default' {
+            $command.DefaultParameterSet | Should -Be 'List'
+        }
+
+        It 'Should have a ById parameter set' {
+            $command.ParameterSets.Name | Should -Contain 'ById'
+        }
+    }
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Get-JIMWorkerTask
+        }
+
+        It 'Should have Id as a guid parameter' {
+            $command.Parameters['Id'].ParameterType.Name | Should -Be 'Guid'
+        }
+
+        It 'Should have Id parameter that accepts pipeline by property name' {
+            $param = $command.Parameters['Id']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ValueFromPipelineByPropertyName } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Page parameter with ValidateRange' {
+            $param = $command.Parameters['Page']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have PageSize parameter with ValidateRange' {
+            $param = $command.Parameters['PageSize']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Get-JIMWorkerTask -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+
+        It 'Should throw when not connected with Id' {
+            { Get-JIMWorkerTask -Id ([guid]::NewGuid()) -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Get-JIMWorkerTask -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Stop-JIMWorkerTask' {
+
+    Context 'Parameter Validation' {
+
+        BeforeAll {
+            $command = Get-Command Stop-JIMWorkerTask
+        }
+
+        It 'Should have a mandatory Id parameter' {
+            $param = $command.Parameters['Id']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have Id parameter that accepts pipeline by property name' {
+            $param = $command.Parameters['Id']
+            $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ValueFromPipelineByPropertyName } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have a Force switch parameter' {
+            $command.Parameters['Force'].SwitchParameter | Should -BeTrue
+        }
+
+        It 'Should support ShouldProcess' {
+            $command.Parameters['WhatIf'] | Should -Not -BeNullOrEmpty
+            $command.Parameters['Confirm'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Requires Connection' {
+
+        BeforeEach {
+            Disconnect-JIM
+        }
+
+        It 'Should throw when not connected' {
+            { Stop-JIMWorkerTask -Id ([guid]::NewGuid()) -Force -ErrorAction Stop } | Should -Throw '*Connect-JIM*'
+        }
+    }
+
+    Context 'Help Documentation' {
+
+        BeforeAll {
+            $help = Get-Help Stop-JIMWorkerTask -Full
+        }
+
+        It 'Should have a synopsis' {
+            $help.Synopsis | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have examples' {
+            $help.Examples.Example.Count | Should -BeGreaterThan 0
+        }
+
+        It 'Should have related links' {
+            $help.RelatedLinks | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/src/JIM.Web/Controllers/Api/ExampleDataController.cs
+++ b/src/JIM.Web/Controllers/Api/ExampleDataController.cs
@@ -7,6 +7,7 @@ using JIM.Web.Models.Api;
 using JIM.Application;
 using JIM.Models.ExampleData;
 using JIM.Models.ExampleData.DTOs;
+using JIM.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -50,6 +51,121 @@ public class ExampleDataController(ILogger<ExampleDataController> logger, JimApp
             .ToPaginatedResponse(pagination);
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Get an Example Data Set
+    /// </summary>
+    /// <param name="id">The unique identifier of the Example Data Set.</param>
+    /// <returns>The full Example Data Set, including its values.</returns>
+    [HttpGet("example-data-sets/{id:int}", Name = "GetExampleDataSet")]
+    [ProducesResponseType(typeof(ExampleDataSet), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetExampleDataSetAsync(int id)
+    {
+        _logger.LogTrace("Requested example data set: {Id}", id);
+        var dataSet = await _application.ExampleData.GetExampleDataSetAsync(id);
+        if (dataSet == null)
+            return NotFound(ApiErrorResponse.NotFound($"Example Data Set with ID {id} not found."));
+
+        return Ok(dataSet);
+    }
+
+    /// <summary>
+    /// Create an Example Data Set
+    /// </summary>
+    /// <param name="request">The Example Data Set to create.</param>
+    /// <returns>The created Example Data Set.</returns>
+    [HttpPost("example-data-sets", Name = "CreateExampleDataSet")]
+    [ProducesResponseType(typeof(ExampleDataSet), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreateExampleDataSetAsync([FromBody] CreateExampleDataSetRequest request)
+    {
+        _logger.LogInformation("Creating Example Data Set: {Name}", LogSanitiser.Sanitise(request.Name));
+
+        var dataSet = new ExampleDataSet
+        {
+            Name = request.Name,
+            Culture = request.Culture,
+            BuiltIn = false,
+            Created = DateTime.UtcNow,
+            Values = (request.Values ?? []).Select(v => new ExampleDataSetValue { StringValue = v }).ToList()
+        };
+
+        await _application.ExampleData.CreateExampleDataSetAsync(dataSet);
+        _logger.LogInformation("Created Example Data Set {Id} ({Name})", dataSet.Id, LogSanitiser.Sanitise(dataSet.Name));
+
+        var created = await _application.ExampleData.GetExampleDataSetAsync(dataSet.Id);
+        return CreatedAtRoute("GetExampleDataSet", new { id = dataSet.Id }, created);
+    }
+
+    /// <summary>
+    /// Update an Example Data Set
+    /// </summary>
+    /// <param name="id">The unique identifier of the Example Data Set to update.</param>
+    /// <param name="request">The properties to update.</param>
+    /// <returns>The updated Example Data Set.</returns>
+    [HttpPut("example-data-sets/{id:int}", Name = "UpdateExampleDataSet")]
+    [ProducesResponseType(typeof(ExampleDataSet), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdateExampleDataSetAsync(int id, [FromBody] UpdateExampleDataSetRequest request)
+    {
+        _logger.LogInformation("Updating Example Data Set: {Id}", id);
+
+        var dataSet = await _application.ExampleData.GetExampleDataSetAsync(id);
+        if (dataSet == null)
+            return NotFound(ApiErrorResponse.NotFound($"Example Data Set with ID {id} not found."));
+
+        if (dataSet.BuiltIn)
+            return BadRequest(ApiErrorResponse.BadRequest("Built-in Example Data Sets cannot be updated."));
+
+        if (!string.IsNullOrWhiteSpace(request.Name))
+            dataSet.Name = request.Name;
+
+        if (!string.IsNullOrWhiteSpace(request.Culture))
+            dataSet.Culture = request.Culture;
+
+        if (request.Values != null)
+        {
+            dataSet.Values.Clear();
+            dataSet.Values.AddRange(request.Values.Select(v => new ExampleDataSetValue { StringValue = v }));
+        }
+
+        await _application.ExampleData.UpdateExampleDataSetAsync(dataSet);
+        _logger.LogInformation("Updated Example Data Set {Id}", id);
+
+        return Ok(dataSet);
+    }
+
+    /// <summary>
+    /// Delete an Example Data Set
+    /// </summary>
+    /// <param name="id">The unique identifier of the Example Data Set to delete.</param>
+    /// <returns>204 No Content on success.</returns>
+    [HttpDelete("example-data-sets/{id:int}", Name = "DeleteExampleDataSet")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> DeleteExampleDataSetAsync(int id)
+    {
+        _logger.LogInformation("Deleting Example Data Set: {Id}", id);
+
+        var dataSet = await _application.ExampleData.GetExampleDataSetAsync(id);
+        if (dataSet == null)
+            return NotFound(ApiErrorResponse.NotFound($"Example Data Set with ID {id} not found."));
+
+        if (dataSet.BuiltIn)
+            return BadRequest(ApiErrorResponse.BadRequest("Built-in Example Data Sets cannot be deleted."));
+
+        await _application.ExampleData.DeleteExampleDataSetAsync(id);
+        _logger.LogInformation("Deleted Example Data Set {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -527,9 +527,55 @@ public class SynchronisationController(
     {
         _logger.LogDebug("Getting connector space count for Connected System {ConnectedSystemId} (TypeId: {TypeId}, PartitionId: {PartitionId})",
             connectedSystemId, objectTypeId, partitionId);
-        var count = await _application.Repository.ConnectedSystems.GetConnectedSystemObjectCountAsync(
+        var count = await _application.ConnectedSystems.GetConnectedSystemObjectCountAsync(
             connectedSystemId, objectTypeId, partitionId);
         return Ok(count);
+    }
+
+    /// <summary>
+    /// List Connected System Objects
+    /// </summary>
+    /// <remarks>
+    /// Returns lightweight header objects. Use the detail endpoint to retrieve full Attribute values for a specific Connected System Object.
+    /// </remarks>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="page">Page number (1-based). Default: 1.</param>
+    /// <param name="pageSize">Number of items per page (1-100). Default: 50.</param>
+    /// <param name="search">Optional search text to filter by display name or external ID.</param>
+    /// <param name="sortBy">Optional property name to sort by.</param>
+    /// <param name="sortDescending">Whether to sort descending. Default: true.</param>
+    /// <param name="status">Optional Connected System Object status values to filter by. Repeat the parameter for multiple values.</param>
+    /// <param name="objectTypeId">Optional Object Type IDs to filter by. Repeat the parameter for multiple values.</param>
+    /// <param name="joinType">Optional join type values to filter by. Repeat the parameter for multiple values.</param>
+    /// <returns>A paginated set of Connected System Object headers.</returns>
+    [HttpGet("connected-systems/{connectedSystemId:int}/connector-space", Name = "GetConnectedSystemObjects")]
+    [ProducesResponseType(typeof(PaginatedResponse<ConnectedSystemObjectHeader>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetConnectedSystemObjectsAsync(
+        int connectedSystemId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        [FromQuery] string? search = null,
+        [FromQuery] string? sortBy = null,
+        [FromQuery] bool sortDescending = true,
+        [FromQuery] List<ConnectedSystemObjectStatus>? status = null,
+        [FromQuery] List<int>? objectTypeId = null,
+        [FromQuery] List<ConnectedSystemObjectJoinType>? joinType = null)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 50;
+        if (pageSize > 100) pageSize = 100;
+
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
+        if (connectedSystem == null)
+            return NotFound(ApiErrorResponse.NotFound($"Connected System with ID {connectedSystemId} not found."));
+
+        var result = await _application.ConnectedSystems.GetConnectedSystemObjectHeadersAsync(
+            connectedSystemId, page, pageSize, search, sortBy, sortDescending, status, objectTypeId, joinType);
+
+        return Ok(PaginatedResponse<ConnectedSystemObjectHeader>.Create(
+            result.Results, result.TotalResults, result.CurrentPage, result.PageSize));
     }
 
     #region Pending Exports

--- a/src/JIM.Web/Controllers/Api/WorkerTasksController.cs
+++ b/src/JIM.Web/Controllers/Api/WorkerTasksController.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using Asp.Versioning;
+using JIM.Application;
+using JIM.Models.Tasking.DTOs;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JIM.Web.Controllers.Api;
+
+/// <summary>
+/// API controller for monitoring and cancelling queued and in-progress worker tasks.
+/// </summary>
+/// <remarks>
+/// Worker tasks are ephemeral: once a task completes, its record is deleted (the associated
+/// Activity is the durable audit record). This controller therefore only ever surfaces
+/// queued, processing, or cancellation-requested tasks.
+/// </remarks>
+[Route("api/v{version:apiVersion}/worker-tasks")]
+[ApiController]
+[ApiVersion("1.0")]
+[Authorize(Roles = "Administrator")]
+[Produces("application/json")]
+public class WorkerTasksController(ILogger<WorkerTasksController> logger, JimApplication application) : ControllerBase
+{
+    private readonly ILogger<WorkerTasksController> _logger = logger;
+    private readonly JimApplication _application = application;
+
+    /// <summary>
+    /// List Worker Tasks
+    /// </summary>
+    /// <remarks>
+    /// Returns lightweight header objects for every currently queued, processing, or
+    /// cancellation-requested task.
+    /// </remarks>
+    /// <param name="page">Page number (1-based). Default: 1.</param>
+    /// <param name="pageSize">Number of items per page (1-100). Default: 50.</param>
+    /// <returns>A paginated set of Worker Task headers, most recent first.</returns>
+    [HttpGet(Name = "GetWorkerTasks")]
+    [ProducesResponseType(typeof(PaginatedResponse<WorkerTaskHeader>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetWorkerTasksAsync(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 50;
+        if (pageSize > 100) pageSize = 100;
+
+        _logger.LogTrace("Requested worker tasks (Page: {Page}, PageSize: {PageSize})", page, pageSize);
+
+        var headers = await _application.Tasking.GetWorkerTaskHeadersAsync();
+        var pagedHeaders = headers.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        return Ok(PaginatedResponse<WorkerTaskHeader>.Create(pagedHeaders, headers.Count, page, pageSize));
+    }
+
+    /// <summary>
+    /// Get a Worker Task
+    /// </summary>
+    /// <param name="id">The unique identifier of the Worker Task.</param>
+    /// <returns>The Worker Task header.</returns>
+    [HttpGet("{id:guid}", Name = "GetWorkerTask")]
+    [ProducesResponseType(typeof(WorkerTaskHeader), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetWorkerTaskAsync(Guid id)
+    {
+        _logger.LogTrace("Requested worker task: {Id}", id);
+
+        var headers = await _application.Tasking.GetWorkerTaskHeadersAsync();
+        var header = headers.FirstOrDefault(h => h.Id == id);
+        if (header == null)
+            return NotFound(ApiErrorResponse.NotFound($"Worker task with ID {id} not found."));
+
+        return Ok(header);
+    }
+
+    /// <summary>
+    /// Cancel a Worker Task
+    /// </summary>
+    /// <remarks>
+    /// For a task actively being processed, this signals the worker to stop and clean up; the
+    /// task remains visible with CancellationRequested status until the worker picks this up.
+    /// For a queued task, it is cancelled and removed immediately.
+    /// </remarks>
+    /// <param name="id">The unique identifier of the Worker Task to cancel.</param>
+    /// <returns>202 Accepted; cancellation completes asynchronously.</returns>
+    [HttpPost("{id:guid}/cancel", Name = "CancelWorkerTask")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CancelWorkerTaskAsync(Guid id)
+    {
+        _logger.LogInformation("Requesting cancellation of worker task: {Id}", id);
+
+        var headers = await _application.Tasking.GetWorkerTaskHeadersAsync();
+        if (headers.All(h => h.Id != id))
+            return NotFound(ApiErrorResponse.NotFound($"Worker task with ID {id} not found."));
+
+        await _application.Tasking.RequestWorkerTaskCancellationAsync(id);
+        _logger.LogInformation("Requested cancellation of worker task: {Id}", id);
+
+        return Accepted();
+    }
+}

--- a/src/JIM.Web/Models/Api/ExampleDataRequestDtos.cs
+++ b/src/JIM.Web/Models/Api/ExampleDataRequestDtos.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace JIM.Web.Models.Api;
+
+/// <summary>
+/// Request DTO for creating an Example Data Set.
+/// </summary>
+public class CreateExampleDataSetRequest
+{
+    [Required]
+    [StringLength(200, MinimumLength = 1)]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// The .NET Culture, i.e. "en-GB", the values are in.
+    /// </summary>
+    [Required]
+    [StringLength(10)]
+    public string Culture { get; set; } = null!;
+
+    public List<string>? Values { get; set; }
+}
+
+/// <summary>
+/// Request DTO for updating an Example Data Set.
+/// </summary>
+public class UpdateExampleDataSetRequest
+{
+    [StringLength(200, MinimumLength = 1)]
+    public string? Name { get; set; }
+
+    [StringLength(10)]
+    public string? Culture { get; set; }
+
+    /// <summary>
+    /// When supplied, replaces the entire set of values.
+    /// </summary>
+    public List<string>? Values { get; set; }
+}

--- a/test/JIM.Web.Api.Tests/ExampleDataControllerExampleDataSetCrudTests.cs
+++ b/test/JIM.Web.Api.Tests/ExampleDataControllerExampleDataSetCrudTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.ExampleData;
+using JIM.Web.Controllers.Api;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for ExampleDataController's Example Data Set CRUD endpoints (issue #154, Phase 2).
+/// </summary>
+[TestFixture]
+public class ExampleDataControllerExampleDataSetCrudTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IExampleDataRepository> _mockExampleDataRepo = null!;
+    private Mock<ILogger<ExampleDataController>> _mockLogger = null!;
+    private JimApplication _application = null!;
+    private ExampleDataController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockExampleDataRepo = new Mock<IExampleDataRepository>();
+        _mockRepository.Setup(r => r.ExampleData).Returns(_mockExampleDataRepo.Object);
+        _mockLogger = new Mock<ILogger<ExampleDataController>>();
+        _application = new JimApplication(_mockRepository.Object);
+        _controller = new ExampleDataController(_mockLogger.Object, _application);
+
+        var claims = new List<Claim>
+        {
+            new("sub", Guid.NewGuid().ToString()),
+            new(ClaimTypes.Role, "Administrator")
+        };
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+            }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application.Dispose();
+    }
+
+    [Test]
+    public async Task GetExampleDataSetAsync_Exists_ReturnsOkWithEntityAsync()
+    {
+        var dataSet = new ExampleDataSet { Id = 5, Name = "UK Cities", Culture = "en-GB" };
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(5)).ReturnsAsync(dataSet);
+
+        var result = await _controller.GetExampleDataSetAsync(5);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var returned = (ExampleDataSet)((OkObjectResult)result).Value!;
+        Assert.That(returned.Id, Is.EqualTo(5));
+    }
+
+    [Test]
+    public async Task GetExampleDataSetAsync_DoesNotExist_ReturnsNotFoundAsync()
+    {
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(999)).ReturnsAsync((ExampleDataSet?)null);
+
+        var result = await _controller.GetExampleDataSetAsync(999);
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task CreateExampleDataSetAsync_ValidRequest_ReturnsCreatedAsync()
+    {
+        var request = new CreateExampleDataSetRequest
+        {
+            Name = "UK Cities",
+            Culture = "en-GB",
+            Values = new List<string> { "London", "Manchester" }
+        };
+
+        ExampleDataSet? created = null;
+        _mockExampleDataRepo.Setup(r => r.CreateExampleDataSetAsync(It.IsAny<ExampleDataSet>()))
+            .Callback<ExampleDataSet>(ds => { ds.Id = 7; created = ds; })
+            .Returns(Task.CompletedTask);
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(7)).ReturnsAsync(() => created);
+
+        var result = await _controller.CreateExampleDataSetAsync(request);
+
+        Assert.That(result, Is.InstanceOf<CreatedAtRouteResult>());
+        var dto = (ExampleDataSet)((CreatedAtRouteResult)result).Value!;
+        Assert.That(dto.Name, Is.EqualTo("UK Cities"));
+        Assert.That(dto.Values, Has.Count.EqualTo(2));
+        _mockExampleDataRepo.Verify(r => r.CreateExampleDataSetAsync(It.IsAny<ExampleDataSet>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateExampleDataSetAsync_DoesNotExist_ReturnsNotFoundAsync()
+    {
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(999)).ReturnsAsync((ExampleDataSet?)null);
+
+        var result = await _controller.UpdateExampleDataSetAsync(999, new UpdateExampleDataSetRequest { Name = "New Name" });
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task UpdateExampleDataSetAsync_BuiltIn_ReturnsBadRequestAsync()
+    {
+        var dataSet = new ExampleDataSet { Id = 1, Name = "Builtin Set", Culture = "en-GB", BuiltIn = true };
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(1)).ReturnsAsync(dataSet);
+
+        var result = await _controller.UpdateExampleDataSetAsync(1, new UpdateExampleDataSetRequest { Name = "New Name" });
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockExampleDataRepo.Verify(r => r.UpdateExampleDataSetAsync(It.IsAny<ExampleDataSet>()), Times.Never);
+    }
+
+    [Test]
+    public async Task UpdateExampleDataSetAsync_ValidRequest_UpdatesAndReturnsOkAsync()
+    {
+        var dataSet = new ExampleDataSet { Id = 3, Name = "Old Name", Culture = "en-GB" };
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(3)).ReturnsAsync(dataSet);
+
+        var result = await _controller.UpdateExampleDataSetAsync(3, new UpdateExampleDataSetRequest { Name = "New Name" });
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(dataSet.Name, Is.EqualTo("New Name"));
+        _mockExampleDataRepo.Verify(r => r.UpdateExampleDataSetAsync(dataSet), Times.Once);
+    }
+
+    [Test]
+    public async Task DeleteExampleDataSetAsync_DoesNotExist_ReturnsNotFoundAsync()
+    {
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(999)).ReturnsAsync((ExampleDataSet?)null);
+
+        var result = await _controller.DeleteExampleDataSetAsync(999);
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task DeleteExampleDataSetAsync_BuiltIn_ReturnsBadRequestAsync()
+    {
+        var dataSet = new ExampleDataSet { Id = 1, Name = "Builtin Set", Culture = "en-GB", BuiltIn = true };
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(1)).ReturnsAsync(dataSet);
+
+        var result = await _controller.DeleteExampleDataSetAsync(1);
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        _mockExampleDataRepo.Verify(r => r.DeleteExampleDataSetAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DeleteExampleDataSetAsync_ValidRequest_DeletesAndReturnsNoContentAsync()
+    {
+        var dataSet = new ExampleDataSet { Id = 4, Name = "Custom Set", Culture = "en-GB" };
+        _mockExampleDataRepo.Setup(r => r.GetExampleDataSetAsync(4)).ReturnsAsync(dataSet);
+
+        var result = await _controller.DeleteExampleDataSetAsync(4);
+
+        Assert.That(result, Is.InstanceOf<NoContentResult>());
+        _mockExampleDataRepo.Verify(r => r.DeleteExampleDataSetAsync(4), Times.Once);
+    }
+}

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerGetConnectedSystemObjectsTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerGetConnectedSystemObjectsTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Application.Expressions;
+using JIM.Application.Interfaces;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+using JIM.Models.Staging.DTOs;
+using JIM.Models.Utility;
+using JIM.Web.Controllers.Api;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for SynchronisationController.GetConnectedSystemObjectsAsync, the paginated Connected
+/// System Object list endpoint (issue #154, Phase 2).
+/// </summary>
+[TestFixture]
+public class SynchronisationControllerGetConnectedSystemObjectsTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IConnectedSystemRepository> _mockConnectedSystemRepo = null!;
+    private Mock<IApiKeyRepository> _mockApiKeyRepo = null!;
+    private Mock<ILogger<SynchronisationController>> _mockLogger = null!;
+    private Mock<ICredentialProtectionService> _mockCredentialProtection = null!;
+    private IExpressionEvaluator _expressionEvaluator = null!;
+    private JimApplication _application = null!;
+    private SynchronisationController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockConnectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _mockApiKeyRepo = new Mock<IApiKeyRepository>();
+        _mockRepository.Setup(r => r.ConnectedSystems).Returns(_mockConnectedSystemRepo.Object);
+        _mockRepository.Setup(r => r.ApiKeys).Returns(_mockApiKeyRepo.Object);
+        _mockLogger = new Mock<ILogger<SynchronisationController>>();
+        _mockCredentialProtection = new Mock<ICredentialProtectionService>();
+        _expressionEvaluator = new DynamicExpressoEvaluator();
+        _application = new JimApplication(_mockRepository.Object);
+        _controller = new SynchronisationController(_mockLogger.Object, _application, _expressionEvaluator, _mockCredentialProtection.Object);
+
+        var claims = new List<Claim>
+        {
+            new("sub", Guid.NewGuid().ToString()),
+            new(ClaimTypes.Role, "Administrator")
+        };
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+            }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application.Dispose();
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectsAsync_ConnectedSystemExists_ReturnsPaginatedHeadersAsync()
+    {
+        // Arrange
+        var system = new ConnectedSystem { Id = 42, Name = "Active Directory" };
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(42, It.IsAny<bool>())).ReturnsAsync(system);
+
+        var headers = new List<ConnectedSystemObjectHeader>
+        {
+            new() { Id = Guid.NewGuid(), ConnectedSystemId = 42, DisplayName = "Alice" },
+            new() { Id = Guid.NewGuid(), ConnectedSystemId = 42, DisplayName = "Bob" }
+        };
+        var pagedResult = new PagedResultSet<ConnectedSystemObjectHeader>
+        {
+            Results = headers,
+            TotalResults = 2,
+            CurrentPage = 1,
+            PageSize = 50
+        };
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectHeadersAsync(
+                42, 1, 50, null, null, true, null, null, null))
+            .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _controller.GetConnectedSystemObjectsAsync(42, page: 1, pageSize: 50);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var response = (PaginatedResponse<ConnectedSystemObjectHeader>)((OkObjectResult)result).Value!;
+        Assert.That(response.TotalCount, Is.EqualTo(2));
+        Assert.That(response.Items, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectsAsync_ConnectedSystemDoesNotExist_ReturnsNotFoundAsync()
+    {
+        // Arrange
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(999, It.IsAny<bool>())).ReturnsAsync((ConnectedSystem?)null);
+
+        // Act
+        var result = await _controller.GetConnectedSystemObjectsAsync(999, page: 1, pageSize: 50);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+        var error = (ApiErrorResponse)((NotFoundObjectResult)result).Value!;
+        Assert.That(error.Code, Is.EqualTo(ApiErrorCodes.NotFound));
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectsAsync_FiltersProvided_PassesThemToRepositoryAsync()
+    {
+        // Arrange
+        var system = new ConnectedSystem { Id = 7, Name = "HR" };
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemCoreAsync(7, It.IsAny<bool>())).ReturnsAsync(system);
+
+        var pagedResult = new PagedResultSet<ConnectedSystemObjectHeader>
+        {
+            Results = new List<ConnectedSystemObjectHeader>(),
+            TotalResults = 0,
+            CurrentPage = 2,
+            PageSize = 10
+        };
+
+        var statusFilter = new List<ConnectedSystemObjectStatus> { ConnectedSystemObjectStatus.Obsolete };
+        var objectTypeFilter = new List<int> { 3 };
+        var joinTypeFilter = new List<ConnectedSystemObjectJoinType> { ConnectedSystemObjectJoinType.NotJoined };
+
+        _mockConnectedSystemRepo.Setup(r => r.GetConnectedSystemObjectHeadersAsync(
+                7, 2, 10, "alice", "DisplayName", false, statusFilter, objectTypeFilter, joinTypeFilter))
+            .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _controller.GetConnectedSystemObjectsAsync(
+            7, page: 2, pageSize: 10, search: "alice", sortBy: "DisplayName", sortDescending: false,
+            status: statusFilter, objectTypeId: objectTypeFilter, joinType: joinTypeFilter);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        _mockConnectedSystemRepo.Verify(r => r.GetConnectedSystemObjectHeadersAsync(
+            7, 2, 10, "alice", "DisplayName", false, statusFilter, objectTypeFilter, joinTypeFilter), Times.Once);
+    }
+}

--- a/test/JIM.Web.Api.Tests/WorkerTasksControllerTests.cs
+++ b/test/JIM.Web.Api.Tests/WorkerTasksControllerTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Tasking;
+using JIM.Models.Tasking.DTOs;
+using JIM.Web.Controllers.Api;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for WorkerTasksController (issue #154, Phase 4).
+/// </summary>
+[TestFixture]
+public class WorkerTasksControllerTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<ITaskingRepository> _mockTaskingRepo = null!;
+    private Mock<IActivityRepository> _mockActivityRepo = null!;
+    private Mock<ILogger<WorkerTasksController>> _mockLogger = null!;
+    private JimApplication _application = null!;
+    private WorkerTasksController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockTaskingRepo = new Mock<ITaskingRepository>();
+        _mockActivityRepo = new Mock<IActivityRepository>();
+        _mockRepository.Setup(r => r.Tasking).Returns(_mockTaskingRepo.Object);
+        _mockRepository.Setup(r => r.Activity).Returns(_mockActivityRepo.Object);
+        _mockLogger = new Mock<ILogger<WorkerTasksController>>();
+        _application = new JimApplication(_mockRepository.Object);
+        _controller = new WorkerTasksController(_mockLogger.Object, _application);
+
+        var claims = new List<Claim>
+        {
+            new("sub", Guid.NewGuid().ToString()),
+            new(ClaimTypes.Role, "Administrator")
+        };
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+            }
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application.Dispose();
+    }
+
+    private static List<WorkerTaskHeader> MakeHeaders(int count)
+    {
+        var headers = new List<WorkerTaskHeader>();
+        for (var i = 0; i < count; i++)
+        {
+            headers.Add(new WorkerTaskHeader
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Task {i}",
+                Type = "Synchronisation",
+                Timestamp = DateTime.UtcNow,
+                Status = WorkerTaskStatus.Queued
+            });
+        }
+        return headers;
+    }
+
+    [Test]
+    public async Task GetWorkerTasksAsync_ReturnsPaginatedHeadersAsync()
+    {
+        var headers = MakeHeaders(3);
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(headers);
+
+        var result = await _controller.GetWorkerTasksAsync(page: 1, pageSize: 50);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var response = (PaginatedResponse<WorkerTaskHeader>)((OkObjectResult)result).Value!;
+        Assert.That(response.TotalCount, Is.EqualTo(3));
+        Assert.That(response.Items, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public async Task GetWorkerTasksAsync_PagesInMemoryAsync()
+    {
+        var headers = MakeHeaders(5);
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(headers);
+
+        var result = await _controller.GetWorkerTasksAsync(page: 2, pageSize: 2);
+
+        var response = (PaginatedResponse<WorkerTaskHeader>)((OkObjectResult)result).Value!;
+        Assert.That(response.TotalCount, Is.EqualTo(5));
+        Assert.That(response.Items, Has.Count.EqualTo(2));
+        Assert.That(response.Page, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetWorkerTaskAsync_Exists_ReturnsOkAsync()
+    {
+        var headers = MakeHeaders(2);
+        var target = headers[1];
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(headers);
+
+        var result = await _controller.GetWorkerTaskAsync(target.Id);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var returned = (WorkerTaskHeader)((OkObjectResult)result).Value!;
+        Assert.That(returned.Id, Is.EqualTo(target.Id));
+    }
+
+    [Test]
+    public async Task GetWorkerTaskAsync_DoesNotExist_ReturnsNotFoundAsync()
+    {
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(new List<WorkerTaskHeader>());
+
+        var result = await _controller.GetWorkerTaskAsync(Guid.NewGuid());
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task CancelWorkerTaskAsync_DoesNotExist_ReturnsNotFoundAsync()
+    {
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(new List<WorkerTaskHeader>());
+
+        var result = await _controller.CancelWorkerTaskAsync(Guid.NewGuid());
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+        _mockTaskingRepo.Verify(r => r.GetWorkerTaskAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CancelWorkerTaskAsync_QueuedTask_ReturnsAcceptedAndDeletesAsync()
+    {
+        var taskId = Guid.NewGuid();
+        var headers = new List<WorkerTaskHeader>
+        {
+            new() { Id = taskId, Name = "Test", Type = "Synchronisation", Status = WorkerTaskStatus.Queued }
+        };
+        var task = new SynchronisationWorkerTask { Id = taskId, Status = WorkerTaskStatus.Queued };
+
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(headers);
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskAsync(taskId)).ReturnsAsync(task);
+        _mockTaskingRepo.Setup(r => r.DeleteWorkerTaskAsync(It.IsAny<WorkerTask>())).Returns(Task.CompletedTask);
+
+        var result = await _controller.CancelWorkerTaskAsync(taskId);
+
+        Assert.That(result, Is.InstanceOf<AcceptedResult>());
+        _mockTaskingRepo.Verify(r => r.DeleteWorkerTaskAsync(It.Is<WorkerTask>(t => t.Id == taskId)), Times.Once);
+    }
+
+    [Test]
+    public async Task CancelWorkerTaskAsync_ProcessingTask_ReturnsAcceptedAndMarksCancellationRequestedAsync()
+    {
+        var taskId = Guid.NewGuid();
+        var headers = new List<WorkerTaskHeader>
+        {
+            new() { Id = taskId, Name = "Test", Type = "Synchronisation", Status = WorkerTaskStatus.Processing }
+        };
+        var task = new SynchronisationWorkerTask
+        {
+            Id = taskId,
+            Status = WorkerTaskStatus.Processing,
+            Activity = new Activity { Id = Guid.NewGuid(), Status = ActivityStatus.InProgress }
+        };
+
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskHeadersAsync()).ReturnsAsync(headers);
+        _mockTaskingRepo.Setup(r => r.GetWorkerTaskAsync(taskId)).ReturnsAsync(task);
+        _mockTaskingRepo.Setup(r => r.UpdateWorkerTaskAsync(It.IsAny<WorkerTask>())).Returns(Task.CompletedTask);
+
+        var result = await _controller.CancelWorkerTaskAsync(taskId);
+
+        Assert.That(result, Is.InstanceOf<AcceptedResult>());
+        _mockTaskingRepo.Verify(r => r.UpdateWorkerTaskAsync(
+            It.Is<WorkerTask>(t => t.Id == taskId && t.Status == WorkerTaskStatus.CancellationRequested)), Times.Once);
+    }
+}


### PR DESCRIPTION
## Description

Completes the remaining API and PowerShell coverage scope for #154, maintaining strict 1:1 API/PowerShell parity:

- Paginated Connected System Object list endpoint plus PowerShell support
- Worker Tasks controller with `Get-JIMWorkerTask` / `Stop-JIMWorkerTask` cmdlets
- Example Data Set CRUD endpoints with `New/Get/Set/Remove-JIMExampleDataSet` cmdlets
- FileSystem (`Get-JIMFileSystemItem`, `Test-JIMFileSystemPath`), Logs (`Get-JIMLogEntry`, `Get-JIMLogFile`) and Metaverse Attribute Priority (`Get/Set/Move-JIMMetaverseAttributePriority`) cmdlets
- PowerShell reference documentation for all new cmdlets and a CHANGELOG entry

Data Generation Template CRUD was split out to #894 and is not in this PR.

Closes #154

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment

`dotnet build JIM.sln`: 0 errors, 0 warnings. `dotnet test JIM.sln`: 2,912 passed, 0 failed, 14 skipped (the RequiresPostgres tier self-skips without a database). New controllers have NUnit coverage (e.g. `WorkerTasksControllerTests`) and new cmdlets have Pester test files.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `docs/powershell/worker-tasks.md`, `docs/powershell/file-system.md`, `docs/powershell/logs.md`, `docs/powershell/metaverse.md`, `docs/powershell/example-data.md`, `docs/powershell/connected-systems.md`

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

This branch was authored in an earlier session; this PR shepherds it to merge. It gates the rest of the API/PowerShell lane in the v1.0 milestone execution plan (#466 rescope, #813 contract normalisation, #487 hardening), so landing it first avoids conflicts across the controllers and PowerShell module it touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UCjAcvVVyEChmUDNtFUWz

---
_Generated by [Claude Code](https://claude.ai/code/session_015UCjAcvVVyEChmUDNtFUWz)_