### PR TITLE
perf(export): deferred-collection fast path and conservative directory-aware Max Export Parallelism default (#985 c+d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 🔄 The JIM PowerShell module now returns output objects with PascalCase property names (`$obj.DisplayName`, `$obj.Type.Name`), following PowerShell convention, instead of the REST API's camelCase wire casing. PowerShell member access is case-insensitive, so most scripts are unaffected, but `Get-Member`, `ConvertTo-Json` and `Format-Table` now surface PascalCase; scripts that compare property-name strings or round-trip output through JSON may need updating. Dictionaries keyed by your own data (a Metaverse Object's Attributes, a log entry's Properties) keep their keys exactly as supplied.
-- 🔄 Exports now default to a connector-recommended degree of parallelism when a Connected System's Max Export Parallelism isn't explicitly configured, instead of always defaulting to sequential. For the LDAP Connector this mirrors its own directory-aware Export Concurrency tuning. An explicitly configured Max Export Parallelism value is always respected.
+- 🔄 Exports now default to a conservative connector-recommended degree of parallelism when a Connected System's Max Export Parallelism isn't explicitly configured, instead of always defaulting to sequential. The LDAP Connector recommends two parallel batch pipelines for capable directories (those tuned to a high Export Concurrency) and stays sequential otherwise. An explicitly configured Max Export Parallelism value is always respected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 🔄 The JIM PowerShell module now returns output objects with PascalCase property names (`$obj.DisplayName`, `$obj.Type.Name`), following PowerShell convention, instead of the REST API's camelCase wire casing. PowerShell member access is case-insensitive, so most scripts are unaffected, but `Get-Member`, `ConvertTo-Json` and `Format-Table` now surface PascalCase; scripts that compare property-name strings or round-trip output through JSON may need updating. Dictionaries keyed by your own data (a Metaverse Object's Attributes, a log entry's Properties) keep their keys exactly as supplied.
+- 🔄 Exports now default to a connector-recommended degree of parallelism when a Connected System's Max Export Parallelism isn't explicitly configured, instead of always defaulting to sequential. For the LDAP Connector this mirrors its own directory-aware Export Concurrency tuning. An explicitly configured Max Export Parallelism value is always respected.
 
 ### Fixed
 
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - ⚡ Exports no longer stall between batches at large scale. Batch collection now walks the Pending Export queue in a single pass (keyset pagination, backed by a new index) instead of rescanning it from the start for every batch; at 200,000 objects with 10,000 reference-bearing groups the old behaviour spent hours re-reading already-collected rows before the first group reached the target system.
+- ⚡ The tail of a large, reference-heavy export no longer spends time paging through Pending Exports it has already identified as deferred. Once a batch turns out to be entirely reference-bearing, JIM now collects the remaining deferred exports in a single query instead of continuing to page through them 100 at a time.
 
 ## [0.13.0] - 2026-07-10
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -154,8 +154,16 @@ The Worker and Scheduler use `IJimApplicationFactory` and `IConnectorFactory` fo
 
 Export parallelism operates on two independent axes:
 
-1. **LDAP Connector Pipelining:** Multiple LDAP operations execute concurrently within a single export batch using `SemaphoreSlim`-based throttling
-2. **Parallel Batch Processing:** Multiple export batches process concurrently with separate `IRepository` and `IConnector` instances per batch, gated by the `SupportsParallelExport` connector capability
+1. **LDAP Connector Pipelining:** Multiple LDAP operations execute concurrently within a single export batch using `SemaphoreSlim`-based throttling, tuned per directory type by Export Concurrency auto-tune (see `LdapConnector.AutoTuneExportConcurrency`)
+2. **Parallel Batch Processing:** Multiple export batches process concurrently with separate `IRepository` and `IConnector` instances per batch, gated by the `SupportsParallelExport` connector capability, and controlled by a Connected System's Max Export Parallelism setting
+
+A Connected System's Max Export Parallelism resolves via `ExportParallelismResolver` (`JIM.Worker.Processors`) in this order:
+
+1. An explicit Max Export Parallelism value on the Connected System always wins, respecting the administrator's choice.
+2. Otherwise, if the connector implements `IConnectorRecommendedExportParallelism`, its recommendation is used, clamped to 1-16. The LDAP Connector mirrors its own auto-tuned Export Concurrency (axis 1 above) so the two knobs stay coherent rather than recommending a contradictory value.
+3. Otherwise, JIM falls back to 1 (sequential), the pre-existing default.
+
+Note that for directories with a single-writer storage backend (for example OpenLDAP's mdb), higher batch parallelism does not translate into proportionally higher write throughput; the recommendation is a starting point, not a guarantee.
 
 ## Process Diagrams
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -157,10 +157,12 @@ Export parallelism operates on two independent axes:
 1. **LDAP Connector Pipelining:** Multiple LDAP operations execute concurrently within a single export batch using `SemaphoreSlim`-based throttling, tuned per directory type by Export Concurrency auto-tune (see `LdapConnector.AutoTuneExportConcurrency`)
 2. **Parallel Batch Processing:** Multiple export batches process concurrently with separate `IRepository` and `IConnector` instances per batch, gated by the `SupportsParallelExport` connector capability, and controlled by a Connected System's Max Export Parallelism setting
 
+The two axes multiply: each parallel batch pipeline gets its own connector instance running its own Export Concurrency operations, so total in-flight operations = Max Export Parallelism x Export Concurrency.
+
 A Connected System's Max Export Parallelism resolves via `ExportParallelismResolver` (`JIM.Worker.Processors`) in this order:
 
 1. An explicit Max Export Parallelism value on the Connected System always wins, respecting the administrator's choice.
-2. Otherwise, if the connector implements `IConnectorRecommendedExportParallelism`, its recommendation is used, clamped to 1-16. The LDAP Connector mirrors its own auto-tuned Export Concurrency (axis 1 above) so the two knobs stay coherent rather than recommending a contradictory value.
+2. Otherwise, if the connector implements `IConnectorRecommendedExportParallelism`, its recommendation is used, clamped to 1-16. The LDAP Connector recommends a deliberately conservative 2 when the system's Export Concurrency signals a capable directory (8 or above; the auto-tune only sets 16, for Active Directory and OpenLDAP), keeping the multiplied total mild (2 x 16 = 32 in-flight operations); otherwise it makes no recommendation.
 3. Otherwise, JIM falls back to 1 (sequential), the pre-existing default.
 
 Note that for directories with a single-writer storage backend (for example OpenLDAP's mdb), higher batch parallelism does not translate into proportionally higher write throughput; the recommendation is a starting point, not a guarantee.

--- a/docs/powershell/connected-systems.md
+++ b/docs/powershell/connected-systems.md
@@ -134,7 +134,7 @@ Set-JIMConnectedSystem -InputObject <PSCustomObject> [-Name <string>]
 | `Name` | `string` | No | | New display name |
 | `Description` | `string` | No | | New description |
 | `SettingValues` | `hashtable` | No | | Connector-specific settings. Keys are setting IDs; values are hashtables with `stringValue`, `intValue`, or `checkboxValue`. |
-| `MaxExportParallelism` | `int` | No | | Maximum number of parallel export threads (1 to 16). Leave unset to let the connector recommend a value (for example, the LDAP Connector mirrors its own directory-aware Export Concurrency tuning); JIM falls back to sequential (1) if the connector offers no recommendation. An explicitly set value always takes precedence. |
+| `MaxExportParallelism` | `int` | No | | Maximum number of parallel export threads (1 to 16). Leave unset to let the connector recommend a conservative value (the LDAP Connector recommends 2 for capable directories, those tuned to a high Export Concurrency); JIM stays sequential (1) if the connector offers no recommendation. An explicitly set value always takes precedence. |
 | `ChangeReason` | `string` | No | | Optional reason ("commit message") recorded with this change and shown in the configuration change history. Maximum 2000 characters. |
 | `PassThru` | `switch` | No | `$false` | Returns the updated Connected System Object |
 

--- a/docs/powershell/connected-systems.md
+++ b/docs/powershell/connected-systems.md
@@ -134,7 +134,7 @@ Set-JIMConnectedSystem -InputObject <PSCustomObject> [-Name <string>]
 | `Name` | `string` | No | | New display name |
 | `Description` | `string` | No | | New description |
 | `SettingValues` | `hashtable` | No | | Connector-specific settings. Keys are setting IDs; values are hashtables with `stringValue`, `intValue`, or `checkboxValue`. |
-| `MaxExportParallelism` | `int` | No | | Maximum number of parallel export threads (1 to 16) |
+| `MaxExportParallelism` | `int` | No | | Maximum number of parallel export threads (1 to 16). Leave unset to let the connector recommend a value (for example, the LDAP Connector mirrors its own directory-aware Export Concurrency tuning); JIM falls back to sequential (1) if the connector offers no recommendation. An explicitly set value always takes precedence. |
 | `ChangeReason` | `string` | No | | Optional reason ("commit message") recorded with this change and shown in the configuration change history. Maximum 2000 characters. |
 | `PassThru` | `switch` | No | `$false` | Returns the updated Connected System Object |
 

--- a/src/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/src/JIM.Application/Servers/ExportExecutionServer.cs
@@ -550,7 +550,8 @@ public class ExportExecutionServer
                         // all accumulated entities — 40K+ entities after 100 batches.
                         SyncRepo.ClearChangeTracker();
                     }
-                    else if (batchDeferred.Count == batch.Count)
+                    else if (batchDeferred.Count == batch.Count
+                        && !await SyncRepo.AnyExecutableNonDeferredExportsAfterAsync(connectedSystem.Id, cursorCreatedAt, cursorId))
                     {
                         // Fast path (issue #985c): the whole batch just loaded was deferred
                         // (reference-bearing) and nothing in it was executable. Continuing to
@@ -560,6 +561,16 @@ public class ExportExecutionServer
                         // Collect everything beyond the cursor with a single set-based query and
                         // stop scanning; a mixed batch (some immediate, some deferred) always
                         // takes the branch above instead and keeps paging normally.
+                        //
+                        // The existence probe above is REQUIRED before breaking out: deferred and
+                        // executable exports interleave in (CreatedAt, Id) order, so a full batch
+                        // of deferred exports does not prove the remainder of the queue is
+                        // deferred too. Without the probe, executable exports created after a
+                        // contiguous deferred run would silently never execute in this run — a
+                        // behaviour regression versus page-by-page scanning. The probe is a cheap
+                        // indexed existence check (no Includes, no materialisation); when it
+                        // finds executable exports beyond the cursor, this branch is skipped and
+                        // normal paging continues for this iteration.
                         using var span = Diagnostics.Diagnostics.Database.StartSpan("CollectRemainingDeferred")
                             .SetTag("afterCreatedAt", cursorCreatedAt?.ToString("O") ?? "start");
 
@@ -585,10 +596,11 @@ public class ExportExecutionServer
                         break;
                     }
                     // Note: no break when a batch has only ineligible/deferred exports and the
-                    // fast path above did not trigger (a mixed batch) — the outer loop continues
-                    // scanning forward since later batches (ordered by CreatedAt) may contain
-                    // eligible exports. The loop only exits when batch.Count == 0 (database
-                    // exhausted, handled above) or via the fast-path break above.
+                    // fast path above did not trigger (a mixed batch, or executable exports still
+                    // exist beyond the cursor) — the outer loop continues scanning forward since
+                    // later batches (ordered by CreatedAt) may contain eligible exports. The loop
+                    // only exits when batch.Count == 0 (database exhausted, handled above) or via
+                    // the fast-path break above.
                 }
 
                 // Second pass: Exports with unresolved references (deferred)

--- a/src/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/src/JIM.Application/Servers/ExportExecutionServer.cs
@@ -550,10 +550,45 @@ public class ExportExecutionServer
                         // all accumulated entities — 40K+ entities after 100 batches.
                         SyncRepo.ClearChangeTracker();
                     }
