### PR TITLE
perf(import): batch CSO hydration, de-quadratic reconciliation and diff, binary COPY attribute inserts (#988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - ⚡ Exports no longer stall between batches at large scale. Batch collection now walks the Pending Export queue in a single pass (keyset pagination, backed by a new index) instead of rescanning it from the start for every batch; at 200,000 objects with 10,000 reference-bearing groups the old behaviour spent hours re-reading already-collected rows before the first group reached the target system.
-- ⚡ Full Imports at large scale are dramatically faster: matched objects are no longer hydrated one database round trip at a time, confirming a large group no longer degrades quadratically with its membership size, and bulk attribute value writes now stream via PostgreSQL binary COPY instead of parameterised inserts. A confirming Full Import of 210,000 objects that previously took around 42 minutes completes dramatically quicker.
+- ⚡ Full Imports at large scale are dramatically faster: matched objects are no longer hydrated one database round trip at a time, confirming a large group no longer degrades quadratically with its membership size, and bulk attribute value writes now stream via PostgreSQL binary COPY instead of parameterised inserts. A Full Import of 210,000 objects that previously took over 40 minutes now completes in around 8.
 - ⚡ Deprovisioning users who are members of large groups no longer slows synchronisation to a crawl. Updating or deleting a large group's pending changes no longer reloads the group's full membership from the database each time.
 
 ## [0.13.0] - 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - ⚡ Exports no longer stall between batches at large scale. Batch collection now walks the Pending Export queue in a single pass (keyset pagination, backed by a new index) instead of rescanning it from the start for every batch; at 200,000 objects with 10,000 reference-bearing groups the old behaviour spent hours re-reading already-collected rows before the first group reached the target system.
+- ⚡ Full Imports at large scale are dramatically faster: matched objects are no longer hydrated one database round trip at a time, confirming a large group no longer degrades quadratically with its membership size, and bulk attribute value writes now stream via PostgreSQL binary COPY instead of parameterised inserts. A confirming Full Import of 210,000 objects that previously took around 42 minutes completes dramatically quicker.
 
 ## [0.13.0] - 2026-07-10
 

--- a/src/JIM.Application/Servers/SyncEngine.Reconciliation.cs
+++ b/src/JIM.Application/Servers/SyncEngine.Reconciliation.cs
@@ -58,6 +58,18 @@ public partial class SyncEngine
             .GroupBy(av => av.AttributeId)
             .ToDictionary(g => g.Key, g => g.ToList());
 
+        // Build a per-attribute value index once per CSO (#988): a HashSet (or, for typed numeric/
+        // temporal/identifier data, a typed set) of comparison-ready values per attribute, built once
+        // from attrValuesByAttrId above. This turns the per-change membership test that ValueExistsOnCso
+        // used to do with List.Any() (O(n) per change - O(n²) for a large multi-valued attribute with
+        // many pending changes, e.g. a 200,000-member group) into an O(1) average-case set lookup.
+        var attrIndexByAttrId = new Dictionary<int, AttributeValueIndex>(attrValuesByAttrId.Count);
+        foreach (var (attributeId, values) in attrValuesByAttrId)
+        {
+            var attrType = values.Count > 0 ? values[0].Attribute?.Type ?? AttributeDataType.NotSet : AttributeDataType.NotSet;
+            attrIndexByAttrId[attributeId] = BuildAttributeValueIndex(attrType, values);
+        }
+
         // Process each attribute change that is awaiting confirmation
         var changesAwaitingConfirmation = pendingExport.AttributeValueChanges
             .Where(ac => ac.Status == PendingExportAttributeChangeStatus.ExportedPendingConfirmation ||
@@ -66,7 +78,7 @@ public partial class SyncEngine
 
         foreach (var attrChange in changesAwaitingConfirmation)
         {
-            var confirmed = IsAttributeChangeConfirmed(attrValuesByAttrId, attrChange);
+            var confirmed = IsAttributeChangeConfirmedFast(attrIndexByAttrId, attrChange);
 
             if (Log.IsEnabled(Serilog.Events.LogEventLevel.Verbose))
             {
@@ -114,9 +126,15 @@ public partial class SyncEngine
             }
         }
 
-        // Remove confirmed changes from the Pending Export
-        foreach (var confirmed in result.ConfirmedChanges)
-            pendingExport.AttributeValueChanges.Remove(confirmed);
+        // Remove confirmed changes from the Pending Export. A single RemoveAll against a HashSet of
+        // the confirmed changes (#988) replaces the previous per-change List.Remove loop, which was
+        // O(n) per removal (List.Remove does a linear search-and-shift) - O(n²) for a Pending Export
+        // with many confirmed changes, e.g. a large group's confirming import.
+        if (result.ConfirmedChanges.Count > 0)
+        {
+            var confirmedChangeIds = new HashSet<PendingExportAttributeValueChange>(result.ConfirmedChanges);
+            pendingExport.AttributeValueChanges.RemoveAll(ac => confirmedChangeIds.Contains(ac));
+        }
 
         // If this was a Create and the Secondary External ID was confirmed, transition to Update
         TransitionCreateToUpdateIfSecondaryExternalIdConfirmed(pendingExport, result);
@@ -245,6 +263,191 @@ public partial class SyncEngine
 
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Per-attribute value index (#988): a comparison-ready structure built once per CSO attribute
+    /// so <see cref="IsAttributeChangeConfirmedFast"/> does O(1) average-case set lookups instead of
+    /// the O(n) linear scans (<c>List.Any(...)</c>) that <see cref="ValueExistsOnCso"/> does. Exactly
+    /// one of the typed sets is populated, matching the attribute's data type.
+    /// </summary>
+    /// <remarks>
+    /// Number/LongNumber/Guid/Boolean/DateTime use typed sets (not stringified keys) so that set
+    /// membership is exactly the same comparison the original code performed (e.g. DateTime equality
+    /// via <c>Ticks</c>, which - like the <c>==</c> operator this replaces - ignores <see cref="DateTimeKind"/>;
+    /// stringifying with a round-trip format would incorrectly make Kind significant). Binary values are
+    /// not indexed: byte arrays do not hash usefully, and Binary attributes are never large multi-valued
+    /// sets in practice (they are typically a single profile picture, certificate, etc.), so the original
+    /// linear <c>SequenceEqual</c> scan is kept for them.
+    /// </remarks>
+    private sealed class AttributeValueIndex
+    {
+        public required int Count { get; init; }
+        public HashSet<string>? TextValues { get; init; }
+        public HashSet<string>? ReferenceValues { get; init; }
+        public HashSet<int>? NumberValues { get; init; }
+        public HashSet<long>? LongNumberValues { get; init; }
+        public HashSet<Guid>? GuidValues { get; init; }
+        public HashSet<bool>? BooleanValues { get; init; }
+        public HashSet<long>? DateTimeTicksValues { get; init; }
+        public List<ConnectedSystemObjectAttributeValue>? BinaryValues { get; init; }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="AttributeValueIndex"/> for one attribute's worth of CSO values (#988).
+    /// Key derivation mirrors <see cref="ValueExistsOnCso"/>'s switch exactly, per data type.
+    /// </summary>
+    private static AttributeValueIndex BuildAttributeValueIndex(AttributeDataType attrType, List<ConnectedSystemObjectAttributeValue> values)
+    {
+        return attrType switch
+        {
+            AttributeDataType.Text => new AttributeValueIndex
+            {
+                Count = values.Count,
+                TextValues = values.Where(v => v.StringValue != null).Select(v => v.StringValue!).ToHashSet(StringComparer.Ordinal)
+            },
+
+            AttributeDataType.Reference => new AttributeValueIndex
+            {
+                Count = values.Count,
+                // Both attrChange.UnresolvedReferenceValue and attrChange.StringValue are matched
+                // against the CSO's UnresolvedReferenceValue (see ValueExistsOnCso's Reference case),
+                // so a single index built from that one CSO-side field covers both probes.
+                ReferenceValues = values.Where(v => v.UnresolvedReferenceValue != null).Select(v => v.UnresolvedReferenceValue!).ToHashSet(StringComparer.Ordinal)
+            },
+
+            AttributeDataType.Number => new AttributeValueIndex
+            {
+                Count = values.Count,
+                NumberValues = values.Where(v => v.IntValue.HasValue).Select(v => v.IntValue!.Value).ToHashSet()
+            },
+
+            AttributeDataType.LongNumber => new AttributeValueIndex
+            {
+                Count = values.Count,
+                LongNumberValues = values.Where(v => v.LongValue.HasValue).Select(v => v.LongValue!.Value).ToHashSet()
+            },
+
+            AttributeDataType.Guid => new AttributeValueIndex
+            {
+                Count = values.Count,
+                GuidValues = values.Where(v => v.GuidValue.HasValue).Select(v => v.GuidValue!.Value).ToHashSet()
+            },
+
+            AttributeDataType.Boolean => new AttributeValueIndex
+            {
+                Count = values.Count,
+                BooleanValues = values.Where(v => v.BoolValue.HasValue).Select(v => v.BoolValue!.Value).ToHashSet()
+            },
+
+            AttributeDataType.DateTime => new AttributeValueIndex
+            {
+                Count = values.Count,
+                DateTimeTicksValues = values.Where(v => v.DateTimeValue.HasValue).Select(v => v.DateTimeValue!.Value.Ticks).ToHashSet()
+            },
+
+            // Binary: keep the existing linear SequenceEqual scan - byte arrays do not hash usefully,
+            // and Binary attributes are never large multi-valued sets in practice, so this is fine.
+            AttributeDataType.Binary => new AttributeValueIndex
+            {
+                Count = values.Count,
+                BinaryValues = values
+            },
+
+            _ => new AttributeValueIndex { Count = values.Count }
+        };
+    }
+
+    /// <summary>
+    /// Set-based equivalent of <see cref="ValueExistsOnCso"/> (#988): checks whether the Pending Export
+    /// attribute change's value exists in a pre-built <see cref="AttributeValueIndex"/>, mirroring
+    /// <see cref="ValueExistsOnCso"/>'s switch exactly per data type but via O(1) set lookups.
+    /// </summary>
+    private static bool ValueExistsInIndex(AttributeValueIndex index, PendingExportAttributeValueChange attrChange)
+    {
+        if (index.Count == 0)
+            return false;
+
+        var attrType = attrChange.Attribute?.Type ?? AttributeDataType.NotSet;
+
+        return attrType switch
+        {
+            AttributeDataType.Text =>
+                !string.IsNullOrEmpty(attrChange.StringValue) &&
+                (index.TextValues?.Contains(attrChange.StringValue) ?? false),
+
+            AttributeDataType.Number =>
+                attrChange.IntValue.HasValue &&
+                (index.NumberValues?.Contains(attrChange.IntValue.Value) ?? false),
+
+            AttributeDataType.LongNumber =>
+                attrChange.LongValue.HasValue &&
+                (index.LongNumberValues?.Contains(attrChange.LongValue.Value) ?? false),
+
+            AttributeDataType.DateTime =>
+                attrChange.DateTimeValue.HasValue &&
+                (index.DateTimeTicksValues?.Contains(attrChange.DateTimeValue.Value.Ticks) ?? false),
+
+            AttributeDataType.Binary =>
+                attrChange.ByteValue != null &&
+                (index.BinaryValues?.Any(v => v.ByteValue != null && v.ByteValue.SequenceEqual(attrChange.ByteValue)) ?? false),
+
+            AttributeDataType.Boolean =>
+                attrChange.BoolValue.HasValue &&
+                (index.BooleanValues?.Contains(attrChange.BoolValue.Value) ?? false),
+
+            AttributeDataType.Guid =>
+                attrChange.GuidValue.HasValue &&
+                (index.GuidValues?.Contains(attrChange.GuidValue.Value) ?? false),
+
+            AttributeDataType.Reference =>
+                (!string.IsNullOrEmpty(attrChange.UnresolvedReferenceValue) &&
+                 (index.ReferenceValues?.Contains(attrChange.UnresolvedReferenceValue) ?? false)) ||
+                (!string.IsNullOrEmpty(attrChange.StringValue) &&
+                 (index.ReferenceValues?.Contains(attrChange.StringValue) ?? false)),
+
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Set-based equivalent of <see cref="IsAttributeChangeConfirmed(Dictionary{int, List{ConnectedSystemObjectAttributeValue}}, PendingExportAttributeValueChange)"/>
+    /// (#988): determines if an attribute change has been confirmed using a pre-built per-attribute
+    /// value index instead of per-attribute value lists, so that <see cref="ReconcileCsoAgainstPendingExport"/>
+    /// does O(1) average-case lookups per change instead of O(n) scans. Semantics are identical to the
+    /// List-based overload; only the underlying comparison mechanism differs.
+    /// </summary>
+    private static bool IsAttributeChangeConfirmedFast(Dictionary<int, AttributeValueIndex> attrIndexByAttrId, PendingExportAttributeValueChange attrChange)
+    {
+        if (attrChange.Attribute == null)
+            return false;
+
+        attrIndexByAttrId.TryGetValue(attrChange.AttributeId, out var index);
+        var count = index?.Count ?? 0;
+
+        switch (attrChange.ChangeType)
+        {
+            case PendingExportAttributeChangeType.Add:
+            case PendingExportAttributeChangeType.Update:
+                // For Add/Update with a null/empty value (clearing a single-valued attribute),
+                // confirmation means the CSO should have no values for this attribute.
+                if (IsPendingChangeEmpty(attrChange))
+                    return count == 0;
+
+                // For Add/Update with a real value, the value should exist on the CSO
+                return index != null && ValueExistsInIndex(index, attrChange);
+
+            case PendingExportAttributeChangeType.Remove:
+                // For Remove, the value should NOT exist on the CSO
+                return !(index != null && ValueExistsInIndex(index, attrChange));
+
+            case PendingExportAttributeChangeType.RemoveAll:
+                // For RemoveAll, there should be no values for this attribute
+                return count == 0;
+
+            default:
+                return false;
+        }
     }
 
     /// <summary>

--- a/src/JIM.Application/Servers/SyncEngine.Reconciliation.cs
+++ b/src/JIM.Application/Servers/SyncEngine.Reconciliation.cs
@@ -283,6 +283,15 @@ public partial class SyncEngine
     private sealed class AttributeValueIndex
     {
         public required int Count { get; init; }
+
+        /// <summary>
+        /// The raw CSO values this index was built from (a reference copy of the caller's list,
+        /// no allocation cost). Kept on EVERY index so <see cref="ValueExistsInIndex"/> can fall
+        /// back to the original <see cref="ValueExistsOnCso"/> linear comparison whenever the
+        /// typed set a probe needs is missing; see the mismatch guard there for the scenario.
+        /// </summary>
+        public required List<ConnectedSystemObjectAttributeValue> RawValues { get; init; }
+
         public HashSet<string>? TextValues { get; init; }
         public HashSet<string>? ReferenceValues { get; init; }
         public HashSet<int>? NumberValues { get; init; }
@@ -304,12 +313,14 @@ public partial class SyncEngine
             AttributeDataType.Text => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 TextValues = values.Where(v => v.StringValue != null).Select(v => v.StringValue!).ToHashSet(StringComparer.Ordinal)
             },
 
             AttributeDataType.Reference => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 // Both attrChange.UnresolvedReferenceValue and attrChange.StringValue are matched
                 // against the CSO's UnresolvedReferenceValue (see ValueExistsOnCso's Reference case),
                 // so a single index built from that one CSO-side field covers both probes.
@@ -319,30 +330,35 @@ public partial class SyncEngine
             AttributeDataType.Number => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 NumberValues = values.Where(v => v.IntValue.HasValue).Select(v => v.IntValue!.Value).ToHashSet()
             },
 
             AttributeDataType.LongNumber => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 LongNumberValues = values.Where(v => v.LongValue.HasValue).Select(v => v.LongValue!.Value).ToHashSet()
             },
 
             AttributeDataType.Guid => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 GuidValues = values.Where(v => v.GuidValue.HasValue).Select(v => v.GuidValue!.Value).ToHashSet()
             },
 
             AttributeDataType.Boolean => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 BooleanValues = values.Where(v => v.BoolValue.HasValue).Select(v => v.BoolValue!.Value).ToHashSet()
             },
 
             AttributeDataType.DateTime => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 DateTimeTicksValues = values.Where(v => v.DateTimeValue.HasValue).Select(v => v.DateTimeValue!.Value.Ticks).ToHashSet()
             },
 
@@ -351,10 +367,11 @@ public partial class SyncEngine
             AttributeDataType.Binary => new AttributeValueIndex
             {
                 Count = values.Count,
+                RawValues = values,
                 BinaryValues = values
             },
 
-            _ => new AttributeValueIndex { Count = values.Count }
+            _ => new AttributeValueIndex { Count = values.Count, RawValues = values }
         };
     }
 
