### PR TITLE
docs: consolidate integration-testing guide; fix Scenario 14 runner

### DIFF
--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -494,6 +494,15 @@ body:has(.jim-home) .md-content__button {
   flex-shrink: 0;
 }
 
+/* Light mode: pin the check green. Material's own `.md-typeset .twemoji svg`
+   rule (fill: currentColor) outranks the base rule above on specificity and
+   would otherwise paint the tick the monochrome body colour; the scheme-prefixed
+   selector here matches the specificity that already lets the dark rule win. */
+[data-md-color-scheme="default"] .jim-capabilities li .twemoji,
+[data-md-color-scheme="default"] .jim-capabilities li svg {
+  fill: #2e9e5a;
+}
+
 /* Dark mode: soften the pill background and brighten the check */
 [data-md-color-scheme="slate"] .jim-capabilities li {
   background: #0d1e30;

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -180,6 +180,7 @@
 .md-typeset .grid.cards > :is(ul, ol) > li,
 .md-typeset .grid > .card {
   background-color: var(--jim-card-bg);
+  border-radius: 8px;   /* match the JIM.Web portal's container/panel radius */
   transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -39,6 +39,10 @@
   --md-typeset-a-color: #0076d3;             /* --jim-link-color */
   --md-accent-fg-color: #0076d3;
 
+  /* Grid card surfaces: faint brand-purple-tinted panel, deepening a touch on hover */
+  --jim-card-bg: #f7f6fb;
+  --jim-card-bg-hover: #efecf8;
+
 }
 
 /* Light mode: search bar styling */
@@ -118,6 +122,10 @@
   /* Links */
   --md-typeset-a-color: #67b9ff;             /* --jim-link-color */
 
+  /* Grid card surfaces: raised navy panel, lifting a touch lighter on hover */
+  --jim-card-bg: #0d1e30;
+  --jim-card-bg-hover: #14293f;
+
 }
 
 /* Dark mode: search bar styling */
@@ -165,11 +173,20 @@
   border-color: var(--md-accent-fg-color);
 }
 
-/* Material grid cards: lighten the border on hover (default behaviour fades it
-   to transparent, which reads as "darker" in dark mode). 2D look, no shadow. */
+/* Material grid cards: give each panel a subtly toned surface so it reads as a
+   distinct card rather than a bordered void, and lift both the surface and the
+   border on hover. Applies site-wide (feature grids, quick links, connector
+   cards, etc.). 2D look, no shadow. */
+.md-typeset .grid.cards > :is(ul, ol) > li,
+.md-typeset .grid > .card {
+  background-color: var(--jim-card-bg);
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
 .md-typeset .grid.cards > :is(ul, ol) > li:hover,
 .md-typeset .grid > .card:hover {
   border-color: var(--md-default-fg-color--lighter);
+  background-color: var(--jim-card-bg-hover);
   box-shadow: none;
 }
 

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -39,9 +39,9 @@
   --md-typeset-a-color: #0076d3;             /* --jim-link-color */
   --md-accent-fg-color: #0076d3;
 
-  /* Grid card surfaces: faint brand-purple-tinted panel, deepening a touch on hover */
-  --jim-card-bg: #f7f6fb;
-  --jim-card-bg-hover: #efecf8;
+  /* Grid card surfaces: JIM.Web navy-o6 light background grey, deepening a touch on hover */
+  --jim-card-bg: #f3f3f3;
+  --jim-card-bg-hover: #ebebeb;
 
 }
 
@@ -179,6 +179,7 @@
    cards, etc.). 2D look, no shadow. */
 .md-typeset .grid.cards > :is(ul, ol) > li,
 .md-typeset .grid > .card {
+  position: relative;   /* positioning context for the stretched-link overlay below */
   background-color: var(--jim-card-bg);
   border-radius: 8px;   /* match the JIM.Web portal's container/panel radius */
   transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
@@ -189,6 +190,34 @@
   border-color: var(--md-default-fg-color--lighter);
   background-color: var(--jim-card-bg-hover);
   box-shadow: none;
+}
+
+/* Make the whole panel a single click target. Each card carries at most one link
+   (a linked title, or a single call-to-action); stretch that link's hit area over
+   the entire card via a transparent ::after overlay, so the user clicks anywhere on
+   the panel rather than hunting for the link text (which otherwise floats at a
+   different height per card depending on body length). This is the Bootstrap
+   "stretched-link" pattern; the trade-off is that body text inside a linked card is
+   no longer selectable, which is acceptable for navigation cards. */
+.md-typeset .grid.cards > :is(ul, ol) > li a::after,
+.md-typeset .grid > .card a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+/* A linked card title should read as a heading, not a blue link; the whole-card
+   hover (surface + border) is the affordance. Reveal the accent colour on hover to
+   confirm the panel is interactive. Bottom call-to-action links (not bold) keep
+   their normal link colour. */
+.md-typeset .grid.cards > :is(ul, ol) > li strong a,
+.md-typeset .grid > .card strong a {
+  color: inherit;
+}
+
+.md-typeset .grid.cards > :is(ul, ol) > li:hover strong a,
+.md-typeset .grid > .card:hover strong a {
+  color: var(--md-accent-fg-color);
 }
 
 /* ========================================

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -39,9 +39,10 @@
   --md-typeset-a-color: #0076d3;             /* --jim-link-color */
   --md-accent-fg-color: #0076d3;
 
-  /* Grid card surfaces: JIM.Web navy-o6 light background grey, deepening a touch on hover */
-  --jim-card-bg: #f3f3f3;
-  --jim-card-bg-hover: #ebebeb;
+  /* Grid card surfaces: soft light grey (lightened a touch from JIM.Web's navy-o6
+     #f3f3f3 background), deepening slightly on hover */
+  --jim-card-bg: #f7f7f7;
+  --jim-card-bg-hover: #efefef;
 
 }
 

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -43,6 +43,7 @@
      #f3f3f3 background), deepening slightly on hover */
   --jim-card-bg: #f7f7f7;
   --jim-card-bg-hover: #efefef;
+  --jim-card-border: rgba(0, 0, 0, 0.13);   /* a touch darker than Material's default lightest */
 
 }
 
@@ -126,6 +127,7 @@
   /* Grid card surfaces: raised navy panel, lifting a touch lighter on hover */
   --jim-card-bg: #0d1e30;
   --jim-card-bg-hover: #14293f;
+  --jim-card-border: var(--md-default-fg-color--lightest);   /* unchanged from Material default */
 
 }
 