-                    // Note: no break when a batch has only ineligible/deferred exports — the outer
-                    // loop continues scanning forward since later batches (ordered by CreatedAt) may
-                    // contain eligible exports. The loop only exits when batch.Count == 0 (database
-                    // exhausted), handled above at line 352.
+                    else if (batchDeferred.Count == batch.Count)
+                    {
+                        // Fast path (issue #985c): the whole batch just loaded was deferred
+                        // (reference-bearing) and nothing in it was executable. Continuing to
+                        // page through the remainder 100 rows at a time would only ever rebuild
+                        // the same deferred list one page slower — at group-heavy scale (10K+
+                        // deferred exports) this was the entire cost of the collection loop.
+                        // Collect everything beyond the cursor with a single set-based query and
+                        // stop scanning; a mixed batch (some immediate, some deferred) always
+                        // takes the branch above instead and keeps paging normally.
+                        using var span = Diagnostics.Diagnostics.Database.StartSpan("CollectRemainingDeferred")
+                            .SetTag("afterCreatedAt", cursorCreatedAt?.ToString("O") ?? "start");
+
+                        var remainingDeferred = await SyncRepo.GetRemainingDeferredExportsAsync(
+                            connectedSystem.Id, cursorCreatedAt, cursorId);
+
+                        // Safety net: mirror the in-loop processedIds guard above, even though a
+                        // strictly-increasing cursor should make duplicates impossible here.
+                        if (processedIds.Count > 0)
+                            remainingDeferred = remainingDeferred.Where(pe => !processedIds.Contains(pe.Id)).ToList();
+
+                        foreach (var pe in remainingDeferred)
+                        {
+                            processedIds.Add(pe.Id);
+                            result.ProcessedPendingExportIds.Add(pe.Id);
+                        }
+
+                        deferredExports.AddRange(remainingDeferred);
+
+                        span.SetTag("collectedCount", remainingDeferred.Count);
+                        span.SetSuccess();
+
+                        break;
+                    }
+                    // Note: no break when a batch has only ineligible/deferred exports and the
+                    // fast path above did not trigger (a mixed batch) — the outer loop continues
+                    // scanning forward since later batches (ordered by CreatedAt) may contain
+                    // eligible exports. The loop only exits when batch.Count == 0 (database
+                    // exhausted, handled above) or via the fast-path break above.
                 }
 
                 // Second pass: Exports with unresolved references (deferred)

--- a/src/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/src/JIM.Application/Servers/ExportExecutionServer.cs
@@ -556,7 +556,7 @@ public class ExportExecutionServer
                         // Fast path (issue #985c): the whole batch just loaded was deferred
                         // (reference-bearing) and nothing in it was executable. Continuing to
                         // page through the remainder 100 rows at a time would only ever rebuild
-                        // the same deferred list one page slower — at group-heavy scale (10K+
+                        // the same deferred list one page slower; at group-heavy scale (10K+
                         // deferred exports) this was the entire cost of the collection loop.
                         // Collect everything beyond the cursor with a single set-based query and
                         // stop scanning; a mixed batch (some immediate, some deferred) always
@@ -566,7 +566,7 @@ public class ExportExecutionServer
                         // executable exports interleave in (CreatedAt, Id) order, so a full batch
                         // of deferred exports does not prove the remainder of the queue is
                         // deferred too. Without the probe, executable exports created after a
-                        // contiguous deferred run would silently never execute in this run — a
+                        // contiguous deferred run would silently never execute in this run; a
                         // behaviour regression versus page-by-page scanning. The probe is a cheap
                         // indexed existence check (no Includes, no materialisation); when it
                         // finds executable exports beyond the cursor, this branch is skipped and
@@ -597,7 +597,7 @@ public class ExportExecutionServer
                     }
                     // Note: no break when a batch has only ineligible/deferred exports and the
                     // fast path above did not trigger (a mixed batch, or executable exports still
-                    // exist beyond the cursor) — the outer loop continues scanning forward since
+                    // exist beyond the cursor); the outer loop continues scanning forward since
                     // later batches (ordered by CreatedAt) may contain eligible exports. The loop
                     // only exits when batch.Count == 0 (database exhausted, handled above) or via
                     // the fast-path break above.

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -478,21 +478,47 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
 
     #region IConnectorRecommendedExportParallelism members
     /// <summary>
-    /// Recommends export batch parallelism aligned with the directory type already detected for
-    /// this Connected System (issue #985d). The directory type itself is not a labelled setting,
-    /// so it cannot be determined from <paramref name="settingValues"/> without a fresh
-    /// connection, which this method must not open. Export Concurrency, however, is auto-tuned
-    /// per directory type at schema import time (see <see cref="AutoTuneExportConcurrency"/>,
-    /// sourced from <see cref="LdapConnectorRootDse.RecommendedExportConcurrency"/>), so its
-    /// current setting value is the best available connection-free, directory-aware signal.
-    /// Mirroring it here keeps the two knobs coherent: an administrator who has manually tuned
-    /// Export Concurrency (or whose directory auto-tuned to a non-default value) gets a matching
-    /// parallelism recommendation rather than a contradictory one.
+    /// The Export Concurrency value at or above which the target is treated as a capable
+    /// directory for batch-parallelism purposes. The auto-tune only sets 16 (well above this)
+    /// for Active Directory and OpenLDAP; Samba AD and Generic directories stay at the
+    /// default of 4.
+    /// </summary>
+    internal const int CAPABLE_DIRECTORY_CONCURRENCY_THRESHOLD = 8;
+
+    /// <summary>
+    /// The deliberately conservative batch-parallelism recommendation for capable directories.
+    /// </summary>
+    internal const int RECOMMENDED_EXPORT_PARALLELISM = 2;
+
+    /// <summary>
+    /// Recommends export batch parallelism for this Connected System (issue #985d).
+    ///
+    /// The two knobs MULTIPLY: each parallel batch pipeline gets its own connector instance,
+    /// and each instance runs its own Export Concurrency concurrent LDAP operations (see
+    /// <see cref="ExportAsync"/>), so total in-flight operations = parallelism x per-instance
+    /// concurrency. Recommending anything near Export Concurrency itself would square the load
+    /// (16 x 16 = 256 in-flight operations, against a setting whose own description warns that
+    /// values above 8 may overwhelm the directory), so the recommendation is a flat, mild 2:
+    /// with an auto-tuned concurrency of 16 that is 2 x 16 = 32 in-flight operations, a safe
+    /// default.
+    ///
+    /// The directory type is not persisted anywhere readable without opening a connection
+    /// (which this method must not do), so Active Directory cannot be distinguished from
+    /// OpenLDAP here; OpenLDAP's mdb backend is single-writer and gains little from batch
+    /// parallelism, a further reason the value is deliberately conservative. An Export
+    /// Concurrency of 8 or above is used as the capable-directory signal (the auto-tune only
+    /// sets 16, for Active Directory and OpenLDAP); below that, no recommendation is made and
+    /// the resolver falls back to sequential. Issue #845 (connector-agnostic classification
+    /// storage) is the future enabler of a genuinely per-directory-type recommendation.
     /// </summary>
     public int? GetRecommendedExportParallelism(List<ConnectedSystemSettingValue> settingValues)
     {
-        return settingValues
+        var exportConcurrency = settingValues
             .FirstOrDefault(s => s.Setting.Name == _settingExportConcurrency)?.IntValue;
+
+        return exportConcurrency >= CAPABLE_DIRECTORY_CONCURRENCY_THRESHOLD
+            ? RECOMMENDED_EXPORT_PARALLELISM
+            : null;
     }
     #endregion
 

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -11,7 +11,7 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 namespace JIM.Connectors.LDAP;
 