@@ -369,6 +386,34 @@ public partial class SyncEngine
             return false;
 
         var attrType = attrChange.Attribute?.Type ?? AttributeDataType.NotSet;
+
+        // Mismatch guard (belt and braces): the index's typed set is derived from the CSO values'
+        // OWN Attribute navigation type, while this probe uses the CHANGE's attribute type. If the
+        // value-side navigation was not loaded (Attribute null, so the index was built as NotSet
+        // with no typed sets despite Count > 0), or the two types genuinely disagree, the set this
+        // probe needs is null even though values exist. Silently probing a null set would report an
+        // actually-confirmed change as unconfirmed (false retries, then false export confirmation
+        // errors), so fall back to the original linear comparison, which switches on the change's
+        // type and compares raw value fields regardless of the value-side navigation - guaranteeing
+        // byte-identical behaviour with ValueExistsOnCso for every mismatch. The fast path below
+        // stays hot for the normal case where the index and probe types agree.
+        var typedSetAvailableForProbe = attrType switch
+        {
+            AttributeDataType.Text => index.TextValues != null,
+            AttributeDataType.Number => index.NumberValues != null,
+            AttributeDataType.LongNumber => index.LongNumberValues != null,
+            AttributeDataType.DateTime => index.DateTimeTicksValues != null,
+            AttributeDataType.Binary => index.BinaryValues != null,
+            AttributeDataType.Boolean => index.BooleanValues != null,
+            AttributeDataType.Guid => index.GuidValues != null,
+            AttributeDataType.Reference => index.ReferenceValues != null,
+            // NotSet and any future types: ValueExistsOnCso's default arm returns false, matching
+            // the fast switch's own default arm, so either route is equivalent; take the fallback
+            // for uniformity.
+            _ => false
+        };
+        if (!typedSetAvailableForProbe)
+            return ValueExistsOnCso(index.RawValues, attrChange);
 
         return attrType switch
         {

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -306,7 +306,7 @@ public class SyncRepository : ISyncRepository
         return Task.FromResult(result);
     }
 
-    public Task<List<ConnectedSystemObject>> GetConnectedSystemObjectsByIdsAsync(int connectedSystemId, IEnumerable<Guid> csoIds)
+    public virtual Task<List<ConnectedSystemObject>> GetConnectedSystemObjectsByIdsAsync(int connectedSystemId, IEnumerable<Guid> csoIds)
     {
         var idSet = new HashSet<Guid>(csoIds);
         var result = GetCsosForSystem(connectedSystemId)

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -508,14 +508,16 @@ public class SyncRepository : ISyncRepository
                 cso.AttributeValues.Add(addition);
             }
 
-            foreach (var removal in cso.PendingAttributeValueRemovals)
+            // Single pass over cso.AttributeValues (#988) instead of one RemoveAll/Remove scan per
+            // pending removal - the latter is O(removals x AttributeValues), quadratic for a large
+            // multi-valued attribute (e.g. a big group's next Full Import replacing membership).
+            if (cso.PendingAttributeValueRemovals.Count > 0)
             {
                 // Use reference equality when Id is Guid.Empty (newly created, not yet persisted).
                 // With EF Core, these objects have DB-generated IDs. In-memory, they remain empty.
-                if (removal.Id == Guid.Empty)
-                    cso.AttributeValues.Remove(removal);
-                else
-                    cso.AttributeValues.RemoveAll(av => av.Id == removal.Id);
+                var removalIds = new HashSet<Guid>(cso.PendingAttributeValueRemovals.Where(r => r.Id != Guid.Empty).Select(r => r.Id));
+                var removalRefs = new HashSet<ConnectedSystemObjectAttributeValue>(cso.PendingAttributeValueRemovals.Where(r => r.Id == Guid.Empty));
+                cso.AttributeValues.RemoveAll(av => (av.Id != Guid.Empty && removalIds.Contains(av.Id)) || removalRefs.Contains(av));
             }
 
             cso.PendingAttributeValueAdditions = new List<ConnectedSystemObjectAttributeValue>();

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -14,6 +14,7 @@ using JIM.Models.Transactional;
 using JIM.Models.Transactional.DTOs;
 using JIM.Models.Utility;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Serilog;
 using System.Diagnostics;
 namespace JIM.PostgresData.Repositories;
@@ -4914,43 +4915,85 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     }
 
     /// <summary>
-    /// Bulk inserts ConnectedSystemObjectAttributeValue rows using parameterised multi-row INSERT.
+    /// Bulk inserts ConnectedSystemObjectAttributeValue rows using Npgsql binary COPY (#988).
     /// Uses the parent CSO ID (shadow FK) passed explicitly since it's not a C# property.
     /// </summary>
