### PR TITLE
docs: update roadmap to reflect v0.9–v0.10 completion

### DIFF
--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -1,26 +1,8 @@
 # Product Roadmap
 
-JIM has reached **MVP completion**. The core identity lifecycle -- Import, Sync, Export, and Schedule -- is fully functional. The roadmap below outlines planned milestones as JIM progresses towards a stable release and beyond.
+JIM has completed **pre-release stabilisation**. The core identity lifecycle -- Import, Sync, Export, and Schedule -- is fully functional, and the platform has been hardened for production with bounded-memory pipelines proven at 100K+ object scale, an OWASP Top 10:2025 assessment, supply chain hardening, and comprehensive integration test coverage across all sync scenarios. The roadmap below outlines the milestones ahead as JIM progresses towards its first stable release and beyond.
 
 For the latest milestone status and issue tracking, see the [GitHub milestones](https://github.com/TetronIO/JIM/milestones).
-
----
-
-## 🔨 v0.9 -- v0.10 -- Pre-release Stabilisation
-
-Hardening and polish ahead of the first stable release. Delivered:
-
-- Bounded-memory pipelines tested at 100K+ object scale
-- EF Core query defaults tuned for read-heavy workloads (AsNoTracking by default with explicit write-path opt-in)
-- Sync integrity overhaul: cross-page reference resolution, change-record persistence, entity tracking conflicts resolved
-- Integration test coverage across all sync scenarios with automated metrics streaming
-- OWASP Top 10:2025 assessment completed with targeted hardening
-- Supply chain hardening: Docker base image digests pinned, GitHub Actions pinned by SHA, main branch protection with required status checks
-- Interactive Scalar API reference available in every environment (including air-gapped), with a public snapshot hosted on the documentation site
-- Role membership management API and PowerShell cmdlets
-- Service identity (Service Name and Service ID) for distinguishing JIM instances
-- OIDC sign-out with identity provider support
-- Predefined Searches that can be disabled and re-enabled without deletion
 
 ---
 


### PR DESCRIPTION
## Description

Updates the product roadmap to reflect the completion of pre-release stabilisation (v0.9–v0.10). The v0.9–v0.10 section has been removed and its accomplishments folded into the opening summary, which now accurately describes JIM's current state: fully functional core identity lifecycle, production hardening at 100K+ object scale, security assessment completion, supply chain hardening, and comprehensive integration test coverage.

This change clarifies the project's progression and sets the stage for the v1.0 stable release milestone.

## Type of change

- [x] Documentation update

## Testing

- [x] No testing needed

## Documentation

- [x] Public documentation updated (`docs/`); page: `docs/reference/roadmap.md`

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

The removed v0.9–v0.10 section documented work already delivered and reflected in the codebase. Moving this summary to the opening paragraph provides a clearer narrative of JIM's maturity level and readiness for the v1.0 stable release.

https://claude.ai/code/session_018JS8PVbasfvUVNyBrZDseK