-public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSettings, IConnectorSchema, IConnectorPartitions, IConnectorImportUsingCalls, IConnectorExportUsingCalls, IConnectorCertificateAware, IConnectorCredentialAware, IConnectorContainerCreation, IDisposable
+public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSettings, IConnectorSchema, IConnectorPartitions, IConnectorImportUsingCalls, IConnectorExportUsingCalls, IConnectorCertificateAware, IConnectorCredentialAware, IConnectorContainerCreation, IConnectorRecommendedExportParallelism, IDisposable
 {
     private LdapConnection? _connection;
     private Func<LdapConnection>? _connectionFactory;
@@ -473,6 +473,26 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         _exportSettings = null;
         _currentExport = null;
         CloseImportConnection();
+    }
+    #endregion
+
+    #region IConnectorRecommendedExportParallelism members
+    /// <summary>
+    /// Recommends export batch parallelism aligned with the directory type already detected for
+    /// this Connected System (issue #985d). The directory type itself is not a labelled setting,
+    /// so it cannot be determined from <paramref name="settingValues"/> without a fresh
+    /// connection, which this method must not open. Export Concurrency, however, is auto-tuned
+    /// per directory type at schema import time (see <see cref="AutoTuneExportConcurrency"/>,
+    /// sourced from <see cref="LdapConnectorRootDse.RecommendedExportConcurrency"/>), so its
+    /// current setting value is the best available connection-free, directory-aware signal.
+    /// Mirroring it here keeps the two knobs coherent: an administrator who has manually tuned
+    /// Export Concurrency (or whose directory auto-tuned to a non-default value) gets a matching
+    /// parallelism recommendation rather than a contradictory one.
+    /// </summary>
+    public int? GetRecommendedExportParallelism(List<ConnectedSystemSettingValue> settingValues)
+    {
+        return settingValues
+            .FirstOrDefault(s => s.Setting.Name == _settingExportConcurrency)?.IntValue;
     }
     #endregion
 

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -184,6 +184,20 @@ public interface IConnectedSystemRepository
     public Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId);
 
     /// <summary>
+    /// Returns whether any executable exports WITHOUT unresolved references exist strictly after
+    /// the given keyset cursor. Guards the deferred-collection fast path (issue #985): deferred
+    /// and executable exports interleave in (CreatedAt, Id) order, so an all-deferred batch does
+    /// not prove the rest of the queue is deferred too. Same filtering semantics and keyset
+    /// predicate as <see cref="GetExecutableExportBatchAsync"/>, restricted to non-deferred
+    /// exports; implemented as an existence check (no Includes, no entity materialisation).
+    /// </summary>
+    /// <param name="connectedSystemId">The Connected System to probe.</param>
+    /// <param name="afterCreatedAt">CreatedAt of the last row already collected, or null to probe from the beginning.</param>
+    /// <param name="afterId">Id of the last row already collected, or null to probe from the beginning.</param>
+    /// <returns>True if at least one executable, non-deferred Pending Export exists beyond the cursor.</returns>
+    public Task<bool> AnyExecutableNonDeferredExportsAfterAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId);
+
+    /// <summary>
     /// Gets lightweight summaries of executable exports for pre-export reconciliation.
     /// Returns only scalar fields via projection query — no Include chains, no entity tracking.
     /// </summary>

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -171,6 +171,19 @@ public interface IConnectedSystemRepository
     public Task<List<PendingExport>> GetExecutableExportBatchAsync(int connectedSystemId, int take, DateTime? afterCreatedAt, Guid? afterId);
 
     /// <summary>
+    /// Collects all remaining executable exports with unresolved references (deferred) strictly
+    /// after the given keyset cursor, in a single query. Used to fast-path the export batch-collection
+    /// loop once a batch is discovered to be made up entirely of deferred exports (issue #985). Same
+    /// Include chain and keyset predicate as <see cref="GetExecutableExportBatchAsync"/>, restricted
+    /// to HasUnresolvedReferences exports, with no page size limit.
+    /// </summary>
+    /// <param name="connectedSystemId">The Connected System to load exports for.</param>
+    /// <param name="afterCreatedAt">CreatedAt of the last row already collected, or null to start from the beginning.</param>
+    /// <param name="afterId">Id of the last row already collected, or null to start from the beginning.</param>
+    /// <returns>Untracked, deferred Pending Exports with ConnectedSystemObject, AttributeValues, and AttributeValueChanges loaded.</returns>
+    public Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId);
+
+    /// <summary>
     /// Gets lightweight summaries of executable exports for pre-export reconciliation.
     /// Returns only scalar fields via projection query — no Include chains, no entity tracking.
     /// </summary>

--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -735,6 +735,16 @@ public interface ISyncRepository
     Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId);
 
     /// <summary>
+    /// Returns whether any executable exports WITHOUT unresolved references exist strictly after
+    /// the given keyset cursor. Guards the deferred-collection fast path (issue #985): deferred
+    /// and executable exports interleave in (CreatedAt, Id) order, so an all-deferred batch does
+    /// not prove the rest of the queue is deferred too. Same filtering semantics as
+    /// <see cref="GetExecutableExportBatchAsync"/>, restricted to non-deferred exports; a cheap
+    /// existence check with no entity materialisation.
+    /// </summary>
+    Task<bool> AnyExecutableNonDeferredExportsAfterAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId);
+
+    /// <summary>
     /// Gets lightweight summaries of executable exports for pre-export reconciliation.
     /// Returns only scalar fields (Id, ChangeType, Status, CsoId, MvoId) via projection
     /// query — no Include chains, no entity tracking. At 100K objects this uses ~3 MB

--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -725,6 +725,16 @@ public interface ISyncRepository
     Task<List<PendingExport>> GetExecutableExportBatchAsync(int connectedSystemId, int take, DateTime? afterCreatedAt, Guid? afterId);
 
     /// <summary>
+    /// Collects all remaining executable exports with unresolved references (deferred) strictly
+    /// after the given keyset cursor, in a single call. Used by the export batch-collection loop
+    /// to fast-path once a batch is discovered to be made up entirely of deferred exports, instead
+    /// of continuing to page through the remainder 100 rows at a time purely to build the deferred
+    /// list (issue #985). Same ordering and filtering semantics as
+    /// <see cref="GetExecutableExportBatchAsync"/>, restricted to HasUnresolvedReferences exports.
+    /// </summary>
+    Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId);
+
+    /// <summary>
     /// Gets lightweight summaries of executable exports for pre-export reconciliation.
     /// Returns only scalar fields (Id, ChangeType, Status, CsoId, MvoId) via projection
     /// query — no Include chains, no entity tracking. At 100K objects this uses ~3 MB

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -1671,6 +1671,29 @@ public class SyncRepository : ISyncRepository
     }
 
     /// <summary>
+    /// Returns whether any executable exports WITHOUT unresolved references exist strictly after
+    /// the given keyset cursor, mirroring the Postgres implementation. Guards the
+    /// deferred-collection fast path (issue #985): deferred and executable exports interleave in
+    /// (CreatedAt, Id) order, so an all-deferred batch does not prove the rest of the queue is
+    /// deferred too.
+    /// </summary>
+    public virtual Task<bool> AnyExecutableNonDeferredExportsAfterAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+    {
+        var query = GetExecutableExportsForSystem(connectedSystemId)
+            .Where(pe => !pe.HasUnresolvedReferences);
+
+        if (afterCreatedAt.HasValue && afterId.HasValue)
+        {
+            var cursorCreatedAt = afterCreatedAt.Value;
+            var cursorId = afterId.Value;
+            query = query.Where(pe => pe.CreatedAt > cursorCreatedAt
+                || (pe.CreatedAt == cursorCreatedAt && pe.Id.CompareTo(cursorId) > 0));
+        }
+
+        return Task.FromResult(query.Any());
+    }
+
+    /// <summary>
     /// Applies the same eligibility filters as the Postgres ExecutableExportsQuery:
     /// status must be Pending, Exported, or ExportNotConfirmed; exports not yet due for retry or
     /// that have exceeded max retries are excluded; Update exports must have at least one Pending or

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -1645,6 +1645,32 @@ public class SyncRepository : ISyncRepository
     }
 
     /// <summary>
