### PR TITLE
fix: capture config snapshots on all Connected System mutation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- 🐛 Every Connected System configuration change now records a versioned snapshot in its change history. Previously, several paths created an Activity but captured nothing, leaving blank Activity detail pages: schema updates and imports, hierarchy imports, container auto-selection after export, bulk attribute updates, matching-mode switches, worker-initiated updates, and the REST API partition/container selection endpoints (which recorded no Activity at all).
+- 🐛 Saving a Connected System or Synchronisation Rule without actually changing anything no longer records a duplicate configuration version; a change entry now always represents a real difference.
+- 🐛 Resetting a Connected System's status after a failed deletion no longer records a spurious configuration change; status is runtime state, not configuration.
 - 🐛 Updated the bundled Microsoft.OpenApi library to a patched release (2.7.5), clearing a high-severity advisory (GHSA-v5pm-xwqc-g5wc: circular schema references could terminate OpenAPI document parsing) present in JIM's API documentation generation.
 - 🐛 A Connected System hierarchy refresh that retrieves no partitions no longer wipes the configured hierarchy. Previously, if the connector returned zero partitions (typically a transient connection, authentication, or scope problem rather than a genuinely empty directory), every existing partition and container, including selected ones, was treated as removed and deleted. JIM now leaves the existing hierarchy untouched in that case and records a warning on the Activity so the cause can be investigated.
 - 🐛 A completed example data generation Activity no longer shows a stale "Persisting to database..." progress line; the transient progress message is cleared when the Activity completes.

--- a/src/JIM.Application/Servers/ActivityServer.cs
+++ b/src/JIM.Application/Servers/ActivityServer.cs
@@ -98,6 +98,24 @@ public class ActivityServer
     }
 
     /// <summary>
+    /// Returns the snapshot JSON of the latest configuration-change version recorded for a configuration object, or
+    /// null if none exists yet. Used by the idempotent capture guard to skip no-change captures.
+    /// </summary>
+    public async Task<string?> GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType targetType, int targetObjectId)
+    {
+        return await Application.Repository.Activity.GetLatestConfigurationChangeSnapshotAsync(targetType, targetObjectId);
+    }
+
+    /// <summary>
+    /// Returns the snapshot JSON of the latest configuration-change version recorded for a Guid-keyed configuration
+    /// object (e.g. a Schedule), or null if none exists yet.
+    /// </summary>
+    public async Task<string?> GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType targetType, Guid targetObjectId)
+    {
+        return await Application.Repository.Activity.GetLatestConfigurationChangeSnapshotAsync(targetType, targetObjectId);
+    }
+
+    /// <summary>
     /// Creates and persists an Activity using an initiator triad (Type, Id, Name).
     /// Used when the full principal object is not available (e.g., from WorkerTask).
     /// </summary>

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -57,9 +57,21 @@ public class ConnectedSystemServer
 
             var hashKey = await Application.ServiceSettings.GetOrCreateConfigurationChangeHashKeyAsync();
             var snapshot = Application.ConfigurationSnapshots.CreateSnapshot(connectedSystem, hashKey);
+            var serialised = ConfigurationSnapshotService.Serialise(snapshot);
             activity.ConnectedSystemId ??= connectedSystem.Id;
+
+            // Idempotent capture guard: serialisation is deterministic (stable ordering, no timestamps, keyed secret
+            // hashes), so an identical string means nothing changed. Skipping keeps no-change saves (e.g. worker paths
+            // that persist after every import) from consuming versions and drowning real changes in noise.
+            var latest = await Application.Activities.GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType.ConnectedSystem, connectedSystem.Id);
+            if (latest == serialised)
+            {
+                Log.Debug("CaptureConfigurationChangeAsync: configuration of Connected System {ConnectedSystemId} is unchanged from its latest snapshot; no new version recorded.", connectedSystem.Id);
+                return;
+            }
+
             activity.ConfigurationChangeVersion = await Application.Activities.GetNextConfigurationChangeVersionAsync(ActivityTargetType.ConnectedSystem, connectedSystem.Id);
-            activity.ConfigurationChangeSnapshot = ConfigurationSnapshotService.Serialise(snapshot);
+            activity.ConfigurationChangeSnapshot = serialised;
         }
         catch (Exception ex) when (ex is InvalidOperationException or NullReferenceException or FormatException or JsonException or DbException)
         {
@@ -82,9 +94,19 @@ public class ConnectedSystemServer
 
             var hashKey = await Application.ServiceSettings.GetOrCreateConfigurationChangeHashKeyAsync();
             var snapshot = Application.ConfigurationSnapshots.CreateSnapshot(syncRule, hashKey);
+            var serialised = ConfigurationSnapshotService.Serialise(snapshot);
             activity.SyncRuleId ??= syncRule.Id;
+
+            // Idempotent capture guard: see the Connected System overload above.
+            var latest = await Application.Activities.GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType.SyncRule, syncRule.Id);
+            if (latest == serialised)
+            {
+                Log.Debug("CaptureConfigurationChangeAsync: configuration of Synchronisation Rule {SyncRuleId} is unchanged from its latest snapshot; no new version recorded.", syncRule.Id);
+                return;
+            }
+
             activity.ConfigurationChangeVersion = await Application.Activities.GetNextConfigurationChangeVersionAsync(ActivityTargetType.SyncRule, syncRule.Id);
