### PR TITLE
chore: align codeql-action version across init/autobuild/analyze steps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -218,6 +218,15 @@ updates:
         update-types: ["version-update:semver-major"]
 
   # GitHub Actions
+  #
+  # Grouped so that the codeql-action sub-actions (init, autobuild, analyze,
+  # upload-sarif) always bump together. They are separate `uses:` lines
+  # (codeql.yml uses three of them in the same job; ci.yml uses upload-sarif
+  # in the Trivy job), so Dependabot otherwise raises one PR per line despite
+  # them sharing a version. init/autobuild/analyze must run the same version
+  # in the same job: CodeQL fails with "Loaded a configuration file for
+  # version 'X', but running version 'Y'" if they drift, so a bump to only
+  # one of the three (an ungrouped PR) cannot pass CI on its own.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -233,3 +242,7 @@ updates:
       # Ignore all major version updates
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,15 +35,15 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6  # v3.36.3
+      uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3.37.0
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@411c4c9a36b3fca4d674f06b6396b2c6d23522c6  # v3.36.3
+      uses: github/codeql-action/autobuild@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3.37.0
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6  # v3.36.3
+      uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3.37.0
       with:
         category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Bumps all three `github/codeql-action/*` steps in `codeql.yml` (`init`, `autobuild`, `analyze`) to v3.37.0 together.
- Adds a `codeql-action` group to `dependabot.yml` so future bumps of these steps land as a single PR.

## Context

Dependabot opened three separate PRs (#969, #968, #965) each bumping only one of the three `codeql-action` steps, since they're on separate `uses:` lines despite being the same versioned action. Mixing versions of `init`/`autobuild`/`analyze` in the same job breaks CodeQL:

> Loaded a configuration file for version '3.36.3', but running version '3.37.0'

Each of the three PRs therefore fails its own required checks and can never merge individually. This PR supersedes them with a consolidated bump, plus a Dependabot group to prevent recurrence.

Superseded PRs #969, #968, #965 will be closed once this merges.

## Test plan

- [x] No `.cs` changes; CI-only. Per CLAUDE.md, workflow file changes don't require local `dotnet build`/`test`.
- [ ] Confirm `Analyze (actions)`, `Analyze (csharp)`, `Analyze (javascript-typescript)` all pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)