+    /// Collects all remaining executable exports with unresolved references (deferred) strictly
+    /// after the given keyset cursor, in a single call, mirroring the Postgres implementation.
+    /// Used to fast-path the export batch-collection loop once a batch is discovered to be made
+    /// up entirely of deferred exports (issue #985).
+    /// </summary>
+    public virtual Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+    {
+        var query = GetExecutableExportsForSystem(connectedSystemId)
+            .Where(pe => pe.HasUnresolvedReferences);
+
+        if (afterCreatedAt.HasValue && afterId.HasValue)
+        {
+            var cursorCreatedAt = afterCreatedAt.Value;
+            var cursorId = afterId.Value;
+            query = query.Where(pe => pe.CreatedAt > cursorCreatedAt
+                || (pe.CreatedAt == cursorCreatedAt && pe.Id.CompareTo(cursorId) > 0));
+        }
+
+        var result = query
+            .OrderBy(pe => pe.CreatedAt)
+            .ThenBy(pe => pe.Id)
+            .ToList();
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
     /// Applies the same eligibility filters as the Postgres ExecutableExportsQuery:
     /// status must be Pending, Exported, or ExportNotConfirmed; exports not yet due for retry or
     /// that have exceeded max retries are excluded; Update exports must have at least one Pending or

--- a/src/JIM.Models/Interfaces/IConnectorRecommendedExportParallelism.cs
+++ b/src/JIM.Models/Interfaces/IConnectorRecommendedExportParallelism.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Staging;
+
+namespace JIM.Models.Interfaces;
+
+/// <summary>
+/// Connectors that can recommend a directory/system-aware degree of export batch parallelism
+/// implement this interface. JIM only consults it when the administrator has not explicitly
+/// configured Max Export Parallelism on the Connected System; an explicit value always wins.
+/// </summary>
+public interface IConnectorRecommendedExportParallelism
+{
+    /// <summary>
+    /// Returns a recommended degree of export batch parallelism for the given Connected System
+    /// setting values, or null if the connector cannot offer a recommendation (for example, no
+    /// schema import has run yet to detect the target system's type). Implementations MUST NOT
+    /// open a network connection to compute this value; base the recommendation only on data
+    /// already available in <paramref name="settingValues"/>.
+    /// </summary>
+    public int? GetRecommendedExportParallelism(List<ConnectedSystemSettingValue> settingValues);
+}

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -2899,6 +2899,45 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     }
 
     /// <summary>
+    /// Collects all remaining executable exports with unresolved references (deferred) strictly
+    /// after the given keyset cursor, in a single query. Used to fast-path the export
+    /// batch-collection loop once a batch is discovered to be made up entirely of deferred
+    /// exports: paging through the remainder 100 rows at a time would only ever build the same
+    /// deferred list one page slower (issue #985). Same Include chain and keyset predicate as
+    /// <see cref="GetExecutableExportBatchAsync"/>, restricted to HasUnresolvedReferences exports,
+    /// with no page size limit.
+    /// </summary>
+    public async Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+    {
+        var query = ExecutableExportsQuery(connectedSystemId)
+            .Where(pe => pe.HasUnresolvedReferences);
+
+        if (afterCreatedAt.HasValue && afterId.HasValue)
+        {
+            var cursorCreatedAt = afterCreatedAt.Value;
+            var cursorId = afterId.Value;
+            query = query.Where(pe => pe.CreatedAt > cursorCreatedAt
+                || (pe.CreatedAt == cursorCreatedAt && pe.Id.CompareTo(cursorId) > 0));
+        }
+
+        return await query
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Include(pe => pe.AttributeValueChanges)
+                .ThenInclude(avc => avc.Attribute)
+            // Same rationale as GetExecutableExportBatchAsync: CSO.Type is required by
+            // LdapConnectorExport (GetObjectClass() fallback, placeholder modifications).
+            .Include(pe => pe.ConnectedSystemObject)
+                .ThenInclude(cso => cso!.Type)
+            .Include(pe => pe.ConnectedSystemObject)
+                .ThenInclude(cso => cso!.AttributeValues)
+                    .ThenInclude(av => av.Attribute)
+            .OrderBy(pe => pe.CreatedAt)
+            .ThenBy(pe => pe.Id)
+            .ToListAsync();
+    }
+
+    /// <summary>
     /// Shared query builder for executable exports. Applies all database-level eligibility filters
     /// including the checks previously done in-memory by IsReadyForExecution:
     /// - Exclude Update exports with no exportable attribute changes

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -2938,6 +2938,32 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     }
 
     /// <summary>
+    /// Returns whether any executable exports WITHOUT unresolved references exist strictly after
+    /// the given keyset cursor. Guards the deferred-collection fast path (issue #985): deferred
+    /// and executable exports interleave in (CreatedAt, Id) order, so a wholly-deferred batch
+    /// does not prove the rest of the queue is deferred too; collecting the deferred remainder
+    /// and breaking out of the scan without this probe would silently drop any executable
+    /// exports created after the deferred run. A cheap indexed existence check (backed by
+    /// IX_PendingExports_ConnectedSystemId_CreatedAt_Id): no Includes, no ordering, no entity
+    /// materialisation.
+    /// </summary>
+    public async Task<bool> AnyExecutableNonDeferredExportsAfterAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+    {
+        var query = ExecutableExportsQuery(connectedSystemId)
+            .Where(pe => !pe.HasUnresolvedReferences);
+
+        if (afterCreatedAt.HasValue && afterId.HasValue)
+        {
+            var cursorCreatedAt = afterCreatedAt.Value;
+            var cursorId = afterId.Value;
+            query = query.Where(pe => pe.CreatedAt > cursorCreatedAt
+                || (pe.CreatedAt == cursorCreatedAt && pe.Id.CompareTo(cursorId) > 0));
+        }
+
+        return await query.AnyAsync();
+    }
+
+    /// <summary>
     /// Shared query builder for executable exports. Applies all database-level eligibility filters
     /// including the checks previously done in-memory by IsReadyForExecution:
     /// - Exclude Update exports with no exportable attribute changes

--- a/src/JIM.PostgresData/Repositories/SyncRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.cs
@@ -454,6 +454,9 @@ public partial class SyncRepository : ISyncRepository
     public Task<List<PendingExport>> GetExecutableExportBatchAsync(int connectedSystemId, int take, DateTime? afterCreatedAt, Guid? afterId)
         => _repo.ConnectedSystems.GetExecutableExportBatchAsync(connectedSystemId, take, afterCreatedAt, afterId);
 
+    public Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+        => _repo.ConnectedSystems.GetRemainingDeferredExportsAsync(connectedSystemId, afterCreatedAt, afterId);
+
     public Task<List<PendingExportSummary>> GetExecutableExportSummariesAsync(int connectedSystemId)
         => _repo.ConnectedSystems.GetExecutableExportSummariesAsync(connectedSystemId);
 

--- a/src/JIM.PostgresData/Repositories/SyncRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.cs
@@ -457,6 +457,9 @@ public partial class SyncRepository : ISyncRepository
     public Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
         => _repo.ConnectedSystems.GetRemainingDeferredExportsAsync(connectedSystemId, afterCreatedAt, afterId);
 
+    public Task<bool> AnyExecutableNonDeferredExportsAfterAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+        => _repo.ConnectedSystems.AnyExecutableNonDeferredExportsAfterAsync(connectedSystemId, afterCreatedAt, afterId);
+
     public Task<List<PendingExportSummary>> GetExecutableExportSummariesAsync(int connectedSystemId)
         => _repo.ConnectedSystems.GetExecutableExportSummariesAsync(connectedSystemId);
 