-            activity.ConfigurationChangeSnapshot = ConfigurationSnapshotService.Serialise(snapshot);
+            activity.ConfigurationChangeSnapshot = serialised;
         }
         catch (Exception ex) when (ex is InvalidOperationException or NullReferenceException or FormatException or JsonException or DbException)
         {
@@ -451,6 +473,8 @@ public class ConnectedSystemServer
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemSchemaAsync(connectedSystem);
 
+        // Reload for the snapshot: schema reconciliation assigns ids server-side, so the caller's graph is stale.
+        await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
         await Application.Activities.CompleteActivityAsync(activity);
     }
 
@@ -557,7 +581,24 @@ public class ConnectedSystemServer
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem);
 
+        await CaptureConfigurationChangeAsync(activity, connectedSystem, changeReason: null);
         await Application.Activities.CompleteActivityAsync(activity);
+    }
+
+    /// <summary>
+    /// Persists a runtime status change (e.g. resetting <see cref="ConnectedSystemStatus.Deleting"/> back to
+    /// <see cref="ConnectedSystemStatus.Active"/> after a failed deletion) without creating an Activity or capturing a
+    /// configuration snapshot. Status is runtime state, not configuration; routing it through the full
+    /// <see cref="UpdateConnectedSystemAsync(ConnectedSystem, MetaverseObject?, string?)"/> would record a spurious
+    /// configuration-change version.
+    /// </summary>
+    public async Task UpdateConnectedSystemStatusAsync(ConnectedSystem connectedSystem, ConnectedSystemStatus status)
+    {
+        if (connectedSystem == null)
+            throw new ArgumentNullException(nameof(connectedSystem));
+
+        connectedSystem.Status = status;
+        await Application.Repository.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem);
     }
 
     /// <summary>
@@ -635,6 +676,7 @@ public class ConnectedSystemServer
 
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem);
 
+        await CaptureConfigurationChangeAsync(activity, connectedSystem, changeReason: null);
         await Application.Activities.CompleteActivityAsync(activity);
 
         return result;
@@ -1377,6 +1419,10 @@ public class ConnectedSystemServer
 
         await PersistConnectedSystemSchemaUpdateAsync(connectedSystem, initiatedBy);
 
+        // A schema import changes the system's configuration (object types and attributes); capture it onto the
+        // ImportSchema activity so the change is versioned in the system's history. Reloaded, as ids are assigned on save.
+        await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
+
         // finish the activity
         await Application.Activities.CompleteActivityAsync(activity);
 
@@ -1531,6 +1577,9 @@ public class ConnectedSystemServer
 
         await PersistConnectedSystemSchemaUpdateAsync(connectedSystem, initiatedByApiKey);
 
+        // Capture the configuration change onto the ImportSchema activity: see the user-initiated overload above.
+        await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
+
         await Application.Activities.CompleteActivityAsync(activity);
 
         return result;
@@ -1599,6 +1648,10 @@ public class ConnectedSystemServer
         // Persist the changes
         await PersistConnectedSystemUpdateAsync(connectedSystem, initiatedBy);
 
+        // A hierarchy import changes the system's configuration (partitions and containers); capture it onto the
+        // ImportHierarchy activity so the change is versioned in the system's history. Reloaded, as ids are assigned on save.
+        await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
+
         // finish the activity
         await Application.Activities.CompleteActivityAsync(activity);
 
@@ -1662,6 +1715,9 @@ public class ConnectedSystemServer
 
         // Persist the changes
         await PersistConnectedSystemUpdateAsync(connectedSystem, initiatedByApiKey);
+
+        // Capture the configuration change onto the ImportHierarchy activity: see the user-initiated overload above.
+        await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
 
         // finish the activity
         await Application.Activities.CompleteActivityAsync(activity);
@@ -1806,6 +1862,10 @@ public class ConnectedSystemServer
                 await PersistConnectedSystemUpdateAsync(connectedSystem, initiatedByUser);
 
             activity.Message = $"Auto-selected {containersAdded} container(s) created during export";
+
+            // Container additions change the system's import scope; capture the configuration change onto this
+            // activity so it is versioned in the system's history. Reloaded, as container ids are assigned on save.
+            await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
         }
 
         await Application.Activities.CompleteActivityAsync(activity);
@@ -1924,6 +1984,10 @@ public class ConnectedSystemServer
         {
             await PersistConnectedSystemUpdateAsync(connectedSystem, initiatorType, initiatorId, initiatorName);
             activity.Message = $"Auto-selected {containersAdded} container(s) created during export";
+
+            // Container additions change the system's import scope; capture the configuration change onto this
+            // activity so it is versioned in the system's history. Reloaded, as container ids are assigned on save.
+            await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
         }
 
         await Application.Activities.CompleteActivityAsync(activity);
@@ -2530,7 +2594,13 @@ public class ConnectedSystemServer
         }
 
         if (updated.Count > 0)
+        {
             await Application.Repository.ConnectedSystems.UpdateAttributesAsync(updated);
+
+            // Attribute selection changes are configuration; capture the change onto this activity so it is
+            // versioned in the system's history. Reloaded so the snapshot reflects persisted truth.
+            await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
+        }
 
         if (errors.Count > 0)
             await Application.Activities.CompleteActivityWithWarningAsync(activity);
@@ -2621,7 +2691,13 @@ public class ConnectedSystemServer
         }
 
         if (updated.Count > 0)
+        {
             await Application.Repository.ConnectedSystems.UpdateAttributesAsync(updated);
+
+            // Attribute selection changes are configuration; capture the change onto this activity so it is
+            // versioned in the system's history. Reloaded so the snapshot reflects persisted truth.
+            await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystem.Id);
+        }
 
         if (errors.Count > 0)
             await Application.Activities.CompleteActivityWithWarningAsync(activity);
