### PR TITLE
Run the database-backed (real-PostgreSQL) test tier in CI (#861)

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -23,6 +23,7 @@
 - `jim` - List all available jim aliases
 - `jim-compile` - Build entire solution (dotnet build)
 - `jim-test` - Run unit + workflow tests (excludes Explicit)
+- `jim-test-db` - Run the database-backed (real-PostgreSQL) test tier against a throwaway container (see `engineering/TESTING_STRATEGY.md`)
 - `jim-test-all` - Run ALL tests (incl. Explicit + Pester)
 - `jim-db` - Start PostgreSQL (for local debugging)
 - `jim-db-stop` - Stop PostgreSQL

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -177,6 +177,7 @@ The setup creates these handy aliases:
 ```bash
 jim-compile        # Build entire solution (dotnet build)
 jim-test           # Run unit + workflow tests (excludes Explicit)
+jim-test-db        # Run database-backed (real-PostgreSQL) tests in a throwaway container
 jim-test-all       # Run ALL tests (incl. Explicit + Pester)
 jim-test-ps        # Run PowerShell Pester tests
 jim-clean          # Clean and rebuild

--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -13,6 +13,7 @@ alias jim='echo "JIM Development Aliases:
 .NET Local Development:
   jim-compile        - dotnet build JIM.sln
   jim-test           - Run unit + workflow tests (excludes Explicit)
+  jim-test-db        - Run database-backed (real-PostgreSQL) tests in a throwaway container
   jim-test-all       - Run ALL tests (incl. Explicit + Pester)
   jim-test-ps        - Run PowerShell Pester tests
   jim-clean          - dotnet clean && build
@@ -166,6 +167,40 @@ jim-unlock-signing() {
 # .NET local development
 alias jim-compile='dotnet build JIM.sln'
 alias jim-test='dotnet test JIM.sln'
+# Run the database-backed (real-PostgreSQL) test tier against a throwaway database.
+# These fixtures are gated by JIM_TEST_RESET_DB and self-skip in a normal `jim-test`
+# run. This spins up a disposable PostgreSQL container, points the tier at it, runs
+# `Category=RequiresPostgres`, then tears the container down. Needs `jim-db` NOT to be
+# using the same container name; it uses a dedicated `jim-test-db` container on port 5433
+# so it never collides with your dev database. See engineering/TESTING_STRATEGY.md.
+jim-test-db() {
+  local container='jim-test-db'
+  local image='postgres:18.4@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20'
+  echo "Starting throwaway PostgreSQL ($container) on port 5433..."
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  docker run -d --name "$container" \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=postgres \
+    -e POSTGRES_DB=jim_test \
+    -p 5433:5432 "$image" >/dev/null || { echo "Failed to start $container"; return 1; }
+
+  echo "Waiting for PostgreSQL to accept connections..."
+  local ready=''
+  for _ in $(seq 1 30); do
+    if docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; then ready=1; break; fi
+    sleep 1
+  done
+  if [ -z "$ready" ]; then echo "PostgreSQL did not become ready"; docker rm -f "$container" >/dev/null 2>&1; return 1; fi
+
+  JIM_TEST_RESET_HOST=localhost JIM_TEST_RESET_PORT=5433 JIM_TEST_RESET_USER=postgres \
+    JIM_TEST_RESET_PASSWORD=postgres JIM_TEST_RESET_DB=jim_test \
+    dotnet test JIM.sln --filter "Category=RequiresPostgres" --verbosity normal
+  local rc=$?
+
+  echo "Removing throwaway PostgreSQL ($container)..."
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  return $rc
+}
 # Kill cached MSBuild worker nodes that stack up across build/test iterations.
 # `dotnet` spawns these with `/nodemode:1 /nodeReuse:true` and they hang around holding
 # 150-220 MB each; `dotnet build-server shutdown` doesn't touch them. Safe to run at any

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,57 @@ jobs:
         name: pester-test-results
         path: ./TestResults/pester-results.xml
 
+  database-tests:
+    # Runs the RequiresPostgres NUnit tier (the "Database-backed component tests"
+    # tier in engineering/TESTING_STRATEGY.md) against a real PostgreSQL service.
+    # These fixtures self-skip in the in-memory build-and-test job (JIM_TEST_RESET_DB
+    # unset); here they execute, guarding provider-specific and raw-SQL behaviour the
+    # EF Core in-memory provider cannot reproduce (the class of bug behind #849/#850).
+    # See issue #861. Runs on every PR so a failure blocks the merge.
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        # Pinned to match the production database image in docker-compose.yml; bump
+        # both together. Dependabot's docker ecosystem does not scan workflow service
+        # images, so this digest pin is maintained by hand.
+        image: postgres:18.4@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: jim_test
+        ports:
+          - 5432:5432
+        # Hold the job's steps until PostgreSQL is accepting connections.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    # The RequiresPostgres fixtures read these to build the connection string and to
+    # opt in (JIM_TEST_RESET_DB being set is what flips them from Assert.Ignore to run).
+    # jim_test is a throwaway database: each fixture migrates the schema once and
+    # TRUNCATEs every table between tests.
+    env:
+      JIM_TEST_RESET_HOST: localhost
+      JIM_TEST_RESET_USER: postgres
+      JIM_TEST_RESET_PASSWORD: postgres
+      JIM_TEST_RESET_DB: jim_test
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+      with:
+        dotnet-version: 10.0.x
+    - name: Restore dependencies
+      run: dotnet restore JIM.sln
+    - name: Build
+      run: dotnet build JIM.sln --no-restore
+    - name: Run database-backed tests (RequiresPostgres)
+      run: dotnet test JIM.sln --no-build --filter "Category=RequiresPostgres" --verbosity normal
+
   discover-base-images:
     # Discover production Dockerfiles and enforce the digest-pinning policy.
     # Production Dockerfiles are identified by the "# jim-compliance: production-image"

--- a/engineering/TESTING_STRATEGY.md
+++ b/engineering/TESTING_STRATEGY.md
@@ -2,15 +2,19 @@
 
 ## Overview
 
-JIM employs a three-tier testing approach to ensure quality at different levels of the application:
+JIM employs a four-tier testing approach to ensure quality at different levels of the application:
 
 ```
-Integration Tests (Full System)
+Integration Tests (Full System, Docker stack + external directories)
          ^
-   Workflow Tests (Multi-Component)
+Database-Backed Component Tests (real PostgreSQL, .NET test host)
          ^
-    Unit Tests (Single Component)
+   Workflow Tests (Multi-Component, in-memory)
+         ^
+    Unit Tests (Single Component, mocked)
 ```
+
+The middle two tiers both run under `dotnet test`; they differ in the database provider. Workflow tests use the EF Core in-memory provider (fast, no infrastructure), while Database-Backed Component tests run against a real PostgreSQL instance so they catch provider-specific and raw-SQL behaviour the in-memory provider cannot reproduce (see tier 3 and the in-memory limitation section below).
 
 ## 1. Unit Tests
 
@@ -107,7 +111,64 @@ Total: 40 tests.
 - Keep workflows focused (test one business process per test)
 - Choose `WorkflowTestBase` for processor-level tests, `WorkflowTestHarness` for full-cycle scenarios
 
-## 3. Integration Tests
+## 3. Database-Backed Component Tests
+
+**Location**: `test/JIM.Worker.Tests/Servers/*DatabaseTests.cs`
+
+**Purpose**: Verify repository and server behaviour against a **real PostgreSQL** database, in the .NET test host, with no other external systems. This tier exists to catch the class of bug the EF Core in-memory provider structurally hides: provider-specific behaviour (query-tracking semantics, shadow foreign keys) and hand-written raw SQL the in-memory provider cannot execute.
+
+**Characteristics**:
+- Fast (the Predefined Search suite runs in ~30s); much faster than the Docker Integration tier
+- Real PostgreSQL, not in-memory: matches the production provider and the production `NoTracking` default
+- No Docker stack, no Samba AD / OpenLDAP / SCIM, not driven by the PowerShell integration runner
+- Each fixture migrates the schema once (`[OneTimeSetUp]`) and `TRUNCATE`s every table between tests (`[SetUp]`), so it needs a **dedicated throwaway database** it may freely wipe
+
+**Gating**: Every fixture carries `[Category("RequiresPostgres")]` and, in `[OneTimeSetUp]`, calls `Assert.Ignore` unless `JIM_TEST_RESET_DB` is set. So a normal `dotnet test` / `jim-test` run (in-memory tiers only) skips them, and they run only when explicitly pointed at a throwaway database.
+
+**Configuration (environment variables)**:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `JIM_TEST_RESET_DB` | Name of the throwaway database; **also the opt-in switch** (unset = skip) | (none; required to run) |
+| `JIM_TEST_RESET_HOST` | PostgreSQL host | `localhost` |
+| `JIM_TEST_RESET_PORT` | PostgreSQL port | `5432` |
+| `JIM_TEST_RESET_USER` | Username | `postgres` |
+| `JIM_TEST_RESET_PASSWORD` | Password | `postgres` |
+
+**When to write a Database-Backed Component test**:
+- The behaviour depends on the real provider: a write path whose persistence turns on tracking vs. no-tracking, a query using raw SQL, a shadow-FK relationship walk
+- A workflow/unit test would pass against in-memory but cannot prove the production database behaves the same (the trigger for #849/#850: creating a Predefined Search Criteria Group was a silent no-op that every in-memory test passed)
+- You are adding repository/server coverage that asserts against real SQL rather than orchestrating a full sync cycle (that is the Workflow tier) or the whole stack (Integration tier)
+
+**Running locally**:
+
+Use the `jim-test-db` alias, which spins up a disposable PostgreSQL container on port 5433 (so it never collides with your dev `jim-db` on 5432), runs the tier, and tears the container down:
+
+```bash
+jim-test-db
+```
+
+Or point the tier at any throwaway database yourself:
+
+```bash
+JIM_TEST_RESET_DB=jim_test JIM_TEST_RESET_HOST=localhost JIM_TEST_RESET_PORT=5432 \
+  JIM_TEST_RESET_USER=postgres JIM_TEST_RESET_PASSWORD=postgres \
+  dotnet test JIM.sln --filter "Category=RequiresPostgres"
+```
+
+**Running in CI**: The `database-tests` job in `.github/workflows/ci.yml` stands up a PostgreSQL service container, points `JIM_TEST_RESET_*` at a throwaway `jim_test` database, and runs `dotnet test JIM.sln --filter "Category=RequiresPostgres"` on every PR. It runs alongside the in-memory `build-and-test` job, so the two tiers give independent feedback and a failure here blocks the PR.
+
+**What Database-Backed Component Tests Are Good At**:
+- ✅ Catching persistence bugs the in-memory provider's auto-tracking masks (silent no-op writes)
+- ✅ Exercising hand-written raw PostgreSQL (query translators, criteria group All/Any semantics)
+- ✅ Verifying shadow foreign keys and parent-chain walks against real columns
+
+**What Database-Backed Component Tests Miss**:
+- ❌ End-to-end system behaviour with real directories/connectors (that is the Integration tier)
+- ❌ UI and API-surface behaviour
+- ❌ Performance at scale
+
+## 4. Integration Tests
 
 **Location**: `test/integration/`
 
@@ -165,6 +226,7 @@ Total: 40 tests.
 |----------|----------------|-------------|
 | Unit Tests | 80%+ of business logic | On every commit (pre-commit hook) |
 | Workflow Tests | Critical workflows (sync, provisioning, deletion) | On every commit |
+| Database-Backed Component Tests | Provider-specific / raw-SQL repository behaviour | On every PR (CI `database-tests` job); locally via `jim-test-db` |
 | Integration Tests | Key scenarios (Scenarios 1-5) | On PR, nightly, before release |
 
 ## Best Practices
@@ -309,12 +371,13 @@ var cso = await context.ConnectedSystemObjects.FirstAsync(c => c.Id == id);
 |-----------|----------------------------------|-------------------------------------|
 | Unit Tests (mocked) | ❌ No - mocks return whatever you configure | ❌ No |
 | Workflow Tests (in-memory) | ❌ No - auto-tracking masks the bug | ❌ No |
+| Database-Backed Component Tests (PostgreSQL) | ✅ Yes - real database behaviour | ✅ Yes |
 | Integration Tests (PostgreSQL) | ✅ Yes - real database behaviour | ✅ Yes |
 
 ### What This Means
 
 1. **Unit and workflow tests CANNOT validate that repository queries load required navigation properties**
-2. **Integration tests are the ONLY reliable way to verify `.Include()` chains are correct**
+2. **Only real-PostgreSQL tests can verify `.Include()` chains are correct**; this means the Database-Backed Component tier (tier 3) or the Integration tier (tier 4). The Database-Backed tier is the cheaper of the two and runs on every PR, so reach for it first
 3. **Any bug involving missing navigation property loading will pass all unit/workflow tests**
 
 ### Defensive Measures
@@ -346,16 +409,17 @@ Because we cannot rely on unit/workflow tests to catch these bugs, we employ:
 
 ### Summary
 
-**Integration tests are the ONLY proof of correct navigation property loading.** Unit and workflow tests provide value for logic correctness, but they fundamentally cannot detect missing `.Include()` statements due to EF Core in-memory provider behaviour. Always run integration tests before releasing changes that modify repository queries.
+**Only real-PostgreSQL tests prove correct navigation property loading** (the Database-Backed Component tier or the Integration tier). Unit and workflow tests provide value for logic correctness, but they fundamentally cannot detect missing `.Include()` statements due to EF Core in-memory provider behaviour. Always run a real-PostgreSQL tier before releasing changes that modify repository queries.
 
 ---
 
 ## Summary
 
-- **Unit Tests**: Fast, isolated, test individual components
-- **Workflow Tests**: Moderate speed, test multi-component workflows, catch integration bugs
-- **Integration Tests**: Slow, test full system, validate production-like behaviour
+- **Unit Tests**: Fast, isolated, test individual components (mocked)
+- **Workflow Tests**: Moderate speed, test multi-component workflows in-memory, catch integration bugs
+- **Database-Backed Component Tests**: Real PostgreSQL in the .NET test host, catch provider-specific and raw-SQL bugs the in-memory provider hides; fast enough to run on every PR
+- **Integration Tests**: Slow, test full system with Docker + external directories, validate production-like behaviour
 
-The three tiers complement each other. The watermark bug demonstrates why we need all three levels - unit tests verify components work individually, workflow tests verify they work together, and integration tests verify the complete system works at scale.
+The four tiers complement each other. The watermark bug demonstrates why unit and workflow tests are not enough on their own; the Predefined Search silent-no-op bug (#849/#850) demonstrates why a real-PostgreSQL tier below the heavy Integration stack is worth having - it caught a persistence bug in ~30s that every in-memory test passed.
 
-**⚠️ Critical Caveat**: Due to EF Core in-memory database limitations (see above), integration tests are the ONLY reliable way to verify navigation property loading. Unit and workflow tests will PASS even when `.Include()` statements are missing.
+**⚠️ Critical Caveat**: Due to EF Core in-memory database limitations (see above), a real-PostgreSQL tier (Database-Backed Component or Integration) is the only reliable way to verify navigation property loading. Unit and workflow tests will PASS even when `.Include()` statements are missing.

--- a/test/JIM.Worker.Tests/Servers/AttributeContributorCountsDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/AttributeContributorCountsDatabaseTests.cs
@@ -45,7 +45,8 @@ public class AttributeContributorCountsDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemDeletionDatabaseTests.cs
@@ -51,7 +51,8 @@ public class ConnectedSystemDeletionDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();

--- a/test/JIM.Worker.Tests/Servers/PredefinedSearchCriteriaDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/PredefinedSearchCriteriaDatabaseTests.cs
@@ -53,7 +53,8 @@ public class PredefinedSearchCriteriaDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();

--- a/test/JIM.Worker.Tests/Servers/PredefinedSearchQueryDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/PredefinedSearchQueryDatabaseTests.cs
@@ -53,7 +53,8 @@ public class PredefinedSearchQueryDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();

--- a/test/JIM.Worker.Tests/Servers/SyncRuleCreationDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SyncRuleCreationDatabaseTests.cs
@@ -54,7 +54,8 @@ public class SyncRuleCreationDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();

--- a/test/JIM.Worker.Tests/Servers/SyncRuleUpdateDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SyncRuleUpdateDatabaseTests.cs
@@ -56,7 +56,8 @@ public class SyncRuleUpdateDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();

--- a/test/JIM.Worker.Tests/Servers/SystemResetDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SystemResetDatabaseTests.cs
@@ -53,7 +53,8 @@ public class SystemResetDatabaseTests
         var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
         var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
         var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
-        _connectionString = $"Host={host};Database={dbName};Username={user};Password={pass}";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
 
         using var ctx = NewContext();
         ctx.Database.Migrate();


### PR DESCRIPTION
## Description

A fourth, previously-undocumented test tier exists in the codebase: real-PostgreSQL NUnit fixtures gated by `[Category("RequiresPostgres")]` and the `JIM_TEST_RESET_*` environment variables. They run in the .NET test host against a real PostgreSQL database (no other external systems), but had no PostgreSQL service in CI, so every fixture self-skipped and provided no regression protection. This is the class of bug that motivated them: the Predefined Search criteria feature (#849/#850) shipped a silent no-op persistence bug that every in-memory Unit/Workflow/API test passed.

This PR makes that tier run automatically on every PR and documents it as a first-class tier.

- **CI**: new `database-tests` job in `.github/workflows/ci.yml` stands up a PostgreSQL service container (18.4, digest-pinned to match `docker-compose.yml`), points `JIM_TEST_RESET_*` at a throwaway `jim_test` database, and runs `dotnet test JIM.sln --filter "Category=RequiresPostgres"`. Runs alongside the in-memory `build-and-test` job on every PR.
- **`JIM_TEST_RESET_PORT` support** added to the seven `*DatabaseTests` fixtures (default `5432`, so CI and existing behaviour are unchanged), so the tier can target a non-default port.
- **`jim-test-db` alias**: runs the tier locally against a disposable PostgreSQL container on port 5433 (no collision with the dev `jim-db` on 5432), then tears it down.
- **Docs**: `engineering/TESTING_STRATEGY.md` now documents the tier ("Database-Backed Component Tests") — purpose, gating, configuration, when to use, and how it runs locally and in CI — and reconciles it with the existing three tiers.

Closes #861

## Type of change

- [x] New feature (non-breaking change that adds functionality) — CI/test infrastructure
- [x] Documentation update

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (the tier itself; this PR wires the existing `RequiresPostgres` fixtures into CI)
- [x] Manually tested in a local development environment

Ran the tier against a real PostgreSQL using the exact CI command and `JIM_TEST_RESET_*` contract (`dotnet test JIM.sln --filter "Category=RequiresPostgres"`): **33 passed, 0 skipped**. Confirms the fixtures execute (not skip) when pointed at a real database, and that the new `JIM_TEST_RESET_PORT` handling works.

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No public documentation needed

<!-- Docs: n/a - CI/test-infrastructure change; no customer-facing behaviour, so no docs/ update and no changelog entry. Engineering docs (TESTING_STRATEGY.md) updated to document the tier. -->

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information

## Additional context

The `database-tests` check will run on PRs but will not **block** merges until it is added to the branch-protection ruleset's required checks (currently 8: `build-and-test`, `discover-base-images`, `scan-base-images-summary`, the three CodeQL analyses, `claude-review`, `changelog-lint`). Adding `database-tests` as the 9th required check is a repo-settings change that cannot be made from code.

Scope note: per #518, the full release gate (running this tier in `release.yml`) is deliberately out of scope here; this PR closes the per-PR gap for the data layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiFU7RUsd6YgiVwQ3cC7RW)_