+    /// <remarks>
+    /// Replaces the previous parameterised multi-row INSERT, which measured ~10k rows/sec effective
+    /// at scale (3.88M rows = ~246s on a 209,984-object confirming import). Binary COPY is typically
+    /// 5-10x faster for bulk row volumes like this. Mirrors
+    /// <see cref="SyncRepository.PersistRpeiCsoChangesAsync"/>'s COPY helpers
+    /// (<c>BulkInsertCsoChangeAttributeValuesRawAsync</c> in
+    /// <c>SyncRepository.RpeiOperations.cs</c>) exactly: same connection handling (COPY on the
+    /// underlying <see cref="NpgsqlConnection"/> participates in any ambient EF transaction
+    /// automatically, so callers that wrap this in a transaction need no changes), same column
+    /// ordering, same per-column <see cref="NpgsqlTypes.NpgsqlDbType"/> mapping and null handling.
+    /// The non-relational (EF InMemory provider) fallback path in
+    /// <see cref="UpdateConnectedSystemObjectsAsync"/> does not call this method and is untouched.
+    /// </remarks>
     private async Task BulkInsertCsoAttributeValuesRawAsync(List<(Guid CsoId, ConnectedSystemObjectAttributeValue Value)> attributeValues)
     {
-        const int columnsPerRow = 12;
-        var chunkSize = BulkSqlHelpers.MaxParametersPerStatement / columnsPerRow;
+        if (attributeValues.Count == 0)
+            return;
 
-        foreach (var chunk in BulkSqlHelpers.ChunkList(attributeValues, chunkSize))
+        var npgsqlConn = (NpgsqlConnection)Repository.Database.Database.GetDbConnection();
+        if (npgsqlConn.State != System.Data.ConnectionState.Open)
+            await npgsqlConn.OpenAsync();
+
+        await using var writer = await npgsqlConn.BeginBinaryImportAsync(
+            """
+            COPY "ConnectedSystemObjectAttributeValues" (
+                "Id", "ConnectedSystemObjectId", "AttributeId", "StringValue", "DateTimeValue",
+                "IntValue", "LongValue", "ByteValue", "GuidValue", "BoolValue",
+                "ReferenceValueId", "UnresolvedReferenceValue"
+            ) FROM STDIN (FORMAT binary)
+            """);
+
+        foreach (var (csoId, av) in attributeValues)
         {
-            var sql = new System.Text.StringBuilder();
-            sql.Append(@"INSERT INTO ""ConnectedSystemObjectAttributeValues"" (""Id"", ""ConnectedSystemObjectId"", ""AttributeId"", ""StringValue"", ""DateTimeValue"", ""IntValue"", ""LongValue"", ""ByteValue"", ""GuidValue"", ""BoolValue"", ""ReferenceValueId"", ""UnresolvedReferenceValue"") VALUES ");
-
-            var parameters = new List<object>();
-            for (var i = 0; i < chunk.Count; i++)
-            {
-                if (i > 0) sql.Append(", ");
-                var offset = i * columnsPerRow;
-                sql.Append($"({{{offset}}}, {{{offset + 1}}}, {{{offset + 2}}}, {{{offset + 3}}}, {{{offset + 4}}}, {{{offset + 5}}}, {{{offset + 6}}}, {{{offset + 7}}}, {{{offset + 8}}}, {{{offset + 9}}}, {{{offset + 10}}}, {{{offset + 11}}})");
-
-                var (csoId, av) = chunk[i];
-                parameters.Add(av.Id);
-                parameters.Add(csoId);
-                parameters.Add(av.AttributeId);
-                parameters.Add(BulkSqlHelpers.NullableParam(av.StringValue, NpgsqlTypes.NpgsqlDbType.Text));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.DateTimeValue, NpgsqlTypes.NpgsqlDbType.TimestampTz));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.IntValue, NpgsqlTypes.NpgsqlDbType.Integer));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.LongValue, NpgsqlTypes.NpgsqlDbType.Bigint));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.ByteValue, NpgsqlTypes.NpgsqlDbType.Bytea));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.GuidValue, NpgsqlTypes.NpgsqlDbType.Uuid));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.BoolValue, NpgsqlTypes.NpgsqlDbType.Boolean));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.ReferenceValueId, NpgsqlTypes.NpgsqlDbType.Uuid));
-                parameters.Add(BulkSqlHelpers.NullableParam(av.UnresolvedReferenceValue, NpgsqlTypes.NpgsqlDbType.Text));
-            }
-
-            await Repository.Database.Database.ExecuteSqlRawAsync(sql.ToString(), parameters.ToArray());
+            await writer.StartRowAsync();
+            await writer.WriteAsync(av.Id, NpgsqlTypes.NpgsqlDbType.Uuid);
+            await writer.WriteAsync(csoId, NpgsqlTypes.NpgsqlDbType.Uuid);
+            await writer.WriteAsync(av.AttributeId, NpgsqlTypes.NpgsqlDbType.Integer);
+            if (av.StringValue is not null)
+                await writer.WriteAsync(av.StringValue, NpgsqlTypes.NpgsqlDbType.Text);
+            else
+                await writer.WriteNullAsync();
+            if (av.DateTimeValue.HasValue)
+                await writer.WriteAsync(av.DateTimeValue.Value, NpgsqlTypes.NpgsqlDbType.TimestampTz);
+            else
+                await writer.WriteNullAsync();
+            if (av.IntValue.HasValue)
+                await writer.WriteAsync(av.IntValue.Value, NpgsqlTypes.NpgsqlDbType.Integer);
+            else
+                await writer.WriteNullAsync();
+            if (av.LongValue.HasValue)
+                await writer.WriteAsync(av.LongValue.Value, NpgsqlTypes.NpgsqlDbType.Bigint);
+            else
+                await writer.WriteNullAsync();
+            if (av.ByteValue is not null)
+                await writer.WriteAsync(av.ByteValue, NpgsqlTypes.NpgsqlDbType.Bytea);
+            else
+                await writer.WriteNullAsync();
+            if (av.GuidValue.HasValue)
+                await writer.WriteAsync(av.GuidValue.Value, NpgsqlTypes.NpgsqlDbType.Uuid);
+            else
+                await writer.WriteNullAsync();
+            if (av.BoolValue.HasValue)
+                await writer.WriteAsync(av.BoolValue.Value, NpgsqlTypes.NpgsqlDbType.Boolean);
+            else
+                await writer.WriteNullAsync();
+            if (av.ReferenceValueId.HasValue)
+                await writer.WriteAsync(av.ReferenceValueId.Value, NpgsqlTypes.NpgsqlDbType.Uuid);
+            else
+                await writer.WriteNullAsync();
+            if (av.UnresolvedReferenceValue is not null)
+                await writer.WriteAsync(av.UnresolvedReferenceValue, NpgsqlTypes.NpgsqlDbType.Text);
+            else
+                await writer.WriteNullAsync();
         }
+
+        await writer.CompleteAsync();
     }
 
     /// <summary>

--- a/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
@@ -1079,10 +1079,91 @@ public class SyncImportTaskProcessor
         }
     }
 
+    /// <summary>
+    /// Maximum number of CSO IDs to hydrate in a single <see cref="ISyncRepository.GetConnectedSystemObjectsByIdsAsync"/>
+    /// call. Chunking keeps individual queries (and their parameter counts) bounded at very large page sizes.
+    /// </summary>
+    private const int CsoHydrationChunkSize = 1000;
+
+    /// <summary>
+    /// Pre-fetch phase (#988): resolves every import object in this page to a candidate CSO ID via the
+    /// existing <see cref="LookupCsoByExternalId"/> dictionary lookup, then hydrates all distinct matched
+    /// IDs with a small, bounded number of batch queries (chunked at <see cref="CsoHydrationChunkSize"/>)
+    /// instead of one query per object. This eliminates the N+1 that remained after #440's lookup-only fix.
+    /// </summary>
+    /// <returns>A dictionary of hydrated CSOs, keyed by ID, for use by the per-object processing loop.</returns>
+    private async Task<Dictionary<Guid, ConnectedSystemObject>> HydrateCsoPageAsync(ConnectedSystemImportResult connectedSystemImportResult)
+    {
+        var hydratedCsoPage = new Dictionary<Guid, ConnectedSystemObject>();
+
+        // Nothing to pre-fetch on a first-ever import (_csIsEmpty) - every object is new by definition.
+        if (_csIsEmpty || _connectedSystem.ObjectTypes == null)
+            return hydratedCsoPage;
+
+        var pageObjectCount = connectedSystemImportResult.ImportObjects.Count;
+        using var span = Diagnostics.Sync.StartSpan("HydrateCsoPage").SetTag("pageObjectCount", pageObjectCount);
+
+        var csoIdsToHydrate = new HashSet<Guid>();
+        foreach (var importObject in connectedSystemImportResult.ImportObjects)
+        {
+            if (string.IsNullOrEmpty(importObject.ObjectType))
+                continue;
+
+            var csObjectType = _connectedSystem.ObjectTypes.SingleOrDefault(q => q.Name.Equals(importObject.ObjectType, StringComparison.OrdinalIgnoreCase));
+            if (csObjectType == null || !csObjectType.Attributes.Any(a => a.IsExternalId))
+                continue;
+
+            // Malformed import objects (missing/multi-valued/empty External Id attribute) are swallowed
+            // here and left for the per-object loop to raise properly via its own RPEI error handling;
+            // this pre-fetch pass only cares about collecting candidate IDs to hydrate in bulk.
+            Guid? csoId;
+            try
+            {
+                csoId = LookupCsoByExternalId(importObject, csObjectType);
+            }
+            catch (MissingExternalIdAttributeException)
+            {
+                continue;
+            }
+            catch (ExternalIdAttributeNotSingleValuedException)
+            {
+                continue;
+            }
+            catch (ExternalIdAttributeValueMissingException)
+            {
+                continue;
+            }
+            catch (InvalidDataException)
+            {
+                continue;
+            }
+
+            if (csoId.HasValue)
+                csoIdsToHydrate.Add(csoId.Value);
+        }
+
+        if (csoIdsToHydrate.Count > 0)
+        {
+            foreach (var chunk in csoIdsToHydrate.Chunk(CsoHydrationChunkSize))
+            {
+                var csos = await _syncRepo.GetConnectedSystemObjectsByIdsAsync(_connectedSystem.Id, chunk);
+                foreach (var cso in csos)
+                    hydratedCsoPage[cso.Id] = cso;
+            }
+        }
+
+        span.SetTag("hydratedCsoCount", hydratedCsoPage.Count);
+        return hydratedCsoPage;
+    }
+
     private async Task ProcessImportObjectsAsync(ConnectedSystemImportResult connectedSystemImportResult, ICollection<ConnectedSystemObject> connectedSystemObjectsToBeCreated, ICollection<ConnectedSystemObject> connectedSystemObjectsToBeUpdated, HashSet<string>? crossPageSeenExternalIds = null)
     {
         if (_connectedSystem.ObjectTypes == null)
             throw new InvalidDataException("ProcessImportObjectsAsync: _connectedSystem.ObjectTypes was null. Cannot continue.");
+
+        // Batch-hydrate this page's matched CSOs in one pass (#988), instead of relying on
+        // per-object hydration inside the loop below.
+        var hydratedCsoPage = await HydrateCsoPageAsync(connectedSystemImportResult);
 
         // Track external IDs seen in THIS batch to detect same-batch duplicates.
         // Key: "objectTypeId:externalIdValue" (composite key to handle multiple object types)
@@ -1265,7 +1346,7 @@ public class SyncImportTaskProcessor
                 ConnectedSystemObject? connectedSystemObject;
                 using (Diagnostics.Sync.StartSpan("FindMatchingCso"))
                 {
-                    connectedSystemObject = await TryAndFindMatchingConnectedSystemObjectAsync(importObject, csObjectType);
+                    connectedSystemObject = await TryAndFindMatchingConnectedSystemObjectAsync(importObject, csObjectType, hydratedCsoPage);
                 }
 
                 // Handle delete requests from delta imports (e.g., LDAP changelog)
@@ -1601,19 +1682,17 @@ public class SyncImportTaskProcessor
     }
 
     /// <summary>
-    /// Hydration phase: Loads a full CSO entity graph by ID with all includes needed for attribute
-    /// diffing during import processing. This is a single PK-based query with includes — much cheaper
-    /// than the previous attribute-value-based search query with LOWER() string comparison.
+    /// Hydration phase: Looks up the full CSO entity graph from the page's pre-fetched hydration
+    /// dictionary (see <see cref="HydrateCsoPageAsync"/>), which was populated with all includes needed
+    /// for attribute diffing during import processing via a small number of batch queries (#988).
     /// Falls back to secondary external ID lookup for PendingProvisioning CSOs not found in the dictionary.
     /// </summary>