@@ -3775,12 +3851,24 @@ public class ConnectedSystemServer
     #endregion
 
     #region Connected System Partitions
-    public async Task CreateConnectedSystemPartitionAsync(ConnectedSystemPartition connectedSystemPartition)
+    // Partition and container writes change the system's import scope, which is configuration: every mutation is
+    // recorded with an Activity and a versioned snapshot via ExecuteScopeConfigurationChangeAsync. There are
+    // deliberately no activity-less overloads, so any future caller inherits capture automatically.
+
+    /// <summary>
+    /// Creates a Connected System Partition, recording the change with an Activity and a versioned configuration
+    /// snapshot of the owning Connected System.
+    /// </summary>
+    public async Task CreateConnectedSystemPartitionAsync(ConnectedSystemPartition connectedSystemPartition, int connectedSystemId, MetaverseObject? initiatedBy)
     {
         if (connectedSystemPartition == null)
             throw new ArgumentNullException(nameof(connectedSystemPartition));
 
-        await Application.Repository.ConnectedSystems.CreateConnectedSystemPartitionAsync(connectedSystemPartition);
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Create partition: {connectedSystemPartition.Name}",
+            () => Application.Repository.ConnectedSystems.CreateConnectedSystemPartitionAsync(connectedSystemPartition),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedBy));
     }
 
     public async Task<IList<ConnectedSystemPartition>> GetConnectedSystemPartitionsAsync(ConnectedSystem connectedSystem)
@@ -3796,20 +3884,52 @@ public class ConnectedSystemServer
         return await Application.Repository.ConnectedSystems.GetConnectedSystemPartitionAsync(id, withChangeTracking);
     }
 
-    public async Task UpdateConnectedSystemPartitionAsync(ConnectedSystemPartition partition)
+    /// <summary>
+    /// Updates a Connected System Partition (e.g. its import-scope selection), recording the change with an Activity
+    /// and a versioned configuration snapshot of the owning Connected System.
+    /// </summary>
+    public async Task UpdateConnectedSystemPartitionAsync(ConnectedSystemPartition partition, int connectedSystemId, MetaverseObject? initiatedBy)
     {
         if (partition == null)
             throw new ArgumentNullException(nameof(partition));
 
-        await Application.Repository.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition);
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Update partition: {partition.Name}",
+            () => Application.Repository.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedBy));
     }
 
-    public async Task DeleteConnectedSystemPartitionAsync(ConnectedSystemPartition connectedSystemPartition)
+    /// <summary>
+    /// Updates a Connected System Partition (initiated by API key), recording the change with an Activity and a
+    /// versioned configuration snapshot of the owning Connected System.
+    /// </summary>
+    public async Task UpdateConnectedSystemPartitionAsync(ConnectedSystemPartition partition, int connectedSystemId, ApiKey initiatedByApiKey)
+    {
+        if (partition == null)
+            throw new ArgumentNullException(nameof(partition));
+
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Update partition: {partition.Name}",
+            () => Application.Repository.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedByApiKey));
+    }
+
+    /// <summary>
+    /// Deletes a Connected System Partition, recording the change with an Activity and a versioned configuration
+    /// snapshot of the owning Connected System.
+    /// </summary>
+    public async Task DeleteConnectedSystemPartitionAsync(ConnectedSystemPartition connectedSystemPartition, int connectedSystemId, MetaverseObject? initiatedBy)
     {
         if (connectedSystemPartition == null)
             throw new ArgumentNullException(nameof(connectedSystemPartition));
 
-        await Application.Repository.ConnectedSystems.DeleteConnectedSystemPartitionAsync(connectedSystemPartition);
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Delete partition: {connectedSystemPartition.Name}",
+            () => Application.Repository.ConnectedSystems.DeleteConnectedSystemPartitionAsync(connectedSystemPartition),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedBy));
     }
     #endregion
 
@@ -3817,13 +3937,18 @@ public class ConnectedSystemServer
     /// <summary>
     /// Used to create a top-level container (optionally with children), when the connector does not implement Partitions.
     /// If the connector implements Partitions, then use CreateConnectedSystemPartitionAsync and add the container to that.
+    /// The change is recorded with an Activity and a versioned configuration snapshot of the owning Connected System.
     /// </summary>
-    public async Task CreateConnectedSystemContainerAsync(ConnectedSystemContainer connectedSystemContainer)
+    public async Task CreateConnectedSystemContainerAsync(ConnectedSystemContainer connectedSystemContainer, int connectedSystemId, MetaverseObject? initiatedBy)
     {
         if (connectedSystemContainer == null)
             throw new ArgumentNullException(nameof(connectedSystemContainer));
 
-        await Application.Repository.ConnectedSystems.CreateConnectedSystemContainerAsync(connectedSystemContainer);
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Create container: {connectedSystemContainer.Name}",
+            () => Application.Repository.ConnectedSystems.CreateConnectedSystemContainerAsync(connectedSystemContainer),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedBy));
     }
 
     public async Task<IList<ConnectedSystemContainer>> GetConnectedSystemContainersAsync(ConnectedSystem connectedSystem)
@@ -3839,21 +3964,83 @@ public class ConnectedSystemServer
         return await Application.Repository.ConnectedSystems.GetConnectedSystemContainerAsync(id);
     }
 