--- a/src/JIM.Worker/Processors/ExportParallelismResolver.cs
+++ b/src/JIM.Worker/Processors/ExportParallelismResolver.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+using Serilog;
+
+namespace JIM.Worker.Processors;
+
+/// <summary>
+/// Resolves the degree of parallelism used for the Export batch-processing loop
+/// (ExportExecutionOptions.MaxParallelism). Extracted from SyncExportTaskProcessor so the
+/// resolution order can be unit tested without a full processor harness (issue #985d).
+/// </summary>
+internal static class ExportParallelismResolver
+{
+    /// <summary>
+    /// Fallback used when neither an explicit Connected System setting nor a connector
+    /// recommendation is available. Matches the pre-#985d default (sequential export).
+    /// </summary>
+    internal const int FallbackParallelism = 1;
+
+    /// <summary>
+    /// Lower bound applied to a connector's recommended parallelism.
+    /// </summary>
+    internal const int MinRecommendedParallelism = 1;
+
+    /// <summary>
+    /// Upper bound applied to a connector's recommended parallelism, so a connector cannot
+    /// recommend an unbounded degree of concurrency against the target system.
+    /// </summary>
+    internal const int MaxRecommendedParallelism = 16;
+
+    /// <summary>
+    /// Resolves the export batch parallelism to use, and logs which source supplied it.
+    /// Resolution order: an explicit Max Export Parallelism value on the Connected System always
+    /// wins (respects the administrator's choice, same philosophy as the LDAP connector's Export
+    /// Concurrency auto-tune guard); otherwise a connector recommendation via
+    /// <see cref="IConnectorRecommendedExportParallelism"/> is used, clamped to
+    /// [<see cref="MinRecommendedParallelism"/>, <see cref="MaxRecommendedParallelism"/>];
+    /// otherwise <see cref="FallbackParallelism"/>.
+    /// </summary>
+    /// <param name="explicitMaxExportParallelism">The Connected System's MaxExportParallelism setting, or null if not explicitly configured.</param>
+    /// <param name="connector">The connector instance for the Connected System, consulted for a recommendation if it implements <see cref="IConnectorRecommendedExportParallelism"/>.</param>
+    /// <param name="settingValues">The Connected System's setting values, passed to the connector's recommendation method.</param>
+    /// <param name="connectedSystemName">Name of the Connected System, for the source log line.</param>
+    public static int Resolve(
+        int? explicitMaxExportParallelism,
+        IConnector connector,
+        List<ConnectedSystemSettingValue> settingValues,
+        string connectedSystemName)
+    {
+        if (explicitMaxExportParallelism.HasValue)
+        {
+            Log.Information(
+                "ExportParallelismResolver: Using explicitly configured Max Export Parallelism {Value} for {SystemName}",
+                explicitMaxExportParallelism.Value, connectedSystemName);
+            return explicitMaxExportParallelism.Value;
+        }
+
+        if (connector is IConnectorRecommendedExportParallelism recommender)
+        {
+            var recommended = recommender.GetRecommendedExportParallelism(settingValues);
+            if (recommended.HasValue)
+            {
+                var clamped = Math.Clamp(recommended.Value, MinRecommendedParallelism, MaxRecommendedParallelism);
+                Log.Information(
+                    "ExportParallelismResolver: Using connector-recommended Max Export Parallelism {Value} (clamped from {Recommended}) for {SystemName}",
+                    clamped, recommended.Value, connectedSystemName);
+                return clamped;
+            }
+        }
+
+        Log.Information(
+            "ExportParallelismResolver: No explicit Max Export Parallelism configured and no connector recommendation available; defaulting to {Value} for {SystemName}",
+            FallbackParallelism, connectedSystemName);
+        return FallbackParallelism;
+    }
+}

