### PR TITLE
docs: link roadmap to public project board instead of milestones

### DIFF
--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -2,7 +2,7 @@
 
 JIM has completed **pre-release stabilisation**. The core identity lifecycle -- Import, Sync, Export, and Schedule -- is fully functional, and the platform has been hardened for production with bounded-memory pipelines proven at 100K+ object scale, an OWASP Top 10:2025 assessment, supply chain hardening, and comprehensive integration test coverage across all sync scenarios. The roadmap below outlines the milestones ahead as JIM progresses towards its first stable release and beyond.
 
-For the latest milestone status and issue tracking, see the [GitHub milestones](https://github.com/TetronIO/JIM/milestones).
+For the latest status and issue tracking, see the public [JIM Roadmap project board](https://github.com/orgs/TetronIO/projects/1).
 
 ---
 


### PR DESCRIPTION
## Description

Updates the product roadmap intro link. It previously pointed at the [GitHub milestones](https://github.com/TetronIO/JIM/milestones) list; the "JIM Roadmap" GitHub Project is now public and gives a clearer view of status and issue tracking, so the page now links to the [project board](https://github.com/orgs/TetronIO/projects/1) instead.

## Type of change

- [x] Documentation update

## Testing

- [x] No testing needed

## Documentation

- [x] Public documentation updated (`docs/`); page: `docs/reference/roadmap.md`

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018JS8PVbasfvUVNyBrZDseK)_