-    public async Task UpdateConnectedSystemContainerAsync(ConnectedSystemContainer container)
+    /// <summary>
+    /// Updates a Connected System Container (e.g. its import-scope selection), recording the change with an Activity
+    /// and a versioned configuration snapshot of the owning Connected System.
+    /// </summary>
+    public async Task UpdateConnectedSystemContainerAsync(ConnectedSystemContainer container, int connectedSystemId, MetaverseObject? initiatedBy)
     {
         if (container == null)
             throw new ArgumentNullException(nameof(container));
 
-        await Application.Repository.ConnectedSystems.UpdateConnectedSystemContainerAsync(container);
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Update container: {container.Name}",
+            () => Application.Repository.ConnectedSystems.UpdateConnectedSystemContainerAsync(container),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedBy));
     }
 
-    public async Task DeleteConnectedSystemContainerAsync(ConnectedSystemContainer connectedSystemContainer)
+    /// <summary>
+    /// Updates a Connected System Container (initiated by API key), recording the change with an Activity and a
+    /// versioned configuration snapshot of the owning Connected System.
+    /// </summary>
+    public async Task UpdateConnectedSystemContainerAsync(ConnectedSystemContainer container, int connectedSystemId, ApiKey initiatedByApiKey)
+    {
+        if (container == null)
+            throw new ArgumentNullException(nameof(container));
+
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Update container: {container.Name}",
+            () => Application.Repository.ConnectedSystems.UpdateConnectedSystemContainerAsync(container),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedByApiKey));
+    }
+
+    /// <summary>
+    /// Deletes a Connected System Container, recording the change with an Activity and a versioned configuration
+    /// snapshot of the owning Connected System.
+    /// </summary>
+    public async Task DeleteConnectedSystemContainerAsync(ConnectedSystemContainer connectedSystemContainer, int connectedSystemId, MetaverseObject? initiatedBy)
     {
         if (connectedSystemContainer == null)
             throw new ArgumentNullException(nameof(connectedSystemContainer));
 
+        await ExecuteScopeConfigurationChangeAsync(
+            connectedSystemId,
+            $"Delete container: {connectedSystemContainer.Name}",
+            () => Application.Repository.ConnectedSystems.DeleteConnectedSystemContainerAsync(connectedSystemContainer),
+            activity => Application.Activities.CreateActivityAsync(activity, initiatedBy));
+    }
 
-        await Application.Repository.ConnectedSystems.DeleteConnectedSystemContainerAsync(connectedSystemContainer);
+    /// <summary>
+    /// Shared execution shape for partition/container configuration changes: create an Update Activity against the
+    /// owning Connected System, persist the change, capture a versioned configuration snapshot (reloaded so it
+    /// reflects persisted truth), then complete the Activity.
+    /// </summary>
+    private async Task ExecuteScopeConfigurationChangeAsync(
+        int connectedSystemId,
+        string message,
+        Func<Task> persistAsync,
+        Func<Activity, Task> createActivityAsync)
+    {
+        var connectedSystem = await Application.Repository.ConnectedSystems.GetConnectedSystemCoreAsync(connectedSystemId);
+
+        // The activity targets the owning Connected System (whose configuration changed), so the operation is always
+        // Update; whether a partition/container was created, updated or deleted is carried by the message.
+        var activity = new Activity
+        {
+            TargetName = connectedSystem?.Name ?? "Unknown",
+            TargetType = ActivityTargetType.ConnectedSystem,
+            TargetOperationType = ActivityTargetOperationType.Update,
+            ConnectedSystemId = connectedSystemId,
+            Message = message
+        };
+        await createActivityAsync(activity);
+
+        await persistAsync();
+
+        await CaptureConnectedSystemConfigurationChangeAsync(activity, connectedSystemId);
+        await Application.Activities.CompleteActivityAsync(activity);
     }
     #endregion
 

--- a/src/JIM.Data/Repositories/IActivityRepository.cs
+++ b/src/JIM.Data/Repositories/IActivityRepository.cs
@@ -107,6 +107,20 @@ public interface IActivityRepository
     public Task<int> GetMaxConfigurationChangeVersionAsync(ActivityTargetType targetType, Guid targetObjectId);
 
     /// <summary>
+    /// Gets the snapshot JSON of the highest configuration-change version recorded for a configuration object, or null
+    /// if none exists yet. Used by the idempotent capture guard: a new capture whose snapshot is identical to the
+    /// latest stored one is skipped rather than recorded as a no-change version.
+    /// </summary>
+    public Task<string?> GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType targetType, int targetObjectId);
+
+    /// <summary>
+    /// Gets the snapshot JSON of the highest configuration-change version recorded for a Guid-keyed configuration
+    /// object (e.g. a <see cref="ActivityTargetType.Schedule"/>), or null if none exists yet. The Guid-keyed
+    /// counterpart of <see cref="GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType,int)"/>.
+    /// </summary>
+    public Task<string?> GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType targetType, Guid targetObjectId);
+
+    /// <summary>
     /// Counts the versioned configuration-change activities recorded for a configuration object.
     /// </summary>
     public Task<int> GetConfigurationChangeCountAsync(ActivityTargetType targetType, int targetObjectId);

--- a/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
@@ -504,6 +504,22 @@ public class ActivityRepository : IActivityRepository
         return max ?? 0;
     }
 