-    private async Task<ConnectedSystemObject?> HydrateCsoAsync(Guid? csoId, ConnectedSystemImportObject connectedSystemImportObject, ConnectedSystemObjectType connectedSystemObjectType)
+    private async Task<ConnectedSystemObject?> HydrateCsoAsync(Guid? csoId, ConnectedSystemImportObject connectedSystemImportObject, ConnectedSystemObjectType connectedSystemObjectType, IReadOnlyDictionary<Guid, ConnectedSystemObject> hydratedCsoPage)
     {
-        // If lookup found a match, hydrate the full entity by ID
+        // If lookup found a match, retrieve the full entity from the page's pre-fetched hydration dictionary
         if (csoId.HasValue)
         {
-            var csos = await _syncRepo.GetConnectedSystemObjectsByIdsAsync(_connectedSystem.Id, new[] { csoId.Value });
-            var cso = csos.FirstOrDefault();
-            if (cso != null)
+            if (hydratedCsoPage.TryGetValue(csoId.Value, out var cso))
                 return cso;
 
             // Cache had the ID but the CSO no longer exists (deleted between pre-fetch and hydrate).
@@ -1656,13 +1735,15 @@ public class SyncImportTaskProcessor
     /// <summary>
     /// Combined Lookup + Hydrate: finds a matching CSO for an imported object.
     /// Phase 1 (Lookup): O(1) dictionary lookup using the pre-fetched external ID mappings.
-    /// Phase 2 (Hydrate): Loads the full CSO entity graph by ID for attribute diffing.
-    /// This replaces the previous per-object attribute-value-based search queries (#440).
+    /// Phase 2 (Hydrate): Looks up the full CSO entity graph from the page's pre-fetched hydration
+    /// dictionary (batch-loaded once per page, see <see cref="HydrateCsoPageAsync"/>) for attribute diffing.
+    /// This replaces the previous per-object attribute-value-based search queries (#440) and,
+    /// subsequently, the per-object hydration query that remained after that fix (#988).
     /// </summary>
-    private async Task<ConnectedSystemObject?> TryAndFindMatchingConnectedSystemObjectAsync(ConnectedSystemImportObject connectedSystemImportObject, ConnectedSystemObjectType connectedSystemObjectType)
+    private async Task<ConnectedSystemObject?> TryAndFindMatchingConnectedSystemObjectAsync(ConnectedSystemImportObject connectedSystemImportObject, ConnectedSystemObjectType connectedSystemObjectType, IReadOnlyDictionary<Guid, ConnectedSystemObject> hydratedCsoPage)
     {
         var csoId = LookupCsoByExternalId(connectedSystemImportObject, connectedSystemObjectType);
-        return await HydrateCsoAsync(csoId, connectedSystemImportObject, connectedSystemObjectType);
+        return await HydrateCsoAsync(csoId, connectedSystemImportObject, connectedSystemObjectType, hydratedCsoPage);
     }
 
     private ConnectedSystemObject? CreateConnectedSystemObjectFromImportObject(ConnectedSystemImportObject connectedSystemImportObject, ConnectedSystemObjectType connectedSystemObjectType, ActivityRunProfileExecutionItem activityRunProfileExecutionItem)

--- a/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
@@ -1103,23 +1103,25 @@ public class SyncImportTaskProcessor
         var pageObjectCount = connectedSystemImportResult.ImportObjects.Count;
         using var span = Diagnostics.Sync.StartSpan("HydrateCsoPage").SetTag("pageObjectCount", pageObjectCount);
 
+        // Only import objects with a resolvable object type that carries an External Id attribute
+        // are candidates for hydration; project the resolved type alongside so the loop below does
+        // not repeat the lookup.
+        var hydrationCandidates = connectedSystemImportResult.ImportObjects
+            .Where(io => !string.IsNullOrEmpty(io.ObjectType))
+            .Select(io => (ImportObject: io, ObjectType: _connectedSystem.ObjectTypes.SingleOrDefault(
+                t => t.Name.Equals(io.ObjectType, StringComparison.OrdinalIgnoreCase))))
+            .Where(pair => pair.ObjectType != null && pair.ObjectType.Attributes.Any(a => a.IsExternalId));
+
         var csoIdsToHydrate = new HashSet<Guid>();
-        foreach (var importObject in connectedSystemImportResult.ImportObjects)
+        foreach (var (importObject, csObjectType) in hydrationCandidates)
         {
-            if (string.IsNullOrEmpty(importObject.ObjectType))
-                continue;
-
-            var csObjectType = _connectedSystem.ObjectTypes.SingleOrDefault(q => q.Name.Equals(importObject.ObjectType, StringComparison.OrdinalIgnoreCase));
-            if (csObjectType == null || !csObjectType.Attributes.Any(a => a.IsExternalId))
-                continue;
-
             // Malformed import objects (missing/multi-valued/empty External Id attribute) are swallowed
             // here and left for the per-object loop to raise properly via its own RPEI error handling;
             // this pre-fetch pass only cares about collecting candidate IDs to hydrate in bulk.
             Guid? csoId;
             try
             {
-                csoId = LookupCsoByExternalId(importObject, csObjectType);
+                csoId = LookupCsoByExternalId(importObject, csObjectType!);
             }
             catch (MissingExternalIdAttributeException)
             {

--- a/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
@@ -1945,37 +1945,64 @@ public class SyncImportTaskProcessor
                 switch (csoAttribute.Type)
                 {
                     case AttributeDataType.Text:
+                    {
+                        // Value sets built once per attribute (#988): replaces nested O(cso*import)
+                        // List.Any() scans with O(1) average-case set membership tests. Comparison
+                        // stays case-SENSITIVE Ordinal, exactly matching the original string.Equals(sv).
+                        var csoStringAttrValues = connectedSystemObject.AttributeValues
+                            .Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.StringValue != null)
+                            .ToList();
+                        var importStringSet = new HashSet<string>(importedObjectAttribute.StringValues, StringComparer.Ordinal);
+
                         // find values on the cso of type string that aren't on the imported object and remove them first
-                        var missingStringAttributeValues = connectedSystemObject.AttributeValues.Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.StringValue != null && !importedObjectAttribute.StringValues.Any(i => i.Equals(av.StringValue))).ToList();
+                        var missingStringAttributeValues = csoStringAttrValues.Where(av => !importStringSet.Contains(av.StringValue!)).ToList();
                         connectedSystemObject.PendingAttributeValueRemovals.AddRange(missingStringAttributeValues);
 
                         // find imported values of type string that aren't on the cso and add them
-                        var newStringValues = importedObjectAttribute.StringValues.Where(sv => !connectedSystemObject.AttributeValues.Any(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.StringValue != null && av.StringValue.Equals(sv))).ToList();
+                        var csoStringSet = csoStringAttrValues.Select(av => av.StringValue!).ToHashSet(StringComparer.Ordinal);
+                        var newStringValues = importedObjectAttribute.StringValues.Where(sv => !csoStringSet.Contains(sv)).ToList();
                         foreach (var newStringValue in newStringValues)
                             connectedSystemObject.PendingAttributeValueAdditions.Add(new ConnectedSystemObjectAttributeValue { ConnectedSystemObject = connectedSystemObject, Attribute = csoAttribute, StringValue = newStringValue });
                         break;
+                    }
 
                     case AttributeDataType.Number:
+                    {
+                        var csoIntAttrValues = connectedSystemObject.AttributeValues
+                            .Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.IntValue != null)
+                            .ToList();
+                        var importIntSet = new HashSet<int>(importedObjectAttribute.IntValues);
+
                         // find values on the cso of type int that aren't on the imported object and remove them first
-                        var missingIntAttributeValues = connectedSystemObject.AttributeValues.Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.IntValue != null && !importedObjectAttribute.IntValues.Any(i => i.Equals(av.IntValue))).ToList();
+                        var missingIntAttributeValues = csoIntAttrValues.Where(av => !importIntSet.Contains(av.IntValue!.Value)).ToList();
                         connectedSystemObject.PendingAttributeValueRemovals.AddRange(missingIntAttributeValues);
 
                         // find imported values of type int that aren't on the cso and add them
-                        var newIntValues = importedObjectAttribute.IntValues.Where(sv => !connectedSystemObject.AttributeValues.Any(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.IntValue != null && av.IntValue.Equals(sv))).ToList();
+                        var csoIntSet = csoIntAttrValues.Select(av => av.IntValue!.Value).ToHashSet();
+                        var newIntValues = importedObjectAttribute.IntValues.Where(sv => !csoIntSet.Contains(sv)).ToList();
                         foreach (var newIntValue in newIntValues)
                             connectedSystemObject.PendingAttributeValueAdditions.Add(new ConnectedSystemObjectAttributeValue { ConnectedSystemObject = connectedSystemObject, Attribute = csoAttribute, IntValue = newIntValue });
                         break;
+                    }
 
                     case AttributeDataType.LongNumber:
+                    {
+                        var csoLongAttrValues = connectedSystemObject.AttributeValues
+                            .Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.LongValue != null)
+                            .ToList();
+                        var importLongSet = new HashSet<long>(importedObjectAttribute.LongValues);
+
                         // find values on the cso of type long that aren't on the imported object and remove them first
-                        var missingLongAttributeValues = connectedSystemObject.AttributeValues.Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.LongValue != null && !importedObjectAttribute.LongValues.Any(i => i.Equals(av.LongValue))).ToList();
+                        var missingLongAttributeValues = csoLongAttrValues.Where(av => !importLongSet.Contains(av.LongValue!.Value)).ToList();
                         connectedSystemObject.PendingAttributeValueRemovals.AddRange(missingLongAttributeValues);
 
                         // find imported values of type long that aren't on the cso and add them
-                        var newLongValues = importedObjectAttribute.LongValues.Where(sv => !connectedSystemObject.AttributeValues.Any(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.LongValue != null && av.LongValue.Equals(sv))).ToList();
+                        var csoLongSet = csoLongAttrValues.Select(av => av.LongValue!.Value).ToHashSet();
+                        var newLongValues = importedObjectAttribute.LongValues.Where(sv => !csoLongSet.Contains(sv)).ToList();
                         foreach (var newLongValue in newLongValues)
                             connectedSystemObject.PendingAttributeValueAdditions.Add(new ConnectedSystemObjectAttributeValue { ConnectedSystemObject = connectedSystemObject, Attribute = csoAttribute, LongValue = newLongValue });
                         break;
+                    }
 
                     case AttributeDataType.DateTime:
                         // date time attribute types can only be single-valued by nature. handle differently to multivalued attribute types.
@@ -2031,16 +2058,22 @@ public class SyncImportTaskProcessor
                                 refCsoId, unresolved);
                         }
 
-                        // Helper: Check if an import reference string matches an existing CSO attribute value.
-                        // This handles both unresolved references and resolved references. Persisted resolved
-                        // references match via refExtIdLookup (built by GetReferenceExternalIdsAsync): hydration
-                        // deliberately does not materialise ReferenceValue navigations (#917), so the navigation
-                        // branch below only fires for values resolved in-memory earlier in this run.
-                        static bool ImportRefMatchesCsoValue(string importRef, ConnectedSystemObjectAttributeValue av, IReadOnlyDictionary<Guid, string>? refExtIdLookup)
+                        // Helper: Check if an import reference string matches an existing CSO attribute value,
+                        // against pre-built sets of the import's reference values (#988) rather than scanning
+                        // the import list per CSO value. This handles both unresolved references and resolved
+                        // references. Persisted resolved references match via refExtIdLookup (built by
+                        // GetReferenceExternalIdsAsync): hydration deliberately does not materialise
+                        // ReferenceValue navigations (#917), so the navigation branch below only fires for
+                        // values resolved in-memory earlier in this run.
+                        static bool CsoValueMatchesAnyImportRef(
+                            ConnectedSystemObjectAttributeValue av,
+                            IReadOnlyDictionary<Guid, string>? refExtIdLookup,
+                            HashSet<string> importRefsOrdinal,
+                            HashSet<string> importRefsIgnoreCase)
                         {
                             // Check unresolved reference (case-sensitive to preserve data fidelity)
                             if (av.UnresolvedReferenceValue != null &&
-                                av.UnresolvedReferenceValue.Equals(importRef, StringComparison.Ordinal))
+                                importRefsOrdinal.Contains(av.UnresolvedReferenceValue))
                                 return true;
 
                             // Check resolved reference - compare against the referenced CSO's external ID
@@ -2051,8 +2084,7 @@ public class SyncImportTaskProcessor
                                 var refExternalId = av.ReferenceValue.SecondaryExternalIdAttributeValue?.StringValue
                                                  ?? av.ReferenceValue.ExternalIdAttributeValue?.StringValue;
                                 // Use case-insensitive comparison for DNs since case may vary
-                                if (refExternalId != null &&
-                                    refExternalId.Equals(importRef, StringComparison.OrdinalIgnoreCase))
+                                if (refExternalId != null && importRefsIgnoreCase.Contains(refExternalId))
                                     return true;
                             }
 
@@ -2061,22 +2093,53 @@ public class SyncImportTaskProcessor
                             if (av.ReferenceValueId.HasValue &&
                                 refExtIdLookup != null &&
                                 refExtIdLookup.TryGetValue(av.ReferenceValueId.Value, out var fallbackExternalId) &&
-                                fallbackExternalId.Equals(importRef, StringComparison.OrdinalIgnoreCase))
+                                importRefsIgnoreCase.Contains(fallbackExternalId))
                                 return true;
 
                             return false;
                         }
 
