### PR TITLE
docs: tick off delivered Configuration Change History items

### DIFF
--- a/engineering/plans/doing/CONFIGURATION_CHANGE_HISTORY.md
+++ b/engineering/plans/doing/CONFIGURATION_CHANGE_HISTORY.md
@@ -1,9 +1,9 @@
 # Configuration Change History - Implementation Plan
 
-- **Status:** Doing (Phases 1, 2, 5, 6 complete)
+- **Status:** Doing (Phases 1, 2, 3, 5, 6 complete)
 - **Issue:** [#14](https://github.com/TetronIO/JIM/issues/14)
-- **PRD:** [`engineering/prd/PRD_CONFIGURATION_CHANGE_HISTORY.md`](../prd/PRD_CONFIGURATION_CHANGE_HISTORY.md)
-- **Note:** The backend (capture, redaction, diff engine, retrieval), REST API, and PowerShell module are delivered. Remaining: Phase 3 (Changes tab UI), Phase 4 (Activities-list filters), Phase 7 (type-aware retention), and Phase 8 (rollback, future). Connected System hard-delete capture is deferred as its own slice (pair with Phase 8 rollback); Synchronisation Rule delete is captured. The keyed-HMAC redaction approach (Open Question 3) is confirmed.
+- **PRD:** [`engineering/prd/PRD_CONFIGURATION_CHANGE_HISTORY.md`](../../prd/PRD_CONFIGURATION_CHANGE_HISTORY.md)
+- **Note (2026-07-03):** The backend (capture, redaction, diff engine, retrieval), REST API, PowerShell module, the per-object Changes tab (as `ConfigurationChangesTab` on Synchronisation Rule and Connected System detail pages, and as a History tab in the Schedule editor), and the Activity-detail diff rendering (Phase 4 item 3) are delivered. Delivered beyond plan: Schedule support (Guid-keyed retrieval, API, PowerShell, UI; write-side capture in progress on a cooperating branch), capture coverage across all Connected System mutation paths, a semantic no-change dedupe guard (a save that changes nothing records no version), Simple Mode Object Matching Rule capture, per-rule attribute-priority capture, runtime state (status, import watermark) excluded from snapshots and Activities, and a "no snapshot" explanation on the Activity detail page. Remaining: the Phase 3 comment-on-save reason dialog, Phase 4 items 1-2 (Activities-list filters and URL persistence), Phase 7 (type-aware retention; until then the generic Activity retention period also deletes configuration-change Activities), and Phase 8 (rollback, future). Connected System hard-delete capture is deferred as its own slice (pair with Phase 8 rollback); Synchronisation Rule delete is captured. The keyed-HMAC redaction approach (Open Question 3) is confirmed.
 
 ## Overview
 
@@ -312,17 +312,17 @@ In `-AsDiff`, `+` lines render green and `-` lines red via `$PSStyle` (git-style
 
 **Files:** `JIM.Application/Servers/ConfigurationDiffService.cs` (new); `ChangeHistoryServer.cs`; `JIM.PostgresData/Repositories/ChangeHistoryRepository.cs`; DTOs under `JIM.Models/.../DTOs/`.
 
-### Phase 3: Per-object Changes tab UI (SyncRule + Connected System)
-1. Configuration tree-diff renderer; integrate as the pluggable detail renderer in the `ChangeHistoryTimeline` shell.
-2. "Changes" tab on `ConnectedSystemDetail.razor` and `SyncRuleDetail.razor` (deep-link, badge, lazy load, load-more, version list, compare).
-3. Comment-on-save dialog wired into the existing save handlers (`Helpers.GetUserAsync` already provides the principal).
+### Phase 3: Per-object Changes tab UI (SyncRule + Connected System) ✅
+1. Configuration tree-diff renderer; integrate as the pluggable detail renderer in the `ChangeHistoryTimeline` shell. ✅ *(Delivered as `ConfigurationChangesTab` + `ConfigurationChangeFieldNode` rather than inside the `ChangeHistoryTimeline` shell.)*
+2. "Changes" tab on `ConnectedSystemDetail.razor` and `SyncRuleDetail.razor` (deep-link, badge, lazy load, load-more, version list, compare). ✅ *(Also hosted as a History tab in `ScheduleEditorDialog`.)*
+3. Comment-on-save dialog wired into the existing save handlers (`Helpers.GetUserAsync` already provides the principal). ⬜ *(Outstanding; the reason is currently only supplied via the API and PowerShell.)*
 
-**Files:** `JIM.Web/Shared/ConfigurationChangeDiff.razor` (new) + `ChangeHistoryTimeline.razor`; the two detail pages.
+**Files:** `JIM.Web/Pages/Admin/Components/ConfigurationChangesTab.razor` + `JIM.Web/Shared/ConfigurationChangeFieldNode.razor`; the two detail pages and the Schedule editor dialog.
 
 ### Phase 4: Activities list integration
-1. Category quick-filter (All / Configuration / Identity data / Sync runs / System) mapping `ActivityTargetType` groups; initiator-type filter; date-range filter.
-2. URL-persisted filter state.
-3. Config-change row links to the object's Changes tab at the version, and the Activity detail page renders the same diff.
+1. Category quick-filter (All / Configuration / Identity data / Sync runs / System) mapping `ActivityTargetType` groups; initiator-type filter; date-range filter. ⬜
+2. URL-persisted filter state. ⬜
+3. Config-change row links to the object's Changes tab at the version, and the Activity detail page renders the same diff. ✅ *(The Activity detail page renders the diff inline, loading by the change's object FK rather than the Activity's target type, links to the changed object, and explains a legitimately-missing snapshot.)*
 
 **Files:** `JIM.Web/Pages/ActivityList.razor`; `ActivityDetail.razor`; application-layer Activity query filters.
 

--- a/engineering/prd/PRD_CONFIGURATION_CHANGE_HISTORY.md
+++ b/engineering/prd/PRD_CONFIGURATION_CHANGE_HISTORY.md
@@ -1,6 +1,6 @@
 # Configuration Change History
 
-- **Status:** Planned
+- **Status:** Doing
 - **Created:** 2026-06-25
 - **Author:** JayVDZ
 - **Issue:** [#14](https://github.com/TetronIO/JIM/issues/14)
@@ -176,17 +176,17 @@ The equivalent capability for business and identity data (Connected System Objec
 
 ## Acceptance Criteria
 
-> **Implementation status (2026-06-29):** ticks below reflect the delivered backend (capture, redaction, diff engine, retrieval), REST API, and PowerShell surfaces. The per-object Changes tab and Activities-list filters (UI) and type-aware retention remain; see the [implementation plan](../plans/CONFIGURATION_CHANGE_HISTORY.md) for phase status.
+> **Implementation status (2026-07-03):** the backend (capture, redaction, diff engine, retrieval), REST API, PowerShell, the per-object Changes tab (Synchronisation Rule, Connected System, and Schedule), and the Activity-detail diff rendering are delivered. Capture integrity has been hardened beyond the original plan: coverage across all Connected System mutation paths, a semantic no-change dedupe guard, Simple Mode Object Matching Rule capture, per-rule attribute-priority capture, and exclusion of runtime state (status, import watermark) from both snapshots and Activities. Remaining: the comment-on-save reason dialog (UI), the Activities-list filters, type-aware retention, Schedule write-side capture (in progress on a cooperating branch), and rollback (future). See the [implementation plan](../plans/doing/CONFIGURATION_CHANGE_HISTORY.md) for phase status.
 
-- [x] Creating, updating, or deleting a supported configuration object records a change entry with initiator, UTC timestamp, version number, and a complete post-change snapshot, carried with its Activity. *(Create and update for both types, plus Synchronisation Rule delete, are captured; Connected System hard-delete capture is deferred to a follow-up.)*
-- [ ] Synchronisation Rule and Connected System detail pages each have a "Changes" tab showing version history with version number, initiator, time, optional reason, and a summary.
-- [ ] Selecting a version renders a structured tree diff (additions, removals, modifications with old-to-new values, friendly labels, unchanged branches collapsed).
-- [x] Any two versions of a supported object can be compared. *(Diff engine plus compare endpoint and cmdlet; in-portal compare ships with the Changes tab.)*
+- [x] Creating, updating, or deleting a supported configuration object records a change entry with initiator, UTC timestamp, version number, and a complete post-change snapshot, carried with its Activity. *(Create and update for both types, plus Synchronisation Rule delete, are captured; Connected System hard-delete capture is deferred to a follow-up. Schedules: retrieval, API, PowerShell, and UI are delivered; write-side capture is in progress on a cooperating branch.)*
+- [x] Synchronisation Rule and Connected System detail pages each have a "Changes" tab showing version history with version number, initiator, time, optional reason, and a summary. *(Delivered as the shared `ConfigurationChangesTab`, also hosted as a History tab in the Schedule editor.)*
+- [x] Selecting a version renders a structured tree diff (additions, removals, modifications with old-to-new values, friendly labels, unchanged branches collapsed).
+- [x] Any two versions of a supported object can be compared. *(Diff engine, compare endpoint and cmdlet, and in-portal compare in the Changes tab.)*
 - [x] Sensitive configuration values are never stored in, or rendered from, the change history in any surface.
-- [ ] An optional reason can be entered on save (UI) and is shown in the history.
+- [ ] An optional reason can be entered on save (UI) and is shown in the history. *(The reason is captured and shown from the API and PowerShell; the UI comment-on-save dialog remains.)*
 - [ ] The Activities list view has a Configuration category quick-filter, initiator-type and date-range filters, and URL-persisted filter state.
-- [ ] A configuration-change activity links through to the relevant object and version diff.
-- [ ] Configuration change history is retained independently of identity-data history (target-type-aware Activity retention).
+- [x] A configuration-change activity links through to the relevant object and version diff. *(The Activity detail page renders the same diff inline, loading by the change's object rather than the Activity's target type, links to the changed object, including Object Matching Rules to their owning object's Matching tab, and explains why no snapshot exists when one was legitimately not captured.)*
+- [ ] Configuration change history is retained independently of identity-data history (target-type-aware Activity retention). *(Not started; note that the existing generic Activity retention currently applies to configuration-change Activities too.)*
 - [x] Configuration change tracking can be disabled via a Service Setting (default enabled); disabling retains existing history.
 - [ ] Expired configuration change history is cleaned up by worker housekeeping and recorded via an Activity.
 - [x] The REST API and PowerShell module have full parity for: recording an optional reason on configuration create/update/delete; retrieving change history (summary and single-change detail); and (when delivered) rollback.


### PR DESCRIPTION
## Summary
- Ticks off the Configuration Change History PRD acceptance criteria verified as delivered against the codebase: the Changes tab (Synchronisation Rule, Connected System, and the Schedule editor's History tab), the structured tree diff, in-portal compare, and the Activity-detail diff link-through. 12 of 18 criteria are now ticked.
- Updates the implementation plan's status note (2026-07-03): Phase 3 complete except the comment-on-save dialog; Phase 4's Activity-detail item complete; records the delivered-beyond-plan capture-integrity hardening and that Schedule write-side capture remains on a cooperating branch.
- Moves the plan to `engineering/plans/doing/` to match its Doing status and fixes the PRD/plan cross-links both ways; PRD status corrected from Planned to Doing.
- Flags in both documents that the generic Activity retention currently also deletes configuration-change Activities (the Phase 7 gap).

Docs: n/a - engineering documentation only (PRD and implementation plan status), no product behaviour change.

## Test plan
- [x] Docs-only change (build/test exempt per CLAUDE.md)
- [x] Cross-references between the moved plan and the PRD verified in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)