@@ -182,6 +184,7 @@
 .md-typeset .grid > .card {
   position: relative;   /* positioning context for the stretched-link overlay below */
   background-color: var(--jim-card-bg);
+  border-color: var(--jim-card-border);
   border-radius: 8px;   /* match the JIM.Web portal's container/panel radius */
   transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,49 +14,49 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-sync:{ .lg .middle } **Hub-and-Spoke Synchronisation**
+-   :material-sync:{ .lg .middle } **[Hub-and-Spoke Synchronisation](concepts/architecture.md)**
 
     ---
 
     Central metaverse architecture for identity correlation across all Connected Systems. Bidirectional sync of Users, Groups, and custom object types.
 
--   :material-server-network:{ .lg .middle } **Multi-Directory LDAP**
+-   :material-server-network:{ .lg .middle } **[Multi-Directory LDAP](connectors/jim-ldap-connector.md)**
 
     ---
 
     Active Directory, OpenLDAP, 389 Directory Server, and other RFC 4512-compliant directories, all supported out of the box.
 
--   :material-docker:{ .lg .middle } **Container-Native Deployment**
+-   :material-docker:{ .lg .middle } **[Container-Native Deployment](administration/deployment.md)**
 
     ---
 
     Deploys as a single Docker stack with no legacy infrastructure requirements. Bundled or external PostgreSQL.
 
--   :material-shield-lock:{ .lg .middle } **Single Sign-On (SSO)**
+-   :material-shield-lock:{ .lg .middle } **[Single Sign-On (SSO)](administration/sso-setup.md)**
 
     ---
 
     OpenID Connect authentication with any OIDC-compliant Identity Provider. PKCE for enhanced security.
 
--   :material-function-variant:{ .lg .middle } **Expression-Based Transforms**
+-   :material-function-variant:{ .lg .middle } **[Expression-Based Transforms](concepts/expressions.md)**
 
     ---
 
     Transform data using expressions with built-in functions for common identity operations.
 
--   :material-api:{ .lg .middle } **REST API & PowerShell**
+-   :material-api:{ .lg .middle } **[REST API & PowerShell](api/index.md)**
 
     ---
 
     Full REST API with OpenAPI documentation, plus a cross-platform PowerShell module for automation and Identity as Code.
 
--   :material-wifi-off:{ .lg .middle } **Air-Gapped Ready**
+-   :material-wifi-off:{ .lg .middle } **[Air-Gapped Ready](administration/deployment.md#air-gapped-deployment)**
 
     ---
 
     Fully functional without internet connectivity. No cloud dependencies -- designed for sensitive and high-assurance environments.
 
--   :material-puzzle:{ .lg .middle } **Extensible Connectors**
+-   :material-puzzle:{ .lg .middle } **[Extensible Connectors](connectors/index.md)**
 
     ---
 
@@ -92,37 +92,29 @@ Enterprise identity synchronisation typically requires cloud connectivity, compl
 
 <div class="grid cards" markdown>
 
--   :material-rocket-launch:{ .lg .middle } **Getting Started**
+-   :material-rocket-launch:{ .lg .middle } **[Getting Started](getting-started/index.md)**
 
     ---
 
     Deploy JIM and run your first synchronisation.
 
-    [:octicons-arrow-right-24: Getting Started](getting-started/index.md)
-
--   :material-book-open-variant:{ .lg .middle } **Concepts**
+-   :material-book-open-variant:{ .lg .middle } **[Concepts](concepts/index.md)**
 
     ---
 
     Understand the metaverse, Connected Systems, Synchronisation Rules, and more.
 
-    [:octicons-arrow-right-24: Concepts](concepts/index.md)
-
--   :material-cog:{ .lg .middle } **Administration**
+-   :material-cog:{ .lg .middle } **[Administration](administration/index.md)**
 
     ---
 
     Configure, monitor, and manage your JIM deployment.
 
-    [:octicons-arrow-right-24: Administration](administration/index.md)
-
--   :material-power-plug:{ .lg .middle } **Connectors**
+-   :material-power-plug:{ .lg .middle } **[Connectors](connectors/index.md)**
 
     ---
 
     Connect JIM to LDAP directories, CSV files, and more.
-
-    [:octicons-arrow-right-24: Connectors](connectors/index.md)
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,12 +128,14 @@ Enterprise identity synchronisation typically requires cloud connectivity, compl
 
 ## State of Development
 
-JIM has reached MVP completion. The core identity lifecycle is fully functional:
+JIM has completed **pre-release stabilisation** and moved well beyond its initial MVP. The core identity lifecycle is fully functional:
 
 - **Import** identities from source systems (LDAP, CSV)
 - **Sync** to reconcile identities in the central metaverse
 - **Export** changes to target systems with Pending Export management
 - **Schedule** automated synchronisation using cron or interval-based triggers
+
+The platform has been hardened for production, with bounded-memory pipelines proven at 100K+ object scale, an OWASP Top 10:2025 assessment, supply chain hardening, and comprehensive integration test coverage across all synchronisation scenarios. See the [Product Roadmap](reference/roadmap.md) for what is coming as JIM progresses towards its first stable release.
 
 ## 💬 Community & Support
 

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -129,13 +129,13 @@ This single script handles everything:
 # Large-scale test with reduced logging and no change tracking
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario1-HRToIdentityDirectory" -Template Large -LogLevel Warning -DisableChangeTracking
 
-# Full pre-release regression suite (all scenarios, both directory types, Samba Medium/Large, OpenLDAP Scale100k50Groups)
+# Full pre-release regression suite (all scenarios, both directory types, Samba AD at Medium, OpenLDAP at Large)
 ./test/integration/Run-IntegrationTests.ps1 -PreRelease
 ```
 
 **Strict-mode hardening:** the runner uses `Set-StrictMode -Version Latest`, so local debugging must treat uninitialised variables and missing properties as errors. This matches CI behaviour and prevents drift between the two environments.
 
-**-PreRelease preset**: shorthand for the full pre-release regression (`-Scenario All -DirectoryType All` for Samba AD with Medium + Large templates and OpenLDAP with Scale100k50Groups). Use this as the final sign-off before cutting a release.
+**-PreRelease preset**: shorthand for the full pre-release regression (`-Scenario All -DirectoryType All -TemplateSambaAD Medium -TemplateOpenLDAP Large`): every implemented scenario against both directory types, with Samba AD at the Medium template and OpenLDAP at the Large template. Use this as the recommended pre-release gate, the final sign-off before cutting a release.
 
 **Available Scenarios (`-Scenario` parameter):**
 

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -77,8 +77,8 @@ This single script handles everything:
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario9-PartitionScopedImports"  # Partition-scoped import Run Profiles
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario10-SyncRuleScoping"          # Synchronisation Rule scoping behaviour (inbound + outbound)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix"    # Scoping criteria evaluation matrix (Default tier)
-./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix" -Quick      # Quick tier (~12 cells, < 90s)
-./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix" -Exhaustive # Exhaustive tier (~152 cells, < 10 min)
+./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix" -Quick      # Quick tier (~12 cells)
+./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix" -Exhaustive # Exhaustive tier (~152 cells)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario12-RelativeDateScoping"       # Relative-date inbound scoping (joiner/leaver)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario13-RelativeDateOutboundScoping" # Relative-date outbound scoping (staged provisioning)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario14-AttributePriority"        # Attribute Priority multi-source winner resolution (#91, OpenLDAP only)
@@ -141,43 +141,45 @@ This single script handles everything:
 
 **Available Scenarios (`-Scenario` parameter):**
 
-| Scenario | Description | Containers Used | OpenLDAP |
-|----------|-------------|-----------------|----------|
-| `Scenario1-HRToIdentityDirectory` | HR + Training CSV -> AD provisioning (Joiner/Mover/Leaver) | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario2-CrossDomainSync` | APAC -> EMEA directory sync | samba-ad-source, samba-ad-target / openldap-primary | ✅ |
-| `Scenario3-GALSYNC` | AD -> CSV global address list export (stub, not implemented) | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario4-DeletionRules` | Deletion rules and grace period testing | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario5-MatchingRules` | Object Matching Rules testing | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario6-SchedulerService` | Scheduler service end-to-end testing | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario7-ClearConnectedSystemObjects` | Clear connector space testing | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario8-CrossDomainEntitlementSync` | Group sync between APAC and EMEA domains | samba-ad-source, samba-ad-target / openldap-primary | ✅ |
-| `Scenario9-PartitionScopedImports` | Partition-scoped import Run Profiles | samba-ad-primary / openldap-primary | ✅ |
-| `Scenario10-SyncRuleScoping` | Synchronisation Rule scoping behaviour: inbound enter/in-scope-update/exit (Disconnect, RemainJoined); outbound enter/exit (Disconnect, Delete); cross-system inline cascade; criteria persistence | file (HR CSV), samba-ad-primary / openldap-primary | ✅ |
-| `Scenario11-ScopingCriteriaMatrix` | Scoping criteria evaluation matrix: full operator x value-type x group-structure coverage via batched per-cell CSO and MV types. Three tiers: Quick (~12 cells, < 90s), Default (~41 cells, < 5 min), Exhaustive (~152 cells, < 10 min). Round-trip persistence and API negative-cell probes run first. | file (bespoke deterministic seed) | n/a |
-| `Scenario12-RelativeDateScoping` | Relative-date inbound scoping: date-driven joiner provisioning and leaver deprovisioning, plus per-run re-evaluation against the live clock | file (HR CSV, metaverse-only) | n/a |
-| `Scenario13-RelativeDateOutboundScoping` | Relative-date outbound scoping: downstream provisioning held until a joiner's start date arrives, released via the Temporal Scope Reconciler's outbound lane | file (HR CSV source, CSV export target) | n/a |
-| `Scenario14-AttributePriority` | Attribute Priority multi-source winner resolution (#91): two import Synchronisation Rules contribute the same Metaverse attributes (Description, Job Title, Manager reference, multi-valued Other Telephones) at different priorities; validates winner-takes-all for scalars, multi-valued handling, recall/re-election, and null/withdrawal/priority-reorder behaviour. OpenLDAP only (two-suffix topology: dc=yellowstone Primary + dc=glitterband Secondary in one container) | openldap-primary (two suffixes) | ✅ (only) |
+In **Containers Used**, `samba-* / openldap-primary` means the scenario runs against Samba AD or OpenLDAP depending on `-DirectoryType`; `file (...)` means no directory container (CSV / metaverse only). Scenario 14 is OpenLDAP only.
+
+| Scenario | Description | Containers Used |
+|----------|-------------|-----------------|
+| `Scenario1-HRToIdentityDirectory` | HR + Training CSV -> AD provisioning (Joiner/Mover/Leaver) | samba-ad-primary / openldap-primary |
+| `Scenario2-CrossDomainSync` | APAC -> EMEA directory sync | samba-ad-source, samba-ad-target / openldap-primary |
+| `Scenario3-GALSYNC` | AD -> CSV global address list export (stub, not implemented) | samba-ad-primary / openldap-primary |
+| `Scenario4-DeletionRules` | Deletion rules and grace period testing | samba-ad-primary / openldap-primary |
+| `Scenario5-MatchingRules` | Object Matching Rules testing | samba-ad-primary / openldap-primary |
+| `Scenario6-SchedulerService` | Scheduler service end-to-end testing | samba-ad-primary / openldap-primary |
+| `Scenario7-ClearConnectedSystemObjects` | Clear connector space testing | samba-ad-primary / openldap-primary |
+| `Scenario8-CrossDomainEntitlementSync` | Group sync between APAC and EMEA domains | samba-ad-source, samba-ad-target / openldap-primary |
+| `Scenario9-PartitionScopedImports` | Partition-scoped import Run Profiles | samba-ad-primary / openldap-primary |
+| `Scenario10-SyncRuleScoping` | Synchronisation Rule scoping behaviour: inbound enter/in-scope-update/exit (Disconnect, RemainJoined); outbound enter/exit (Disconnect, Delete); cross-system inline cascade; criteria persistence | file (HR CSV), samba-ad-primary / openldap-primary |
+| `Scenario11-ScopingCriteriaMatrix` | Scoping criteria evaluation matrix: full operator x value-type x group-structure coverage via batched per-cell CSO and MV types. Three tiers: Quick (~12 cells), Default (~41 cells), Exhaustive (~152 cells). Round-trip persistence and API negative-cell probes run first. | file (bespoke deterministic seed) |
+| `Scenario12-RelativeDateScoping` | Relative-date inbound scoping: date-driven joiner provisioning and leaver deprovisioning, plus per-run re-evaluation against the live clock | file (HR CSV, metaverse-only) |
+| `Scenario13-RelativeDateOutboundScoping` | Relative-date outbound scoping: downstream provisioning held until a joiner's start date arrives, released via the Temporal Scope Reconciler's outbound lane | file (HR CSV source, CSV export target) |
+| `Scenario14-AttributePriority` | Attribute Priority multi-source winner resolution (#91): two import Synchronisation Rules contribute the same Metaverse attributes (Description, Job Title, Manager reference, multi-valued Other Telephones) at different priorities; validates winner-takes-all for scalars, multi-valued handling, recall/re-election, and null/withdrawal/priority-reorder behaviour. OpenLDAP only (two-suffix topology: dc=yellowstone Primary + dc=glitterband Secondary in one container) | openldap-primary (two suffixes) |
 
 **Available Templates (`-Template` parameter):**
 
-Choose a template based on your testing goals. The time shown is a rough **single import/sync/export cycle** at that size, not a scenario or a full run; for measured per-scenario and full-regression times see [Run-Time Estimates](#run-time-estimates).
+Choose a template based on your testing goals. For measured run times see [Run-Time Estimates](#run-time-estimates).
 
-- **Nano** (default): 3 users, 1 group - **< 10 sec** - Fast dev iteration and debugging
-- **Micro**: 10 users, 3 groups - **< 30 sec** - Quick smoke tests and development
-- **Small**: 100 users, 20 groups - **< 2 min** - Small business scenarios, unit testing
-- **Medium**: 1,000 users, 100 groups - **< 2 min** - Medium enterprise, CI/CD pipelines
-- **MediumLarge**: 5,000 users, 250 groups - **< 5 min** - Large medium enterprise, performance validation
-- **Large**: 10,000 users, 500 groups - **< 15 min** - Large enterprise, performance baselines
-- **Scale100k50Groups**: 100,000 users, 50 groups - **< 2 hours** - Very large enterprise, stress testing (**requires 20+ GB host RAM**; see note below)
-- **Scale200k55Groups**: 200,000 users, 55 groups - **TBD** - Very large enterprise, extended stress testing (**requires 24+ GB host RAM**)
-- **Scale500k65Groups**: 500,000 users, 65 groups - **TBD** - Massive enterprise, scale validation (**requires 32+ GB host RAM**)
-- **Scale750k70Groups**: 750,000 users, 70 groups - **TBD** - Near-million scale validation (**requires 32+ GB host RAM**)
-- **Scale1m80Groups**: 1,000,000 users, 70 groups - **TBD** - Global enterprise, scale limits (**requires 64+ GB host RAM**). _Note: the name's "80" reflects the originally planned group count; the actual count is 70. The capped-groups Samba-friendly templates above are kept for Samba scale testing; long-tail counterparts (Scale*k*kGroups) are listed below._
-- **Scale100k5kGroups**: 100,000 users, 5,027 groups (realistic long-tail shape) - **< 2 hours** - Scenario 8 entitlement sync against representative enterprise group topology. **OpenLDAP only**; rejected on Samba AD. Same memory requirements as Scale100k50Groups.
-- **Scale200k10kGroups**: 200,000 users, 9,984 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. Same memory profile as Scale200k55Groups plus additional RAM for the larger group/membership working set (~28+ GB recommended).
-- **Scale500k25kGroups**: 500,000 users, 24,997 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. ~40+ GB recommended.
-- **Scale750k40kGroups**: 750,000 users, 40,011 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. ~48+ GB recommended.
-- **Scale1m60kGroups**: 1,000,000 users, 60,073 groups (long-tail shape) - **TBD** - Scenario 8 only. **OpenLDAP only**. ~64+ GB recommended; also requires raising the OpenLDAP accesslog `olcDbMaxSize` proportionally (see Troubleshooting → "OpenLDAP accesslog full" below).
+- **Nano** (default): 3 users, 1 group - Fast dev iteration and debugging
+- **Micro**: 10 users, 3 groups - Quick smoke tests and development
+- **Small**: 100 users, 20 groups - Small business scenarios, unit testing
+- **Medium**: 1,000 users, 100 groups - Medium enterprise, CI/CD pipelines
+- **MediumLarge**: 5,000 users, 250 groups - Large medium enterprise, performance validation
+- **Large**: 10,000 users, 500 groups - Large enterprise, performance baselines
+- **Scale100k50Groups**: 100,000 users, 50 groups - Very large enterprise, stress testing (**requires 20+ GB host RAM**; see note below)
+- **Scale200k55Groups**: 200,000 users, 55 groups - Very large enterprise, extended stress testing (**requires 24+ GB host RAM**)
+- **Scale500k65Groups**: 500,000 users, 65 groups - Massive enterprise, scale validation (**requires 32+ GB host RAM**)
+- **Scale750k70Groups**: 750,000 users, 70 groups - Near-million scale validation (**requires 32+ GB host RAM**)
+- **Scale1m80Groups**: 1,000,000 users, 70 groups - Global enterprise, scale limits (**requires 64+ GB host RAM**). _Note: the name's "80" reflects the originally planned group count; the actual count is 70. The capped-groups Samba-friendly templates above are kept for Samba scale testing; long-tail counterparts (Scale*k*kGroups) are listed below._
+- **Scale100k5kGroups**: 100,000 users, 5,027 groups (realistic long-tail shape) - Scenario 8 entitlement sync against representative enterprise group topology. **OpenLDAP only**; rejected on Samba AD. Same memory requirements as Scale100k50Groups.
+- **Scale200k10kGroups**: 200,000 users, 9,984 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. Same memory profile as Scale200k55Groups plus additional RAM for the larger group/membership working set (~28+ GB recommended).
+- **Scale500k25kGroups**: 500,000 users, 24,997 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. ~40+ GB recommended.
+- **Scale750k40kGroups**: 750,000 users, 40,011 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. ~48+ GB recommended.
+- **Scale1m60kGroups**: 1,000,000 users, 60,073 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. ~64+ GB recommended; also requires raising the OpenLDAP accesslog `olcDbMaxSize` proportionally (see Troubleshooting → "OpenLDAP accesslog full" below).
 
 > **Memory requirements for large templates:** The Scale100k50Groups and above templates require significantly more memory than smaller templates. The worker loads all imported objects into memory during processing; a 100K object import produces a worker peak working set of approximately 2.3 GB, plus 1–2 GB for the database during bulk inserts. **A 16 GB machine is not sufficient for Scale100k50Groups**; the worker will be OOM-killed during the save phase even without IDE overhead. In a GitHub Codespace (16 GB total), the problem is worse because the IDE and dev tools consume additional memory. Run Scale100k50Groups tests on a machine with at least 20–24 GB total RAM. See the [Deployment Guide - Memory Scaling](../DEPLOYMENT_GUIDE.md#memory-scaling-by-identity-object-count) for detailed requirements.
 
@@ -409,26 +411,26 @@ flowchart TD
 
 ## Data Scale Templates
 
-Choose the appropriate template based on test goals. The **Per cycle** column is a rough single import/sync/export cycle at that size; for full-scenario and full-regression run times see [Run-Time Estimates](#run-time-estimates).
+Choose the appropriate template based on test goals. For run times see [Run-Time Estimates](#run-time-estimates).
 
-| Template   | Users     | Groups  | Avg Memberships | Total Objects | Use Case                          | Per cycle  |
-|------------|-----------|---------|-----------------|---------------|-----------------------------------|------------|
-| **Nano**   | 3         | 1       | 1               | 4             | Fast dev iteration, debugging     | < 10 sec   |
-| **Micro**  | 10        | 3       | 3               | 13            | Quick smoke tests, development    | < 30 sec   |
-| **Small**  | 100       | 20      | 5               | 120           | Small business, unit tests        | < 2 min    |
-| **Medium** | 1,000     | 100     | 8               | 1,100         | Medium enterprise, CI/CD          | < 2 min    |
-| **MediumLarge** | 5,000 | 250     | 9               | 5,250         | Large medium enterprise, validation | < 5 min  |
-| **Large**  | 10,000    | 500     | 10              | 10,500        | Large enterprise, baselines       | < 15 min   |
-| **Scale100k50Groups** | 100,000   | 50      | 12              | 100,050       | Very large enterprise, stress     | < 2 hours  |
-| **Scale100k5kGroups** | 100,000   | 5,027   | ~9 (measured)   | 105,027       | Scenario 8 long-tail group shape (OpenLDAP only) | < 2 hours |
-| **Scale200k55Groups** | 200,000   | 55      | 12              | 200,055       | Very large enterprise, extended   | TBD        |
-| **Scale200k10kGroups** | 200,000  | 9,984   | ~8              | 209,984       | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
-| **Scale500k65Groups** | 500,000   | 65      | 13              | 500,065       | Massive enterprise, validation    | TBD        |
-| **Scale500k25kGroups** | 500,000  | 24,997  | ~10             | 524,997       | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
-| **Scale750k70Groups** | 750,000   | 70      | 14              | 750,070       | Near-million scale validation     | TBD        |
-| **Scale750k40kGroups** | 750,000  | 40,011  | ~11             | 790,011       | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
-| **Scale1m80Groups** | 1,000,000 | 70      | 15              | 1,000,070     | Global enterprise, scale limits (group count reshape pending) | TBD |
-| **Scale1m60kGroups** | 1,000,000 | 60,073 | ~13             | 1,060,073     | Scenario 8 long-tail group shape (OpenLDAP only) | TBD |
+| Template   | Users     | Groups  | Avg Memberships | Total Objects | Use Case                          |
+|------------|-----------|---------|-----------------|---------------|-----------------------------------|
+| **Nano**   | 3         | 1       | 1               | 4             | Fast dev iteration, debugging     |
+| **Micro**  | 10        | 3       | 3               | 13            | Quick smoke tests, development    |
+| **Small**  | 100       | 20      | 5               | 120           | Small business, unit tests        |
+| **Medium** | 1,000     | 100     | 8               | 1,100         | Medium enterprise, CI/CD          |
+| **MediumLarge** | 5,000 | 250     | 9               | 5,250         | Large medium enterprise, validation |
+| **Large**  | 10,000    | 500     | 10              | 10,500        | Large enterprise, baselines       |
+| **Scale100k50Groups** | 100,000   | 50      | 12              | 100,050       | Very large enterprise, stress     |
+| **Scale100k5kGroups** | 100,000   | 5,027   | ~9 (measured)   | 105,027       | Scenario 8 long-tail group shape (OpenLDAP only) |
+| **Scale200k55Groups** | 200,000   | 55      | 12              | 200,055       | Very large enterprise, extended   |
+| **Scale200k10kGroups** | 200,000  | 9,984   | ~8              | 209,984       | Scenario 8 long-tail group shape (OpenLDAP only) |
+| **Scale500k65Groups** | 500,000   | 65      | 13              | 500,065       | Massive enterprise, validation    |
+| **Scale500k25kGroups** | 500,000  | 24,997  | ~10             | 524,997       | Scenario 8 long-tail group shape (OpenLDAP only) |
+| **Scale750k70Groups** | 750,000   | 70      | 14              | 750,070       | Near-million scale validation     |
+| **Scale750k40kGroups** | 750,000  | 40,011  | ~11             | 790,011       | Scenario 8 long-tail group shape (OpenLDAP only) |
+| **Scale1m80Groups** | 1,000,000 | 70      | 15              | 1,000,070     | Global enterprise, scale limits (group count reshape pending) |
+| **Scale1m60kGroups** | 1,000,000 | 60,073 | ~13             | 1,060,073     | Scenario 8 long-tail group shape (OpenLDAP only) |
 
 ### Data Characteristics
 

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -27,10 +27,9 @@
 14. [Troubleshooting](#troubleshooting)
 15. [Appendix](#appendix)
 16. [Current Progress & Known Issues](#current-progress--known-issues)
-17. [Known Issues & TODOs](#known-issues--todos)
-18. [Workflow Tests vs Integration Tests](#workflow-tests-vs-integration-tests)
-19. [Metrics Streaming](#metrics-streaming)
-20. [Related Documentation](#related-documentation)
+17. [Workflow Tests vs Integration Tests](#workflow-tests-vs-integration-tests)
+18. [Metrics Streaming](#metrics-streaming)
+19. [Related Documentation](#related-documentation)
 
 ---
 
@@ -83,23 +82,11 @@ This single script handles everything:
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario13-RelativeDateOutboundScoping" # Relative-date outbound scoping (staged provisioning)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario14-AttributePriority"        # Attribute Priority multi-source winner resolution (#91, OpenLDAP only)
 
-# Run with a specific template size
-./test/integration/Run-IntegrationTests.ps1 -Template Nano
-./test/integration/Run-IntegrationTests.ps1 -Template Micro
-./test/integration/Run-IntegrationTests.ps1 -Template Small
-./test/integration/Run-IntegrationTests.ps1 -Template Medium
-./test/integration/Run-IntegrationTests.ps1 -Template MediumLarge
-./test/integration/Run-IntegrationTests.ps1 -Template Large
-./test/integration/Run-IntegrationTests.ps1 -Template Scale100k50Groups
+# Run with a specific template size (see Data Scale Templates for the full list)
+./test/integration/Run-IntegrationTests.ps1 -Template Nano                    # smallest; fast dev iteration
+./test/integration/Run-IntegrationTests.ps1 -Template Medium                  # typical CI/CD size
+./test/integration/Run-IntegrationTests.ps1 -Template Scale100k50Groups       # scale/stress
 ./test/integration/Run-IntegrationTests.ps1 -Template Scale100k5kGroups       # long-tail, OpenLDAP + Scenario 8 only
-./test/integration/Run-IntegrationTests.ps1 -Template Scale200k55Groups
-./test/integration/Run-IntegrationTests.ps1 -Template Scale200k10kGroups      # long-tail, OpenLDAP + Scenario 8 only
-./test/integration/Run-IntegrationTests.ps1 -Template Scale500k65Groups
-./test/integration/Run-IntegrationTests.ps1 -Template Scale500k25kGroups      # long-tail, OpenLDAP + Scenario 8 only
-./test/integration/Run-IntegrationTests.ps1 -Template Scale750k70Groups
-./test/integration/Run-IntegrationTests.ps1 -Template Scale750k40kGroups      # long-tail, OpenLDAP + Scenario 8 only
-./test/integration/Run-IntegrationTests.ps1 -Template Scale1m80Groups
-./test/integration/Run-IntegrationTests.ps1 -Template Scale1m60kGroups        # long-tail, OpenLDAP + Scenario 8 only
 
 # Run only a specific test step (steps vary by scenario)
 ./test/integration/Run-IntegrationTests.ps1 -Step Joiner                          # Scenario 1: Joiner, Mover, Mover-Rename, Mover-Move, Disable, Enable, Leaver, Reconnection
@@ -218,48 +205,20 @@ Integration tests require a complete environment reset between runs to ensure re
 
 > **Directory reset between scenarios (full-regression runs):** the runner's per-scenario `Reset-JIMForNextScenario` removes the JIM database volume and clears the test data from *both* directory types. Samba AD's test OUs are deleted; OpenLDAP's `ou=People` and `ou=Groups` subtrees under `dc=yellowstone,dc=local` and `dc=glitterband,dc=local` are deleted and the empty base OUs recreated. OpenLDAP is a long-lived container whose data volume is not removed between scenarios, so without this explicit purge each OpenLDAP scenario would import the accumulated objects of every earlier OpenLDAP scenario. Fixed-size scenarios should assert their expected object count (see `Assert-ImportedObjectCount`) so a reset gap fails loudly rather than silently synchronising stale data.
 
-### DevContainer / Local Development
-
-For developers running tests locally in a DevContainer or development environment:
+Both locally and in CI, every run follows the same six-stage lifecycle. `Run-IntegrationTests.ps1` (see [Quick Start](#-quick-start)) automates all six stages; you do not drive them by hand.
 
 ```mermaid
 flowchart TD
-    A["<b>1. STAND UP</b><br/># Start external systems<br/>docker compose -f test/integration/docker/docker-compose.integration-tests.yml up -d"]
-    B["<b>2. POPULATE</b><br/># Populate test data<br/>./Populate-SambaAD.ps1 -Template Small<br/>./Generate-TestCSV.ps1 -Template Small"]
-    C["<b>3. CONFIGURE JIM</b><br/># Configure via API<br/>./Setup-Scenario1.ps1 -ApiKey $key"]
-    D["<b>4. EXECUTE TESTS</b><br/># Run scenario steps<br/>./Invoke-Scenario1... -Step All -Template Small"]
-    E["<b>5. RESET (for next run)</b><br/># Reset BOTH external systems AND JIM database<br/>docker compose -f test/integration/docker/docker-compose.integration-tests.yml down -v<br/>docker compose -f docker-compose.yml down -v<br/><br/># Then stand up fresh for next test run<br/>docker compose -f docker-compose.yml up -d<br/>docker compose -f test/integration/docker/docker-compose.integration-tests.yml up -d"]
-    A --> B --> C --> D --> E
+    A["<b>1. STAND UP</b><br/>JIM stack + directory/database containers"]
+    B["<b>2. POPULATE</b><br/>Generate CSV + populate Samba AD / OpenLDAP for the chosen template"]
+    C["<b>3. CONFIGURE JIM</b><br/>Create Connected Systems, Synchronisation Rules, Run Profiles via the PowerShell module"]
+    D["<b>4. EXECUTE</b><br/>Run the scenario's steps with waits between each import/sync/export cycle"]
+    E["<b>5. VALIDATE</b><br/>Assert expected objects, attributes and outcomes"]
+    F["<b>6. RESET / TEAR DOWN</b><br/>Remove JIM database + external system data so the next run starts clean"]
+    A --> B --> C --> D --> E --> F --> A
 ```
 
-**Key Commands:**
-
-| Step | Command | Purpose |
-|------|---------|---------|
-| Stand up external systems | `docker compose -f test/integration/docker/docker-compose.integration-tests.yml up -d` | Start Samba AD, databases |
-| Stand up JIM | `jim-stack` or `docker compose up -d` | Start JIM services |
-| Populate test data | `./Populate-SambaAD.ps1 -Template Small` | Create users/groups in external systems |
-| Configure JIM | `./Setup-Scenario1.ps1` | Create Connected Systems, Synchronisation Rules |
-| Run tests | `./Invoke-Scenario1-HRToIdentityDirectory.ps1 -Step All` | Execute test scenario |
-| Reset external systems | `docker compose -f test/integration/docker/docker-compose.integration-tests.yml down -v` | Remove external system data |
-| Reset JIM | `docker compose -f docker-compose.yml down -v` | Remove JIM database (metaverse, config) |
-
-### CI/CD Pipeline
-
-For automated testing in GitHub Actions:
-
-```mermaid
-flowchart TD
-    T["<b>WORKFLOW TRIGGER</b> (Manual via workflow_dispatch)<br/>- Select Template: Micro / Small / Medium / Large / Scale100k50Groups-Scale1m80Groups / Scale100k5kGroups-Scale1m60kGroups (long-tail, OpenLDAP only)<br/>- Select Phase: 1 (Supported) or 2 (Road-mapped)"]
-    S1["<b>1. STAND UP</b><br/>- JIM stack<br/>- External systems"]
-    S2["<b>2. BUILD JIM</b><br/>- dotnet build<br/>- Wait ready"]
-    S3["<b>3. CONFIGURE</b><br/>- Setup scripts<br/>- Populate data"]
-    S4["<b>4. EXECUTE</b><br/>- Run scenarios<br/>- Validate"]
-    S5["<b>5. COLLECT</b><br/>- Test results<br/>- Upload artefacts"]
-    S6["<b>6. TEAR DOWN</b> (always runs)<br/>- down -v ALL"]
-    C["<b>CLEAN STATE:</b> Runner is fresh for next workflow run<br/>No persistent volumes = automatic reset"]
-    T --> S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> C
-```
+**Local vs CI:** locally the runner performs the reset between runs (and `Reset-JIMForNextScenario` between scenarios of a full-regression sweep). In CI each run gets a fresh GitHub runner, so there are no persistent volumes and the reset is automatic. See [CI/CD Integration](#cicd-integration) for the workflow itself.
 
 **CI/CD Characteristics:**
 
@@ -325,7 +284,7 @@ Each scenario script supports a `-Step` parameter that controls which test case 
 
 **Common parameters across all scenario scripts**:
 - `-Step <StepName>` - Execute a specific test step (or `All` for full sequence)
-- `-Template <Size>` - Data scale template (Nano, Micro, Small, Medium, Large, Scale100k50Groups, Scale200k55Groups, Scale500k65Groups, Scale750k70Groups, Scale1m80Groups, Scale100k5kGroups, Scale200k10kGroups, Scale500k25kGroups, Scale750k40kGroups, Scale1m60kGroups)
+- `-Template <Size>` - Data scale template; see [Data Scale Templates](#data-scale-templates) for the full list
 - `-TemplateSambaAD <Size>` - Override `-Template` for Samba AD when using `-DirectoryType All`
 - `-TemplateOpenLDAP <Size>` - Override `-Template` for OpenLDAP when using `-DirectoryType All`
 - `-WaitSeconds <N>` - Override default wait time between steps (default: 60)
@@ -358,10 +317,10 @@ flowchart TB
         direction TB
         subgraph P1["Phase 1 (Supported)"]
             direction TB
-            P1A["Panoply AD<br/>(Scenarios 1 & 3)<br/>Port: 389/636"]
-            P1B["Panoply APAC<br/>(Scenario 2)<br/>Port: 10389/636"]
-            P1C["Quantum Dynamics EMEA<br/>Port: 11389"]
-            P1D["OpenLDAP<br/>Port: 1389/1636"]
+            P1A["samba-ad-primary<br/>(primary directory)<br/>389/636"]
+            P1B["samba-ad-source<br/>(cross-domain source)<br/>389/636"]
+            P1C["samba-ad-target<br/>(cross-domain target)<br/>389/636"]
+            P1D["openldap-primary<br/>(two suffixes)<br/>1389/1636"]
             CSV["CSV Files (mounted volume at /connector-files)"]
         end
         subgraph P2["Phase 2 (Road-mapped)"]
@@ -375,18 +334,7 @@ flowchart TB
     end
 ```
 
-### Test Flow
-
-```mermaid
-flowchart TD
-    A["<b>1. Stand Up Systems</b><br/>docker&nbsp;compose&nbsp;up&nbsp;(selected&nbsp;services&nbsp;based&nbsp;on&nbsp;phase/scenario)"]
-    B["<b>2. Populate Test Data</b><br/>PowerShell scripts generate realistic data:<br/>-&nbsp;Populate-SambaAD.ps1&nbsp;-Template&nbsp;Medium<br/>-&nbsp;Generate-TestCSV.ps1&nbsp;-Template&nbsp;Medium<br/>-&nbsp;Populate-SqlServer.ps1&nbsp;-Template&nbsp;Medium&nbsp;(Phase&nbsp;2)"]
-    C["<b>3. Configure JIM</b><br/>PowerShell module creates Connected Systems, Synchronisation Rules, Run Profiles:<br/>-&nbsp;Connect-JIM&nbsp;-ApiKey&nbsp;$env:JIM_API_KEY<br/>-&nbsp;New-JIMConnectedSystem&nbsp;(HR&nbsp;CSV,&nbsp;Samba&nbsp;AD)<br/>-&nbsp;New-JIMSyncRule&nbsp;(attribute&nbsp;flows)<br/>-&nbsp;New-JIMRunProfile&nbsp;(import,&nbsp;sync,&nbsp;export&nbsp;steps)"]
-    D["<b>4. Execute Scenarios</b><br/>Run scenario scripts:<br/>-&nbsp;Invoke-Scenario1-HRToIdentityDirectory.ps1<br/>-&nbsp;Invoke-Scenario2-CrossDomainSync.ps1<br/>-&nbsp;Invoke-Scenario3-GALSYNC.ps1<br/>-&nbsp;Invoke-Scenario7-ClearConnectedSystemObjects.ps1<br/>-&nbsp;..."]
-    E["<b>5. Validate Results</b><br/>Assertions check expected outcomes:<br/>-&nbsp;User&nbsp;provisioned&nbsp;correctly?<br/>-&nbsp;Attributes&nbsp;flowed&nbsp;as&nbsp;configured?<br/>-&nbsp;Performance&nbsp;within&nbsp;thresholds?"]
-    F["<b>6. Tear Down</b><br/>docker&nbsp;compose&nbsp;down&nbsp;-v&nbsp;(complete&nbsp;cleanup)"]
-    A --> B --> C --> D --> E --> F
-```
+The end-to-end run lifecycle (stand up, populate, configure, execute, validate, tear down) is shown under [Test Lifecycle Quick Reference](#test-lifecycle-quick-reference).
 
 ---
 
@@ -839,58 +787,10 @@ Step 8 [SEQUENTIAL]:  Delta Sync AD
 
 These scenarios test group management capabilities - a core ILM function where the system manages group memberships based on identity attributes.
 
-#### Deferred: Entitlement Management - JIM to AD ⏸️
+Two further entitlement scenarios are designed but **deferred**, both blocked on the same prerequisite: **Internally-managed MVOs** (Metaverse Objects created within JIM rather than imported from a Connected System). No scenario numbers are assigned; each will be allocated when work begins.
 
-> **Status**: ⏸️ **DEFERRED** - This scenario requires proper design and implementation of Internally-managed MVOs (Metaverse Objects created within JIM rather than imported from a Connected System). Deferred until Internal MVO support is designed and implemented. No scenario number assigned; will be allocated when work begins.
-
-**Purpose**: Validate JIM as the authoritative source for entitlement groups, provisioning them to AD with membership derived from person attributes.
-
-**Concept**: JIM creates and manages role-based groups (e.g., department groups, company groups, job title groups). Group membership is calculated from person attributes in the metaverse. Groups are provisioned to AD, and JIM detects and corrects any unauthorised changes made directly in AD.
-
-**Systems**:
-- Source: JIM Metaverse (groups created via JIM API, not imported from a Connected System)
-- Target: Panoply AD (OU=Entitlements,OU=Groups,OU=Corp,DC=panoply,DC=local)
-
-**Group Types Created**:
-- **Department Groups**: `Dept-{Department}` (e.g., `Dept-Finance`, `Dept-Information Technology`)
-- **Company Groups**: `Company-{Company}` (e.g., `Company-Panoply`, `Company-Nexus Dynamics`)
-- **Job Title Groups**: `Role-{Title}` (e.g., `Role-Manager`, `Role-Analyst`)
-
-**Test Steps** (executed sequentially):
-
-| Step | Test Case | Description |
-|------|-----------|-------------|
-| 1 | **CreateGroups** | Groups created in JIM via API -> provisioned to AD with calculated membership |
-| 2 | **UpdateMembership** | User department changes in HR -> membership updated (removed from old group, added to new) |
-| 3 | **DetectDrift** | Admin manually adds/removes member in AD -> JIM detects drift on next sync |
-| 4 | **ReassertState** | JIM reasserts expected membership, overwriting unauthorised AD changes |
-| 5 | **DeleteGroup** | Group deleted from JIM MV -> group deleted from AD |
-| 6 | **DeleteMember** | User deleted from JIM MV -> user removed from all group memberships in AD |
-
----
-
-#### Deferred: Entitlement Management - Convert AD Group Authority to JIM ⏸️
-
-> **Status**: ⏸️ **DEFERRED** - This scenario requires proper design and implementation of Internally-managed MVOs. After import, groups would need to be marked as JIM-authoritative (Internal origin), which requires the same Internal MVO support as the scenario above. Deferred until Internal MVO support is designed and implemented. No scenario number assigned; will be allocated when work begins.
-
-**Purpose**: Validate importing existing AD groups into JIM and converting authority so JIM becomes the authoritative source. After conversion, any changes made directly in AD are overwritten by JIM.
-
-**Concept**: Organisations often have existing groups in AD that were created manually or by other tools. This scenario tests bringing those groups under JIM management, making JIM authoritative for their membership.
-
-**Systems**:
-- Source: Panoply AD (existing groups in OU=Legacy Groups,OU=Groups,OU=Corp)
-- Target: JIM Metaverse (becomes authoritative after import)
-- Export Target: Panoply AD (same groups, now JIM-managed)
-
-**Test Steps** (executed sequentially):
-
-| Step | Test Case | Description |
-|------|-----------|-------------|
-| 1 | **ImportGroups** | Existing AD groups imported into JIM metaverse with current membership |
-| 2 | **ConvertAuthority** | Groups marked as JIM-authoritative (export Synchronisation Rule enabled) |
-| 3 | **UpdateViaJIM** | Membership changed via JIM API -> changes exported to AD |
-| 4 | **DetectDrift** | Admin manually modifies group in AD -> JIM detects drift |
-| 5 | **ReassertState** | JIM overwrites AD changes, reasserting JIM-managed membership |
+- **Entitlement Management - JIM to AD** ⏸️: JIM as the authoritative source for role-based groups (department/company/job-title), provisioning them to AD with membership derived from person attributes and correcting drift. Needs Internal MVO support to create the groups inside JIM.
+- **Entitlement Management - Convert AD Group Authority to JIM** ⏸️: import existing AD groups, then mark them JIM-authoritative (Internal origin) so JIM overwrites subsequent direct-AD changes. Needs the same Internal MVO support to flip imported groups to Internal origin.
 
 ---
 
@@ -1202,90 +1102,11 @@ The scenario seeds its own fixed test users positioned relative to "now" and ign
 
 > The scenario numbers below (Multi-Source Aggregation, Database Source/Target, Performance Baselines) have been renumbered repeatedly as implemented scenarios claimed each range: Partition-Scoped Imports, Synchronisation Rule Scoping and the Scoping Criteria Matrix took 9-11, the Relative-Date Scoping scenarios took 12-13, and Attribute Priority (#91) took 14. The planned scenarios are now numbered 15-17.
 
-#### Scenario 15: Multi-Source Aggregation
+All three Phase 2 scenarios are blocked on the **Database Connector** ([#170](https://github.com/TetronIO/JIM/issues/170)); the scripts do not exist yet. Planned shape:
 
-**Purpose**: Validate multiple database sources feeding the metaverse with join rules and attribute precedence.
-
-**Systems**:
-- Source 1: SQL Server (HRIS System A - Business Unit A)
-- Source 2: Oracle Database (HRIS System B - Business Unit B)
-- Target 1: Panoply AD
-- Target 2: CSV (Reporting)
-
-**Test Steps** (executed sequentially):
-
-| Step | Test Case | Description |
-|------|-----------|-------------|
-| 1 | **InitialLoad** | Both sources -> metaverse -> both targets |
-| 2 | **JoinRules** | Matching employeeID across sources -> single Metaverse Object |
-| 3 | **Precedence** | SQL Server authoritative for email/phone, Oracle for department/title |
-| 4 | **DataTypes** | VARCHAR, NVARCHAR, DATE, DATETIME, INT, BIT -> correct mapping |
-
-**Script**: `test/integration/scenarios/Invoke-Scenario15-MultiSourceAggregation.ps1`
-
-**Execution Model**:
-
-```powershell
-# Individual steps
-./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step InitialLoad -Template Small
-./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step JoinRules -Template Small
-./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step Precedence -Template Small
-./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step DataTypes -Template Small
-
-# Run all steps sequentially
-./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step All -Template Small
-```
-
----
-
-#### Scenario 16: Database Source/Target
-
-**Purpose**: Validate database connector import/export capabilities.
-
-**Systems**:
-- Source: SQL Server
-- Target: PostgreSQL
-
-**Test Steps** (executed sequentially):
-
-| Step | Test Case | Description |
-|------|-----------|-------------|
-| 1 | **Import** | Import users from SQL Server |
-| 2 | **Export** | Export users to PostgreSQL |
-| 3 | **DataTypes** | Data type handling (text, numeric, date, boolean) |
-| 4 | **MultiValue** | Multi-valued attributes (if supported) |
-
-**Script**: `test/integration/scenarios/Invoke-Scenario16-DatabaseSourceTarget.ps1`
-
-**Execution Model**:
-
-```powershell
-# Individual steps
-./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step Import -Template Small
-./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step Export -Template Small
-./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step DataTypes -Template Small
-./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step MultiValue -Template Small
-
-# Run all steps sequentially
-./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step All -Template Small
-```
-
----
-
-#### Scenario 17: Performance Baselines
-
-**Purpose**: Establish performance characteristics at various scales.
-
-**Systems**: All (depending on scenario)
-
-**Test Coverage**:
-1. Run each scenario at each template scale
-2. Measure import, sync, export times
-3. Measure memory consumption
-4. Identify bottlenecks
-5. Establish acceptable thresholds
-
-**Script**: `test/integration/scenarios/Invoke-Scenario17-Performance.ps1`
+- **Scenario 15: Multi-Source Aggregation** - two database sources (SQL Server + Oracle) feeding the metaverse, exercising join rules across sources, attribute precedence (each source authoritative for different attributes), and database data-type mapping. Targets Samba AD plus a CSV reporting export.
+- **Scenario 16: Database Source/Target** - straight database connector import/export (SQL Server -> PostgreSQL), covering data-type handling and multi-valued attributes.
+- **Scenario 17: Performance Baselines** - run each scenario across template scales, measuring import/sync/export time and memory to establish thresholds and identify bottlenecks.
 
 ---
 
@@ -1426,137 +1247,23 @@ Write-Host "Scenario 1 configuration complete" -ForegroundColor Green
 | API Key Authentication | [#175](https://github.com/TetronIO/JIM/issues/175) | **✅ Complete** | API key authentication fully functional for all endpoints |
 | PowerShell Module | [#176](https://github.com/TetronIO/JIM/issues/176) | **✅ Complete** | Core cmdlets implemented and tested |
 
-#### API Key Authentication Status (Issue #175)
-
-**✅ RESOLVED** - API key authentication is now fully functional for both GET and POST/PUT/DELETE operations.
-
-**Completed:**
-- ✅ Created 3 connector definition API endpoints (GET list, GET by ID, GET by name)
-- ✅ Created `Get-JIMConnectorDefinition` PowerShell cmdlet
-- ✅ Added cmdlet to module manifest exports
-- ✅ OIDC redirect suppressed for API requests (returns 401 JSON instead of 302)
-- ✅ Added detailed logging to API key authentication handler
-- ✅ **Fixed**: API key handler now invoked for `[Authorize]` protected endpoints
-- ✅ **Fixed**: DbContext threading issues in authentication handler
-- ✅ **Fixed**: Write operations (POST/PUT/DELETE) now work with API key auth
-- ✅ **Fixed**: Null initiatedBy handling for API key authentication
-- ✅ Build succeeds, all 395 unit tests pass
-
-**Root Cause & Fix:**
-The issue was that ASP.NET Core's authentication pipeline only runs the DefaultScheme (Cookie) by default. Other schemes are only tried when explicitly requested. The fix was to add `ForwardDefaultSelector` to Cookie authentication options, which conditionally forwards to API Key authentication when the `X-API-Key` header is present.
-
-**Technical Details:**
-- Added `ForwardDefaultSelector` in Program.cs Cookie options
-- Changed `ApiKeyAuthenticationHandler` to inject `IServiceProvider` instead of `JimApplication`
-- Create new DI scope for each database operation to prevent DbContext threading issues
-- Separate scope for background usage tracking task
-- Allow null `initiatedBy` for API key auth in SynchronisationController
-- Use appropriate constructors for worker tasks when user context unavailable
-
-#### PowerShell Module Status (Issue #176)
-
-**✅ Core cmdlets implemented and tested.**
-
-**Completed Cmdlets:**
-- ✅ `Connect-JIM` - API key authentication
-- ✅ `Get-JIMConnectorDefinition` - List and retrieve connector definitions
-- ✅ `Get-JIMConnectedSystem` / `New-JIMConnectedSystem` / `Set-JIMConnectedSystem` - Manage Connected Systems
-- ✅ `Get-JIMRunProfile` / `New-JIMRunProfile` / `Start-JIMRunProfile` - Manage and execute Run Profiles
-- ✅ `Get-JIMSyncRule` / `New-JIMSyncRule` - Manage Synchronisation Rules
-
-**Fixes Applied:**
-- ✅ Fixed pagination handling for empty arrays (Get-JIMConnectedSystem, Get-JIMSyncRule)
-- ✅ Fixed parameter types (Get-JIMConnectorDefinition -Id uses int, not Guid)
-- ✅ Fixed JSON serialization of hashtable keys (Set-JIMConnectedSystem)
-
-**Remaining Work:**
-- Synchronisation Rules require object type IDs from imported connector schema (needs schema import cmdlet)
+Both dependencies above are complete (see the Dependencies table). API key authentication works for all verbs (GET/POST/PUT/DELETE), and the core cmdlets (`Connect-JIM`, `Get-JIMConnectorDefinition`, and the `*-JIMConnectedSystem` / `*-JIMRunProfile` / `*-JIMSyncRule` families) are implemented and tested. The one known gap is a schema-import cmdlet: Synchronisation Rules need object-type IDs from the imported connector schema.
 
 ---
 
 ## Running Tests Locally
 
-### Quick Start - Single Scenario
+**Use the runner.** `Run-IntegrationTests.ps1` (see [Quick Start](#-quick-start)) is the supported way to run tests locally; it stands up the stack, populates data, configures JIM, runs the scenario, and tears down, for any scenario, template, and directory type. Everything below is for low-level debugging only.
+
+**Driving the pieces by hand** (when you need to inspect state between stages): stand up the environment with `Start-IntegrationTestEnvironment.ps1`, create an API key with `Setup-InfrastructureApiKey.ps1`, then invoke a scenario script directly (see the [Manual step-by-step](#-quick-start) block in Quick Start). Scenario 2 and Scenario 8 need two Samba AD instances, brought up with the `scenario2` compose profile:
 
 ```powershell
-# Stand up Phase 1 systems
-docker compose -f test/integration/docker/docker-compose.integration-tests.yml up -d
-
-# Wait for systems to be ready (AD takes ~2 minutes to initialise)
-Start-Sleep -Seconds 120
-
-# Populate with Small template
-./test/integration/Populate-SambaAD.ps1 -Template Small -Instance Primary
-./test/integration/Generate-TestCSV.ps1 -Template Small
-
-# Run Scenario 1
-./test/integration/scenarios/Invoke-Scenario1-HRToIdentityDirectory.ps1 -Template Small
-
-# Tear down when complete
-docker compose -f test/integration/docker/docker-compose.integration-tests.yml down -v
-```
-
-### Running Specific Scenario
-
-#### Scenario 2 (Directory Sync)
-
-Scenario 2 requires two AD instances, so use the `scenario2` profile:
-
-```powershell
-# Stand up Scenario 2 systems (Source and Target AD)
 docker compose -f test/integration/docker/docker-compose.integration-tests.yml --profile scenario2 up -d
-
-# Wait for systems
-Start-Sleep -Seconds 180
-
-# Populate both AD instances
-./test/integration/Populate-SambaAD.ps1 -Template Medium -Instance Source
-./test/integration/Populate-SambaAD.ps1 -Template Medium -Instance Target
-
-# Run scenario
-./test/integration/scenarios/Invoke-Scenario2-CrossDomainSync.ps1 -Template Medium
-
-# Tear down
-docker compose -f test/integration/docker/docker-compose.integration-tests.yml --profile scenario2 down -v
 ```
 
-### Running All Phase 1 Scenarios
+**Alternative all-Phase-1 invoker:** `./test/integration/Invoke-IntegrationTests.ps1 -Template Medium -Phase 1` stands up every Phase 1 system, runs all scenarios, collects results to `test/integration/results/`, and tears down. Prefer `Run-IntegrationTests.ps1 -Scenario All` unless you specifically need this script.
 
-```powershell
-# Use master script
-./test/integration/Invoke-IntegrationTests.ps1 -Template Medium -Phase 1
-```
-
-This script will:
-1. Stand up all Phase 1 systems
-2. Populate data
-3. Run all Phase 1 scenarios
-4. Collect results to `test/integration/results/`
-5. Tear down systems
-6. Display summary report
-
-### Phase 2 (Database Scenarios)
-
-Phase 2 requires the Database Connector (#170) to be complete:
-
-```powershell
-# Stand up Phase 2 systems
-docker compose -f test/integration/docker/docker-compose.integration-tests.yml --profile phase2 up -d
-
-# Wait for databases (Oracle can take 5-10 minutes)
-./test/integration/Wait-SystemsReady.ps1 -Phase 2
-
-# Populate databases
-./test/integration/Populate-SqlServer.ps1 -Template Medium
-./test/integration/Populate-Oracle.ps1 -Template Medium
-./test/integration/Populate-PostgreSQL.ps1 -Template Medium
-
-# Run Phase 2 scenarios
-./test/integration/Invoke-IntegrationTests.ps1 -Template Medium -Phase 2
-
-# Tear down
-docker compose -f test/integration/docker/docker-compose.integration-tests.yml --profile phase2 down -v
-```
+Phase 2 (database) scenarios are not yet runnable; they are blocked on the Database Connector ([#170](https://github.com/TetronIO/JIM/issues/170)).
 
 ---
 
@@ -1780,27 +1487,16 @@ foreach ($attr in $ldapUserType.attributes) {
 
 JIM includes built-in performance diagnostics that automatically measure and log operation timings during sync operations. This is invaluable for identifying performance bottlenecks during integration testing.
 
-### Performance Optimization Results
+### Performance Optimisation
 
-Following extensive optimization work (see [GitHub Issue #190](https://github.com/TetronIO/JIM/issues/190)), JIM now delivers exceptional synchronisation performance:
+JIM's synchronisation hot paths were heavily optimised under [#190](https://github.com/TetronIO/JIM/issues/190). The durable wins:
 
-**Actual Performance (December 2024):**
-- **Medium dataset (~1,000 users)**: 78 seconds total (import + sync + export)
-  - FullSync: 34.5s (8 runs, avg 4.3s)
-  - FullImport: 13.8s (8 runs, avg 1.7s)
-  - Export: 30.1s (7 runs, avg 4.3s)
-- **Performance improvement**: 192x faster than original baseline (4 users/minute -> ~768 users/minute)
-
-**Key Optimizations:**
 1. Eliminated O(N×M) query complexity through pre-loaded caching
 2. Batch database operations for Metaverse Objects
-3. Query optimization with `.AsSplitQuery()` to prevent cartesian explosion
+3. `.AsSplitQuery()` to prevent cartesian explosion on eager-loaded graphs
 4. Pre-loaded lookup dictionaries for export rules and Connected System Objects
 
-**Production Readiness:**
-- ✅ All acceptance criteria exceeded (100 users < 60s, 1000 users < 5min)
-- ✅ 98.8% improvement in FullSync operation time
-- ✅ Production-ready for large-scale identity synchronisation workloads
+For current measured run times see [Run-Time Estimates](#run-time-estimates); the diagnostics below are how you profile a specific run.
 
 ### Automatic Enablement
 
@@ -2204,20 +1900,18 @@ JIM/
 
 ### Container Port Reference
 
-| Service              | Container Port | Host Port | Protocol |
-|----------------------|----------------|-----------|----------|
-| Panoply AD     | 389            | 389       | LDAP     |
-| Panoply AD     | 636            | 636       | LDAPS    |
-| Panoply APAC | 389            | 10389     | LDAP     |
-| Panoply APAC | 636            | 10636     | LDAPS    |
-| Panoply EMEA | 389            | 11389     | LDAP     |
-| Panoply EMEA | 636            | 11636     | LDAPS    |
-| SQL Server           | 1433           | 1433      | TCP      |
-| Oracle XE            | 1521           | 1521      | TCP      |
-| PostgreSQL (Test)    | 5432           | 5433      | TCP      |
-| MySQL                | 3306           | 3306      | TCP      |
-| OpenLDAP             | 389            | 12389     | LDAP     |
-| OpenLDAP             | 636            | 12636     | LDAPS    |
+All integration-test containers are internal to the `jim-network` Docker network; **no ports are published to the host**. The JIM containers reach them by container name, and you can `docker exec` in for ad-hoc queries. The ports below are container-internal.
+
+| Container | Role | Port | Protocol |
+|-----------|------|------|----------|
+| `samba-ad-primary` | Primary directory (single-directory scenarios) | 389 / 636 | LDAP / LDAPS |
+| `samba-ad-source` | Cross-domain source (Scenarios 2 & 8) | 389 / 636 | LDAP / LDAPS |
+| `samba-ad-target` | Cross-domain target (Scenarios 2 & 8) | 389 / 636 | LDAP / LDAPS |
+| `openldap-primary` | OpenLDAP, two suffixes (all directory scenarios; Scenario 14 only) | 1389 / 1636 | LDAP / LDAPS |
+| `sqlserver-hris-a` | Phase 2 source (road-mapped) | 1433 | TCP |
+| `oracle-hris-b` | Phase 2 source (road-mapped) | 1521 | TCP |
+| `postgres-target` | Phase 2 target (road-mapped) | 5432 | TCP |
+| `mysql-test` | Phase 2 (road-mapped) | 3306 | TCP |
 
 ### Environment Variables
 
@@ -2262,27 +1956,13 @@ JIM/
 
 ### Remaining Work
 
-1. **Complete Scenario 3** - GALSYNC (AD to CSV export); stub script exists but not implemented
-2. **Create GitHub Actions workflow** - `.github/workflows/integration-tests.yml` for CI/CD automation
-3. **Road-mapped: Entitlement Management** - Internal MVO design required (deferred scenarios above)
-4. **Road-mapped: Scenarios 15-17** - Database connector testing (SQL Server, PostgreSQL, Oracle, MySQL)
+- **Scenario 3 (GALSYNC)** - stub exists; AD-to-CSV export not yet implemented
+- **GitHub Actions workflow** - `.github/workflows/integration-tests.yml` for CI/CD automation
+- **Entitlement Management** (both deferred scenarios) and **Scenarios 15-17** - blocked on Internal MVO design and the Database Connector ([#170](https://github.com/TetronIO/JIM/issues/170)) respectively
 
----
+### Known Gaps
 
-## Known Issues & TODOs
-
-### Test Data Reset Automation
-**Priority: Low | Status: Partial**
-
-**Current State:**
-- CSV reset works (`Generate-TestCSV.ps1`)
-- AD cleanup attempts but often fails (users don't exist)
-- JIM database reset requires full stack down/up
-
-**Improvements Needed:**
-- Silent cleanup (suppress "user not found" warnings)
-- Faster JIM reset without full stack restart
-- Automated metaverse purge API endpoint for testing
+- **Test data reset (low priority):** between-scenario reset is handled by the runner's `Reset-JIMForNextScenario`, and scenarios self-reset via `Reset-JIMSystem -Force`. Residual rough edges: standalone/manual AD cleanup can still emit "user not found" noise, and there is no dedicated metaverse-purge API for testing (reset is via a full DB-volume teardown).
 
 ---
 

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -162,28 +162,9 @@ In **Containers Used**, `samba-* / openldap-primary` means the scenario runs aga
 
 **Available Templates (`-Template` parameter):**
 
-Choose a template based on your testing goals. For measured run times see [Run-Time Estimates](#run-time-estimates).
-
-- **Nano** (default): 3 users, 1 group - Fast dev iteration and debugging
-- **Micro**: 10 users, 3 groups - Quick smoke tests and development
-- **Small**: 100 users, 20 groups - Small business scenarios, unit testing
-- **Medium**: 1,000 users, 100 groups - Medium enterprise, CI/CD pipelines
-- **MediumLarge**: 5,000 users, 250 groups - Large medium enterprise, performance validation
-- **Large**: 10,000 users, 500 groups - Large enterprise, performance baselines
-- **Scale100k50Groups**: 100,000 users, 50 groups - Very large enterprise, stress testing (**requires 20+ GB host RAM**; see note below)
-- **Scale200k55Groups**: 200,000 users, 55 groups - Very large enterprise, extended stress testing (**requires 24+ GB host RAM**)
-- **Scale500k65Groups**: 500,000 users, 65 groups - Massive enterprise, scale validation (**requires 32+ GB host RAM**)
-- **Scale750k70Groups**: 750,000 users, 70 groups - Near-million scale validation (**requires 32+ GB host RAM**)
-- **Scale1m80Groups**: 1,000,000 users, 70 groups - Global enterprise, scale limits (**requires 64+ GB host RAM**). _Note: the name's "80" reflects the originally planned group count; the actual count is 70. The capped-groups Samba-friendly templates above are kept for Samba scale testing; long-tail counterparts (Scale*k*kGroups) are listed below._
-- **Scale100k5kGroups**: 100,000 users, 5,027 groups (realistic long-tail shape) - Scenario 8 entitlement sync against representative enterprise group topology. **OpenLDAP only**; rejected on Samba AD. Same memory requirements as Scale100k50Groups.
-- **Scale200k10kGroups**: 200,000 users, 9,984 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. Same memory profile as Scale200k55Groups plus additional RAM for the larger group/membership working set (~28+ GB recommended).
-- **Scale500k25kGroups**: 500,000 users, 24,997 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. ~40+ GB recommended.
-- **Scale750k40kGroups**: 750,000 users, 40,011 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. ~48+ GB recommended.
-- **Scale1m60kGroups**: 1,000,000 users, 60,073 groups (long-tail shape) - Scenario 8 only. **OpenLDAP only**. ~64+ GB recommended; also requires raising the OpenLDAP accesslog `olcDbMaxSize` proportionally (see Troubleshooting → "OpenLDAP accesslog full" below).
+See [Data Scale Templates](#data-scale-templates) for the full list: sizes, group counts, use case and minimum host RAM.
 
 > **Memory requirements for large templates:** The Scale100k50Groups and above templates require significantly more memory than smaller templates. The worker loads all imported objects into memory during processing; a 100K object import produces a worker peak working set of approximately 2.3 GB, plus 1–2 GB for the database during bulk inserts. **A 16 GB machine is not sufficient for Scale100k50Groups**; the worker will be OOM-killed during the save phase even without IDE overhead. In a GitHub Codespace (16 GB total), the problem is worse because the IDE and dev tools consume additional memory. Run Scale100k50Groups tests on a machine with at least 20–24 GB total RAM. See the [Deployment Guide - Memory Scaling](../DEPLOYMENT_GUIDE.md#memory-scaling-by-identity-object-count) for detailed requirements.
-
-See [Data Scale Templates](#data-scale-templates) for detailed template specifications.
 
 **Available Directory Types (`-DirectoryType` parameter):**
 
@@ -413,24 +394,27 @@ flowchart TD
 
 Choose the appropriate template based on test goals. For run times see [Run-Time Estimates](#run-time-estimates).
 
-| Template   | Users     | Groups  | Avg Memberships | Total Objects | Use Case                          |
-|------------|-----------|---------|-----------------|---------------|-----------------------------------|
-| **Nano**   | 3         | 1       | 1               | 4             | Fast dev iteration, debugging     |
-| **Micro**  | 10        | 3       | 3               | 13            | Quick smoke tests, development    |
-| **Small**  | 100       | 20      | 5               | 120           | Small business, unit tests        |
-| **Medium** | 1,000     | 100     | 8               | 1,100         | Medium enterprise, CI/CD          |
-| **MediumLarge** | 5,000 | 250     | 9               | 5,250         | Large medium enterprise, validation |
-| **Large**  | 10,000    | 500     | 10              | 10,500        | Large enterprise, baselines       |
-| **Scale100k50Groups** | 100,000   | 50      | 12              | 100,050       | Very large enterprise, stress     |
-| **Scale100k5kGroups** | 100,000   | 5,027   | ~9 (measured)   | 105,027       | Scenario 8 long-tail group shape (OpenLDAP only) |
-| **Scale200k55Groups** | 200,000   | 55      | 12              | 200,055       | Very large enterprise, extended   |
-| **Scale200k10kGroups** | 200,000  | 9,984   | ~8              | 209,984       | Scenario 8 long-tail group shape (OpenLDAP only) |
-| **Scale500k65Groups** | 500,000   | 65      | 13              | 500,065       | Massive enterprise, validation    |
-| **Scale500k25kGroups** | 500,000  | 24,997  | ~10             | 524,997       | Scenario 8 long-tail group shape (OpenLDAP only) |
-| **Scale750k70Groups** | 750,000   | 70      | 14              | 750,070       | Near-million scale validation     |
-| **Scale750k40kGroups** | 750,000  | 40,011  | ~11             | 790,011       | Scenario 8 long-tail group shape (OpenLDAP only) |
-| **Scale1m80Groups** | 1,000,000 | 70      | 15              | 1,000,070     | Global enterprise, scale limits (group count reshape pending) |
-| **Scale1m60kGroups** | 1,000,000 | 60,073 | ~13             | 1,060,073     | Scenario 8 long-tail group shape (OpenLDAP only) |
+| Template | Users | Groups | Avg Memberships | Total Objects | Use Case | Min RAM |
+|----------|-------|--------|-----------------|---------------|----------|---------|
+| **Nano** | 3 | 1 | 1 | 4 | Fast dev iteration, debugging | - |
+| **Micro** | 10 | 3 | 3 | 13 | Quick smoke tests, development | - |
+| **Small** | 100 | 20 | 5 | 120 | Small business, unit tests | - |
+| **Medium** | 1,000 | 100 | 8 | 1,100 | Medium enterprise, CI/CD | - |
+| **MediumLarge** | 5,000 | 250 | 9 | 5,250 | Large medium enterprise, validation | - |
+| **Large** | 10,000 | 500 | 10 | 10,500 | Large enterprise, baselines | - |
+| **Scale100k50Groups** | 100,000 | 50 | 12 | 100,050 | Very large enterprise, stress | 20+ GB |
+| **Scale100k5kGroups** | 100,000 | 5,027 | ~9 (measured) | 105,027 | Scenario 8 long-tail group shape (OpenLDAP only) | 20+ GB |
+| **Scale200k55Groups** | 200,000 | 55 | 12 | 200,055 | Very large enterprise, extended | 24+ GB |
+| **Scale200k10kGroups** | 200,000 | 9,984 | ~8 | 209,984 | Scenario 8 long-tail group shape (OpenLDAP only) | 28+ GB |
+| **Scale500k65Groups** | 500,000 | 65 | 13 | 500,065 | Massive enterprise, validation | 32+ GB |
+| **Scale500k25kGroups** | 500,000 | 24,997 | ~10 | 524,997 | Scenario 8 long-tail group shape (OpenLDAP only) | 40+ GB |
+| **Scale750k70Groups** | 750,000 | 70 | 14 | 750,070 | Near-million scale validation | 32+ GB |
+| **Scale750k40kGroups** | 750,000 | 40,011 | ~11 | 790,011 | Scenario 8 long-tail group shape (OpenLDAP only) | 48+ GB |
+| **Scale1m80Groups** | 1,000,000 | 70 | 15 | 1,000,070 | Global enterprise, scale limits | 64+ GB |
+| **Scale1m60kGroups** | 1,000,000 | 60,073 | ~13 | 1,060,073 | Scenario 8 long-tail group shape (OpenLDAP only) | 64+ GB |
+
+- **Scale1m80Groups**: the name's "80" reflects the originally planned group count; the actual count is 70. The capped-groups templates (`Scale*Groups`) are kept for Samba AD scale testing; the long-tail counterparts (`Scale*kGroups`) model realistic group topology and are OpenLDAP only.
+- **Scale1m60kGroups**: also requires raising the OpenLDAP accesslog `olcDbMaxSize` proportionally (see Troubleshooting -> "OpenLDAP accesslog full").
 
 ### Data Characteristics
 
@@ -446,36 +430,46 @@ All templates generate realistic enterprise data following normal distribution p
 
 ## Run-Time Estimates
 
-> Wall-clock times **measured on this devcontainer** (best endeavours; cold-cache figures marked *(est.)* are extrapolated, not directly measured). **Time (cached)** assumes the directory snapshot images and JIM stack images already exist, the normal case after the first run on a machine. **First run adds** is the one-time build of those images on top. Two things dominate: run time is driven almost entirely by **Scenarios 1, 7 and 8**, and it is strongly **directory-dependent**, because `samba-tool` takes a per-write LDB lock, Samba AD's Scenario 8 is far slower than OpenLDAP's (Scenario 8 alone measured 96 min on Samba MediumLarge versus 19 min on OpenLDAP at the larger Large template). Scenarios 2, 4, 6, 10, 11, 12, 13 use fixed small data and barely move with `-Template`.
+> Wall-clock times **measured on this devcontainer** (best endeavours; cold-cache figures marked *(est.)* are extrapolated, not directly measured). **Time (cached)** assumes the directory snapshot images and JIM stack images already exist, the normal case after the first run on a machine. **First run adds** is the one-time build of those images on top. Two things dominate: run time is driven almost entirely by **Scenarios 1, 7 and 8**, and it is strongly **directory-dependent**, because `samba-tool` takes a per-write LDB lock, Samba AD's Scenario 8 is far slower than OpenLDAP's (Scenario 8 alone measured 96 min on Samba MediumLarge versus 19 min on OpenLDAP at the larger Large template). Scenarios 2, 4, 6, 11, 12, 13 use fixed small data and barely move with `-Template`. Directory-selectable scenarios have a separate Samba AD and OpenLDAP row.
 
-| Runner option | Directory | Template | Time (cached) | First run adds *(est.)* |
-|---------------|-----------|----------|---------------|-------------------------|
-| `-PreRelease` | Samba + OpenLDAP | Medium + Large | **~2h 45m** | +~15 min |
-| `-Scenario All` | SambaAD | Medium | ~1h 00m | +~10 min |
-| `-Scenario All` | SambaAD | MediumLarge | ~2h 40m | +~10 min |
-| `-Scenario All` | OpenLDAP | Large | ~1h 45m | +~15 min |
-| `-Scenario All` | OpenLDAP | Scale100k50Groups | ~7h 15m | +~1h |
-| `-Scenario All` | either | Nano / Micro / Small | ~30-40 min *(est.)* | +~5 min |
-| Scenario1 HRToIdentityDirectory | both | Medium / Large / 100k | 11m / 21m / 3h | scales strongly |
-| Scenario2 CrossDomainSync | both | any | ~1.5m | fixed |
+| Runner option | Directory | Template(s) | Time (cached) | Notes |
+|---------------|-----------|-------------|---------------|-------|
+| `-PreRelease` | Samba AD + OpenLDAP | Medium + Large | **~2h 45m** | first run +~15 min |
+| `-Scenario All` | Samba AD | Medium | ~1h 00m | first run +~10 min |
+| `-Scenario All` | Samba AD | MediumLarge | ~2h 40m | first run +~10 min |
+| `-Scenario All` | OpenLDAP | Large | ~1h 45m | first run +~15 min |
+| `-Scenario All` | OpenLDAP | Scale100k50Groups | ~7h 15m | first run +~1h |
+| `-Scenario All` | Samba AD or OpenLDAP | Nano / Micro / Small | ~30-40m *(est.)* | not directly measured |
+| Scenario1 HRToIdentityDirectory | Samba AD | Medium / MediumLarge | 11m / 24m | scales strongly |
+| Scenario1 HRToIdentityDirectory | OpenLDAP | Large / 100k | 21m / 3h | scales strongly |
+| Scenario2 CrossDomainSync | Samba AD | any | ~1.5m | fixed |
+| Scenario2 CrossDomainSync | OpenLDAP | any | ~1.5m | fixed |
 | Scenario3 GALSYNC | n/a | n/a | stub, not implemented | n/a |
-| Scenario4 DeletionRules | both | any | ~7m (grace-period waits) | fixed |
-| Scenario5 MatchingRules | both | Medium / 100k | 2m / 22m | scales |
-| Scenario6 SchedulerService | both | any | ~1m | fixed |
-| Scenario7 ClearConnectedSystemObjects | both | Medium / 100k | 1.5m / 52m | scales |
-| Scenario8 CrossDomainEntitlementSync | both | see note | Samba 8m (Med) / 96m (ML); OpenLDAP 19m (Large) / 137m (100k) | scales; Samba far slower |
-| Scenario9 PartitionScopedImports | both | Medium / 100k | 1m / 9m | scales |
-| Scenario10 SyncRuleScoping | both | any | ~3m | ~fixed |
-| Scenario11 ScopingCriteriaMatrix | both (file) | any | ~1m Default (90s Quick, 10m Exhaustive) | tier-driven |
-| Scenario12 RelativeDateScoping | both (file) | any | ~2.5m (date-window wait) | fixed |
-| Scenario13 RelativeDateOutboundScoping | both (file) | any | ~3m (date-window wait) | fixed |
-| Scenario14 AttributePriority | OpenLDAP only | (ignored) | ~2m (fixed six-user dataset) | +~4m JIM build |
+| Scenario4 DeletionRules | Samba AD | any | ~7m | fixed (grace-period waits) |
+| Scenario4 DeletionRules | OpenLDAP | any | ~7m | fixed (grace-period waits) |
+| Scenario5 MatchingRules | Samba AD | Medium / MediumLarge | ~2m | fixed (Nano data) |
+| Scenario5 MatchingRules | OpenLDAP | Large / 100k | 5m / 22m | see reset-overhead note |
+| Scenario6 SchedulerService | Samba AD | any | ~1m | fixed |
+| Scenario6 SchedulerService | OpenLDAP | any | ~1m | fixed |
+| Scenario7 ClearConnectedSystemObjects | Samba AD | Medium / MediumLarge | 1.5m / 3m | scales |
+| Scenario7 ClearConnectedSystemObjects | OpenLDAP | Large / 100k | 4.5m / 52m | scales |
+| Scenario8 CrossDomainEntitlementSync | Samba AD | Medium / MediumLarge | 8m / 96m | scales; samba-tool per-write lock |
+| Scenario8 CrossDomainEntitlementSync | OpenLDAP | Large / 100k | 19m / 2h 17m | scales |
+| Scenario9 PartitionScopedImports | Samba AD | Medium / MediumLarge | ~1m | ~fixed |
+| Scenario9 PartitionScopedImports | OpenLDAP | Large / 100k | 2m / 9m | scales |
+| Scenario10 SyncRuleScoping | Samba AD | Medium / MediumLarge | ~2.5m | ~fixed |
+| Scenario10 SyncRuleScoping | OpenLDAP | Large / 100k | 3m / 5m | mild scale |
+| Scenario11 ScopingCriteriaMatrix | file-based (no directory) | any | ~1m Default | Quick / Default / Exhaustive tiers |
+| Scenario12 RelativeDateScoping | file-based (no directory) | any | ~2.5m | date-window wait |
+| Scenario13 RelativeDateOutboundScoping | file-based (no directory) | any | ~3m | date-window wait |
+| Scenario14 AttributePriority | OpenLDAP only | (ignored) | ~2m | fixed six-user; -Template ignored |
 
 **Notes:**
 
 - Per-scenario times are the scenario's contribution inside a full run. Run one **standalone** and add the fixed harness overhead (reset, start services, cleanup): roughly +1 min warm, or +5 min on a first run that also rebuilds the JIM images (~4 min).
 - Nano/Micro/Small full-regression times are estimates, not directly measured. A run floors at roughly 25-30 min from fixed-duration scenarios (Scenario 4's grace periods, Scenarios 12/13's date-window waits) plus ~12 between-scenario resets, so shrinking the template below Medium buys little.
 - The first-run directory-snapshot build scales with user count: negligible for light templates, ~45-60 min at Scale100k50Groups (100k users). At scale, also mind the reset-hygiene caveat in [issue #961](https://github.com/TetronIO/JIM/issues/961).
+- OpenLDAP per-scenario times at scale can include between-scenario reset/directory overhead (see [#961](https://github.com/TetronIO/JIM/issues/961)); for the non-scaling scenarios (e.g. Scenario 5) treat the 100k figure as an upper bound, not the scenario's intrinsic cost.
 - Scenario 14 ignores `-Template` (it always uses its bespoke six-user, two-suffix dataset) and runs on OpenLDAP only.
 
 ---

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -81,6 +81,7 @@ This single script handles everything:
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix" -Exhaustive # Exhaustive tier (~152 cells, < 10 min)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario12-RelativeDateScoping"       # Relative-date inbound scoping (joiner/leaver)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario13-RelativeDateOutboundScoping" # Relative-date outbound scoping (staged provisioning)
+./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario14-AttributePriority"        # Attribute Priority multi-source winner resolution (#91, OpenLDAP only)
 
 # Run with a specific template size
 ./test/integration/Run-IntegrationTests.ps1 -Template Nano
@@ -107,6 +108,7 @@ This single script handles everything:
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario8-CrossDomainEntitlementSync" -Step InitialSync  # Scenario 8: InitialSync, ForwardSync, DetectDrift, ReassertState, NewGroup, DeleteGroup, LeaverCohort (OpenLDAP only)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario10-SyncRuleScoping" -Step InboundEnterScope  # Scenario 10: InboundEnterScope/InboundInScopeUpdate/InboundExitDisconnect/InboundExitRemainJoined/OutboundEnterScope/OutboundExitDisconnect/OutboundExitDelete/CrossSystemCascade/CriteriaOperators
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario11-ScopingCriteriaMatrix" -OperatorFilter NotEquals  # Scenario 11: filter to cells using a single operator
+./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario14-AttributePriority" -Step BaselineResolution  # Scenario 14: BaselineResolution, RecallReElection, IdenticalValueHandOver, WithdrawalReElection, NoContributorCleared, AssertedNullOverridesSurvivor, NotJoinedNoOpinion, MidLifeJoinBlanksClear, MvaNullIsValueAssertsEmptySet, DisabledRuleNoOpinion, PriorityReorderPropagation, OutOfScopeNoOpinion (OpenLDAP only)
 
 # Combine scenario, template, and step
 ./test/integration/Run-IntegrationTests.ps1 -Scenario "Scenario2-CrossDomainSync" -Template Small -Step All
@@ -154,6 +156,7 @@ This single script handles everything:
 | `Scenario11-ScopingCriteriaMatrix` | Scoping criteria evaluation matrix: full operator x value-type x group-structure coverage via batched per-cell CSO and MV types. Three tiers: Quick (~12 cells, < 90s), Default (~41 cells, < 5 min), Exhaustive (~152 cells, < 10 min). Round-trip persistence and API negative-cell probes run first. | file (bespoke deterministic seed) | n/a |
 | `Scenario12-RelativeDateScoping` | Relative-date inbound scoping: date-driven joiner provisioning and leaver deprovisioning, plus per-run re-evaluation against the live clock | file (HR CSV, metaverse-only) | n/a |
 | `Scenario13-RelativeDateOutboundScoping` | Relative-date outbound scoping: downstream provisioning held until a joiner's start date arrives, released via the Temporal Scope Reconciler's outbound lane | file (HR CSV source, CSV export target) | n/a |
+| `Scenario14-AttributePriority` | Attribute Priority multi-source winner resolution (#91): two import Synchronisation Rules contribute the same Metaverse attributes (Description, Job Title, Manager reference, multi-valued Other Telephones) at different priorities; validates winner-takes-all for scalars, multi-valued handling, recall/re-election, and null/withdrawal/priority-reorder behaviour. OpenLDAP only (two-suffix topology: dc=yellowstone Primary + dc=glitterband Secondary in one container) | openldap-primary (two suffixes) | ✅ (only) |
 
 **Available Templates (`-Template` parameter):**
 
@@ -1165,9 +1168,9 @@ The scenario seeds its own fixed test users positioned relative to "now" and ign
 
 ### Phase 2 (Road-mapped) - Database Scenarios
 
-> The scenario numbers below (Multi-Source Aggregation, Database Source/Target, Performance Baselines) were originally drafted as 9, 10, and 11, then renumbered to 12, 13, and 14 as implemented Phase 1 scenarios claimed each range: Partition-Scoped Imports, Synchronisation Rule Scoping and the Scoping Criteria Matrix took 9-11, and the Relative-Date Scoping scenarios took 12-13. The planned scenarios are now numbered 14-16.
+> The scenario numbers below (Multi-Source Aggregation, Database Source/Target, Performance Baselines) have been renumbered repeatedly as implemented scenarios claimed each range: Partition-Scoped Imports, Synchronisation Rule Scoping and the Scoping Criteria Matrix took 9-11, the Relative-Date Scoping scenarios took 12-13, and Attribute Priority (#91) took 14. The planned scenarios are now numbered 15-17.
 
-#### Scenario 14: Multi-Source Aggregation
+#### Scenario 15: Multi-Source Aggregation
 
 **Purpose**: Validate multiple database sources feeding the metaverse with join rules and attribute precedence.
 
@@ -1186,24 +1189,24 @@ The scenario seeds its own fixed test users positioned relative to "now" and ign
 | 3 | **Precedence** | SQL Server authoritative for email/phone, Oracle for department/title |
 | 4 | **DataTypes** | VARCHAR, NVARCHAR, DATE, DATETIME, INT, BIT -> correct mapping |
 
-**Script**: `test/integration/scenarios/Invoke-Scenario14-MultiSourceAggregation.ps1`
+**Script**: `test/integration/scenarios/Invoke-Scenario15-MultiSourceAggregation.ps1`
 
 **Execution Model**:
 
 ```powershell
 # Individual steps
-./Invoke-Scenario14-MultiSourceAggregation.ps1 -Step InitialLoad -Template Small
-./Invoke-Scenario14-MultiSourceAggregation.ps1 -Step JoinRules -Template Small
-./Invoke-Scenario14-MultiSourceAggregation.ps1 -Step Precedence -Template Small
-./Invoke-Scenario14-MultiSourceAggregation.ps1 -Step DataTypes -Template Small
+./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step InitialLoad -Template Small
+./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step JoinRules -Template Small
+./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step Precedence -Template Small
+./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step DataTypes -Template Small
 
 # Run all steps sequentially
-./Invoke-Scenario14-MultiSourceAggregation.ps1 -Step All -Template Small
+./Invoke-Scenario15-MultiSourceAggregation.ps1 -Step All -Template Small
 ```
 
 ---
 
-#### Scenario 15: Database Source/Target
+#### Scenario 16: Database Source/Target
 
 **Purpose**: Validate database connector import/export capabilities.
 
@@ -1220,24 +1223,24 @@ The scenario seeds its own fixed test users positioned relative to "now" and ign
 | 3 | **DataTypes** | Data type handling (text, numeric, date, boolean) |
 | 4 | **MultiValue** | Multi-valued attributes (if supported) |
 
-**Script**: `test/integration/scenarios/Invoke-Scenario15-DatabaseSourceTarget.ps1`
+**Script**: `test/integration/scenarios/Invoke-Scenario16-DatabaseSourceTarget.ps1`
 
 **Execution Model**:
 
 ```powershell
 # Individual steps
-./Invoke-Scenario15-DatabaseSourceTarget.ps1 -Step Import -Template Small
-./Invoke-Scenario15-DatabaseSourceTarget.ps1 -Step Export -Template Small
-./Invoke-Scenario15-DatabaseSourceTarget.ps1 -Step DataTypes -Template Small
-./Invoke-Scenario15-DatabaseSourceTarget.ps1 -Step MultiValue -Template Small
+./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step Import -Template Small
+./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step Export -Template Small
+./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step DataTypes -Template Small
+./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step MultiValue -Template Small
 
 # Run all steps sequentially
-./Invoke-Scenario15-DatabaseSourceTarget.ps1 -Step All -Template Small
+./Invoke-Scenario16-DatabaseSourceTarget.ps1 -Step All -Template Small
 ```
 
 ---
 
-#### Scenario 16: Performance Baselines
+#### Scenario 17: Performance Baselines
 
 **Purpose**: Establish performance characteristics at various scales.
 
@@ -1250,7 +1253,7 @@ The scenario seeds its own fixed test users positioned relative to "now" and ign
 4. Identify bottlenecks
 5. Establish acceptable thresholds
 
-**Script**: `test/integration/scenarios/Invoke-Scenario16-Performance.ps1`
+**Script**: `test/integration/scenarios/Invoke-Scenario17-Performance.ps1`
 
 ---
 
@@ -2140,6 +2143,7 @@ JIM/
         │   ├── Invoke-Scenario11-ScopingCriteriaMatrix.ps1       # Scoping criteria evaluation matrix
         │   ├── Invoke-Scenario12-RelativeDateScoping.ps1         # Relative-date inbound scoping
         │   ├── Invoke-Scenario13-RelativeDateOutboundScoping.ps1 # Relative-date outbound scoping
+        │   ├── Invoke-Scenario14-AttributePriority.ps1          # Attribute Priority winner resolution (OpenLDAP only)
         │   ├── data/                                             # Per-scenario data + manifests (incl. Scenario 11 matrix)
         │   └── data/                                              # Scenario-specific CSV overlays (Scenarios 4, 5)
         ├── docker/

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -160,7 +160,7 @@ This single script handles everything:
 
 **Available Templates (`-Template` parameter):**
 
-Choose a template based on your testing goals:
+Choose a template based on your testing goals. The time shown is a rough **single import/sync/export cycle** at that size, not a scenario or a full run; for measured per-scenario and full-regression times see [Run-Time Estimates](#run-time-estimates).
 
 - **Nano** (default): 3 users, 1 group - **< 10 sec** - Fast dev iteration and debugging
 - **Micro**: 10 users, 3 groups - **< 30 sec** - Quick smoke tests and development
@@ -409,9 +409,9 @@ flowchart TD
 
 ## Data Scale Templates
 
-Choose the appropriate template based on test goals:
+Choose the appropriate template based on test goals. The **Per cycle** column is a rough single import/sync/export cycle at that size; for full-scenario and full-regression run times see [Run-Time Estimates](#run-time-estimates).
 
-| Template   | Users     | Groups  | Avg Memberships | Total Objects | Use Case                          | Est. Time  |
+| Template   | Users     | Groups  | Avg Memberships | Total Objects | Use Case                          | Per cycle  |
 |------------|-----------|---------|-----------------|---------------|-----------------------------------|------------|
 | **Nano**   | 3         | 1       | 1               | 4             | Fast dev iteration, debugging     | < 10 sec   |
 | **Micro**  | 10        | 3       | 3               | 13            | Quick smoke tests, development    | < 30 sec   |
@@ -439,6 +439,42 @@ All templates generate realistic enterprise data following normal distribution p
 - **Group Memberships**: Normal distribution (most users 5-15 groups, power users 30+)
 - **Attributes**: Valid names, email patterns, phone numbers, addresses
 - **Organisational Structure**: Tree hierarchy with realistic spans of control
+
+---
+
+## Run-Time Estimates
+
+> Wall-clock times **measured on this devcontainer** (best endeavours; cold-cache figures marked *(est.)* are extrapolated, not directly measured). **Time (cached)** assumes the directory snapshot images and JIM stack images already exist, the normal case after the first run on a machine. **First run adds** is the one-time build of those images on top. Two things dominate: run time is driven almost entirely by **Scenarios 1, 7 and 8**, and it is strongly **directory-dependent**, because `samba-tool` takes a per-write LDB lock, Samba AD's Scenario 8 is far slower than OpenLDAP's (Scenario 8 alone measured 96 min on Samba MediumLarge versus 19 min on OpenLDAP at the larger Large template). Scenarios 2, 4, 6, 10, 11, 12, 13 use fixed small data and barely move with `-Template`.
+
+| Runner option | Directory | Template | Time (cached) | First run adds *(est.)* |
+|---------------|-----------|----------|---------------|-------------------------|
+| `-PreRelease` | Samba + OpenLDAP | Medium + Large | **~2h 45m** | +~15 min |
+| `-Scenario All` | SambaAD | Medium | ~1h 00m | +~10 min |
+| `-Scenario All` | SambaAD | MediumLarge | ~2h 40m | +~10 min |
+| `-Scenario All` | OpenLDAP | Large | ~1h 45m | +~15 min |
+| `-Scenario All` | OpenLDAP | Scale100k50Groups | ~7h 15m | +~1h |
+| `-Scenario All` | either | Nano / Micro / Small | ~30-40 min *(est.)* | +~5 min |
+| Scenario1 HRToIdentityDirectory | both | Medium / Large / 100k | 11m / 21m / 3h | scales strongly |
+| Scenario2 CrossDomainSync | both | any | ~1.5m | fixed |
+| Scenario3 GALSYNC | n/a | n/a | stub, not implemented | n/a |
+| Scenario4 DeletionRules | both | any | ~7m (grace-period waits) | fixed |
+| Scenario5 MatchingRules | both | Medium / 100k | 2m / 22m | scales |
+| Scenario6 SchedulerService | both | any | ~1m | fixed |
+| Scenario7 ClearConnectedSystemObjects | both | Medium / 100k | 1.5m / 52m | scales |
+| Scenario8 CrossDomainEntitlementSync | both | see note | Samba 8m (Med) / 96m (ML); OpenLDAP 19m (Large) / 137m (100k) | scales; Samba far slower |
+| Scenario9 PartitionScopedImports | both | Medium / 100k | 1m / 9m | scales |
+| Scenario10 SyncRuleScoping | both | any | ~3m | ~fixed |
+| Scenario11 ScopingCriteriaMatrix | both (file) | any | ~1m Default (90s Quick, 10m Exhaustive) | tier-driven |
+| Scenario12 RelativeDateScoping | both (file) | any | ~2.5m (date-window wait) | fixed |
+| Scenario13 RelativeDateOutboundScoping | both (file) | any | ~3m (date-window wait) | fixed |
+| Scenario14 AttributePriority | OpenLDAP only | (ignored) | ~2m (fixed six-user dataset) | +~4m JIM build |
+
+**Notes:**
+
+- Per-scenario times are the scenario's contribution inside a full run. Run one **standalone** and add the fixed harness overhead (reset, start services, cleanup): roughly +1 min warm, or +5 min on a first run that also rebuilds the JIM images (~4 min).
+- Nano/Micro/Small full-regression times are estimates, not directly measured. A run floors at roughly 25-30 min from fixed-duration scenarios (Scenario 4's grace periods, Scenarios 12/13's date-window waits) plus ~12 between-scenario resets, so shrinking the template below Medium buys little.
+- The first-run directory-snapshot build scales with user count: negligible for light templates, ~45-60 min at Scale100k50Groups (100k users). At scale, also mind the reset-hygiene caveat in [issue #961](https://github.com/TetronIO/JIM/issues/961).
+- Scenario 14 ignores `-Template` (it always uses its bespoke six-user, two-suffix dataset) and runs on OpenLDAP only.
 
 ---
 

--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -2202,13 +2202,13 @@ JIM/
 
 ## Current Progress & Known Issues
 
-### Phase 1 Status (as of 2026-07-03) - ✅ COMPLETE
+### Phase 1 Status (as of 2026-07-10) - ✅ COMPLETE
 
 | Component | Status | Notes |
 |-----------|--------|-------|
 | Infrastructure | ✅ Complete | Samba AD, CSV file mounting, volume orchestration |
 | API Endpoints | ✅ Complete | Schema management, Synchronisation Rules, mappings, Run Profiles |
-| PowerShell Module | ✅ Complete | Cmdlets cover every scenario currently in use (1, 2, 4, 5, 6, 7, 8, 9, 10) |
+| PowerShell Module | ✅ Complete | Cmdlets cover every scenario currently in use (1, 2, 4-14) |
 | Scenario 1 | ✅ Complete | 8 lifecycle tests (Joiner, Mover, Mover-Rename, Mover-Move, Disable, Enable, Leaver, Reconnection) plus ImportOnly/SyncOnly diagnostic steps |
 | Scenario 2 | ✅ Complete | All 4 tests (Provision, ForwardSync, ReverseSync, Conflict) |
 | Scenario 3 | ⏳ Pending | Stub script exists, not yet implemented |
@@ -2222,9 +2222,10 @@ JIM/
 | Scenario 11 | ✅ Complete | Scoping criteria evaluation matrix: three tiers (Quick / Default / Exhaustive) covering operator x value-type x group-structure end-to-end via batched per-cell CSO types, plus round-trip persistence and API negative-cell probes |
 | Scenario 12 | ✅ Complete | Relative-date inbound scoping: date-driven joiner provisioning and leaver deprovisioning, plus per-run re-evaluation against the live clock (#85) |
 | Scenario 13 | ✅ Complete | Relative-date outbound scoping: staged downstream provisioning via the Temporal Scope Reconciler's outbound lane (#892) |
+| Scenario 14 | ✅ Complete | Attribute Priority multi-source winner resolution: 12 steps covering winner-takes-all scalar resolution, multi-valued handling, recall/re-election and null/withdrawal/priority-reorder behaviour (OpenLDAP only) (#91) |
 | Entitlement (JIM-to-AD) | ⏸️ Deferred | Requires Internal MVO design |
 | Entitlement (Convert Authority) | ⏸️ Deferred | Requires Internal MVO design |
-| Scenarios 14-16 | ⏳ Road-mapped | Database scenarios (multi-source aggregation, database source/target, performance baselines): require Database Connector (#170) |
+| Scenarios 15-17 | ⏳ Road-mapped | Database scenarios (multi-source aggregation, database source/target, performance baselines): require Database Connector (#170) |
 | GitHub Actions | ⏳ Pending | CI/CD workflow not yet created |
 
 ### Remaining Work
@@ -2232,7 +2233,7 @@ JIM/
 1. **Complete Scenario 3** - GALSYNC (AD to CSV export); stub script exists but not implemented
 2. **Create GitHub Actions workflow** - `.github/workflows/integration-tests.yml` for CI/CD automation
 3. **Road-mapped: Entitlement Management** - Internal MVO design required (deferred scenarios above)
-4. **Road-mapped: Scenarios 14-16** - Database connector testing (SQL Server, PostgreSQL, Oracle, MySQL)
+4. **Road-mapped: Scenarios 15-17** - Database connector testing (SQL Server, PostgreSQL, Oracle, MySQL)
 
 ---
 

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -314,14 +314,10 @@ function Test-LongTailTemplateCompatibility {
 Test-LongTailTemplateCompatibility -Template $Template -DirectoryType $DirectoryType `
     -TemplateSambaAD $TemplateSambaAD -TemplateOpenLDAP $TemplateOpenLDAP
 
-# Hard-fail: Scenario 14 (Attribute Priority) depends on two LDAP suffixes hosted on a single
-# OpenLDAP container (docker/openldap/scripts/01-add-second-suffix.sh); Samba AD has no
-# equivalent multi-suffix mechanism. Reject early rather than failing deep into setup.
-# -DirectoryType All is exempt: its handler below runs the OpenLDAP leg and skips the
-# Samba AD leg for this scenario, and the -Scenario All loop likewise skips it on Samba AD.
-if ($Scenario -like "*Scenario14*" -and $DirectoryType -eq "SambaAD") {
-    throw "Scenario 14 (Attribute Priority) requires two LDAP suffixes on a single OpenLDAP container and is OpenLDAP only. Rejected -DirectoryType $DirectoryType. Use -DirectoryType OpenLDAP."
-}
+# NOTE: Scenario 14 (Attribute Priority) is OpenLDAP only (two-suffix topology). Its
+# directory-type handling runs *after* scenario/directory resolution (see "Scenario 14
+# directory coercion" below), not here, because when the scenario is chosen from the
+# interactive menu $Scenario is still empty at this point.
 
 # Resolve directory configuration (used throughout for Docker profiles, population, setup)
 # Skip for "All" — the DirectoryType All handler orchestrates multiple runs with specific types.
@@ -1259,9 +1255,15 @@ if (-not $Scenario) {
         }
     }
 
-    # Show directory type menu only if not explicitly provided
+    # Show directory type menu only if not explicitly provided. Scenario 14 is OpenLDAP
+    # only (two-suffix topology), so don't offer a choice; go straight to OpenLDAP.
     if (-not $DirectoryTypeWasExplicitlySet) {
-        $DirectoryType = Show-DirectoryTypeMenu
+        if ($Scenario -like "*Scenario14*") {
+            $DirectoryType = "OpenLDAP"
+        }
+        else {
+            $DirectoryType = Show-DirectoryTypeMenu
+        }
         # Re-resolve directory config with the selected type (skip for "All" — handled below)
         if ($DirectoryType -ne "All") {
             $script:DirectoryConfig = Get-DirectoryConfig -DirectoryType $DirectoryType
@@ -1288,6 +1290,25 @@ if (-not $Scenario) {
             'Default'    { } # neither switch set
         }
     }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 14 directory coercion (Attribute Priority is OpenLDAP only)
+# ---------------------------------------------------------------------------
+# Scenario 14 depends on two LDAP suffixes hosted on a single OpenLDAP container
+# (docker/openldap/scripts/01-add-second-suffix.sh); Samba AD has no equivalent
+# multi-suffix mechanism. This runs after scenario/directory resolution (whether the
+# values came from parameters or the interactive menu) and before the build, so the
+# constraint is enforced whichever way they were chosen. If -DirectoryType SambaAD was
+# explicitly passed, respect the explicit intent and reject; otherwise coerce to
+# OpenLDAP. -DirectoryType All is handled by its own block below.
+if ($Scenario -like "*Scenario14*" -and $DirectoryType -eq "SambaAD") {
+    if ($DirectoryTypeWasExplicitlySet) {
+        throw "Scenario 14 (Attribute Priority) requires two LDAP suffixes on a single OpenLDAP container and is OpenLDAP only. Rejected -DirectoryType SambaAD. Use -DirectoryType OpenLDAP."
+    }
+    Write-Host "${YELLOW}Scenario 14 (Attribute Priority) is OpenLDAP only; using -DirectoryType OpenLDAP.${NC}"
+    $DirectoryType = "OpenLDAP"
+    $script:DirectoryConfig = Get-DirectoryConfig -DirectoryType "OpenLDAP"
 }
 
 # ---------------------------------------------------------------------------

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -164,8 +164,8 @@
     ./Run-IntegrationTests.ps1 -PreRelease
 
     Runs the full pre-release regression: every implemented scenario against both
-    directory types, with Samba AD at the MediumLarge template and OpenLDAP at Scale100k50Groups.
-    Equivalent to: -Scenario All -DirectoryType All -TemplateSambaAD MediumLarge -TemplateOpenLDAP Scale100k50Groups.
+    directory types, with Samba AD at the Medium template and OpenLDAP at Large.
+    Equivalent to: -Scenario All -DirectoryType All -TemplateSambaAD Medium -TemplateOpenLDAP Large.
 #>
 
 param(
@@ -543,7 +543,7 @@ function Show-ScenarioMenu {
         }
         @{
             Name = "Pre-Release"
-            Description = "Runs every implemented scenario sequentially for both Samba AD and OpenLDAP at MediumLarge and Scale100k50Groups templates, respectively"
+            Description = "Runs every implemented scenario sequentially for both Samba AD and OpenLDAP at Medium and Large templates, respectively"
             Disabled = $false
             SeparatorAfter = $true
         }
@@ -1223,12 +1223,12 @@ function Test-TemplateRelevant {
     return $true
 }
 
-# -PreRelease is shorthand for: -Scenario All -DirectoryType All -TemplateSambaAD MediumLarge -TemplateOpenLDAP Scale100k50Groups
+# -PreRelease is shorthand for: -Scenario All -DirectoryType All -TemplateSambaAD Medium -TemplateOpenLDAP Large
 if ($PreRelease) {
     $Scenario               = "All"
     $DirectoryType          = "All"
-    $TemplateSambaAD        = "MediumLarge"
-    $TemplateOpenLDAP       = "Scale100k50Groups"
+    $TemplateSambaAD        = "Medium"
+    $TemplateOpenLDAP       = "Large"
     $DirectoryTypeWasExplicitlySet = $true
     $TemplateWasExplicitlySet      = $true
 }
@@ -1238,13 +1238,13 @@ if (-not $Scenario) {
     $Scenario = Show-ScenarioMenu
 
     # "Pre-Release" is a special menu entry that expands to all-scenarios, both directory
-    # types, with Samba AD at MediumLarge and OpenLDAP at Scale100k50Groups. It bypasses the Template
+    # types, with Samba AD at Medium and OpenLDAP at Large. It bypasses the Template
     # and DirectoryType sub-menus since those are fixed by the Pre-Release preset.
     if ($Scenario -eq "Pre-Release") {
         $Scenario                      = "All"
         $DirectoryType                 = "All"
-        $TemplateSambaAD               = "MediumLarge"
-        $TemplateOpenLDAP              = "Scale100k50Groups"
+        $TemplateSambaAD               = "Medium"
+        $TemplateOpenLDAP              = "Large"
         $DirectoryTypeWasExplicitlySet = $true
         $TemplateWasExplicitlySet      = $true
     }


### PR DESCRIPTION
## Summary
- **Consolidate `engineering/INTEGRATION_TESTING.md`**: remove the competing manual run flow, resolved-issue postmortems, and the stale Dec-2024 benchmark; fix container naming/ports (real names, correct internal ports, nothing published to host); collapse deferred and road-mapped scenarios to stubs; four lifecycle diagrams down to two (2354 -> ~2030 lines).
- **Run-Time Estimates matrix**: measured per directory type (Samba AD vs OpenLDAP), replacing the duplicated per-template timing columns.
- **Fix `Run-IntegrationTests.ps1`**: Scenario 14 (Attribute Priority) is OpenLDAP only, but the guard ran before the interactive menu resolved the selection, so a menu-picked "Scenario 14 + SambaAD" built the stack for ~4 min and then failed. It now auto-selects OpenLDAP when SambaAD was not explicitly forced; explicit `-DirectoryType SambaAD` still hard-fails.
- **Dial `-PreRelease` down** to Samba AD Medium + OpenLDAP Large.
- **Docs-portal styling** (parallel session): clickable grid cards, light-mode tweaks, homepage/roadmap links.

## Test plan
- [x] Build/test N/A: changes touch only `.md`, `.css`, and `.ps1` (CLAUDE.md build/test exception).
- [x] Runtime-verified the Scenario 14 fix: `Run-IntegrationTests.ps1 -Scenario Scenario14-AttributePriority` with no `-DirectoryType` coerces to OpenLDAP and passes end-to-end (6m05s, all Attribute Priority assertions green).
- [x] PowerShell parse check clean on `Run-IntegrationTests.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)