--- a/src/JIM.Worker/Processors/SyncExportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncExportTaskProcessor.cs
@@ -136,11 +136,21 @@ public class SyncExportTaskProcessor
 
         try
         {
+            // Resolve the degree of export batch parallelism (issue #985d): an explicit
+            // Max Export Parallelism setting always wins; otherwise the connector may recommend
+            // a directory-aware degree of parallelism (e.g. LdapConnector, mirroring its own
+            // Export Concurrency auto-tune); otherwise fall back to sequential.
+            var resolvedParallelism = ExportParallelismResolver.Resolve(
+                _connectedSystem.MaxExportParallelism,
+                _connector,
+                _connectedSystem.SettingValues,
+                _connectedSystem.Name);
+
             // Execute exports using the ExportExecutionServer with progress reporting
             var options = new ExportExecutionOptions
             {
                 BatchSize = 100,
-                MaxParallelism = _connectedSystem.MaxExportParallelism ?? 1
+                MaxParallelism = resolvedParallelism
             };
 
             var throughput = new ThroughputTracker();

--- a/test/JIM.Worker.Tests/Connectors/LdapExportParallelismRecommendationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapExportParallelismRecommendationTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors.LDAP;
+using JIM.Models.Staging;
+using NUnit.Framework;
+using Serilog;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// Issue #985 (d): the LDAP connector's export batch-parallelism recommendation
+/// (IConnectorRecommendedExportParallelism) must stay coherent with the directory-type-aware
+/// Export Concurrency auto-tune (LdapExportConcurrencyAutoTuneTests). Export Concurrency is
+/// auto-tuned per directory type at schema import time from
+/// LdapConnectorRootDse.RecommendedExportConcurrency, so its current setting value is the best
+/// available connection-free, directory-aware signal for a parallelism recommendation.
+/// </summary>
+[TestFixture]
+public class LdapExportParallelismRecommendationTests
+{
+    private static readonly ILogger Logger = Serilog.Core.Logger.None;
+
+    #region GetRecommendedExportParallelism — mirrors RecommendedExportConcurrency per directory type
+
+    // LdapDirectoryType is internal, so it can't appear in a public [TestCase] method signature
+    // (CS0051) — one test per directory type instead, mirroring LdapExportConcurrencyAutoTuneTests.
+
+    [Test]
+    public void GetRecommendedExportParallelism_ActiveDirectoryAfterAutoTune_MatchesRecommendedExportConcurrency()
+        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.ActiveDirectory);
+
+    [Test]
+    public void GetRecommendedExportParallelism_OpenLDAPAfterAutoTune_MatchesRecommendedExportConcurrency()
+        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.OpenLDAP);
+
+    [Test]
+    public void GetRecommendedExportParallelism_SambaADAfterAutoTune_MatchesRecommendedExportConcurrency()
+        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.SambaAD);
+
+    [Test]
+    public void GetRecommendedExportParallelism_GenericAfterAutoTune_MatchesRecommendedExportConcurrency()
+        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.Generic);
+
+    /// <summary>
+    /// Simulates a Connected System whose schema import has already auto-tuned Export
+    /// Concurrency for the given directory type, then asserts the parallelism recommendation
+    /// matches LdapConnectorRootDse.RecommendedExportConcurrency for that same directory type.
+    /// </summary>
+    private static void AssertRecommendationMatchesAutoTune(LdapDirectoryType directoryType)
+    {
+        var settings = CreateSettingsWithExportConcurrency(LdapConnectorConstants.DEFAULT_EXPORT_CONCURRENCY);
+        var rootDse = new LdapConnectorRootDse { DirectoryType = directoryType };
+        LdapConnector.AutoTuneExportConcurrency(settings, rootDse, Logger);
+        var connector = new LdapConnector();
+
+        var recommendation = connector.GetRecommendedExportParallelism(settings);
+
+        Assert.That(recommendation, Is.EqualTo(rootDse.RecommendedExportConcurrency));
+    }
+
+    [Test]
+    public void GetRecommendedExportParallelism_AdminOverriddenExportConcurrency_MirrorsOverride()
+    {
+        // An administrator's explicit Export Concurrency choice is respected by the auto-tune
+        // guard, so the parallelism recommendation mirrors that override too, not the directory
+        // type's textbook value.
+        var settings = CreateSettingsWithExportConcurrency(8);
+        var rootDse = new LdapConnectorRootDse { DirectoryType = LdapDirectoryType.ActiveDirectory };
+        LdapConnector.AutoTuneExportConcurrency(settings, rootDse, Logger);
+        var connector = new LdapConnector();
+
+        var recommendation = connector.GetRecommendedExportParallelism(settings);
+
+        Assert.That(recommendation, Is.EqualTo(8));
+    }
+
+    #endregion
+
+    #region GetRecommendedExportParallelism — no recommendation available
+
+    [Test]
+    public void GetRecommendedExportParallelism_ExportConcurrencySettingMissing_ReturnsNull()
+    {
+        // No schema import has happened yet (e.g. a brand new Connected System) — the connector
+        // must not open a connection here, and has no cached/derivable value to offer.
+        var connector = new LdapConnector();
+
+        var recommendation = connector.GetRecommendedExportParallelism([]);
+
+        Assert.That(recommendation, Is.Null);
+    }
+
+    [Test]
+    public void GetRecommendedExportParallelism_ExportConcurrencyIntValueNull_ReturnsNull()
+    {
+        var settings = CreateSettingsWithExportConcurrency(null);
+        var connector = new LdapConnector();
+
+        var recommendation = connector.GetRecommendedExportParallelism(settings);
+
+        Assert.That(recommendation, Is.Null);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static List<ConnectedSystemSettingValue> CreateSettingsWithExportConcurrency(int? value)
+    {
+        return
+        [
+            new ConnectedSystemSettingValue
+            {
+                Setting = new ConnectorDefinitionSetting { Name = "Export Concurrency" },
+                IntValue = value
+            }
+        ];
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Connectors/LdapExportParallelismRecommendationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapExportParallelismRecommendationTests.cs
@@ -29,10 +29,10 @@ public class LdapExportParallelismRecommendationTests
     /// </summary>
     private const int ExpectedCapableDirectoryRecommendation = 2;
 
-    #region GetRecommendedExportParallelism — per directory type, after Export Concurrency auto-tune
+    #region GetRecommendedExportParallelism: per directory type, after Export Concurrency auto-tune
 
     // LdapDirectoryType is internal, so it can't appear in a public [TestCase] method signature
-    // (CS0051) — one test per directory type instead, mirroring LdapExportConcurrencyAutoTuneTests.
+    // (CS0051); one test per directory type instead, mirroring LdapExportConcurrencyAutoTuneTests.
 
     [Test]
     public void GetRecommendedExportParallelism_ActiveDirectoryAfterAutoTune_Returns2()
@@ -96,12 +96,12 @@ public class LdapExportParallelismRecommendationTests
 
     #endregion
 
-    #region GetRecommendedExportParallelism — no recommendation available
+    #region GetRecommendedExportParallelism: no recommendation available
 
     [Test]
     public void GetRecommendedExportParallelism_ExportConcurrencySettingMissing_ReturnsNull()
     {
-        // No schema import has happened yet (e.g. a brand new Connected System) — the connector
+        // No schema import has happened yet (e.g. a brand new Connected System); the connector
         // must not open a connection here, and has no cached/derivable value to offer.
         var connector = new LdapConnector();
 

--- a/test/JIM.Worker.Tests/Connectors/LdapExportParallelismRecommendationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapExportParallelismRecommendationTests.cs
@@ -10,44 +10,53 @@ namespace JIM.Worker.Tests.Connectors;
 
 /// <summary>
 /// Issue #985 (d): the LDAP connector's export batch-parallelism recommendation
-/// (IConnectorRecommendedExportParallelism) must stay coherent with the directory-type-aware
-/// Export Concurrency auto-tune (LdapExportConcurrencyAutoTuneTests). Export Concurrency is
-/// auto-tuned per directory type at schema import time from
-/// LdapConnectorRootDse.RecommendedExportConcurrency, so its current setting value is the best
-/// available connection-free, directory-aware signal for a parallelism recommendation.
+/// (IConnectorRecommendedExportParallelism) must be deliberately conservative because the two
+/// knobs MULTIPLY: each parallel batch pipeline gets its own connector instance, and each LDAP
+/// connector instance runs its own Export Concurrency concurrent operations, so total in-flight
+/// LDAP operations = parallelism x per-instance concurrency. The connector therefore recommends
+/// a parallelism of 2 only when the Connected System's Export Concurrency signals a capable
+/// directory (>= 8; the auto-tune only sets 16 for Active Directory and OpenLDAP), and no
+/// recommendation otherwise (the resolver falls back to sequential).
 /// </summary>
 [TestFixture]
 public class LdapExportParallelismRecommendationTests
 {
     private static readonly ILogger Logger = Serilog.Core.Logger.None;
 
-    #region GetRecommendedExportParallelism — mirrors RecommendedExportConcurrency per directory type
+    /// <summary>
+    /// The conservative parallelism recommendation for capable directories: 2 pipelines of
+    /// (auto-tuned) 16 concurrent operations each = 32 in-flight operations, a mild default.
+    /// </summary>
+    private const int ExpectedCapableDirectoryRecommendation = 2;
+
+    #region GetRecommendedExportParallelism — per directory type, after Export Concurrency auto-tune
 
     // LdapDirectoryType is internal, so it can't appear in a public [TestCase] method signature
     // (CS0051) — one test per directory type instead, mirroring LdapExportConcurrencyAutoTuneTests.
 
     [Test]
-    public void GetRecommendedExportParallelism_ActiveDirectoryAfterAutoTune_MatchesRecommendedExportConcurrency()
-        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.ActiveDirectory);
+    public void GetRecommendedExportParallelism_ActiveDirectoryAfterAutoTune_Returns2()
+        => AssertRecommendationAfterAutoTune(LdapDirectoryType.ActiveDirectory, ExpectedCapableDirectoryRecommendation);
 
     [Test]
-    public void GetRecommendedExportParallelism_OpenLDAPAfterAutoTune_MatchesRecommendedExportConcurrency()
-        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.OpenLDAP);
+    public void GetRecommendedExportParallelism_OpenLDAPAfterAutoTune_Returns2()
+        => AssertRecommendationAfterAutoTune(LdapDirectoryType.OpenLDAP, ExpectedCapableDirectoryRecommendation);
 
     [Test]
-    public void GetRecommendedExportParallelism_SambaADAfterAutoTune_MatchesRecommendedExportConcurrency()
-        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.SambaAD);
+    public void GetRecommendedExportParallelism_SambaADAfterAutoTune_ReturnsNull()
+        => AssertRecommendationAfterAutoTune(LdapDirectoryType.SambaAD, null);
 
     [Test]
-    public void GetRecommendedExportParallelism_GenericAfterAutoTune_MatchesRecommendedExportConcurrency()
-        => AssertRecommendationMatchesAutoTune(LdapDirectoryType.Generic);
+    public void GetRecommendedExportParallelism_GenericAfterAutoTune_ReturnsNull()
+        => AssertRecommendationAfterAutoTune(LdapDirectoryType.Generic, null);
 
     /// <summary>
     /// Simulates a Connected System whose schema import has already auto-tuned Export
-    /// Concurrency for the given directory type, then asserts the parallelism recommendation
-    /// matches LdapConnectorRootDse.RecommendedExportConcurrency for that same directory type.
+    /// Concurrency for the given directory type, then asserts the parallelism recommendation:
+    /// 2 for capable directories (auto-tuned Export Concurrency of 16: Active Directory and
+    /// OpenLDAP), null for the rest (auto-tune leaves them at the default of 4).
     /// </summary>
-    private static void AssertRecommendationMatchesAutoTune(LdapDirectoryType directoryType)
+    private static void AssertRecommendationAfterAutoTune(LdapDirectoryType directoryType, int? expected)
     {
         var settings = CreateSettingsWithExportConcurrency(LdapConnectorConstants.DEFAULT_EXPORT_CONCURRENCY);
         var rootDse = new LdapConnectorRootDse { DirectoryType = directoryType };
@@ -56,23 +65,33 @@ public class LdapExportParallelismRecommendationTests
 
         var recommendation = connector.GetRecommendedExportParallelism(settings);
 
-        Assert.That(recommendation, Is.EqualTo(rootDse.RecommendedExportConcurrency));
+        Assert.That(recommendation, Is.EqualTo(expected));
     }
 
     [Test]
-    public void GetRecommendedExportParallelism_AdminOverriddenExportConcurrency_MirrorsOverride()
+    public void GetRecommendedExportParallelism_AdminSetConcurrencyAtThreshold_Returns2()
     {
-        // An administrator's explicit Export Concurrency choice is respected by the auto-tune
-        // guard, so the parallelism recommendation mirrors that override too, not the directory
-        // type's textbook value.
+        // An Export Concurrency of 8 or above (whether admin-set or auto-tuned) signals a
+        // capable directory, so the conservative parallelism recommendation applies.
         var settings = CreateSettingsWithExportConcurrency(8);
-        var rootDse = new LdapConnectorRootDse { DirectoryType = LdapDirectoryType.ActiveDirectory };
-        LdapConnector.AutoTuneExportConcurrency(settings, rootDse, Logger);
         var connector = new LdapConnector();
 
         var recommendation = connector.GetRecommendedExportParallelism(settings);
 
-        Assert.That(recommendation, Is.EqualTo(8));
+        Assert.That(recommendation, Is.EqualTo(ExpectedCapableDirectoryRecommendation));
+    }
+
+    [Test]
+    public void GetRecommendedExportParallelism_AdminSetConcurrencyBelowThreshold_ReturnsNull()
+    {
+        // Below the capable-directory threshold there is no recommendation; the resolver falls
+        // back to sequential (1).
+        var settings = CreateSettingsWithExportConcurrency(6);
+        var connector = new LdapConnector();
+
+        var recommendation = connector.GetRecommendedExportParallelism(settings);
+
+        Assert.That(recommendation, Is.Null);
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
@@ -2085,7 +2085,7 @@ public class ExportExecutionTests
         var baseTime = DateTime.UtcNow.AddMinutes(-10);
         var offset = 0;
 
-        // Page 1 (4 rows): interleaved immediate/deferred — must NOT fast-path.
+        // Page 1 (4 rows): interleaved immediate/deferred; must NOT fast-path.
         var page1Types = new[] { false, true, false, true };
         foreach (var deferred in page1Types)
         {
@@ -2094,7 +2094,7 @@ public class ExportExecutionTests
             countingRepo.SeedPendingExport(pe);
         }
 
-        // Page 2 (4 rows): entirely deferred — must fast-path and bulk-collect the rest.
+        // Page 2 (4 rows): entirely deferred; must fast-path and bulk-collect the rest.
         for (var i = 0; i < 4; i++)
         {
             var pe = CreateSeededCreateExport(targetSystem, targetUserType,
@@ -2127,7 +2127,7 @@ public class ExportExecutionTests
         Assert.That(result.ProcessedPendingExportIds, Has.Count.EqualTo(exportCount));
         Assert.That(result.SuccessCount, Is.EqualTo(exportCount));
 
-        // Only the 2 pages that were actually loaded — no further page loads once the
+        // Only the 2 pages that were actually loaded; no further page loads once the
         // wholly-deferred second page triggered the fast path.
         Assert.That(countingRepo.BatchLoadCalls, Is.EqualTo(2),
             $"Expected exactly 2 page loads (mixed page 1, all-deferred page 2); got {countingRepo.BatchLoadCalls}.");

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
@@ -1896,11 +1896,18 @@ public class ExportExecutionTests
     private sealed class BatchLoadCountingSyncRepository : SyncRepository
     {
         public int BatchLoadCalls;
+        public int RemainingDeferredCalls;
 
         public override Task<List<PendingExport>> GetExecutableExportBatchAsync(int connectedSystemId, int take, DateTime? afterCreatedAt, Guid? afterId)
         {
             Interlocked.Increment(ref BatchLoadCalls);
             return base.GetExecutableExportBatchAsync(connectedSystemId, take, afterCreatedAt, afterId);
+        }
+
+        public override Task<List<PendingExport>> GetRemainingDeferredExportsAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+        {
+            Interlocked.Increment(ref RemainingDeferredCalls);
+            return base.GetRemainingDeferredExportsAsync(connectedSystemId, afterCreatedAt, afterId);
         }
     }
 
@@ -1992,6 +1999,131 @@ public class ExportExecutionTests
             $"Batch collection re-scanned the Pending Export query: {countingRepo.BatchLoadCalls} page loads " +
             $"for {exportCount} deferred exports at batch size {batchSize} (expected <= {maxExpectedBatchLoads}). " +
             "See issue #985.");
+    }
+
+    /// <summary>
+    /// Issue #985 (c): once a loaded batch is discovered to contain only deferred
+    /// (reference-bearing) exports and nothing executable, the collection loop must stop
+    /// page-by-page scanning and collect all remaining deferred exports with a single bulk
+    /// repository call, rather than continuing to page 100 at a time purely to build the
+    /// deferred list. With N=1000 deferred exports and batch size 100, the first page already
+    /// reveals the batch is entirely deferred, so at most one further page load plus exactly
+    /// one bulk collect call are needed (previously this cost ceil(N/B)+1 = 11 page loads).
+    /// </summary>
+    [Test]
+    public async Task ExecuteExportsAsync_AllDeferredExports_FastPathsRemainingCollectionInSingleBulkCallAsync()
+    {
+        // Arrange: a fresh application wired to a counting repository.
+        var countingRepo = new BatchLoadCountingSyncRepository();
+        var syncRepo = TestUtilities.CreateSyncRepository(activity: ActivitiesData.First(), repository: countingRepo);
+        using var jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: syncRepo);
+
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+
+        const int exportCount = 1000;
+        const int batchSize = 100;
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        for (var i = 0; i < exportCount; i++)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(i), hasUnresolvedReferences: true);
+            countingRepo.SeedPendingExport(pe);
+        }
+
+        var mockConnector = CreateSucceedingCallsConnector();
+        var options = new ExportExecutionOptions { BatchSize = batchSize };
+
+        // Act
+        var result = await jim.ExportExecution.ExecuteExportsAsync(
+            targetSystem,
+            mockConnector.Object,
+            SyncRunMode.PreviewAndSync,
+            options,
+            CancellationToken.None);
+
+        // Assert: every export was still collected...
+        Assert.That(result.ProcessedPendingExportIds, Has.Count.EqualTo(exportCount));
+
+        // ...via at most 2 page loads plus exactly one bulk "collect the rest" call, not
+        // ceil(N/B) = 10 page loads (plus an exhaustion probe).
+        Assert.That(countingRepo.BatchLoadCalls, Is.LessThanOrEqualTo(2),
+            $"Batch collection paged through deferred exports instead of fast-pathing: " +
+            $"{countingRepo.BatchLoadCalls} page loads for {exportCount} deferred exports at batch size {batchSize}. " +
+            "See issue #985 (c).");
+        Assert.That(countingRepo.RemainingDeferredCalls, Is.EqualTo(1),
+            "Expected exactly one bulk GetRemainingDeferredExportsAsync call to collect the deferred tail.");
+    }
+
+    /// <summary>
+    /// Issue #985 (c): the fast path must only trigger for a batch that is entirely deferred.
+    /// A batch mixing executable and deferred exports must execute the executable ones exactly
+    /// as before (no fast path), while a later batch that is entirely deferred should still
+    /// trigger the fast path for the remainder.
+    /// </summary>
+    [Test]
+    public async Task ExecuteExportsAsync_MixedThenAllDeferredBatch_ExecutesImmediateNormallyAndFastPathsRestAsync()
+    {
+        // Arrange
+        var countingRepo = new BatchLoadCountingSyncRepository();
+        var syncRepo = TestUtilities.CreateSyncRepository(activity: ActivitiesData.First(), repository: countingRepo);
+        using var jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: syncRepo);
+
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+
+        const int batchSize = 4;
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        var offset = 0;
+
+        // Page 1 (4 rows): interleaved immediate/deferred — must NOT fast-path.
+        var page1Types = new[] { false, true, false, true };
+        foreach (var deferred in page1Types)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(offset++), hasUnresolvedReferences: deferred);
+            countingRepo.SeedPendingExport(pe);
+        }
+
+        // Page 2 (4 rows): entirely deferred — must fast-path and bulk-collect the rest.
+        for (var i = 0; i < 4; i++)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(offset++), hasUnresolvedReferences: true);
+            countingRepo.SeedPendingExport(pe);
+        }
+
+        // Remaining tail (4 rows): all deferred, collected via the bulk call, not further pages.
+        for (var i = 0; i < 4; i++)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(offset++), hasUnresolvedReferences: true);
+            countingRepo.SeedPendingExport(pe);
+        }
+
+        const int exportCount = 12;
+        var mockConnector = CreateSucceedingCallsConnector();
+        var options = new ExportExecutionOptions { BatchSize = batchSize };
+
+        // Act
+        var result = await jim.ExportExecution.ExecuteExportsAsync(
+            targetSystem,
+            mockConnector.Object,
+            SyncRunMode.PreviewAndSync,
+            options,
+            CancellationToken.None);
+
+        // Assert: every export accounted for and (trivially, since none reference real MVOs)
+        // successfully exported, exactly as the pre-#985(c) page-by-page loop would produce.
+        Assert.That(result.ProcessedPendingExportIds, Has.Count.EqualTo(exportCount));
+        Assert.That(result.SuccessCount, Is.EqualTo(exportCount));
+
+        // Only the 2 pages that were actually loaded — no further page loads once the
+        // wholly-deferred second page triggered the fast path.
+        Assert.That(countingRepo.BatchLoadCalls, Is.EqualTo(2),
+            $"Expected exactly 2 page loads (mixed page 1, all-deferred page 2); got {countingRepo.BatchLoadCalls}.");
+        Assert.That(countingRepo.RemainingDeferredCalls, Is.EqualTo(1),
+            "Expected exactly one bulk GetRemainingDeferredExportsAsync call once page 2 was found to be entirely deferred.");
     }
 
     /// <summary>

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
@@ -1897,6 +1897,7 @@ public class ExportExecutionTests
     {
         public int BatchLoadCalls;
         public int RemainingDeferredCalls;
+        public int ExecutableProbeCalls;
 
         public override Task<List<PendingExport>> GetExecutableExportBatchAsync(int connectedSystemId, int take, DateTime? afterCreatedAt, Guid? afterId)
         {
@@ -1908,6 +1909,12 @@ public class ExportExecutionTests
         {
             Interlocked.Increment(ref RemainingDeferredCalls);
             return base.GetRemainingDeferredExportsAsync(connectedSystemId, afterCreatedAt, afterId);
+        }
+
+        public override Task<bool> AnyExecutableNonDeferredExportsAfterAsync(int connectedSystemId, DateTime? afterCreatedAt, Guid? afterId)
+        {
+            Interlocked.Increment(ref ExecutableProbeCalls);
+            return base.AnyExecutableNonDeferredExportsAfterAsync(connectedSystemId, afterCreatedAt, afterId);
         }
     }
 
@@ -2053,6 +2060,8 @@ public class ExportExecutionTests
             "See issue #985 (c).");
         Assert.That(countingRepo.RemainingDeferredCalls, Is.EqualTo(1),
             "Expected exactly one bulk GetRemainingDeferredExportsAsync call to collect the deferred tail.");