+    public async Task<string?> GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType targetType, int targetObjectId)
+    {
+        return await ConfigurationChangeQuery(targetType, targetObjectId)
+            .OrderByDescending(a => a.ConfigurationChangeVersion)
+            .Select(a => a.ConfigurationChangeSnapshot)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<string?> GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType targetType, Guid targetObjectId)
+    {
+        return await ConfigurationChangeQuery(targetType, targetObjectId)
+            .OrderByDescending(a => a.ConfigurationChangeVersion)
+            .Select(a => a.ConfigurationChangeSnapshot)
+            .FirstOrDefaultAsync();
+    }
+
     public async Task<int> GetConfigurationChangeCountAsync(ActivityTargetType targetType, int targetObjectId)
     {
         return await ConfigurationChangeQuery(targetType, targetObjectId).CountAsync();

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -763,7 +763,12 @@ public class SynchronisationController(
         if (request.Selected.HasValue)
             partition.Selected = request.Selected.Value;
 
-        await _application.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition);
+        // Partition selection is configuration; the server records the change with an Activity and a versioned snapshot.
+        var apiKey = await GetCurrentApiKeyAsync();
+        if (apiKey != null)
+            await _application.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition, connectedSystemId, apiKey);
+        else
+            await _application.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition, connectedSystemId, initiatedBy);
 
         // Reload to get full entity with relationships
         var updated = await _application.ConnectedSystems.GetConnectedSystemPartitionAsync(partitionId);
@@ -814,7 +819,12 @@ public class SynchronisationController(
         if (request.Selected.HasValue)
             container.Selected = request.Selected.Value;
 
-        await _application.ConnectedSystems.UpdateConnectedSystemContainerAsync(container);
+        // Container selection is configuration; the server records the change with an Activity and a versioned snapshot.
+        var apiKey = await GetCurrentApiKeyAsync();
+        if (apiKey != null)
+            await _application.ConnectedSystems.UpdateConnectedSystemContainerAsync(container, connectedSystemId, apiKey);
+        else
+            await _application.ConnectedSystems.UpdateConnectedSystemContainerAsync(container, connectedSystemId, initiatedBy);
 
         // Reload to get full entity with relationships
         var updated = await _application.ConnectedSystems.GetConnectedSystemContainerAsync(containerId);

--- a/src/JIM.Worker/Worker.cs
+++ b/src/JIM.Worker/Worker.cs
@@ -453,8 +453,9 @@ public class Worker : BackgroundService
                                             var connectedSystem = await taskJim.ConnectedSystems.GetConnectedSystemCoreAsync(deleteConnectedSystemTask.ConnectedSystemId, withChangeTracking: true);
                                             if (connectedSystem != null && connectedSystem.Status == ConnectedSystemStatus.Deleting)
                                             {
-                                                connectedSystem.Status = ConnectedSystemStatus.Active;
-                                                await taskJim.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem, (MetaverseObject?)null);
+                                                // Status is runtime state, not configuration: the status-only update avoids
+                                                // recording a spurious configuration-change version for the reset.
+                                                await taskJim.ConnectedSystems.UpdateConnectedSystemStatusAsync(connectedSystem, ConnectedSystemStatus.Active);
                                                 Log.Warning("ExecuteAsync: Reset Connected System {Id} status to Active after deletion failure", deleteConnectedSystemTask.ConnectedSystemId);
                                             }
                                         }