+                        // Value sets built once per attribute (#988): two comparers mirror the original dual
+                        // case-sensitivity exactly (Ordinal for unresolved refs, OrdinalIgnoreCase for resolved
+                        // refs via either the in-memory navigation or the persisted lookup dictionary).
+                        var importRefsOrdinalSet = new HashSet<string>(importedObjectAttribute.ReferenceValues, StringComparer.Ordinal);
+                        var importRefsIgnoreCaseSet = new HashSet<string>(importedObjectAttribute.ReferenceValues, StringComparer.OrdinalIgnoreCase);
+
                         // Find CSO reference values that aren't in the import - mark for removal
                         var missingReferenceValues = csoRefAttrValues
                             .Where(av => (av.UnresolvedReferenceValue != null || av.ReferenceValue != null || av.ReferenceValueId.HasValue) &&
-                                        !importedObjectAttribute.ReferenceValues.Any(importRef => ImportRefMatchesCsoValue(importRef, av, referenceExternalIdLookup)))
+                                        !CsoValueMatchesAnyImportRef(av, referenceExternalIdLookup, importRefsOrdinalSet, importRefsIgnoreCaseSet))
                             .ToList();
                         connectedSystemObject.PendingAttributeValueRemovals.AddRange(missingReferenceValues);
 
+                        // CSO-side sets built once per attribute, for the reverse (addition) direction:
+                        // does any CSO value match a given import reference? Both resolution paths (in-memory
+                        // navigation and persisted lookup dictionary) feed the SAME case-insensitive set,
+                        // since either one matching is sufficient - exactly as the original || chain allowed.
+                        var csoUnresolvedRefSet = csoRefAttrValues
+                            .Where(av => av.UnresolvedReferenceValue != null)
+                            .Select(av => av.UnresolvedReferenceValue!)
+                            .ToHashSet(StringComparer.Ordinal);
+                        var csoResolvedRefExternalIdSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var av in csoRefAttrValues)
+                        {
+                            if (av.ReferenceValue != null)
+                            {
+                                var navExternalId = av.ReferenceValue.SecondaryExternalIdAttributeValue?.StringValue
+                                                 ?? av.ReferenceValue.ExternalIdAttributeValue?.StringValue;
+                                if (navExternalId != null)
+                                    csoResolvedRefExternalIdSet.Add(navExternalId);
+                            }
+
+                            if (av.ReferenceValueId.HasValue &&
+                                referenceExternalIdLookup != null &&
+                                referenceExternalIdLookup.TryGetValue(av.ReferenceValueId.Value, out var fallbackExternalId))
+                                csoResolvedRefExternalIdSet.Add(fallbackExternalId);
+                        }
+
                         // Find imported reference values that aren't on the CSO - mark for addition
                         var newReferenceValues = importedObjectAttribute.ReferenceValues
-                            .Where(importRef => !csoRefAttrValues.Any(av => ImportRefMatchesCsoValue(importRef, av, referenceExternalIdLookup)))
+                            .Where(importRef => !csoUnresolvedRefSet.Contains(importRef) && !csoResolvedRefExternalIdSet.Contains(importRef))
                             .ToList();
 
                         // Resolved references are matched via the SQL dictionary by design (#917):
@@ -2108,15 +2171,23 @@ public class SyncImportTaskProcessor
                         break;
 
                     case AttributeDataType.Guid:
+                    {
+                        var csoGuidAttrValues = connectedSystemObject.AttributeValues
+                            .Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.GuidValue != null)
+                            .ToList();
+                        var importGuidSet = new HashSet<Guid>(importedObjectAttribute.GuidValues);
+
                         // find values on the cso of type Guid that aren't on the imported object and remove them first
-                        var missingGuidAttributeValues = connectedSystemObject.AttributeValues.Where(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.GuidValue != null && !importedObjectAttribute.GuidValues.Any(i => i.Equals(av.GuidValue))).ToList();
+                        var missingGuidAttributeValues = csoGuidAttrValues.Where(av => !importGuidSet.Contains(av.GuidValue!.Value)).ToList();
                         connectedSystemObject.PendingAttributeValueRemovals.AddRange(missingGuidAttributeValues);
 
                         // find imported values of type Guid that aren't on the cso and add them
-                        var newGuidValues = importedObjectAttribute.GuidValues.Where(sv => !connectedSystemObject.AttributeValues.Any(av => (av.AttributeId != 0 ? av.AttributeId : av.Attribute?.Id) == csoAttribute.Id && av.GuidValue != null && av.GuidValue.Equals(sv))).ToList();
+                        var csoGuidSet = csoGuidAttrValues.Select(av => av.GuidValue!.Value).ToHashSet();
+                        var newGuidValues = importedObjectAttribute.GuidValues.Where(sv => !csoGuidSet.Contains(sv)).ToList();
                         foreach (var newGuidValue in newGuidValues)
                             connectedSystemObject.PendingAttributeValueAdditions.Add(new ConnectedSystemObjectAttributeValue { ConnectedSystemObject = connectedSystemObject, Attribute = csoAttribute, GuidValue = newGuidValue });
                         break;
+                    }
 
                     case AttributeDataType.Boolean:
                         // there will be only a single value for a bool. is it the same or different?

--- a/test/JIM.Worker.Tests/SyncEngineTests/SyncEngineReconciliationTests.cs
+++ b/test/JIM.Worker.Tests/SyncEngineTests/SyncEngineReconciliationTests.cs
@@ -564,7 +564,7 @@ public class SyncEngineReconciliationTests
 
     #endregion
 
-    #region ReconcileCsoAgainstPendingExport — per data type, via full orchestration (issue #988 pin)
+    #region ReconcileCsoAgainstPendingExport: per data type, via full orchestration (issue #988 pin)
     //
     // These pin ReconcileCsoAgainstPendingExport's behaviour per data type and change type directly
     // (rather than via the single-CSO IsAttributeChangeConfirmed convenience overload above), because

--- a/test/JIM.Worker.Tests/SyncEngineTests/SyncEngineReconciliationTests.cs
+++ b/test/JIM.Worker.Tests/SyncEngineTests/SyncEngineReconciliationTests.cs
@@ -564,6 +564,369 @@ public class SyncEngineReconciliationTests
 
     #endregion
 
+    #region ReconcileCsoAgainstPendingExport — per data type, via full orchestration (issue #988 pin)
+    //
+    // These pin ReconcileCsoAgainstPendingExport's behaviour per data type and change type directly
+    // (rather than via the single-CSO IsAttributeChangeConfirmed convenience overload above), because
+    // this is the method issue #988 refactors to use a per-attribute value index instead of repeated
+    // List.Any() scans. Written before the refactor to confirm the refactor changes nothing observable.
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_NumberAdd_Confirmed_MarksForDeletion()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Number, intValue: 42);
+        var attrChange = CreateAttrChange(1, AttributeDataType.Number, PendingExportAttributeChangeType.Add, intValue: 42);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+        Assert.That(result.ConfirmedChanges, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_NumberAdd_Unconfirmed_MarksForRetry()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Number, intValue: 1);
+        var attrChange = CreateAttrChange(1, AttributeDataType.Number, PendingExportAttributeChangeType.Add, intValue: 42);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.RetryChanges, Has.Count.EqualTo(1));
+        Assert.That(result.ConfirmedChanges, Is.Empty);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_LongNumberAdd_Confirmed_MarksForDeletion()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.LongNumber, longValue: 9999999999L);
+        var attrChange = CreateAttrChange(1, AttributeDataType.LongNumber, PendingExportAttributeChangeType.Add, longValue: 9999999999L);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_DateTimeAdd_Confirmed_MarksForDeletion()
+    {
+        var dt = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.DateTime, dateTimeValue: dt);
+        var attrChange = CreateAttrChange(1, AttributeDataType.DateTime, PendingExportAttributeChangeType.Add, dateTimeValue: dt);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_GuidAdd_Confirmed_MarksForDeletion()
+    {
+        var guid = Guid.NewGuid();
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Guid, guidValue: guid);
+        var attrChange = CreateAttrChange(1, AttributeDataType.Guid, PendingExportAttributeChangeType.Add, guidValue: guid);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_BinaryAdd_Confirmed_MarksForDeletion()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Binary, byteValue: [0x01, 0x02, 0x03]);
+        var attrChange = CreateAttrChange(1, AttributeDataType.Binary, PendingExportAttributeChangeType.Add, byteValue: [0x01, 0x02, 0x03]);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_BinaryAdd_Unconfirmed_MarksForRetry()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Binary, byteValue: [0x09, 0x09]);
+        var attrChange = CreateAttrChange(1, AttributeDataType.Binary, PendingExportAttributeChangeType.Add, byteValue: [0x01, 0x02, 0x03]);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.RetryChanges, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_ReferenceAdd_ViaUnresolvedReferenceValue_MarksForDeletion()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Reference, unresolvedReferenceValue: "CN=User1,DC=test");
+        var attrChange = CreateAttrChange(1, AttributeDataType.Reference, PendingExportAttributeChangeType.Add, unresolvedReferenceValue: "CN=User1,DC=test");
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_ReferenceAdd_ViaStringValueMatchingUnresolved_MarksForDeletion()
+    {
+        // Export resolution clears UnresolvedReferenceValue and sets StringValue instead; the CSO's
+        // UnresolvedReferenceValue must still be matched against the change's StringValue.
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Reference, unresolvedReferenceValue: "CN=User1,DC=test");
+        var attrChange = CreateAttrChange(1, AttributeDataType.Reference, PendingExportAttributeChangeType.Add, stringValue: "CN=User1,DC=test");
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_TextRemove_ValueAbsent_Confirmed_MarksForDeletion()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Text, stringValue: "other");
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.Remove, stringValue: "removed");
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+        Assert.That(result.ConfirmedChanges, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_TextRemove_ValueStillPresent_Unconfirmed_MarksForRetry()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Text, stringValue: "stillhere");
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.Remove, stringValue: "stillhere");
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.RetryChanges, Has.Count.EqualTo(1));
+        Assert.That(result.ConfirmedChanges, Is.Empty);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_RemoveAll_NoValuesLeft_Confirmed_MarksForDeletion()
+    {
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.RemoveAll);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_RemoveAll_ValuesStillExist_Unconfirmed_MarksForRetry()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Text, stringValue: "still");
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.RemoveAll);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.RetryChanges, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_UpdateEmptyValue_NoCsoValues_Confirmed_MarksForDeletion()
+    {
+        // Clearing a single-valued attribute: pending change has all nulls, CSO should have no values.
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.Update);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.PendingExportDeleted, Is.True);
+    }
+
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_UpdateEmptyValue_CsoStillHasValues_Unconfirmed_MarksForRetry()
+    {
+        var cso = CreateCsoWithAttributeValue(1, attributeType: AttributeDataType.Text, stringValue: "not cleared");
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.Update);
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.RetryChanges, Has.Count.EqualTo(1));
+    }
+
+    /// <summary>
+    /// Pins the per-attribute value-index helper introduced by #988: several independent pending
+    /// changes targeting the same multi-valued attribute must each be evaluated correctly against
+    /// the CSO's values for that attribute (confirmed only when actually present/absent as expected),
+    /// with the shared index reused across all of them rather than rebuilt or bled between changes.
+    /// </summary>
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_MultipleChangesSameMultiValuedAttribute_EachEvaluatedIndependently()
+    {
+        var attribute = new ConnectedSystemObjectTypeAttribute { Id = 1, Name = "member", Type = AttributeDataType.Reference };
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        foreach (var dn in new[] { "CN=A,DC=test", "CN=B,DC=test", "CN=C,DC=test" })
+        {
+            cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue
+            {
+                AttributeId = 1,
+                Attribute = attribute,
+                UnresolvedReferenceValue = dn
+            });
+        }
+
+        var confirmedAdd = new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), AttributeId = 1, Attribute = attribute,
+            ChangeType = PendingExportAttributeChangeType.Add, UnresolvedReferenceValue = "CN=A,DC=test",
+            Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation
+        };
+        var unconfirmedAdd = new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), AttributeId = 1, Attribute = attribute,
+            ChangeType = PendingExportAttributeChangeType.Add, UnresolvedReferenceValue = "CN=NOT-THERE,DC=test",
+            Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation
+        };
+        var confirmedRemove = new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), AttributeId = 1, Attribute = attribute,
+            ChangeType = PendingExportAttributeChangeType.Remove, UnresolvedReferenceValue = "CN=ALREADY-GONE,DC=test",
+            Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation
+        };
+        var unconfirmedRemove = new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), AttributeId = 1, Attribute = attribute,
+            ChangeType = PendingExportAttributeChangeType.Remove, UnresolvedReferenceValue = "CN=C,DC=test",
+            Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation
+        };
+
+        var pe = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            Status = PendingExportStatus.Exported,
+            AttributeValueChanges = [confirmedAdd, unconfirmedAdd, confirmedRemove, unconfirmedRemove]
+        };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.ConfirmedChanges, Is.EquivalentTo(new[] { confirmedAdd, confirmedRemove }));
+        Assert.That(result.RetryChanges, Is.EquivalentTo(new[] { unconfirmedAdd, unconfirmedRemove }));
+        // Confirmed changes are removed from the Pending Export; unconfirmed ones remain.
+        Assert.That(pe.AttributeValueChanges, Is.EquivalentTo(new[] { unconfirmedAdd, unconfirmedRemove }));
+    }
+
+    /// <summary>
+    /// Issue #988: the confirmed-change removal loop used List.Remove per confirmed change (O(n) scan
+    /// each), quadratic for a Pending Export with many confirmed changes. This is a functional pin
+    /// (correct end state), with the accompanying scale-guard test below proving the complexity fix.
+    /// </summary>
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_ManyConfirmedChanges_AllRemovedFromPendingExport()
+    {
+        const int changeCount = 500;
+        var attribute = new ConnectedSystemObjectTypeAttribute { Id = 1, Name = "member", Type = AttributeDataType.Reference };
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        var changes = new List<PendingExportAttributeValueChange>(changeCount);
+        for (var i = 0; i < changeCount; i++)
+        {
+            var dn = $"CN=user{i},DC=test";
+            cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { AttributeId = 1, Attribute = attribute, UnresolvedReferenceValue = dn });
+            changes.Add(new PendingExportAttributeValueChange
+            {
+                Id = Guid.NewGuid(), AttributeId = 1, Attribute = attribute,
+                ChangeType = PendingExportAttributeChangeType.Add, UnresolvedReferenceValue = dn,
+                Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation
+            });
+        }
+
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = changes };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.ConfirmedChanges, Has.Count.EqualTo(changeCount));
+        Assert.That(result.PendingExportDeleted, Is.True, "All changes confirmed - Pending Export should be marked for deletion.");
+    }
+
+    /// <summary>
+    /// Issue #988 scale guard: reconciling a large group's worth of confirmed Reference changes must
+    /// stay fast. Before the fix, ValueExistsOnCso's per-change List.Any() scan and the per-change
+    /// List.Remove in the confirmed-change removal loop are both O(n) per change, i.e. O(n²) overall -
+    /// this is a stable red/green discriminator (the unfixed code takes tens of seconds here, not a
+    /// flaky micro-benchmark), not a tight timing assertion.
+    /// </summary>
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_LargeGroupManyReferenceChanges_CompletesWithinBound()
+    {
+        const int memberCount = 50_000;
+        var attribute = new ConnectedSystemObjectTypeAttribute { Id = 1, Name = "member", Type = AttributeDataType.Reference };
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        var changes = new List<PendingExportAttributeValueChange>(memberCount);
+        for (var i = 0; i < memberCount; i++)
+        {
+            var dn = $"CN=user{i},DC=test";
+            cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { AttributeId = 1, Attribute = attribute, UnresolvedReferenceValue = dn });
+            changes.Add(new PendingExportAttributeValueChange
+            {
+                Id = Guid.NewGuid(), AttributeId = 1, Attribute = attribute,
+                ChangeType = PendingExportAttributeChangeType.Add, UnresolvedReferenceValue = dn,
+                Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation
+            });
+        }
+
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = changes };
+        var result = new PendingExportReconciliationResult();
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+        stopwatch.Stop();
+
+        Assert.That(result.ConfirmedChanges, Has.Count.EqualTo(memberCount));
+        Assert.That(result.PendingExportDeleted, Is.True);
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
+            $"Reconciling a {memberCount:N0}-member group with {memberCount:N0} pending Reference changes took " +
+            $"{stopwatch.Elapsed.TotalSeconds:N1}s; expected well under 5s with the #988 fix applied.");
+    }
+
+    #endregion
+
     #region Helpers
 
     private static ConnectedSystemObject CreateCsoWithAttributeValue(

--- a/test/JIM.Worker.Tests/SyncEngineTests/SyncEngineReconciliationTests.cs
+++ b/test/JIM.Worker.Tests/SyncEngineTests/SyncEngineReconciliationTests.cs
@@ -853,6 +853,72 @@ public class SyncEngineReconciliationTests
     }
 
     /// <summary>
