### PR TITLE
docs: expand Attribute Priority section on Synchronisation Rules page

### DIFF
--- a/docs/configuration/synchronisation-rules.md
+++ b/docs/configuration/synchronisation-rules.md
@@ -164,20 +164,44 @@ Four controls are available:
 - **Collapse internal whitespace**<br /> Reduces runs of consecutive whitespace inside the value to a single space, so multiple spaces or tabs between words collapse to one. For example, `John···Smith` becomes `John Smith` (each `·` represents a space).
 - **Case normalisation**<br /> Converts the value to `Upper`, `Lower`, or `Title` case, or leaves it unchanged (`None`). Useful for folding usernames or email addresses to a consistent case.
 
-The transforms run in a fixed order: **trim, then collapse, then case normalisation, then the whitespace-as-no-value decision**. Because the whitespace decision runs last, a value that trims down to nothing is correctly treated as no value. Value processing is *normalisation*; it runs before [priority](#priority) resolves which rule's value wins.
+The transforms run in a fixed order: **trim, then collapse, then case normalisation, then the whitespace-as-no-value decision**. Because the whitespace decision runs last, a value that trims down to nothing is correctly treated as no value. Value processing is *normalisation*; it runs before [Attribute Priority](#attribute-priority) resolves which rule's value wins.
 
 When **Treat whitespace as no value** is switched off and a whitespace-only value is therefore stored, the portal flags it with a `(whitespace)` indicator rather than rendering a misleading blank cell, so administrators can tell a real-but-invisible value apart from an absent one.
 
-## Priority
+## Attribute Priority
 
-When multiple import rules write to the same MVO attribute, **priority** determines which rule's value wins. Each Synchronisation Rule has a priority level, and the rule with the highest priority wins.
+When more than one import rule maps to the same Metaverse Object attribute, **Attribute Priority** decides which contributor wins, so the result never depends on the order your synchronisations happen to run in. It is an inbound concern: it governs how values flow from Connected Systems into the metaverse, and does not change how the metaverse is exported back out.
 
-This matters when an identity has data flowing from multiple source systems. For example:
+Priority is held **per attribute, per contributing rule**, not as a single level on the whole Synchronisation Rule. The same Connected System can therefore rank first for one attribute and second for another, and a single system can even contribute through several differently-scoped rules at different priorities.
 
-- HR system provides `First Name` and `Last Name` (high priority: authoritative)
-- Badge system also provides `First Name` (lower priority: secondary)
+### How a winner is chosen
 
-The HR system's values win because its Synchronisation Rule has a higher priority.
+For a given Metaverse attribute, JIM evaluates every contributing import rule in priority order (1 is highest):
+
+- **The first contributor with a value wins.**<br /> Lower-priority contributors are not consulted.
+- **A rule with no opinion is skipped.**<br /> If a rule does not apply to the object (it is disabled, no object from its Connected System is joined, or the joined object is out of the rule's scope), it is passed over and the next priority is considered.
+- **If nobody contributes, the attribute is left unset.**
+
+For example, an identity drawing data from two source systems:
+
+- HR system provides `First Name` and `Last Name` (priority 1: authoritative)
+- Badge system also provides `First Name` (priority 2: secondary)
+
+The HR system's `First Name` wins because its contribution ranks higher; the badge system only fills in where HR has no opinion.
+
+### Null is a value
+
+By default, if the highest-priority source has **no** value for an attribute, JIM falls through to the next source. That is usually right, but not always: when the authoritative source deliberately *clears* a value, you want the clear to propagate, not to be back-filled from a stale secondary copy that still holds the old value.
+
+Enabling **Null is a value** on a contributor changes that. If the contributor is connected and in scope but supplies no value, JIM stops there and asserts "no value": the attribute is cleared downstream, and lower-priority sources are not consulted. This is distinct from a rule simply having no opinion; a rule that does not apply to the object is still skipped regardless of this setting.
+
+Typical uses are a manager or department cleared at the authoritative source that must propagate as a clear, and a primary-system migration where the new system is authoritative for the people it knows about (including their blanks). It is deliberately powerful: a misbehaving priority-1 import (an empty file, a truncated delta) becomes a mass-clearing event rather than a harmless no-op, so treat Null is a value as an authoritative, considered choice.
+
+### Configuring priority
+
+Attribute Priority is configured per (Metaverse Object Type, attribute), not on the Synchronisation Rule editor. Open the Metaverse Object Type (**Administration → Schema → Object Types**), select the **Attributes** tab, and expand the **contributors** list for any attribute that has more than one contributor. From there you drag contributors to reorder them and toggle **Null is a value** per contributor. A newly added import mapping joins at the **lowest** priority, so a new source never silently takes over an attribute until you promote it explicitly. The same configuration is available via the [PowerShell cmdlets](../powershell/metaverse.md) and the REST API.
+
+> **Full detail:** [Attribute Priority](../concepts/attribute-priority.md) covers re-election when a winning source disconnects or withdraws, multi-valued attribute semantics, per-value provenance, and how to see resolution decisions in [Synchronisation Activities](activities.md).
 
 ## Common workflows
 
@@ -226,6 +250,7 @@ This rule imports full-time employees from the HR system, joins them to existing
 
 - [Connected Systems](connected-systems.md) -- the systems a Synchronisation Rule connects to
 - [Concepts: Synchronisation Pipeline](../concepts/synchronisation-pipeline.md) -- where Synchronisation Rules fit in the import/sync/export flow
+- [Concepts: Attribute Priority](../concepts/attribute-priority.md) -- how JIM resolves which source wins when several rules feed the same attribute, and the "Null is a value" setting
 - [Concepts: JML Lifecycle](../concepts/jml-lifecycle.md) -- how scoping and provisioning drive joiner/mover/leaver behaviour
 - [Concepts: Expressions](../concepts/expressions.md) -- the expression language used in scoping criteria and attribute mappings
 - [Concepts: Case Sensitivity](../concepts/case-sensitivity.md) -- where matching and scoping are exact, and how to make them case-insensitive

--- a/docs/developer/diagrams/PENDING_EXPORT_LIFECYCLE.md
+++ b/docs/developer/diagrams/PENDING_EXPORT_LIFECYCLE.md
@@ -58,9 +58,9 @@ A Pending Export's journey typically spans three separate Run Profile executions
 ```mermaid
 flowchart LR
     subgraph "1. Sync (Full or Delta)"
-        SyncStart[MVO attribute changes<br/>during inbound flow] --> CheckRecall{Pure recall?<br/>All changes are<br/>attribute removals}
-        CheckRecall -->|Yes| SkipRecall[Skip export evaluation<br/>Prevents expression mapping<br/>errors against incomplete data<br/>No PE created]
-        CheckRecall -->|No| EvalExport[EvaluateExportRules:<br/>Find export Synchronisation Rules<br/>for MVO type]
+        SyncStart[MVO attribute changes<br/>during inbound flow<br/>incl. attribute recall +<br/>#91 next-contributor re-election] --> CheckDelete{MVO queued for<br/>immediate deletion?}
+        CheckDelete -->|Yes| SkipDelete[Skip export evaluation<br/>MVO about to be deleted;<br/>work would be discarded #390<br/>No PE created]
+        CheckDelete -->|No| EvalExport[EvaluateExportRules:<br/>Find export Synchronisation Rules<br/>for MVO type]
         EvalExport --> InScope{MVO in scope<br/>for export rule?}
         InScope -->|No| EvalDeprov[Evaluate deprovisioning:<br/>Create Delete PE if CSO exists]
         InScope -->|Yes| MapAttrs[Map MVO attributes<br/>to CSO attributes<br/>via export Synchronisation Rule mappings]
@@ -197,7 +197,7 @@ This prevents silent loss of drift corrections when merging with export evaluati
 
 - **Drift correction**<br /> When `EnforceState` is enabled on an export Synchronisation Rule and the CSO has values that don't match the MVO, a corrective PE is created to reassert the correct values. This detects and corrects unauthorised changes made directly in target systems.
 
-- **Pure recall skip**<br /> When all changed attributes on an MVO are removals (attribute recall due to CSO disconnection), export evaluation is skipped entirely. Expression-based mappings (e.g., DN templates) would evaluate against post-recall null attributes and produce invalid values. Target systems retain their existing attribute values until attribute priority (Issue #91) enables replacement value resolution.
+- **Attribute recall and re-election**<br /> When a Connected System Object disconnects (obsoleted, or fallen out of scope), JIM recalls the values that system contributed. If a lower-priority Synchronisation Rule still contributes, the next contributor is re-elected in the same sync run ([Attribute Priority](../../concepts/attribute-priority.md), #91) and export evaluation stages a change-of-value on the target; if no contributor survives, the attribute is cleared and export evaluation stages a null-clear. Export evaluation is no longer skipped for recall. Expression-based mappings (e.g. DN templates) are protected from evaluating against post-recall nulls by re-election supplying a replacement value, by grace-period freezing of identity-critical single-source attributes, and by the #390 skip of recall when the MVO is about to be deleted.
 
 - **Value-level drift merge**<br /> When merging drift corrections with export evaluation changes, the merge key is a composite of `AttributeId` + value identity (not just `AttributeId`). This prevents silent loss of multi-valued attribute drift corrections; e.g., 117 member removals would be dropped if merged by `AttributeId` alone.
 


### PR DESCRIPTION
## Description

The Attribute Priority feature (#91) shipped without the customer-facing documentation being brought up to date. This PR closes two gaps:

**1. Synchronisation Rules how-to page (`docs/configuration/synchronisation-rules.md`).** Its "Priority" section still described the **old rule-level** model ("Each Synchronisation Rule has a priority level, and the rule with the highest priority wins"), which is now inaccurate: priority is held per attribute, per contributing rule. The section also never mentioned the **Null is a value** setting. Rewritten as a correct, appropriately-scoped how-to:

- **Corrects the model** to per-attribute, per-contributing-rule priority.
- **Explains winner selection**: highest-priority contributor with a value wins; rules with no opinion (disabled, unjoined, or out of scope) are skipped; the attribute is left unset if nobody contributes.
- **Adds the missing "Null is a value" setting**: what it does (asserts a clear rather than falling through), typical uses, and its blast-radius caveat.
- **Says where it is configured** (Metaverse Object Type → Attributes tab, not the Sync Rule editor) plus the PowerShell/REST route.
- **Links to** the existing `concepts/attribute-priority.md` for the deep material, keeping the how-to page from duplicating the concept doc per Diátaxis.
- Fixes the internal `#priority` → `#attribute-priority` anchor used by the inbound value-processing section, and adds Attribute Priority to "See also".

**2. Pending Export lifecycle developer doc (`docs/developer/diagrams/PENDING_EXPORT_LIFECYCLE.md`).** Its "Pure recall skip" flowchart node and bullet were stale on all three claims: the "skip export evaluation when all changes are removals" behaviour no longer exists post-#91. Rewritten (verified against `SyncTaskProcessorBase.ProcessObsoleteConnectedSystemObjectAsync`):

- Recall now re-elects a surviving lower-priority contributor in the same sync run; export stages a change-of-value where one survives, a null-clear where none does.
- The only genuine export-evaluation skip left is the #390 immediate-deletion optimisation.
- DN-template/expression safety now comes from re-election, grace-period freezing of single-source values, and the #390 skip, not a removals-only skip.

A sweep of the rest of `docs/` confirmed the concept doc, PowerShell page, and expressions page already describe the correct per-attribute model; these two pages were the only stale ones.

## Type of change

- [x] Documentation update

## Testing

Docs-only change (`.md`); no build or test required per the repository's build/test exceptions. Behavioural claims in the developer doc were verified against source (`SyncTaskProcessorBase.cs`, `ExportEvaluationServer.cs`). Link targets and heading anchors checked.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `docs/configuration/synchronisation-rules.md`, `docs/developer/diagrams/PENDING_EXPORT_LIFECYCLE.md`

<!-- Docs: n/a - documentation-only PR; no ✨/🔄 changelog entry, so docs-coupling lint does not apply -->

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)