+        Assert.That(countingRepo.ExecutableProbeCalls, Is.EqualTo(1),
+            "Expected exactly one executable-exports existence probe before the fast path fired.");
     }
 
     /// <summary>
@@ -2124,6 +2133,77 @@ public class ExportExecutionTests
             $"Expected exactly 2 page loads (mixed page 1, all-deferred page 2); got {countingRepo.BatchLoadCalls}.");
         Assert.That(countingRepo.RemainingDeferredCalls, Is.EqualTo(1),
             "Expected exactly one bulk GetRemainingDeferredExportsAsync call once page 2 was found to be entirely deferred.");
+        Assert.That(countingRepo.ExecutableProbeCalls, Is.EqualTo(1),
+            "Expected exactly one executable-exports existence probe (for the all-deferred page 2; " +
+            "the mixed page 1 must not probe).");
+    }
+
+    /// <summary>
+    /// Issue #985 (c) correctness guard: deferred and executable Pending Exports interleave in
+    /// (CreatedAt, Id) order, so a contiguous run of a full batch of deferred exports can be
+    /// followed by later executable ones. The fast path must NOT trigger in that case; breaking
+    /// out of the scan after bulk-collecting only the deferred remainder would silently skip the
+    /// executable exports for the whole run, a behaviour regression versus normal paging.
+    /// </summary>
+    [Test]
+    public async Task ExecuteExportsAsync_FullDeferredBatchFollowedByExecutableExports_ExecutesExecutableExportsAsync()
+    {
+        // Arrange
+        var countingRepo = new BatchLoadCountingSyncRepository();
+        var syncRepo = TestUtilities.CreateSyncRepository(activity: ActivitiesData.First(), repository: countingRepo);
+        using var jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: syncRepo);
+
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+
+        const int batchSize = 4;
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        var offset = 0;
+
+        // Page 1 (exactly one full batch): entirely deferred.
+        for (var i = 0; i < batchSize; i++)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(offset++), hasUnresolvedReferences: true);
+            countingRepo.SeedPendingExport(pe);
+        }
+
+        // Later rows: executable (non-deferred) exports created after the deferred run.
+        var executableIds = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(offset++), hasUnresolvedReferences: false);
+            countingRepo.SeedPendingExport(pe);
+            executableIds.Add(pe.Id);
+        }
+
+        const int exportCount = batchSize + 3;
+        var mockConnector = CreateSucceedingCallsConnector();
+        var options = new ExportExecutionOptions { BatchSize = batchSize };
+
+        // Act
+        var result = await jim.ExportExecution.ExecuteExportsAsync(
+            targetSystem,
+            mockConnector.Object,
+            SyncRunMode.PreviewAndSync,
+            options,
+            CancellationToken.None);
+
+        // Assert: the executable exports created after the all-deferred batch must have been
+        // collected and executed in this run, exactly as page-by-page scanning would have done.
+        Assert.That(result.ProcessedPendingExportIds, Is.SupersetOf(executableIds),
+            "Executable exports beyond an all-deferred batch were never collected; the fast path " +
+            "must not break out of the scan while executable exports remain. See issue #985 (c).");
+        Assert.That(result.SuccessCount, Is.EqualTo(exportCount),
+            $"All {exportCount} exports (deferred + executable) should have exported successfully in this run.");
+
+        // The probe found executable exports beyond the cursor, so the fast path must not have
+        // fired; the loop kept paging normally instead.
+        Assert.That(countingRepo.RemainingDeferredCalls, Is.EqualTo(0),
+            "The deferred bulk-collect must not fire while executable exports remain beyond the cursor.");
+        Assert.That(countingRepo.ExecutableProbeCalls, Is.GreaterThanOrEqualTo(1),
+            "Expected the all-deferred page 1 to trigger the executable-exports existence probe.");
     }
 
     /// <summary>

