### PR TITLE
fix(ui): stop Activity filter toolbar orphaning the pause icon

### DIFF
--- a/src/JIM.Web/Pages/ActivityList.razor
+++ b/src/JIM.Web/Pages/ActivityList.razor
@@ -125,8 +125,11 @@
             <MudSelectItem T="ActivityInitiatorType" Value="ActivityInitiatorType.System">System</MudSelectItem>
         </MudSelect>
     </MudItem>
-    <MudItem Class="flex-grow-1">
-        @* No dense margin: matches the height of the neighbouring filter selects. *@
+    <MudItem Class="flex-grow-1" Style="max-width: 280px;">
+        @* No dense margin: matches the height of the neighbouring filter selects.
+           Max-width caps MudDateRangePicker's much wider default (~2x a select),
+           which otherwise starves the trailing checkbox and pause button of row
+           space and pushes them onto their own line. *@
         <MudDateRangePicker Label="Created between" Variant="Variant.Outlined"
                             DateRange="_filterDateRange" DateRangeChanged="OnDateRangeChanged"
                             Clearable="true" AutoClose="true" />


### PR DESCRIPTION
## Summary
- `MudDateRangePicker` on the Activity page's filter toolbar rendered nearly 2x as wide as its sibling filter dropdowns (512px vs 256px) despite sharing the same `flex-grow-1` class
- That excess width was just enough to strand the pause/resume auto-refresh button alone on its own line below the "Has child activities" checkbox
- Capped the date range picker at `max-width: 280px`, matching its siblings' width, so the full filter row fits on one line at the default (collapsed) drawer width

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors) - UI-only change, no test suite run per CLAUDE.md's Razor-change exception
- [x] Verified live in the browser (rebuilt and restarted JIM.Web natively): filters, checkbox, and pause button now stay on one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)