--- a/test/JIM.Worker.Tests/Servers/ConfigurationChangeCaptureCoverageTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConfigurationChangeCaptureCoverageTests.cs
@@ -1,0 +1,363 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Text;
+using JIM.Application;
+using JIM.Application.Interfaces;
+using JIM.Connectors;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Interfaces;
+using JIM.Models.Logic;
+using JIM.Models.Security;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Tests that close the configuration-change capture coverage gaps: every code path that mutates a Connected System's
+/// configuration must record a versioned snapshot on its Activity (schema updates, worker-initiated triad updates,
+/// object-matching mode switches, container auto-selection, bulk attribute updates and the partition/container API
+/// endpoints), while runtime-state writes (a status flip) must not pollute the configuration history. Also covers the
+/// idempotent capture guard: a capture whose snapshot is identical to the object's latest stored one records no new
+/// version, so worker paths can capture liberally without generating no-change noise.
+/// </summary>
+[TestFixture]
+public class ConfigurationChangeCaptureCoverageTests
+{
+    private Mock<IRepository> _repo = null!;
+    private Mock<IActivityRepository> _activityRepo = null!;
+    private Mock<IServiceSettingsRepository> _settingsRepo = null!;
+    private Mock<IConnectedSystemRepository> _csRepo = null!;
+    private FakeProtection _protection = null!;
+    private JimApplication _jim = null!;
+    private Activity? _createdActivity;
+    private Activity? _completedActivity;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _createdActivity = null;
+        _completedActivity = null;
+
+        _repo = new Mock<IRepository>();
+        _activityRepo = new Mock<IActivityRepository>();
+        _settingsRepo = new Mock<IServiceSettingsRepository>();
+        _csRepo = new Mock<IConnectedSystemRepository>();
+        _repo.Setup(r => r.Activity).Returns(_activityRepo.Object);
+        _repo.Setup(r => r.ServiceSettings).Returns(_settingsRepo.Object);
+        _repo.Setup(r => r.ConnectedSystems).Returns(_csRepo.Object);
+
+        _activityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<Activity>()))
+            .Callback<Activity>(a => _createdActivity = a)
+            .Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<Activity>()))
+            .Callback<Activity>(a => _completedActivity = a)
+            .Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.GetMaxConfigurationChangeVersionAsync(It.IsAny<ActivityTargetType>(), It.IsAny<int>()))
+            .ReturnsAsync(6);
+        _activityRepo.Setup(r => r.GetLatestConfigurationChangeSnapshotAsync(It.IsAny<ActivityTargetType>(), It.IsAny<int>()))
+            .ReturnsAsync((string?)null);
+
+        _csRepo.Setup(r => r.UpdateConnectedSystemAsync(It.IsAny<ConnectedSystem>())).Returns(Task.CompletedTask);
+        _csRepo.Setup(r => r.UpdateConnectedSystemSchemaAsync(It.IsAny<ConnectedSystem>())).Returns(Task.CompletedTask);
+        _csRepo.Setup(r => r.GetConnectedSystemAsync(1, It.IsAny<bool>())).ReturnsAsync(BuildConnectedSystem);
+
+        _protection = new FakeProtection();
+        _jim = new JimApplication(_repo.Object) { CredentialProtection = _protection };
+
+        SetupTrackingSetting(enabled: true);
+        SetupHashKeySetting();
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    // -- gap paths: an Activity existed but no snapshot was captured ------------------------------------------------------
+
+    [Test]
+    public async Task UpdateConnectedSystemWithTriadAsync_WhenTrackingEnabled_CapturesVersionedSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemWithTriadAsync(
+            connectedSystem, ActivityInitiatorType.System, null, "Infrastructure Key");
+
+        AssertCapturedConnectedSystemVersion();
+    }
+
+    [Test]
+    public async Task UpdateConnectedSystemSchemaAsync_WhenTrackingEnabled_CapturesVersionedSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemSchemaAsync(connectedSystem, NewUser());
+
+        AssertCapturedConnectedSystemVersion();
+    }
+
+    [Test]
+    public async Task SwitchObjectMatchingModeAsync_WhenTrackingEnabled_CapturesVersionedSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+        connectedSystem.ObjectMatchingRuleMode = ObjectMatchingRuleMode.ConnectedSystem;
+        _csRepo.Setup(r => r.GetSyncRulesAsync(1, true, It.IsAny<bool>())).ReturnsAsync([]);
+
+        var result = await _jim.ConnectedSystems.SwitchObjectMatchingModeAsync(
+            connectedSystem, ObjectMatchingRuleMode.SyncRule, NewUser());
+
+        Assert.That(result.Success, Is.True);
+        AssertCapturedConnectedSystemVersion();
+    }
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersWithTriadAsync_WhenContainersAdded_CapturesVersionedSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+        connectedSystem.Partitions =
+        [
+            new ConnectedSystemPartition
+            {
+                Id = 20, ExternalId = "DC=corp,DC=local", Name = "corp.local", Selected = true,
+                Containers = []
+            }
+        ];
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersWithTriadAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,DC=corp,DC=local"],
+            ActivityInitiatorType.System, null, "Infrastructure Key");
+
+        AssertCapturedConnectedSystemVersion();
+        Assert.That(_completedActivity!.Message, Does.StartWith("Auto-selected 1 container(s)"));
+    }
+
+    [Test]
+    public async Task BulkUpdateAttributesAsync_WhenTrackingEnabled_CapturesVersionedSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+        var objectType = new ConnectedSystemObjectType
+        {
+            Id = 7,
+            Name = "user",
+            ConnectedSystemId = 1,
+            Attributes = [new ConnectedSystemObjectTypeAttribute { Id = 9, Name = "displayName", Selected = false }]
+        };
+        _csRepo.Setup(r => r.UpdateAttributesAsync(It.IsAny<List<ConnectedSystemObjectTypeAttribute>>()))
+            .Returns(Task.CompletedTask);
+
+        await _jim.ConnectedSystems.BulkUpdateAttributesAsync(
+            connectedSystem, objectType,
+            new Dictionary<int, (bool? Selected, bool? IsExternalId, bool? IsSecondaryExternalId)> { [9] = (true, null, null) },
+            NewUser());
+
+        AssertCapturedConnectedSystemVersion();
+    }
+
+    // -- gap paths: no Activity at all (the REST API partition/container endpoints) ---------------------------------------
+
+    [Test]
+    public async Task UpdateConnectedSystemPartitionAsync_WithInitiator_CreatesActivityAndCapturesSnapshotAsync()
+    {
+        var partition = new ConnectedSystemPartition { Id = 20, ExternalId = "DC=corp,DC=local", Name = "corp.local", Selected = true };
+        _csRepo.Setup(r => r.UpdateConnectedSystemPartitionAsync(partition)).Returns(Task.CompletedTask);
+        _csRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(BuildConnectedSystem);
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemPartitionAsync(partition, 1, NewUser());
+
+        Assert.That(_createdActivity, Is.Not.Null, "a partition-selection change must be recorded with an Activity");
+        Assert.That(_createdActivity!.TargetType, Is.EqualTo(ActivityTargetType.ConnectedSystem));
+        Assert.That(_createdActivity.TargetOperationType, Is.EqualTo(ActivityTargetOperationType.Update));
+        AssertCapturedConnectedSystemVersion();
+    }
+
+    [Test]
+    public async Task UpdateConnectedSystemContainerAsync_WithApiKeyInitiator_CreatesActivityAndCapturesSnapshotAsync()
+    {
+        var container = new ConnectedSystemContainer { Id = 30, ExternalId = "OU=People,DC=corp,DC=local", Name = "People", Selected = false };
+        _csRepo.Setup(r => r.UpdateConnectedSystemContainerAsync(container)).Returns(Task.CompletedTask);
+        _csRepo.Setup(r => r.GetConnectedSystemCoreAsync(1, It.IsAny<bool>())).ReturnsAsync(BuildConnectedSystem);
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemContainerAsync(container, 1, NewApiKey());
+
+        Assert.That(_createdActivity, Is.Not.Null, "a container-selection change must be recorded with an Activity");
+        Assert.That(_createdActivity!.TargetType, Is.EqualTo(ActivityTargetType.ConnectedSystem));
+        AssertCapturedConnectedSystemVersion();
+    }
+
+    // -- runtime state must not pollute the configuration history ---------------------------------------------------------
+
+    [Test]
+    public async Task UpdateConnectedSystemStatusAsync_DoesNotCreateActivityOrCaptureSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+        connectedSystem.Status = ConnectedSystemStatus.Deleting;
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemStatusAsync(connectedSystem, ConnectedSystemStatus.Active);
+
+        Assert.That(connectedSystem.Status, Is.EqualTo(ConnectedSystemStatus.Active));
+        _csRepo.Verify(r => r.UpdateConnectedSystemAsync(connectedSystem), Times.Once);
+        Assert.That(_createdActivity, Is.Null, "a runtime status flip is not a configuration change and must not create an Activity");
+        Assert.That(_completedActivity, Is.Null);
+    }
+
+    // -- idempotent capture guard ------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdateConnectedSystemAsync_WhenSnapshotUnchanged_SkipsVersionAndSnapshotAsync()
+    {
+        var connectedSystem = BuildConnectedSystem();
+
+        // First save: no prior snapshot exists, so a versioned snapshot is captured.
+        await _jim.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem, NewUser());
+        Assert.That(_completedActivity, Is.Not.Null);
+        var storedSnapshot = _completedActivity!.ConfigurationChangeSnapshot;
+        Assert.That(storedSnapshot, Is.Not.Null);
+        Assert.That(_completedActivity.ConfigurationChangeVersion, Is.EqualTo(7));
+
+        // Second save of the identical configuration: the latest stored snapshot matches, so no version is recorded.
+        _activityRepo.Setup(r => r.GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType.ConnectedSystem, 1))
+            .ReturnsAsync(storedSnapshot);
+        _completedActivity = null;
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem, NewUser(), changeReason: "no-op save");
+
+        Assert.That(_completedActivity, Is.Not.Null);
+        Assert.That(_completedActivity!.ConfigurationChangeVersion, Is.Null, "an unchanged configuration must not consume a version");
+        Assert.That(_completedActivity.ConfigurationChangeSnapshot, Is.Null, "an unchanged configuration must not store a duplicate snapshot");
+        Assert.That(_completedActivity.ChangeReason, Is.EqualTo("no-op save"), "the reason is still recorded independently of the dedupe guard");
+    }
+
+    [Test]
+    public async Task CreateOrUpdateSyncRuleAsync_WhenSnapshotUnchanged_SkipsVersionAndSnapshotAsync()
+    {
+        _csRepo.Setup(r => r.UpdateSyncRuleAsync(It.IsAny<SyncRule>())).Returns(Task.CompletedTask);
+        var rule = BuildExportRule();
+
+        // First save captures; harvest the stored snapshot.
+        await _jim.ConnectedSystems.CreateOrUpdateSyncRuleAsync(rule, NewApiKey());
+        var storedSnapshot = _completedActivity!.ConfigurationChangeSnapshot;
+        Assert.That(storedSnapshot, Is.Not.Null);
+
+        // Second identical save records no new version.
+        _activityRepo.Setup(r => r.GetLatestConfigurationChangeSnapshotAsync(ActivityTargetType.SyncRule, 55))
+            .ReturnsAsync(storedSnapshot);
+        _completedActivity = null;
+
+        await _jim.ConnectedSystems.CreateOrUpdateSyncRuleAsync(rule, NewApiKey());
+
+        Assert.That(_completedActivity, Is.Not.Null);
+        Assert.That(_completedActivity!.ConfigurationChangeVersion, Is.Null, "an unchanged Synchronisation Rule must not consume a version");
+        Assert.That(_completedActivity.ConfigurationChangeSnapshot, Is.Null);
+    }
+
+    // -- helpers -------------------------------------------------------------------------------------------------------
+
+    private void AssertCapturedConnectedSystemVersion()
+    {
+        Assert.That(_completedActivity, Is.Not.Null);
+        Assert.That(_completedActivity!.ConfigurationChangeVersion, Is.EqualTo(7), "version is the existing maximum (6) + 1");
+        Assert.That(_completedActivity.ConnectedSystemId, Is.EqualTo(1), "the activity must carry the Connected System id so the change is queryable in its history");
+        Assert.That(_completedActivity.ConfigurationChangeSnapshot, Is.Not.Null);
+        Assert.That(_completedActivity.ConfigurationChangeSnapshot, Does.Contain("\"objectType\":\"ConnectedSystem\""));
+    }
+
+    // A minimal valid Connected System: the File connector needs no configured connector instance to validate settings.
+    private static ConnectedSystem BuildConnectedSystem() => new()
+    {
+        Id = 1,
+        Name = "HR System",
+        ConnectorDefinition = new ConnectorDefinition { Name = ConnectorConstants.FileConnectorName },
+        SettingValues =
+        [
+            new ConnectedSystemSettingValue
+            {
+                Id = 10,
+                Setting = new ConnectorDefinitionSetting { Name = "File Path", Required = true, Type = ConnectedSystemSettingType.File },
+                StringValue = "/data/users.csv"
+            },
+            new ConnectedSystemSettingValue
+            {
+                Id = 11,
+                Setting = new ConnectorDefinitionSetting { Name = "Mode", Required = true, Type = ConnectedSystemSettingType.DropDown },
+                StringValue = "Import Only"
+            }
+        ],
+        RunProfiles = [],
+        ObjectTypes = [],
+        Partitions = []
+    };
+
+    private static SyncRule BuildExportRule() => new()
+    {
+        Id = 55,
+        Name = "AD Export",
+        Direction = SyncRuleDirection.Export,
+        ConnectedSystem = new ConnectedSystem { Id = 3, Name = "AD" },
+        ConnectedSystemId = 3,
+        ConnectedSystemObjectType = new ConnectedSystemObjectType { Id = 7, Name = "user" },
+        ConnectedSystemObjectTypeId = 7,
+        MetaverseObjectType = new MetaverseObjectType { Id = 1, Name = "Person" },
+        MetaverseObjectTypeId = 1
+    };
+
+    private void SetupTrackingSetting(bool enabled) =>
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled,
+                DisplayName = "Track configuration changes",
+                ValueType = ServiceSettingValueType.Boolean,
+                Value = enabled ? "true" : "false"
+            });
+
+    private void SetupHashKeySetting() =>
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ConfigurationChangeHashKey))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ConfigurationChangeHashKey,
+                DisplayName = "Configuration change hash key",
+                ValueType = ServiceSettingValueType.StringEncrypted,
+                Value = _protection.Protect(Convert.ToBase64String(new byte[32]))
+            });
+
+    private static ApiKey NewApiKey() => new() { Id = Guid.NewGuid(), Name = "test-key" };
+
+    private static MetaverseObject NewUser() => new() { Id = Guid.NewGuid(), CachedDisplayName = "Admin User" };
+
+    /// <summary>A connector test double that reports container-creation support for the auto-selection path.</summary>
+    private sealed class FakeContainerCreatingConnector : IConnector, IConnectorContainerCreation
+    {
+        public string Name => "Fake Directory";
+        public string? Description => null;
+        public string? Url => null;
+        public IReadOnlyList<string> CreatedContainerExternalIds { get; } = [];
+        public Task<bool> VerifyContainerExistsAsync(string containerExternalId) => Task.FromResult(true);
+        public string? GetParentContainerExternalId(string containerExternalId) =>
+            containerExternalId.Contains(',') ? containerExternalId[(containerExternalId.IndexOf(',') + 1)..] : null;
+        public string GetContainerDisplayName(string containerExternalId) =>
+            containerExternalId.Split(',')[0].Split('=')[^1];
+    }
+
+    /// <summary>A round-trip credential-protection test double using a recognisable encrypted-value prefix.</summary>
+    private sealed class FakeProtection : ICredentialProtectionService
+    {
+        private const string Prefix = "$JIM$v1$";
+
+        public string? Protect(string? plainText) =>
+            string.IsNullOrEmpty(plainText) ? plainText : Prefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText));
+
+        public string? Unprotect(string? protectedData) =>
+            string.IsNullOrEmpty(protectedData) || !IsProtected(protectedData)
+                ? protectedData
+                : Encoding.UTF8.GetString(Convert.FromBase64String(protectedData[Prefix.Length..]));
+
+        public bool IsProtected(string? value) =>
+            !string.IsNullOrEmpty(value) && value.StartsWith(Prefix, StringComparison.Ordinal);
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/ConfigurationChangeCaptureCoverageTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConfigurationChangeCaptureCoverageTests.cs
@@ -229,8 +229,8 @@ public class ConfigurationChangeCaptureCoverageTests
 
         Assert.That(_completedActivity, Is.Not.Null);
         Assert.That(_completedActivity!.ConfigurationChangeVersion, Is.Null, "an unchanged configuration must not consume a version");