--- a/test/JIM.Worker.Tests/OutboundSync/ExportParallelismResolverTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportParallelismResolverTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+using JIM.Worker.Processors;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.OutboundSync;
+
+/// <summary>
+/// Issue #985 (d): unit tests for the Max Export Parallelism resolution order, extracted from
+/// SyncExportTaskProcessor into ExportParallelismResolver so it can be tested without a full
+/// processor harness. Resolution order: an explicit Connected System value always wins; otherwise
+/// a connector recommendation (via IConnectorRecommendedExportParallelism) is used, clamped to
+/// [1, 16]; otherwise the fallback of 1 (sequential, matching the pre-#985d default).
+/// </summary>
+[TestFixture]
+public class ExportParallelismResolverTests
+{
+    private static readonly List<ConnectedSystemSettingValue> EmptySettingValues = [];
+
+    [Test]
+    public void Resolve_ExplicitValueSet_ReturnsExplicitValue()
+    {
+        var connector = new Mock<IConnector>();
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: 5,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Resolve_ExplicitValueSet_IgnoresConnectorRecommendation()
+    {
+        // An admin's explicit choice must always win, even when the connector recommends
+        // something different (same philosophy as the Export Concurrency auto-tune guard).
+        var connector = new Mock<IConnector>();
+        var recommender = connector.As<IConnectorRecommendedExportParallelism>();
+        recommender.Setup(r => r.GetRecommendedExportParallelism(It.IsAny<List<ConnectedSystemSettingValue>>()))
+            .Returns(16);
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: 5,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Resolve_NoExplicitValue_UsesConnectorRecommendation()
+    {
+        var connector = new Mock<IConnector>();
+        var recommender = connector.As<IConnectorRecommendedExportParallelism>();
+        recommender.Setup(r => r.GetRecommendedExportParallelism(It.IsAny<List<ConnectedSystemSettingValue>>()))
+            .Returns(8);
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: null,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void Resolve_NoExplicitValue_RecommendationAboveMax_ClampsTo16()
+    {
+        var connector = new Mock<IConnector>();
+        var recommender = connector.As<IConnectorRecommendedExportParallelism>();
+        recommender.Setup(r => r.GetRecommendedExportParallelism(It.IsAny<List<ConnectedSystemSettingValue>>()))
+            .Returns(32);
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: null,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(16));
+    }
+
+    [Test]
+    public void Resolve_NoExplicitValue_RecommendationBelowMin_ClampsTo1()
+    {
+        var connector = new Mock<IConnector>();
+        var recommender = connector.As<IConnectorRecommendedExportParallelism>();
+        recommender.Setup(r => r.GetRecommendedExportParallelism(It.IsAny<List<ConnectedSystemSettingValue>>()))
+            .Returns(0);
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: null,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Resolve_NoExplicitValue_ConnectorDoesNotImplementRecommendationInterface_ReturnsFallbackOf1()
+    {
+        var connector = new Mock<IConnector>();
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: null,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Resolve_NoExplicitValue_ConnectorRecommendsNull_ReturnsFallbackOf1()
+    {
+        var connector = new Mock<IConnector>();
+        var recommender = connector.As<IConnectorRecommendedExportParallelism>();
+        recommender.Setup(r => r.GetRecommendedExportParallelism(It.IsAny<List<ConnectedSystemSettingValue>>()))
+            .Returns((int?)null);
+
+        var result = ExportParallelismResolver.Resolve(
+            explicitMaxExportParallelism: null,
+            connector: connector.Object,
+            settingValues: EmptySettingValues,
+            connectedSystemName: "Test System");
+
+        Assert.That(result, Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
Completes the remaining items of #985 (items a and b, keyset pagination and query-side exclusion, landed in #989).

## Item (c): deferred-collection fast path

Once a loaded export batch turns out to be entirely reference-bearing (deferred), the batch loop now collects the remaining deferred Pending Exports in a single set-based query and stops paging, instead of walking the tail 100 rows at a time.

Correctness guard: deferred and executable exports interleave in (CreatedAt, Id) order, so before breaking out the loop probes for any executable non-deferred exports beyond the cursor (cheap indexed existence check, no Includes). If any exist, normal paging continues; nothing can be silently skipped. Covered by a red-first regression test that fails against the unguarded fast path.

## Item (d): directory-aware default for Max Export Parallelism

When a Connected System has no explicit Max Export Parallelism, the connector can now recommend a value via a new `IConnectorRecommendedExportParallelism` capability interface, resolved by a new testable `ExportParallelismResolver` (explicit value always wins; recommendation clamped to 1-16; fallback 1, the pre-existing default).

The LDAP Connector recommends a deliberately conservative 2 for capable directories (Export Concurrency >= 8; the auto-tune only sets 16, for Active Directory and OpenLDAP) and nothing otherwise. The two parallelism axes multiply (total in-flight LDAP operations = parallelism x per-instance Export Concurrency), so mirroring concurrency into parallelism would square the load; 2 x 16 = 32 in-flight operations is the safe default. The directory type is not persisted connection-free, so AD cannot be distinguished from single-writer OpenLDAP today; #845 is the future enabler of a genuinely per-directory-type recommendation.

## Testing

- TDD red -> green throughout; red-run evidence in commit messages/test output.
- `dotnet build JIM.sln`: 0 warnings. `dotnet test JIM.sln`: 3,397 passed, 0 failed (35 pre-existing integration-only skips).
- New tests: fast-path single-bulk-call, mixed-then-deferred, executable-beyond-deferred regression, 15 resolver/LDAP recommendation tests.

Docs updated in-branch: `docs/developer/architecture.md` (Export Parallelism resolution order and the multiplicative relationship), `docs/powershell/connected-systems.md` (`MaxExportParallelism` description). Changelog: one ⚡ and one 🔄 entry.

Closes #985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