+    /// Issue #988 revision: the per-attribute value index derives its type from the CSO values' OWN
+    /// Attribute navigation. If that navigation is null (values loaded without the Attribute include,
+    /// e.g. a partially hydrated entity), the index is built as NotSet with no typed sets, and a naive
+    /// set-only probe would report an actually-confirmed change as unconfirmed - a silent divergence
+    /// from ValueExistsOnCso, which switches on the CHANGE's attribute type and compares raw value
+    /// fields regardless of the value-side navigation. The fallback path must preserve the original
+    /// semantics exactly: a Text Add whose value is present on the CSO is confirmed.
+    /// </summary>
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_TextAddWithNullAttributeNavigationOnCsoValue_StillConfirmed()
+    {
+        // CSO value carries the AttributeId but NOT the Attribute navigation.
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue
+        {
+            AttributeId = 1,
+            Attribute = null!,
+            StringValue = "expected"
+        });
+
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.Add, stringValue: "expected");
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.ConfirmedChanges, Has.Count.EqualTo(1),
+            "The exported value IS present on the CSO; a null value-side Attribute navigation must not stop confirmation.");
+        Assert.That(result.PendingExportDeleted, Is.True);
+        Assert.That(result.RetryChanges, Is.Empty,
+            "A falsely-unconfirmed change here would surface spurious retries and, after max retries, false export confirmation errors.");
+    }
+
+    /// <summary>
+    /// Issue #988 revision, mirror case of the null-navigation Add test above: a Remove change whose
+    /// value is STILL present on the CSO (with a null value-side Attribute navigation) must NOT be
+    /// confirmed. This exercises the fallback finding the value (returning true internally), where a
+    /// naive set-only probe would miss it and falsely confirm the removal.
+    /// </summary>
+    [Test]
+    public void ReconcileCsoAgainstPendingExport_TextRemoveWithNullAttributeNavigationOnCsoValue_NotConfirmed()
+    {
+        // CSO value carries the AttributeId but NOT the Attribute navigation, and the value the
+        // Remove change asserts is gone is in fact still present.
+        var cso = new ConnectedSystemObject { Id = Guid.NewGuid() };
+        cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue
+        {
+            AttributeId = 1,
+            Attribute = null!,
+            StringValue = "stillhere"
+        });
+
+        var attrChange = CreateAttrChange(1, AttributeDataType.Text, PendingExportAttributeChangeType.Remove, stringValue: "stillhere");
+        attrChange.Status = PendingExportAttributeChangeStatus.ExportedPendingConfirmation;
+        var pe = new PendingExport { Id = Guid.NewGuid(), Status = PendingExportStatus.Exported, AttributeValueChanges = [attrChange] };
+        var result = new PendingExportReconciliationResult();
+
+        _engine.ReconcileCsoAgainstPendingExport(cso, pe, result);
+
+        Assert.That(result.ConfirmedChanges, Is.Empty,
+            "The value is still on the CSO; confirming its removal would silently corrupt reconciliation state.");
+        Assert.That(result.RetryChanges, Has.Count.EqualTo(1));
+    }
+
+    /// <summary>
     /// Issue #988: the confirmed-change removal loop used List.Remove per confirmed change (O(n) scan
     /// each), quadratic for a Pending Export with many confirmed changes. This is a functional pin
     /// (correct end state), with the accompanying scale-guard test below proving the complexity fix.

