### PR TITLE
fix: equalise bottom gap after the last diff card in change history

### DIFF
--- a/src/JIM.Web/Pages/Admin/Components/ConfigurationChangesTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConfigurationChangesTab.razor
@@ -105,7 +105,10 @@ else
                                     </div>
                                     @if (canClamp)
                                     {
-                                        <div class="mt-1">
+                                        @* mt-4 restores the gap the last diff card no longer provides (its bottom
+                                           margin is dropped so panel padding closes the layout), keeping the toggle
+                                           evenly spaced above and below. *@
+                                        <div class="mt-4">
                                             <MudButton Variant="Variant.Text" DropShadow="false" Size="Size.Small"
                                                        StartIcon="@(clamped ? Icons.Material.Filled.UnfoldMore : Icons.Material.Filled.UnfoldLess)"
                                                        OnClick="@(() => ToggleShowFull(item.Version))">

--- a/src/JIM.Web/Shared/ConfigurationChangeFieldNode.razor.css
+++ b/src/JIM.Web/Shared/ConfigurationChangeFieldNode.razor.css
@@ -61,11 +61,17 @@
 }
 
 /* A wholly added / removed item, drawn as a small tinted card of its values. The vertical margin matches the card's
-   horizontal breathing room inside its parent panel, so stacked cards read as evenly spaced on all sides. */
+   horizontal breathing room inside its parent panel, so stacked cards read as evenly spaced on all sides. The last
+   card drops its bottom margin: the parent panel's own padding then closes the layout, keeping the gap beneath the
+   final card equal to the gaps at its sides. */
 .fh-card {
     border-radius: 8px;
     padding: 0.55rem 0.75rem;
     margin: 1rem 0;
+}
+
+.fh-card:last-child {
+    margin-bottom: 0;
 }
 
 .fh-card-added {


### PR DESCRIPTION
## Summary
- The last `.fh-card` in a rendered configuration diff now drops its bottom margin (`:last-child`), so the space beneath the final card comes solely from the parent panel's padding and matches the side gaps.
- One rule in the shared `ConfigurationChangeFieldNode` stylesheet, so it applies to both the Activity detail page and the object's Changes tab.

## Test plan
- [x] `dotnet build src/JIM.Web/` clean (UI-only CSS change; no UI tests exist per repo policy)

Docs: n/a - trivial UI spacing tweak

🤖 Generated with [Claude Code](https://claude.com/claude-code)