-        Assert.That(_completedActivity.ConfigurationChangeSnapshot, Is.Null, "an unchanged configuration must not store a duplicate snapshot");
-        Assert.That(_completedActivity.ChangeReason, Is.EqualTo("no-op save"), "the reason is still recorded independently of the dedupe guard");
+        Assert.That(_completedActivity!.ConfigurationChangeSnapshot, Is.Null, "an unchanged configuration must not store a duplicate snapshot");
+        Assert.That(_completedActivity!.ChangeReason, Is.EqualTo("no-op save"), "the reason is still recorded independently of the dedupe guard");
     }
 
     [Test]
@@ -253,7 +253,7 @@ public class ConfigurationChangeCaptureCoverageTests
 
         Assert.That(_completedActivity, Is.Not.Null);
         Assert.That(_completedActivity!.ConfigurationChangeVersion, Is.Null, "an unchanged Synchronisation Rule must not consume a version");
-        Assert.That(_completedActivity.ConfigurationChangeSnapshot, Is.Null);
+        Assert.That(_completedActivity!.ConfigurationChangeSnapshot, Is.Null);
     }
 
     // -- helpers -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Every Connected System configuration mutation now records a versioned snapshot on its Activity: schema updates and imports, hierarchy imports, container auto-selection after export ("Auto-selected N container(s)" activities were previously blank), bulk attribute updates, matching-mode switches, and worker-initiated (Infrastructure Key) updates.
- The REST API partition/container selection endpoints previously wrote with no Activity at all; they are now initiator-aware and record an Update Activity plus snapshot. Latent partition/container create/delete server methods get the same treatment so future callers inherit capture automatically.
- New idempotent capture guard: a snapshot byte-identical to the latest stored version records no new version, so no-change saves (e.g. worker persists after every import) cannot pile up noise versions. Backed by new `GetLatestConfigurationChangeSnapshotAsync` repository methods (int- and Guid-keyed).
- Fixed the inverse anomaly: the worker's deletion-failure status reset was recording a spurious configuration version for a runtime state flip; it now uses a lean status-only update.

## Test plan
- [x] TDD: 10 new tests in `ConfigurationChangeCaptureCoverageTests` written first and confirmed failing for the right reasons, then implementation
- [x] `dotnet build JIM.sln` clean
- [x] `dotnet test JIM.sln` clean (2,937 passed, 0 failed)

Docs: n/a - bug fix restoring documented change-history behaviour (#14); no behaviour contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)