--- a/test/JIM.Worker.Tests/Synchronisation/ImportCsoHydrationBatchingTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportCsoHydrationBatchingTests.cs
@@ -1,0 +1,340 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Connectors.Mock;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+using JIM.PostgresData;
+using JIM.Worker.Tests.Models;
+using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
+using Moq;
+using SyncRepository = JIM.InMemoryData.SyncRepository;
+
+namespace JIM.Worker.Tests.Synchronisation;
+
+/// <summary>
+/// Tests for issue #988 finding 1: batch CSO hydration during full/delta import.
+/// Before the fix, <c>HydrateCsoAsync</c> called <c>GetConnectedSystemObjectsByIdsAsync</c>
+/// once per matched import object (a single-element array each time), an N+1 pattern that
+/// measured ~893s at 209,984 objects. The fix hydrates a whole page's worth of matched CSO
+/// IDs with one (or a handful of chunked) batch call(s) instead.
+/// </summary>
+[TestFixture]
+public class ImportCsoHydrationBatchingTests
+{
+    #region accessors
+    private MetaverseObject InitiatedBy { get; set; } = null!;
+    private List<ConnectedSystem> ConnectedSystemsData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystem>> MockDbSetConnectedSystems { get; set; } = null!;
+    private List<ConnectedSystemRunProfile> ConnectedSystemRunProfilesData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystemRunProfile>> MockDbSetConnectedSystemRunProfiles { get; set; } = null!;
+    private List<ConnectedSystemObjectType> ConnectedSystemObjectTypesData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystemObjectType>> MockDbSetConnectedSystemObjectTypes { get; set; } = null!;
+    private List<ConnectedSystemPartition> ConnectedSystemPartitionsData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystemPartition>> MockDbSetConnectedSystemPartitions { get; set; } = null!;
+    private List<Activity> ActivitiesData { get; set; } = null!;
+    private Mock<DbSet<Activity>> MockDbSetActivities { get; set; } = null!;
+    private List<ServiceSetting> ServiceSettingsData { get; set; } = null!;
+    private Mock<DbSet<ServiceSetting>> MockDbSetServiceSettings { get; set; } = null!;
+    private List<PendingExport> PendingExportsData { get; set; } = null!;
+    private Mock<DbSet<PendingExport>> MockDbSetPendingExports { get; set; } = null!;
+    private List<ConnectedSystemObject> ConnectedSystemObjectsData { get; set; } = new();
+    private Mock<JimDbContext> MockJimDbContext { get; set; } = null!;
+    private JimApplication Jim { get; set; } = null!;
+    private SyncRepository SyncRepo { get; set; } = null!;
+    #endregion
+
+    [TearDown]
+    public void TearDown()
+    {
+        Jim?.Dispose();
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        TestUtilities.SetEnvironmentVariables();
+        InitiatedBy = TestUtilities.GetInitiatedBy();
+
+        ConnectedSystemsData = TestUtilities.GetConnectedSystemData();
+        MockDbSetConnectedSystems = ConnectedSystemsData.BuildMockDbSet();
+
+        ConnectedSystemRunProfilesData = TestUtilities.GetConnectedSystemRunProfileData();
+        MockDbSetConnectedSystemRunProfiles = ConnectedSystemRunProfilesData.BuildMockDbSet();
+
+        ConnectedSystemObjectTypesData = TestUtilities.GetConnectedSystemObjectTypeData();
+        MockDbSetConnectedSystemObjectTypes = ConnectedSystemObjectTypesData.BuildMockDbSet();
+
+        ConnectedSystemPartitionsData = TestUtilities.GetConnectedSystemPartitionData();
+        MockDbSetConnectedSystemPartitions = ConnectedSystemPartitionsData.BuildMockDbSet();
+
+        var fullImportRunProfile = ConnectedSystemRunProfilesData[0];
+        ActivitiesData = TestUtilities.GetActivityData(fullImportRunProfile.RunType, fullImportRunProfile.Id);
+        MockDbSetActivities = ActivitiesData.BuildMockDbSet();
+
+        ServiceSettingsData = TestUtilities.GetServiceSettingsData();
+        MockDbSetServiceSettings = ServiceSettingsData.BuildMockDbSet();
+
+        PendingExportsData = new List<PendingExport>();
+        MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
+
+        MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
+        MockJimDbContext.Setup(m => m.Activities).Returns(MockDbSetActivities.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(MockDbSetConnectedSystems.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystemRunProfiles).Returns(MockDbSetConnectedSystemRunProfiles.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystemPartitions).Returns(MockDbSetConnectedSystemPartitions.Object);
+        MockJimDbContext.Setup(m => m.ServiceSettingItems).Returns(MockDbSetServiceSettings.Object);
+        MockJimDbContext.Setup(m => m.PendingExports).Returns(MockDbSetPendingExports.Object);
+
+        ConnectedSystemObjectsData = new List<ConnectedSystemObject>();
+    }
+
+    #region N+1 elimination: batched hydration, not per-object
+
+    /// <summary>
+    /// Issue #988 finding 1: a re-import of N already-matched objects must hydrate their CSOs
+    /// with a small, bounded number of batch calls (one per page-sized chunk of matched IDs),
+    /// not N individual single-row round trips.
+    /// </summary>
+    [Test]
+    public async Task ProcessImportObjectsAsync_ReImportOfManyExistingCsos_HydratesCsosInBatchesNotPerObjectAsync()
+    {
+        // Arrange — seed 2,500 existing CSOs (spans more than one 1,000-id hydration chunk)
+        // and re-import all of them with a changed DISPLAY_NAME, so every object matches an
+        // existing CSO and requires hydration.
+        const int objectCount = 2500;
+        var (existingCsos, hrIds) = CreateExistingCsos(objectCount);
+        ConnectedSystemObjectsData = existingCsos;
+        SetupDbContextWithCsoData();
+
+        var countingRepo = new HydrationCallCountingSyncRepository();
+        SyncRepo = TestUtilities.CreateSyncRepository(csos: existingCsos, activity: ActivitiesData.First(), repository: countingRepo);
+        Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: SyncRepo);
+
+        var mockFileConnector = new MockFileConnector();
+        for (var i = 0; i < objectCount; i++)
+            mockFileConnector.TestImportObjects.Add(CreateImportObject(hrIds[i], $"Updated Name {i}"));
+
+        // Act
+        var processor = await CreateProcessorAsync(mockFileConnector);
+        await processor.PerformImportAsync();
+
+        // Assert — batched hydration means ceil(2500/1000) = 3 chunked calls, plus a small
+        // constant of slack for any incidental calls elsewhere. Nowhere near the 2,500 calls
+        // the old per-object hydration would have made.
+        const int maxExpectedHydrationCalls = 3 + 2;
+        Assert.That(countingRepo.HydrationCalls, Is.LessThanOrEqualTo(maxExpectedHydrationCalls),
+            $"Expected batched hydration (<= {maxExpectedHydrationCalls} calls for {objectCount} objects), " +
+            $"but GetConnectedSystemObjectsByIdsAsync was called {countingRepo.HydrationCalls} times. See issue #988.");
+
+        // Every object should have been matched and updated in place, not recreated.
+        Assert.That(SyncRepo.ConnectedSystemObjects.Count, Is.EqualTo(objectCount),
+            "Re-import of existing objects should not create duplicate CSOs.");
+
+        for (var i = 0; i < objectCount; i++)
+        {
+            var cso = SyncRepo.ConnectedSystemObjects[existingCsos[i].Id];
+            var displayName = cso.AttributeValues
+                .SingleOrDefault(av => av.Attribute?.Name == MockSourceSystemAttributeNames.DISPLAY_NAME.ToString());
+            Assert.That(displayName?.StringValue, Is.EqualTo($"Updated Name {i}"),
+                $"CSO {i} should have been updated via the batched hydration path.");
+        }
+    }
+
+    #endregion
+
+    #region Concurrent deletion fallback: pre-fetch dictionary has a stale ID
+
+    /// <summary>
+    /// Issue #988 finding 1: if the pre-fetch dictionary knows about a CSO ID that no longer
+    /// exists in the store by the time the batch hydration query runs (e.g. concurrently
+    /// deleted), the importer must fall through gracefully - exactly as the previous
+    /// per-object hydration's "cache had ID but CSO gone" path did - not throw or corrupt state.
+    /// </summary>
+    [Test]
+    public async Task ProcessImportObjectsAsync_CsoVanishesBeforeBatchHydration_FallsThroughGracefullyAsync()
+    {
+        // Arrange — one existing CSO, whose ID is known to the pre-fetch external ID lookup
+        // dictionary, but the batch hydration call always returns nothing (simulating the CSO
+        // having been deleted between the pre-fetch and the hydration query).
+        var (existingCsos, hrIds) = CreateExistingCsos(1);
+        ConnectedSystemObjectsData = existingCsos;
+        SetupDbContextWithCsoData();
+
+        var vanishingRepo = new CsoVanishesAtHydrationSyncRepository();
+        SyncRepo = TestUtilities.CreateSyncRepository(csos: existingCsos, activity: ActivitiesData.First(), repository: vanishingRepo);
+        Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: SyncRepo);
+
+        var mockFileConnector = new MockFileConnector();
+        mockFileConnector.TestImportObjects.Add(CreateImportObject(hrIds[0], "Re-added After Concurrent Delete"));
+
+        // Act
+        var processor = await CreateProcessorAsync(mockFileConnector);
+        await processor.PerformImportAsync();
+
+        // Assert — the importer should not throw, and should fall through to treating the
+        // object as new (the secondary external ID lookup also finds nothing), exactly as the
+        // pre-batching code did for this scenario. The original (now "vanished" from hydration's
+        // point of view, but never actually removed from the store) CSO is untouched - imported
+        // external IDs are still recorded as "seen", so deletion detection leaves it alone - and
+        // a second, brand new CSO is created for the same external ID.
+        Assert.That(SyncRepo.ConnectedSystemObjects.Count, Is.EqualTo(2),
+            "The original CSO should remain untouched and a new CSO created for the fallen-through object.");
+        Assert.That(SyncRepo.ConnectedSystemObjects.ContainsKey(existingCsos[0].Id), Is.True,
+            "The original CSO should not have been removed just because hydration could not find it.");
+        var newCso = SyncRepo.ConnectedSystemObjects.Values.Single(c => c.Id != existingCsos[0].Id);
+        var newDisplayName = newCso.AttributeValues
+            .SingleOrDefault(av => av.Attribute?.Name == MockSourceSystemAttributeNames.DISPLAY_NAME.ToString());
+        Assert.That(newDisplayName?.StringValue, Is.EqualTo("Re-added After Concurrent Delete"),
+            "The newly created CSO should carry the imported object's attribute values.");
+    }
+
+    #endregion
+
+    #region Private helpers
+
+    private async Task<JIM.Worker.Processors.SyncImportTaskProcessor> CreateProcessorAsync(MockFileConnector connector)
+    {
+        var connectedSystem = await Jim.ConnectedSystems.GetConnectedSystemAsync(1);
+        Assert.That(connectedSystem, Is.Not.Null, "Expected to retrieve a Connected System.");
+
+        var runProfile = ConnectedSystemRunProfilesData.Single(
+            q => q.ConnectedSystemId == connectedSystem!.Id && q.RunType == ConnectedSystemRunType.FullImport);
+        var activity = ActivitiesData.First();
+
+        return new JIM.Worker.Processors.SyncImportTaskProcessor(
+            Jim, SyncRepo, new JIM.Application.Servers.SyncServer(Jim), new JIM.Application.Servers.SyncEngine(),
+            connector, connectedSystem!, runProfile,
+            TestUtilities.CreateTestWorkerTask(activity, InitiatedBy),
+            new CancellationTokenSource());
+    }
+
+    private void SetupDbContextWithCsoData()
+    {
+        var mockDbSetConnectedSystemObject = ConnectedSystemObjectsData.BuildMockDbSet();
+        mockDbSetConnectedSystemObject.Setup(set => set.AddRange(It.IsAny<IEnumerable<ConnectedSystemObject>>()))
+            .Callback((IEnumerable<ConnectedSystemObject> entities) =>
+            {
+                var connectedSystemObjects = entities as ConnectedSystemObject[] ?? entities.ToArray();
+                foreach (var entity in connectedSystemObjects)
+                    entity.Id = Guid.NewGuid();
+                ConnectedSystemObjectsData.AddRange(connectedSystemObjects);
+            });
+        MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(mockDbSetConnectedSystemObject.Object);
+    }
+
+    private static ConnectedSystemImportObject CreateImportObject(Guid hrId, string displayName)
+    {
+        return new ConnectedSystemImportObject
+        {
+            ChangeType = ObjectChangeType.NotSet,
+            ObjectType = "SOURCE_USER",
+            Attributes = new List<ConnectedSystemImportObjectAttribute>
+            {
+                new()
+                {
+                    Name = MockSourceSystemAttributeNames.HR_ID.ToString(),
+                    GuidValues = new List<Guid> { hrId }
+                },
+                new()
+                {
+                    Name = MockSourceSystemAttributeNames.DISPLAY_NAME.ToString(),
+                    StringValues = new List<string> { displayName }
+                },
+                new()
+                {
+                    Name = MockSourceSystemAttributeNames.EMPLOYEE_ID.ToString(),
+                    IntValues = new List<int> { 1 }
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Creates <paramref name="count"/> existing CSOs with unique HR_ID (external ID) values,
+    /// returning the CSOs and their HR_IDs (index-aligned) so a test can re-import them.
+    /// </summary>
+    private (List<ConnectedSystemObject> csos, List<Guid> hrIds) CreateExistingCsos(int count)
+    {
+        var connectedSystemObjectType = ConnectedSystemObjectTypesData.First();
+        var csos = new List<ConnectedSystemObject>(count);
+        var hrIds = new List<Guid>(count);
+
+        for (var i = 0; i < count; i++)
+        {
+            var hrId = Guid.NewGuid();
+            hrIds.Add(hrId);
+
+            var cso = new ConnectedSystemObject
+            {
+                Id = Guid.NewGuid(),
+                ConnectedSystemId = 1,
+                ConnectedSystem = ConnectedSystemsData.First(),
+                Type = connectedSystemObjectType,
+                ExternalIdAttributeId = (int)MockSourceSystemAttributeNames.HR_ID
+            };
+            cso.AttributeValues = new List<ConnectedSystemObjectAttributeValue>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    GuidValue = hrId,
+                    Attribute = connectedSystemObjectType.Attributes.Single(q => q.Name == MockSourceSystemAttributeNames.HR_ID.ToString()),
+                    ConnectedSystemObject = cso
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    StringValue = $"Original Name {i}",
+                    Attribute = connectedSystemObjectType.Attributes.Single(q => q.Name == MockSourceSystemAttributeNames.DISPLAY_NAME.ToString()),
+                    ConnectedSystemObject = cso
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    IntValue = i,
+                    Attribute = connectedSystemObjectType.Attributes.Single(q => q.Name == MockSourceSystemAttributeNames.EMPLOYEE_ID.ToString()),
+                    ConnectedSystemObject = cso
+                }
+            };
+            csos.Add(cso);
+        }
+
+        return (csos, hrIds);
+    }
+
+    /// <summary>
+    /// Spy repository that counts calls to <see cref="SyncRepository.GetConnectedSystemObjectsByIdsAsync"/>,
+    /// so tests can assert the import pipeline batches CSO hydration instead of calling it once per object.
+    /// </summary>
+    private sealed class HydrationCallCountingSyncRepository : SyncRepository
+    {
+        public int HydrationCalls;
+
+        public override Task<List<ConnectedSystemObject>> GetConnectedSystemObjectsByIdsAsync(int connectedSystemId, IEnumerable<Guid> csoIds)
+        {
+            Interlocked.Increment(ref HydrationCalls);
+            return base.GetConnectedSystemObjectsByIdsAsync(connectedSystemId, csoIds);
+        }
+    }
+
+    /// <summary>
+    /// Repository double that always returns no results from the batch hydration call, simulating
+    /// a CSO that was concurrently deleted after the pre-fetch external ID dictionary was built but
+    /// before the batch hydration query ran.
+    /// </summary>
+    private sealed class CsoVanishesAtHydrationSyncRepository : SyncRepository
+    {
+        public override Task<List<ConnectedSystemObject>> GetConnectedSystemObjectsByIdsAsync(int connectedSystemId, IEnumerable<Guid> csoIds)
+            => Task.FromResult(new List<ConnectedSystemObject>());
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Synchronisation/ImportCsoHydrationBatchingTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportCsoHydrationBatchingTests.cs
@@ -106,7 +106,7 @@ public class ImportCsoHydrationBatchingTests
     [Test]
     public async Task ProcessImportObjectsAsync_ReImportOfManyExistingCsos_HydratesCsosInBatchesNotPerObjectAsync()
     {
-        // Arrange — seed 2,500 existing CSOs (spans more than one 1,000-id hydration chunk)
+        // Arrange: seed 2,500 existing CSOs (spans more than one 1,000-id hydration chunk)
         // and re-import all of them with a changed DISPLAY_NAME, so every object matches an
         // existing CSO and requires hydration.
         const int objectCount = 2500;
@@ -126,7 +126,7 @@ public class ImportCsoHydrationBatchingTests
         var processor = await CreateProcessorAsync(mockFileConnector);
         await processor.PerformImportAsync();
 
-        // Assert — batched hydration means ceil(2500/1000) = 3 chunked calls, plus a small
+        // Assert: batched hydration means ceil(2500/1000) = 3 chunked calls, plus a small
         // constant of slack for any incidental calls elsewhere. Nowhere near the 2,500 calls
         // the old per-object hydration would have made.
         const int maxExpectedHydrationCalls = 3 + 2;
@@ -161,7 +161,7 @@ public class ImportCsoHydrationBatchingTests
     [Test]
     public async Task ProcessImportObjectsAsync_CsoVanishesBeforeBatchHydration_FallsThroughGracefullyAsync()
     {
-        // Arrange — one existing CSO, whose ID is known to the pre-fetch external ID lookup
+        // Arrange: one existing CSO, whose ID is known to the pre-fetch external ID lookup
         // dictionary, but the batch hydration call always returns nothing (simulating the CSO
         // having been deleted between the pre-fetch and the hydration query).
         var (existingCsos, hrIds) = CreateExistingCsos(1);
@@ -179,7 +179,7 @@ public class ImportCsoHydrationBatchingTests
         var processor = await CreateProcessorAsync(mockFileConnector);
         await processor.PerformImportAsync();
 
-        // Assert — the importer should not throw, and should fall through to treating the
+        // Assert: the importer should not throw, and should fall through to treating the
         // object as new (the secondary external ID lookup also finds nothing), exactly as the
         // pre-batching code did for this scenario. The original (now "vanished" from hydration's
         // point of view, but never actually removed from the store) CSO is untouched - imported

--- a/test/JIM.Worker.Tests/Synchronisation/ImportUpdateDiffScaleTests.cs
+++ b/test/JIM.Worker.Tests/Synchronisation/ImportUpdateDiffScaleTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Diagnostics;
+using System.Reflection;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Staging;
+using JIM.Worker.Processors;
+using JIM.Worker.Tests.Models;
+
+namespace JIM.Worker.Tests.Synchronisation;
+
+/// <summary>
+/// Scale guard for issue #988 finding 4: <c>UpdateConnectedSystemObjectFromImportObject</c> diffs
+/// every attribute with nested <c>.Any()</c> scans in both directions (removals: CSO values vs
+/// import values; additions: import values vs CSO values). Quadratic for large multi-valued
+/// attributes - a 200,008-member group's next Full Import would do ~8x10^10 comparisons for that
+/// one object.
+/// <para>
+/// This invokes <c>UpdateConnectedSystemObjectFromImportObject</c> directly via reflection (it is
+/// private static) rather than driving the full <c>PerformImportAsync</c> pipeline. That keeps the
+/// measurement isolated to the diff logic issue #988 actually changes: the full pipeline also runs
+/// reference resolution and change-tracking stages with their own, separate scaling
+/// characteristics that are out of scope for this fix and would otherwise confound the timing.
+/// </para>
+/// </summary>
+[TestFixture]
+public class ImportUpdateDiffScaleTests
+{
+    private static readonly MethodInfo UpdateMethod = typeof(SyncImportTaskProcessor).GetMethod(
+        "UpdateConnectedSystemObjectFromImportObject",
+        BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("UpdateConnectedSystemObjectFromImportObject method not found via reflection - has it been renamed?");
+
+    /// <summary>
+    /// A user CSO with 50,000 existing values on a multi-valued Text attribute (QUALIFICATIONS),
+    /// re-diffed against a completely disjoint set of 50,000 import values, forces both the
+    /// removal-direction scan (50,000 CSO values x 50,000 import values) and the addition-direction
+    /// scan (the reverse) - the worst case for finding 4's nested .Any() pattern.
+    /// </summary>
+    [Test]
+    public void UpdateConnectedSystemObjectFromImportObject_LargeMvaFullyDisjointValueChange_CompletesWithinBound()
+    {
+        const int valueCount = 50_000;
+        var userObjectType = TestUtilities.GetConnectedSystemObjectTypeData().Single(t => t.Name == "SOURCE_USER");
+        var qualificationsAttribute = userObjectType.Attributes.Single(a => a.Name == MockSourceSystemAttributeNames.QUALIFICATIONS.ToString());
+        var hrIdAttribute = userObjectType.Attributes.Single(a => a.IsExternalId);
+
+        var hrId = Guid.NewGuid();
+        var cso = new ConnectedSystemObject
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = 1,
+            Type = userObjectType,
+            ExternalIdAttributeId = hrIdAttribute.Id
+        };
+        cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue
+        {
+            Id = Guid.NewGuid(),
+            AttributeId = hrIdAttribute.Id,
+            GuidValue = hrId,
+            Attribute = hrIdAttribute,
+            ConnectedSystemObject = cso
+        });
+        for (var i = 0; i < valueCount; i++)
+        {
+            cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue
+            {
+                Id = Guid.NewGuid(),
+                AttributeId = qualificationsAttribute.Id,
+                StringValue = $"existing-qualification-{i}",
+                Attribute = qualificationsAttribute,
+                ConnectedSystemObject = cso
+            });
+        }
+
+        var newQualificationValues = new List<string>(valueCount);
+        for (var i = 0; i < valueCount; i++)
+            newQualificationValues.Add($"new-qualification-{i}");
+
+        var importObject = new ConnectedSystemImportObject
+        {
+            ChangeType = ObjectChangeType.NotSet,
+            ObjectType = "SOURCE_USER",
+            Attributes = new List<ConnectedSystemImportObjectAttribute>
+            {
+                new() { Name = MockSourceSystemAttributeNames.HR_ID.ToString(), GuidValues = new List<Guid> { hrId }, Type = AttributeDataType.Guid },
+                new() { Name = MockSourceSystemAttributeNames.QUALIFICATIONS.ToString(), StringValues = newQualificationValues, Type = AttributeDataType.Text }
+            }
+        };
+
+        var rpei = new ActivityRunProfileExecutionItem();
+
+        var stopwatch = Stopwatch.StartNew();
+        UpdateMethod.Invoke(null, new object?[] { importObject, cso, userObjectType, rpei, null });
+        stopwatch.Stop();
+
+        var newValueSet = new HashSet<string>(newQualificationValues, StringComparer.Ordinal);
+        var additions = cso.PendingAttributeValueAdditions.Where(av => av.Attribute?.Name == MockSourceSystemAttributeNames.QUALIFICATIONS.ToString()).ToList();
+        var removals = cso.PendingAttributeValueRemovals.Where(av => av.Attribute?.Name == MockSourceSystemAttributeNames.QUALIFICATIONS.ToString()).ToList();
+
+        Assert.That(additions, Has.Count.EqualTo(valueCount), "Every new value should be queued as an addition.");
+        Assert.That(additions.All(av => newValueSet.Contains(av.StringValue!)), Is.True, "Every addition should be one of the new import values.");
+        Assert.That(removals, Has.Count.EqualTo(valueCount), "Every existing value should be queued as a removal (fully disjoint from the import).");
+
+        Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
+            $"Diffing a {valueCount:N0}-value multi-valued Text attribute against a fully disjoint {valueCount:N0}-value import took " +
+            $"{stopwatch.Elapsed.TotalSeconds:N1}s; expected well under 5s with the #988 fix applied.");
+    }
+}


### PR DESCRIPTION
Implements the four findings of #988 (confirming Full Import took 42m29s at `Scale200k10kGroups`; see the issue for the full phase-timing evidence).

## Changes

1. **Batch CSO hydration per import page** (finding 1): the per-object `GetConnectedSystemObjectsByIdsAsync(new[] { id })` N+1 (209,984 single-row queries, ~893s) is replaced by a page-level pre-fetch: external IDs resolve via the existing #440 dictionary, matched IDs hydrate in chunks of 1,000. Fallbacks preserved exactly (concurrent-deletion warning path, per-object secondary-external-ID PendingProvisioning lookup). New `HydrateCsoPage` diagnostic span.
2. **De-quadratic Pending Export reconciliation** (finding 2): per-attribute typed value indexes (HashSet membership) replace `List.Any()` scans, and confirmed-change removal is a single `RemoveAll` instead of per-change `List.Remove`. Both were O(n²) for the template's 200,008-member group (370.6s + 207.2s pages measured). Belt-and-braces: every index carries the raw value list and falls back to the original `ValueExistsOnCso` comparison whenever the probe's data type cannot be served by the index (e.g. value-side `Attribute` navigation not loaded), guaranteeing byte-identical semantics; the divergence was caught in review and pinned red-first.
3. **Binary COPY for CSO attribute value bulk insert** (finding 3): the parameterised multi-row INSERT (~10k rows/sec effective) becomes an Npgsql binary COPY, an exact mirror of the proven `SyncRepository.RpeiOperations` COPY helpers (same connection handling, column order, null handling). EF InMemory fallback path untouched.
4. **De-quadratic import update-diff** (finding 4): every data-type branch of `UpdateConnectedSystemObjectFromImportObject` now diffs via per-attribute HashSets in both directions, preserving exact comparison semantics per type (Text stays case-sensitive Ordinal; Binary keeps linear `SequenceEqual`; Reference keeps its dual resolved/unresolved semantics). Pre-fix, the next Full Import over a populated 200k-member group would have performed ~8x10^10 comparisons for that one object.

## Testing

- TDD red -> green throughout. Highlights: hydration call-count spy red at 2,500 calls vs <= 5; reconciliation 50k-member scale guard red at 10.3s vs 5s bound, green at 84ms; diff scale guard red at 58.6s, green at ~110ms; index-fallback divergence tests red (confirmed change reported unconfirmed) then green.
- `dotnet build JIM.sln`: 0 warnings. `dotnet test JIM.sln`: 3,402 passed, 0 failed (35 pre-existing integration-only skips).

## Runtime verification (live stack, PostgreSQL + OpenLDAP, 209,984 objects)

Full Import of Yellowstone APAC on this branch's worker build, converged no-change state:

| | Before (measured 2026-07-12) | After |
|---|---|---|
| Whole run | 42m29s (confirming import) | **8m04s**, 0 errors |
| Import + processing phase | 893s | 455.6s (of which batched hydration 134s) |
| Save phase | 815s | 10.3s (no-change run) |
| 200k-member group diff | never previously exercised (would be hours) | completes invisibly, no stall |

Honest caveats: the before/after runs differ in nature (confirming import with 3.88M attribute confirmations vs no-change re-import), so the phase rows are the meaningful comparison, not the wall-clock ratio alone; and the COPY path (finding 3) was only lightly exercised at runtime by this no-change run (near-zero additions); it is covered by its exact structural mirror of the proven RPEI COPY precedent and will be exercised at volume by the next large-template InitialSync run.

The remaining ~320s of per-object in-memory processing at 200k scale is a per-object constant-cost profile (schema scans, RPEI construction), noted for potential follow-up on #988 rather than expanded here.

Docs: n/a - performance-only changes, no behaviour or configuration change to document (changelog ⚡ entry included).

Closes #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
