### PR TITLE
perf(sync): lean Pending Export fetch for the export evaluation merge path (#986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - ⚡ Exports no longer stall between batches at large scale. Batch collection now walks the Pending Export queue in a single pass (keyset pagination, backed by a new index) instead of rescanning it from the start for every batch; at 200,000 objects with 10,000 reference-bearing groups the old behaviour spent hours re-reading already-collected rows before the first group reached the target system.
-- ⚡ Deprovisioning users who are members of large groups no longer slows synchronisation to a crawl. Updating a large group's pending changes no longer reloads the group's full membership from the database each time.
+- ⚡ Deprovisioning users who are members of large groups no longer slows synchronisation to a crawl. Updating or deleting a large group's pending changes no longer reloads the group's full membership from the database each time.
 
 ## [0.13.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - ⚡ Exports no longer stall between batches at large scale. Batch collection now walks the Pending Export queue in a single pass (keyset pagination, backed by a new index) instead of rescanning it from the start for every batch; at 200,000 objects with 10,000 reference-bearing groups the old behaviour spent hours re-reading already-collected rows before the first group reached the target system.
+- ⚡ Deprovisioning users who are members of large groups no longer slows synchronisation to a crawl. Updating a large group's pending changes no longer reloads the group's full membership from the database each time.
 
 ## [0.13.0] - 2026-07-10
 

--- a/src/JIM.Application/Servers/ExportEvaluationServer.cs
+++ b/src/JIM.Application/Servers/ExportEvaluationServer.cs
@@ -1363,9 +1363,15 @@ public class ExportEvaluationServer
         if (csoId.HasValue && (changeType == PendingExportChangeType.Update || changeType == PendingExportChangeType.Create))
         {
             PendingExport? dbPendingExport;
-            using (var peLookupSpan = JIM.Application.Diagnostics.Diagnostics.Sync.StartSpan("GetPendingExportByCsoIdForMerge"))
+            using (var peLookupSpan = JIM.Application.Diagnostics.Diagnostics.Sync.StartSpan("GetPendingExportByCsoIdForMerge")
+                .SetTag("leanFetch", true))
             {
-                dbPendingExport = await SyncRepo.GetPendingExportByConnectedSystemObjectIdAsync(csoId.Value);
+                // Lean fetch (issue #986): the merge logic below only ever reads Id and
+                // AttributeValueChanges off dbPendingExport, never ConnectedSystemObject,
+                // SourceMetaverseObject or ConnectedSystem. The heavy GetPendingExportByConnectedSystemObjectIdAsync
+                // also loads those CSO/MVO attribute value graphs, which for a large group can run into
+                // the hundreds of thousands of rows and dominated this fetch (measured 99.5% of merge cost).
+                dbPendingExport = await SyncRepo.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId.Value);
                 peLookupSpan.SetTag("found", dbPendingExport != null);
                 peLookupSpan.SetTag("existingChangeCount", dbPendingExport?.AttributeValueChanges.Count ?? 0);
                 peLookupSpan.SetSuccess();

--- a/src/JIM.Application/Servers/ExportEvaluationServer.cs
+++ b/src/JIM.Application/Servers/ExportEvaluationServer.cs
@@ -635,7 +635,12 @@ public class ExportEvaluationServer
         Guid sourceMetaverseObjectId,
         List<PendingExportAttributeValueChange>? attributeValueChanges = null)
     {
-        var existingPe = await SyncRepo.GetPendingExportByConnectedSystemObjectIdAsync(cso.Id);
+        // Lean fetch (issue #986): this method only reads ChangeType/Id/Status off the existing
+        // Pending Export and passes it to DeletePendingExportAsync, which needs AttributeValueChanges
+        // loaded for EF-tracked child-row disposal. The heavy fetch also loaded the CSO's and source
+        // Metaverse Object's full attribute value graphs, which for a large group CSO (group
+        // deprovisioning) runs into the hundreds of thousands of rows, none of them read here.
+        var existingPe = await SyncRepo.GetPendingExportLightweightByConnectedSystemObjectIdAsync(cso.Id);
 
         if (existingPe != null)
         {
@@ -1371,7 +1376,7 @@ public class ExportEvaluationServer
                 // SourceMetaverseObject or ConnectedSystem. The heavy GetPendingExportByConnectedSystemObjectIdAsync
                 // also loads those CSO/MVO attribute value graphs, which for a large group can run into
                 // the hundreds of thousands of rows and dominated this fetch (measured 99.5% of merge cost).
-                dbPendingExport = await SyncRepo.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId.Value);
+                dbPendingExport = await SyncRepo.GetPendingExportLightweightByConnectedSystemObjectIdAsync(csoId.Value);
                 peLookupSpan.SetTag("found", dbPendingExport != null);
                 peLookupSpan.SetTag("existingChangeCount", dbPendingExport?.AttributeValueChanges.Count ?? 0);
                 peLookupSpan.SetSuccess();

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -336,11 +336,12 @@ public interface IConnectedSystemRepository
     public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId);
 
     /// <summary>
-    /// Lean fetch for the export evaluation merge-and-replace path (see
-    /// <c>ExportEvaluationServer.CreateOrUpdatePendingExportWithNoNetChangeAsync</c>). Only
+    /// Lightweight fetch for export evaluation hot paths: the merge-and-replace path
+    /// (<c>ExportEvaluationServer.CreateOrUpdatePendingExportWithNoNetChangeAsync</c>) and the
+    /// deprovisioning delete path (<c>ExportEvaluationServer.EnsureDeletePendingExportAsync</c>). Only
     /// AttributeValueChanges (with Attribute) are loaded; ConnectedSystemObject, ConnectedSystem
-    /// and SourceMetaverseObject and their attribute value graphs are skipped because the merge
-    /// logic never reads them. <see cref="GetPendingExportByConnectedSystemObjectIdAsync"/>'s full
+    /// and SourceMetaverseObject and their attribute value graphs are skipped because neither
+    /// caller reads them. <see cref="GetPendingExportByConnectedSystemObjectIdAsync"/>'s full
     /// Include chain could load hundreds of thousands of rows per fetch for a large group's
     /// Connected System Object and source Metaverse Object, re-fetched once per removed member
     /// during cohort deprovisioning (issue #986). Use this method on that hot path instead;
@@ -349,7 +350,7 @@ public interface IConnectedSystemRepository
     /// </summary>
     /// <param name="connectedSystemObjectId">The unique identifier of the Connected System Object.</param>
     /// <returns>The PendingExport for the CSO with AttributeValueChanges loaded, or null if none exists.</returns>
-    public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId);
+    public Task<PendingExport?> GetPendingExportLightweightByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId);
 
     /// <summary>
     /// Retrieves Pending Exports for multiple Connected System Objects in a single query.

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -336,6 +336,22 @@ public interface IConnectedSystemRepository
     public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId);
 
     /// <summary>
+    /// Lean fetch for the export evaluation merge-and-replace path (see
+    /// <c>ExportEvaluationServer.CreateOrUpdatePendingExportWithNoNetChangeAsync</c>). Only
+    /// AttributeValueChanges (with Attribute) are loaded; ConnectedSystemObject, ConnectedSystem
+    /// and SourceMetaverseObject and their attribute value graphs are skipped because the merge
+    /// logic never reads them. <see cref="GetPendingExportByConnectedSystemObjectIdAsync"/>'s full
+    /// Include chain could load hundreds of thousands of rows per fetch for a large group's
+    /// Connected System Object and source Metaverse Object, re-fetched once per removed member
+    /// during cohort deprovisioning (issue #986). Use this method on that hot path instead;
+    /// <see cref="GetPendingExportByConnectedSystemObjectIdAsync"/> stays as-is for callers that
+    /// need the full graph (for example the Pending Export detail page).
+    /// </summary>
+    /// <param name="connectedSystemObjectId">The unique identifier of the Connected System Object.</param>
+    /// <returns>The PendingExport for the CSO with AttributeValueChanges loaded, or null if none exists.</returns>
+    public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId);
+
+    /// <summary>
     /// Retrieves Pending Exports for multiple Connected System Objects in a single query.
     /// More efficient than calling GetPendingExportByConnectedSystemObjectIdAsync multiple times.
     /// </summary>

--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -393,7 +393,7 @@ public interface ISyncRepository
     /// SourceMetaverseObject and their attribute value graphs (issue #986). Use this instead of
     /// <see cref="GetPendingExportByConnectedSystemObjectIdAsync"/> on the merge hot path.
     /// </summary>
-    Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId);
+    Task<PendingExport?> GetPendingExportLightweightByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId);
 
     /// <summary>
     /// Gets Pending Exports for multiple CSOs in a single query.

--- a/src/JIM.Data/Repositories/ISyncRepository.cs
+++ b/src/JIM.Data/Repositories/ISyncRepository.cs
@@ -388,6 +388,14 @@ public interface ISyncRepository
     Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId);
 
     /// <summary>
+    /// Lean fetch for the export evaluation merge-and-replace path: only AttributeValueChanges
+    /// (with Attribute) are loaded, skipping ConnectedSystemObject, ConnectedSystem and
+    /// SourceMetaverseObject and their attribute value graphs (issue #986). Use this instead of
+    /// <see cref="GetPendingExportByConnectedSystemObjectIdAsync"/> on the merge hot path.
+    /// </summary>
+    Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId);
+
+    /// <summary>
     /// Gets Pending Exports for multiple CSOs in a single query.
     /// Returns a dictionary keyed by CSO ID.
     /// </summary>

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -1002,7 +1002,7 @@ public class SyncRepository : ISyncRepository
     // is already a fully wired-up graph in memory), so the lean merge-fetch variant is behaviourally
     // identical to the heavy one here. The distinction only exists - and is only provable - at the
     // Postgres repository layer, where Include chains genuinely control what gets loaded.
-    public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId)
+    public Task<PendingExport?> GetPendingExportLightweightByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId)
         => GetPendingExportByConnectedSystemObjectIdAsync(connectedSystemObjectId);
 
     public Task<Dictionary<Guid, PendingExport>> GetPendingExportsByConnectedSystemObjectIdsAsync(

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -998,6 +998,13 @@ public class SyncRepository : ISyncRepository
         return Task.FromResult(result);
     }
 
+    // This fake store has no Include-shape concept (there is no lazy loading and every seeded object
+    // is already a fully wired-up graph in memory), so the lean merge-fetch variant is behaviourally
+    // identical to the heavy one here. The distinction only exists - and is only provable - at the
+    // Postgres repository layer, where Include chains genuinely control what gets loaded.
+    public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId)
+        => GetPendingExportByConnectedSystemObjectIdAsync(connectedSystemObjectId);
+
     public Task<Dictionary<Guid, PendingExport>> GetPendingExportsByConnectedSystemObjectIdsAsync(
         IEnumerable<Guid> connectedSystemObjectIds)
     {

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -3480,7 +3480,7 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     }
 
     /// <inheritdoc />
-    public async Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId)
+    public async Task<PendingExport?> GetPendingExportLightweightByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId)
     {
         // Lean Include shape for the merge-and-replace path (issue #986): only AttributeValueChanges
         // (with Attribute, needed by GetAttributeChangeMergeKey for single-vs-multi-valued dedup) are

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -3479,6 +3479,22 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             .FirstOrDefaultAsync(pe => pe.ConnectedSystemObject != null && pe.ConnectedSystemObject.Id == connectedSystemObjectId);
     }
 
+    /// <inheritdoc />
+    public async Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId)
+    {
+        // Lean Include shape for the merge-and-replace path (issue #986): only AttributeValueChanges
+        // (with Attribute, needed by GetAttributeChangeMergeKey for single-vs-multi-valued dedup) are
+        // loaded. Deliberately no ConnectedSystemObject.AttributeValues or SourceMetaverseObject.AttributeValues -
+        // the merge logic in ExportEvaluationServer only reads Id and AttributeValueChanges off the
+        // fetched PendingExport, but for a large group's CSO/MVO those value collections can run into
+        // the hundreds of thousands of rows (see the heavy GetPendingExportByConnectedSystemObjectIdAsync
+        // above, which this call site used before this fix).
+        return await Repository.Database.PendingExports
+            .Include(pe => pe.AttributeValueChanges)
+                .ThenInclude(avc => avc.Attribute)
+            .FirstOrDefaultAsync(pe => pe.ConnectedSystemObjectId == connectedSystemObjectId);
+    }
+
     public async Task<Dictionary<Guid, PendingExport>> GetPendingExportsByConnectedSystemObjectIdsAsync(IEnumerable<Guid> connectedSystemObjectIds)
     {
         var csoIdList = connectedSystemObjectIds.ToList();

--- a/src/JIM.PostgresData/Repositories/SyncRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.cs
@@ -239,8 +239,8 @@ public partial class SyncRepository : ISyncRepository
     public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId)
         => _repo.ConnectedSystems.GetPendingExportByConnectedSystemObjectIdAsync(connectedSystemObjectId);
 
-    public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId)
-        => _repo.ConnectedSystems.GetPendingExportByConnectedSystemObjectIdForMergeAsync(connectedSystemObjectId);
+    public Task<PendingExport?> GetPendingExportLightweightByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId)
+        => _repo.ConnectedSystems.GetPendingExportLightweightByConnectedSystemObjectIdAsync(connectedSystemObjectId);
 
     public Task<Dictionary<Guid, PendingExport>> GetPendingExportsByConnectedSystemObjectIdsAsync(IEnumerable<Guid> connectedSystemObjectIds)
         => _repo.ConnectedSystems.GetPendingExportsByConnectedSystemObjectIdsAsync(connectedSystemObjectIds);

--- a/src/JIM.PostgresData/Repositories/SyncRepository.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.cs
@@ -239,6 +239,9 @@ public partial class SyncRepository : ISyncRepository
     public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdAsync(Guid connectedSystemObjectId)
         => _repo.ConnectedSystems.GetPendingExportByConnectedSystemObjectIdAsync(connectedSystemObjectId);
 
+    public Task<PendingExport?> GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid connectedSystemObjectId)
+        => _repo.ConnectedSystems.GetPendingExportByConnectedSystemObjectIdForMergeAsync(connectedSystemObjectId);
+
     public Task<Dictionary<Guid, PendingExport>> GetPendingExportsByConnectedSystemObjectIdsAsync(IEnumerable<Guid> connectedSystemObjectIds)
         => _repo.ConnectedSystems.GetPendingExportsByConnectedSystemObjectIdsAsync(connectedSystemObjectIds);
 

--- a/test/JIM.InMemoryData.Tests/SyncRepositoryPendingExportTests.cs
+++ b/test/JIM.InMemoryData.Tests/SyncRepositoryPendingExportTests.cs
@@ -123,21 +123,21 @@ public class SyncRepositoryPendingExportTests
     /// JIM.Worker.Tests PendingExportMergeFetchDatabaseTests.
     /// </summary>
     [Test]
-    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_FindsPeAsync()
+    public async Task GetPendingExportLightweightByConnectedSystemObjectIdAsync_FindsPeAsync()
     {
         var csoId = Guid.NewGuid();
         var pe = CreatePe(csoId: csoId);
         _repo.SeedPendingExport(pe);
 
-        var result = await _repo.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId);
+        var result = await _repo.GetPendingExportLightweightByConnectedSystemObjectIdAsync(csoId);
         Assert.That(result, Is.Not.Null);
         Assert.That(result!.Id, Is.EqualTo(pe.Id));
     }
 
     [Test]
-    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_NotFound_ReturnsNullAsync()
+    public async Task GetPendingExportLightweightByConnectedSystemObjectIdAsync_NotFound_ReturnsNullAsync()
     {
-        var result = await _repo.GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid.NewGuid());
+        var result = await _repo.GetPendingExportLightweightByConnectedSystemObjectIdAsync(Guid.NewGuid());
         Assert.That(result, Is.Null);
     }
 

--- a/test/JIM.InMemoryData.Tests/SyncRepositoryPendingExportTests.cs
+++ b/test/JIM.InMemoryData.Tests/SyncRepositoryPendingExportTests.cs
@@ -116,6 +116,31 @@ public class SyncRepositoryPendingExportTests
         Assert.That(result, Is.Null);
     }
 
+    /// <summary>
+    /// The lean merge-fetch variant (issue #986) has no Include-shape distinction in this fake store -
+    /// every seeded object is already a fully wired-up graph in memory - so it must behave identically
+    /// to the heavy fetch here. The fetch-shape distinction itself is proven against real PostgreSQL in
+    /// JIM.Worker.Tests PendingExportMergeFetchDatabaseTests.
+    /// </summary>
+    [Test]
+    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_FindsPeAsync()
+    {
+        var csoId = Guid.NewGuid();
+        var pe = CreatePe(csoId: csoId);
+        _repo.SeedPendingExport(pe);
+
+        var result = await _repo.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId);
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Id, Is.EqualTo(pe.Id));
+    }
+
+    [Test]
+    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_NotFound_ReturnsNullAsync()
+    {
+        var result = await _repo.GetPendingExportByConnectedSystemObjectIdForMergeAsync(Guid.NewGuid());
+        Assert.That(result, Is.Null);
+    }
+
     [Test]
     public async Task GetPendingExportsByConnectedSystemObjectIdsAsync_ReturnsDictionaryAsync()
     {

--- a/test/JIM.Worker.Tests/OutboundSync/ExportEvaluationTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportEvaluationTests.cs
@@ -416,6 +416,74 @@ public class ExportEvaluationTests
             "Should create exactly one new Delete PE");
     }
 
+    /// <summary>
+    /// Tests that when EvaluateMvoDeletionAsync replaces an existing non-Delete Pending Export, the
+    /// replaced Pending Export is removed from the store together with its attribute value changes;
+    /// none of them may leak onto the replacement Delete Pending Export. Pins the delete-path fetch
+    /// behaviour across the lean-fetch call-site change (issue #986): child-row disposal on delete
+    /// relies on the fetched entity having its AttributeValueChanges loaded.
+    /// </summary>
+    [Test]
+    public async Task EvaluateMvoDeletionAsync_WhenCreatePeWithAttributeChangesExists_ReplacementDisposesOldPeAndChangesAsync()
+    {
+        // Arrange
+        var mvo = MetaverseObjectsData[0];
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+        var targetAttribute = targetUserType.Attributes.First(a => a.Type == AttributeDataType.Text);
+
+        var provisionedCso = new ConnectedSystemObject
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = targetSystem.Id,
+            Type = targetUserType,
+            TypeId = targetUserType.Id,
+            MetaverseObject = mvo,
+            MetaverseObjectId = mvo.Id,
+            JoinType = ConnectedSystemObjectJoinType.Provisioned
+        };
+
+        ConnectedSystemObjectsData.Add(provisionedCso);
+        SyncRepo.SeedConnectedSystemObject(provisionedCso);
+
+        // Pre-populate with an existing Create PE carrying attribute value changes
+        // Must set ConnectedSystemObject navigation property because mock DbSet doesn't auto-load it
+        var existingCreatePe = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = targetSystem.Id,
+            ConnectedSystemObjectId = provisionedCso.Id,
+            ConnectedSystemObject = provisionedCso,
+            ChangeType = PendingExportChangeType.Create,
+            Status = PendingExportStatus.Pending,
+            SourceMetaverseObjectId = mvo.Id,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5)
+        };
+        existingCreatePe.AttributeValueChanges.Add(new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(),
+            PendingExportId = existingCreatePe.Id,
+            Attribute = targetAttribute,
+            AttributeId = targetAttribute.Id,
+            ChangeType = PendingExportAttributeChangeType.Add,
+            StringValue = "stale value from the replaced Create PE"
+        });
+        PendingExportsData.Add(existingCreatePe);
+        SyncRepo.SeedPendingExport(existingCreatePe);
+
+        // Act
+        var result = await Jim.ExportEvaluation.EvaluateMvoDeletionAsync(mvo);
+
+        // Assert: the old Create PE and its changes are gone; the replacement carries none of them
+        Assert.That(result.Count, Is.EqualTo(1), "Should return exactly one PE");
+        Assert.That(result[0].ChangeType, Is.EqualTo(PendingExportChangeType.Delete), "Should be a Delete PE");
+        Assert.That(SyncRepo.PendingExports.ContainsKey(existingCreatePe.Id), Is.False,
+            "The replaced Create PE should be removed from the store");
+        Assert.That(SyncRepo.PendingExports.Count, Is.EqualTo(1), "Only the replacement Delete PE should remain");
+        Assert.That(result[0].AttributeValueChanges.Any(avc => avc.StringValue == "stale value from the replaced Create PE"),
+            Is.False, "No attribute value change from the replaced PE may leak onto the replacement");
+    }
+
     #region EvaluateOutOfScopeExportsAsync (cascade) — Delete-PE collision handling
 
     /// <summary>

--- a/test/JIM.Worker.Tests/OutboundSync/PendingExportMergeSemanticsTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/PendingExportMergeSemanticsTests.cs
@@ -22,13 +22,13 @@ namespace JIM.Worker.Tests.OutboundSync;
 /// <see cref="JIM.Application.Servers.ExportEvaluationServer.EvaluateExportRulesWithNoNetChangeDetectionAsync"/>
 /// entry point. These characterise the merge outcomes that must stay byte-identical regardless of
 /// which repository method (<c>GetPendingExportByConnectedSystemObjectIdAsync</c> or the lean
-/// <c>GetPendingExportByConnectedSystemObjectIdForMergeAsync</c>) supplies the existing database
+/// <c>GetPendingExportLightweightByConnectedSystemObjectIdAsync</c>) supplies the existing database
 /// Pending Export - synchronisation integrity depends on the merge/delete-and-recreate outcome being
 /// unaffected by the fetch-shape optimisation.
 /// </summary>
 /// <remarks>
 /// The <see cref="JIM.InMemoryData.SyncRepository"/> fake used here has no Include-shape concept (see
-/// its own <c>GetPendingExportByConnectedSystemObjectIdForMergeAsync</c> comment), so these tests
+/// its own <c>GetPendingExportLightweightByConnectedSystemObjectIdAsync</c> comment), so these tests
 /// cannot themselves distinguish the heavy fetch from the lean one - that distinction is proven
 /// separately, against real PostgreSQL, in <c>PendingExportMergeFetchDatabaseTests</c>. What these
 /// tests pin is the merge *outcome*: the business logic these two fetch methods feed.

--- a/test/JIM.Worker.Tests/OutboundSync/PendingExportMergeSemanticsTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/PendingExportMergeSemanticsTests.cs
@@ -1,0 +1,439 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+using JIM.PostgresData;
+using JIM.Worker.Tests.Models;
+using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
+using Moq;
+using SyncRepository = JIM.InMemoryData.SyncRepository;
+
+namespace JIM.Worker.Tests.OutboundSync;
+
+/// <summary>
+/// Pins the merge-and-replace behaviour of
+/// <c>ExportEvaluationServer.CreateOrUpdatePendingExportWithNoNetChangeAsync</c> (the
+/// "GetPendingExportByCsoIdForMerge" fallback branch, issue #986) end-to-end via the public
+/// <see cref="JIM.Application.Servers.ExportEvaluationServer.EvaluateExportRulesWithNoNetChangeDetectionAsync"/>
+/// entry point. These characterise the merge outcomes that must stay byte-identical regardless of
+/// which repository method (<c>GetPendingExportByConnectedSystemObjectIdAsync</c> or the lean
+/// <c>GetPendingExportByConnectedSystemObjectIdForMergeAsync</c>) supplies the existing database
+/// Pending Export - synchronisation integrity depends on the merge/delete-and-recreate outcome being
+/// unaffected by the fetch-shape optimisation.
+/// </summary>
+/// <remarks>
+/// The <see cref="JIM.InMemoryData.SyncRepository"/> fake used here has no Include-shape concept (see
+/// its own <c>GetPendingExportByConnectedSystemObjectIdForMergeAsync</c> comment), so these tests
+/// cannot themselves distinguish the heavy fetch from the lean one - that distinction is proven
+/// separately, against real PostgreSQL, in <c>PendingExportMergeFetchDatabaseTests</c>. What these
+/// tests pin is the merge *outcome*: the business logic these two fetch methods feed.
+/// </remarks>
+public class PendingExportMergeSemanticsTests
+{
+    #region accessors
+    private Mock<JimDbContext> MockJimDbContext { get; set; } = null!;
+    private List<ConnectedSystem> ConnectedSystemsData { get; set; } = null!;
+    private List<ConnectedSystemObject> ConnectedSystemObjectsData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystemObject>> MockDbSetConnectedSystemObjects { get; set; } = null!;
+    private List<ConnectedSystemObjectType> ConnectedSystemObjectTypesData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystemObjectType>> MockDbSetConnectedSystemObjectTypes { get; set; } = null!;
+    private List<PendingExport> PendingExportsData { get; set; } = null!;
+    private Mock<DbSet<PendingExport>> MockDbSetPendingExports { get; set; } = null!;
+    private List<MetaverseObjectType> MetaverseObjectTypesData { get; set; } = null!;
+    private Mock<DbSet<MetaverseObjectType>> MockDbSetMetaverseObjectTypes { get; set; } = null!;
+    private List<MetaverseObject> MetaverseObjectsData { get; set; } = null!;
+    private Mock<DbSet<MetaverseObject>> MockDbSetMetaverseObjects { get; set; } = null!;
+    private List<SyncRule> SyncRulesData { get; set; } = null!;
+    private Mock<DbSet<SyncRule>> MockDbSetSyncRules { get; set; } = null!;
+    private List<ConnectedSystemObjectAttributeValue> ConnectedSystemObjectAttributeValuesData { get; set; } = null!;
+    private Mock<DbSet<ConnectedSystemObjectAttributeValue>> MockDbSetConnectedSystemObjectAttributeValues { get; set; } = null!;
+    private JimApplication Jim { get; set; } = null!;
+    private SyncRepository SyncRepo { get; set; } = null!;
+    #endregion
+
+    [TearDown]
+    public void TearDown()
+    {
+        Jim?.Dispose();
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        ConnectedSystemsData = TestUtilities.GetConnectedSystemData();
+        var mockDbSetConnectedSystems = ConnectedSystemsData.BuildMockDbSet();
+
+        ConnectedSystemObjectTypesData = TestUtilities.GetConnectedSystemObjectTypeData();
+        MockDbSetConnectedSystemObjectTypes = ConnectedSystemObjectTypesData.BuildMockDbSet();
+
+        ConnectedSystemObjectsData = TestUtilities.GetConnectedSystemObjectData();
+        MockDbSetConnectedSystemObjects = ConnectedSystemObjectsData.BuildMockDbSet();
+
+        PendingExportsData = new List<PendingExport>();
+        MockDbSetPendingExports = PendingExportsData.BuildMockDbSet();
+
+        MetaverseObjectTypesData = TestUtilities.GetMetaverseObjectTypeData();
+        MockDbSetMetaverseObjectTypes = MetaverseObjectTypesData.BuildMockDbSet();
+
+        MetaverseObjectsData = TestUtilities.GetMetaverseObjectData();
+        MockDbSetMetaverseObjects = MetaverseObjectsData.BuildMockDbSet();
+
+        SyncRulesData = TestUtilities.GetSyncRuleData();
+        MockDbSetSyncRules = SyncRulesData.BuildMockDbSet();
+
+        ConnectedSystemObjectAttributeValuesData = new List<ConnectedSystemObjectAttributeValue>();
+        MockDbSetConnectedSystemObjectAttributeValues = ConnectedSystemObjectAttributeValuesData.BuildMockDbSet();
+
+        MockJimDbContext = new Mock<JimDbContext>();
+        TestUtilities.SetUpEmptyConnectedSystemGraphMocks(MockJimDbContext);
+        MockJimDbContext.Setup(m => m.ConnectedSystemObjectTypes).Returns(MockDbSetConnectedSystemObjectTypes.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystemObjects).Returns(MockDbSetConnectedSystemObjects.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystemObjectAttributeValues).Returns(MockDbSetConnectedSystemObjectAttributeValues.Object);
+        MockJimDbContext.Setup(m => m.ConnectedSystems).Returns(mockDbSetConnectedSystems.Object);
+        MockJimDbContext.Setup(m => m.MetaverseObjectTypes).Returns(MockDbSetMetaverseObjectTypes.Object);
+        MockJimDbContext.Setup(m => m.MetaverseObjects).Returns(MockDbSetMetaverseObjects.Object);
+        MockJimDbContext.Setup(m => m.PendingExports).Returns(MockDbSetPendingExports.Object);
+        MockJimDbContext.Setup(m => m.SyncRules).Returns(MockDbSetSyncRules.Object);
+
+        SyncRepo = TestUtilities.CreateSyncRepository();
+        Jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: SyncRepo);
+    }
+
+    /// <summary>
+    /// Builds a single-valued export Synchronisation Rule mapping Employee ID (source) to the
+    /// target system's Employee ID attribute, plus a confirmed (Normal-status) target CSO and its
+    /// export evaluation cache. Shared arrangement for the single-valued pinning scenarios.
+    /// </summary>
+    private (SyncRule ExportSyncRule, MetaverseObject Mvo, ConnectedSystemObject TargetCso,
+        ConnectedSystemObjectTypeAttribute TargetEmployeeIdAttr, ExportEvaluationCache Cache) ArrangeSingleValuedScenario(
+        ConnectedSystemObjectStatus targetCsoStatus = ConnectedSystemObjectStatus.Normal)
+    {
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+        var mvUserType = MetaverseObjectTypesData.Single(q => q.Name == "User");
+        var employeeIdMvAttr = mvUserType.Attributes.Single(a => a.Id == (int)MockMetaverseAttributeName.EmployeeId);
+        var targetEmployeeIdAttr = targetUserType.Attributes.Single(a => a.Name == MockTargetSystemAttributeNames.EmployeeId.ToString());
+
+        var exportSyncRule = SyncRulesData.Single(sr => sr.Name == "Dummy User Export Synchronisation Rule 1");
+        exportSyncRule.ConnectedSystemId = targetSystem.Id;
+        exportSyncRule.ConnectedSystem = targetSystem;
+        exportSyncRule.MetaverseObjectTypeId = mvUserType.Id;
+        exportSyncRule.AttributeFlowRules.Clear();
+        exportSyncRule.AttributeFlowRules.Add(new SyncRuleMapping
+        {
+            Id = 100,
+            SyncRule = exportSyncRule,
+            TargetConnectedSystemAttribute = targetEmployeeIdAttr,
+            TargetConnectedSystemAttributeId = targetEmployeeIdAttr.Id,
+            Sources = { new SyncRuleMappingSource
+            {
+                Id = 200,
+                Order = 0,
+                MetaverseAttribute = employeeIdMvAttr,
+                MetaverseAttributeId = employeeIdMvAttr.Id
+            }}
+        });
+
+        var mvo = MetaverseObjectsData[0];
+        mvo.Type = mvUserType;
+
+        var targetCso = new ConnectedSystemObject
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = targetSystem.Id,
+            ConnectedSystem = targetSystem,
+            Type = targetUserType,
+            Status = targetCsoStatus,
+            MetaverseObjectId = mvo.Id,
+            MetaverseObject = mvo
+        };
+
+        var exportRulesByMvoTypeId = new Dictionary<int, List<SyncRule>> { { mvUserType.Id, new List<SyncRule> { exportSyncRule } } };
+        var csoLookup = new Dictionary<(Guid MvoId, int ConnectedSystemId), ConnectedSystemObject> { { (mvo.Id, targetSystem.Id), targetCso } };
+        var csoAttributeValues = Enumerable.Empty<ConnectedSystemObjectAttributeValue>().ToLookup(av => (av.ConnectedSystemObject.Id, av.AttributeId));
+        var cache = new ExportEvaluationCache(exportRulesByMvoTypeId, csoLookup, csoAttributeValues, new List<int> { targetSystem.Id });
+
+        return (exportSyncRule, mvo, targetCso, targetEmployeeIdAttr, cache);
+    }
+
+    private static PendingExportAttributeValueChange CreateChange(
+        ConnectedSystemObjectTypeAttribute attribute, PendingExportAttributeChangeType changeType, string stringValue) => new()
+    {
+        Id = Guid.NewGuid(),
+        Attribute = attribute,
+        AttributeId = attribute.Id,
+        StringValue = stringValue,
+        ChangeType = changeType
+    };
+
+    /// <summary>
+    /// Merge into a database Pending Export that has both an export-eval-overlapping change and a
+    /// drift-only change: the drift-only change on an unrelated attribute must survive the merge
+    /// alongside the fresh export evaluation change.
+    /// </summary>
+    [Test]
+    public async Task EvaluateExportRules_ExistingDbPendingExportWithDriftOnlyChange_MergesBothAsync()
+    {
+        var (_, mvo, targetCso, targetEmployeeIdAttr, cache) = ArrangeSingleValuedScenario();
+        var driftOnlyAttr = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER")
+            .Attributes.Single(a => a.Name == MockTargetSystemAttributeNames.DisplayName.ToString());
+
+        var dbPendingExport = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystem = targetCso.ConnectedSystem,
+            ConnectedSystemId = targetCso.ConnectedSystemId,
+            ConnectedSystemObject = targetCso,
+            ConnectedSystemObjectId = targetCso.Id,
+            ChangeType = PendingExportChangeType.Update,
+            Status = PendingExportStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+        dbPendingExport.AttributeValueChanges.Add(CreateChange(driftOnlyAttr, PendingExportAttributeChangeType.Update, "Drift Display Name"));
+        SyncRepo.SeedPendingExport(dbPendingExport);
+
+        var employeeIdMvAttr = mvo.Type!.Attributes.Single(a => a.Id == (int)MockMetaverseAttributeName.EmployeeId);
+        var newEmployeeIdValue = mvo.AttributeValues.Single(av => av.AttributeId == employeeIdMvAttr.Id);
+        newEmployeeIdValue.StringValue = "E999";
+        var changedAttributes = new List<MetaverseObjectAttributeValue> { newEmployeeIdValue };
+
+        var result = await Jim.ExportEvaluation.EvaluateExportRulesWithNoNetChangeDetectionAsync(
+            mvo, changedAttributes, sourceSystem: null, cache);
+
+        Assert.That(result.PendingExports, Has.Count.EqualTo(1));
+        var merged = result.PendingExports.Single();
+        Assert.That(merged.Id, Is.Not.EqualTo(dbPendingExport.Id), "Delete-and-recreate must produce a new PE, not reuse the old one's Id.");
+        Assert.That(merged.AttributeValueChanges, Has.Count.EqualTo(2), "Export eval change plus the surviving drift-only change.");
+        Assert.That(merged.AttributeValueChanges.Any(c => c.AttributeId == targetEmployeeIdAttr.Id && c.StringValue == "E999"), Is.True,
+            "Fresh export evaluation change must be present.");
+        Assert.That(merged.AttributeValueChanges.Any(c => c.AttributeId == driftOnlyAttr.Id && c.StringValue == "Drift Display Name"), Is.True,
+            "Drift-only change on an unrelated attribute must survive the merge.");
+    }
+
+    /// <summary>
+    /// A stale database Pending Export left over from before the CSO's secondary external ID was
+    /// confirmed (Status transitioned PendingProvisioning -> Normal) has ChangeType Create. Once the
+    /// CSO is confirmed, the merge-and-replace must produce a PE typed Update (the freshly computed
+    /// changeType), not silently keep the stale PE's Create typing.
+    /// </summary>
+    [Test]
+    public async Task EvaluateExportRules_StaleCreatePendingExportOnConfirmedCso_ReplacementIsTypedUpdateAsync()
+    {
+        var (_, mvo, targetCso, targetEmployeeIdAttr, cache) = ArrangeSingleValuedScenario(ConnectedSystemObjectStatus.Normal);
+
+        var dbPendingExport = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystem = targetCso.ConnectedSystem,
+            ConnectedSystemId = targetCso.ConnectedSystemId,
+            ConnectedSystemObject = targetCso,
+            ConnectedSystemObjectId = targetCso.Id,
+            ChangeType = PendingExportChangeType.Create,
+            Status = PendingExportStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+        dbPendingExport.AttributeValueChanges.Add(CreateChange(targetEmployeeIdAttr, PendingExportAttributeChangeType.Update, "E123"));
+        SyncRepo.SeedPendingExport(dbPendingExport);
+
+        var employeeIdMvAttr = mvo.Type!.Attributes.Single(a => a.Id == (int)MockMetaverseAttributeName.EmployeeId);
+        var newEmployeeIdValue = mvo.AttributeValues.Single(av => av.AttributeId == employeeIdMvAttr.Id);
+        newEmployeeIdValue.StringValue = "E456";
+        var changedAttributes = new List<MetaverseObjectAttributeValue> { newEmployeeIdValue };
+
+        var result = await Jim.ExportEvaluation.EvaluateExportRulesWithNoNetChangeDetectionAsync(
+            mvo, changedAttributes, sourceSystem: null, cache);
+
+        Assert.That(result.PendingExports, Has.Count.EqualTo(1));
+        var merged = result.PendingExports.Single();
+        Assert.That(merged.ChangeType, Is.EqualTo(PendingExportChangeType.Update),
+            "CSO is confirmed (Normal status): the replacement PE must reflect the current evaluation (Update), not the stale DB PE's Create typing.");
+        Assert.That(merged.AttributeValueChanges.Single().StringValue, Is.EqualTo("E456"));
+    }
+
+    /// <summary>
+    /// A stale database Pending Export has an old value for a single-valued attribute; the fresh
+    /// export evaluation supersedes it with a new value. Only the new value must survive - this is
+    /// the exact shape that caused the LDAP "SINGLE-VALUE attribute specified more than once" error
+    /// before merge-key deduplication existed.
+    /// </summary>
+    [Test]
+    public async Task EvaluateExportRules_SupersedingChangeOnSameAttribute_OnlyNewValueSurvivesAsync()
+    {
+        var (_, mvo, targetCso, targetEmployeeIdAttr, cache) = ArrangeSingleValuedScenario();
+
+        var dbPendingExport = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystem = targetCso.ConnectedSystem,
+            ConnectedSystemId = targetCso.ConnectedSystemId,
+            ConnectedSystemObject = targetCso,
+            ConnectedSystemObjectId = targetCso.Id,
+            ChangeType = PendingExportChangeType.Update,
+            Status = PendingExportStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+        dbPendingExport.AttributeValueChanges.Add(CreateChange(targetEmployeeIdAttr, PendingExportAttributeChangeType.Update, "E123-OLD"));
+        SyncRepo.SeedPendingExport(dbPendingExport);
+
+        var employeeIdMvAttr = mvo.Type!.Attributes.Single(a => a.Id == (int)MockMetaverseAttributeName.EmployeeId);
+        var newEmployeeIdValue = mvo.AttributeValues.Single(av => av.AttributeId == employeeIdMvAttr.Id);
+        newEmployeeIdValue.StringValue = "E123-NEW";
+        var changedAttributes = new List<MetaverseObjectAttributeValue> { newEmployeeIdValue };
+
+        var result = await Jim.ExportEvaluation.EvaluateExportRulesWithNoNetChangeDetectionAsync(
+            mvo, changedAttributes, sourceSystem: null, cache);
+
+        Assert.That(result.PendingExports, Has.Count.EqualTo(1));
+        var merged = result.PendingExports.Single();
+        Assert.That(merged.AttributeValueChanges, Has.Count.EqualTo(1),
+            "Single-valued attribute merge keys by attribute ID only: the stale value must be replaced, not accumulated.");
+        Assert.That(merged.AttributeValueChanges.Single().StringValue, Is.EqualTo("E123-NEW"));
+    }
+
+    /// <summary>
+    /// Multi-valued reference add + remove sequence: the database Pending Export has drift Remove
+    /// entries for two members; export evaluation re-adds one of them (should win, replacing the
+    /// drift Remove with an Add for that value) and adds a brand-new member (distinct value,
+    /// preserved alongside the untouched drift Remove for the other member).
+    /// </summary>
+    [Test]
+    public async Task EvaluateExportRules_MultiValuedReferenceAddAndRemoveSequence_MergesAtValueLevelAsync()
+    {
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+        var mvGroupType = MetaverseObjectTypesData.Single(q => q.Name == "Group");
+
+        var mvMemberAttr = new MetaverseAttribute
+        {
+            Id = 9001, Name = "TestMember", Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.MultiValued, BuiltIn = false
+        };
+        mvGroupType.Attributes.Add(mvMemberAttr);
+
+        var targetMemberAttr = new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 9002, Name = "member", Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.MultiValued, ConnectedSystemObjectType = targetUserType, Selected = true
+        };
+        targetUserType.Attributes.Add(targetMemberAttr);
+
+        var exportSyncRule = SyncRulesData.Single(sr => sr.Name == "Dummy User Export Synchronisation Rule 1");
+        exportSyncRule.ConnectedSystemId = targetSystem.Id;
+        exportSyncRule.ConnectedSystem = targetSystem;
+        exportSyncRule.MetaverseObjectTypeId = mvGroupType.Id;
+        exportSyncRule.AttributeFlowRules.Clear();
+        exportSyncRule.AttributeFlowRules.Add(new SyncRuleMapping
+        {
+            Id = 100,
+            SyncRule = exportSyncRule,
+            TargetConnectedSystemAttribute = targetMemberAttr,
+            TargetConnectedSystemAttributeId = targetMemberAttr.Id,
+            Sources = { new SyncRuleMappingSource
+            {
+                Id = 200,
+                Order = 0,
+                MetaverseAttribute = mvMemberAttr,
+                MetaverseAttributeId = mvMemberAttr.Id
+            }}
+        });
+
+        var mvo = new MetaverseObject { Id = Guid.NewGuid(), Type = mvGroupType };
+        var targetCso = new ConnectedSystemObject
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = targetSystem.Id,
+            ConnectedSystem = targetSystem,
+            Type = targetUserType,
+            Status = ConnectedSystemObjectStatus.Normal,
+            MetaverseObjectId = mvo.Id,
+            MetaverseObject = mvo
+        };
+
+        var exportRulesByMvoTypeId = new Dictionary<int, List<SyncRule>> { { mvGroupType.Id, new List<SyncRule> { exportSyncRule } } };
+        var csoLookup = new Dictionary<(Guid MvoId, int ConnectedSystemId), ConnectedSystemObject> { { (mvo.Id, targetSystem.Id), targetCso } };
+        var csoAttributeValues = Enumerable.Empty<ConnectedSystemObjectAttributeValue>().ToLookup(av => (av.ConnectedSystemObject.Id, av.AttributeId));
+        var cache = new ExportEvaluationCache(exportRulesByMvoTypeId, csoLookup, csoAttributeValues, new List<int> { targetSystem.Id });
+
+        // Database PE: drift-detected removals for Alice and Bob.
+        var dbPendingExport = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystem = targetCso.ConnectedSystem,
+            ConnectedSystemId = targetCso.ConnectedSystemId,
+            ConnectedSystemObject = targetCso,
+            ConnectedSystemObjectId = targetCso.Id,
+            ChangeType = PendingExportChangeType.Update,
+            Status = PendingExportStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+        dbPendingExport.AttributeValueChanges.Add(CreateChange(targetMemberAttr, PendingExportAttributeChangeType.Remove, "CN=Alice,DC=test"));
+        dbPendingExport.AttributeValueChanges.Add(CreateChange(targetMemberAttr, PendingExportAttributeChangeType.Remove, "CN=Bob,DC=test"));
+        SyncRepo.SeedPendingExport(dbPendingExport);
+
+        // Export evaluation: Alice is re-added (should win over the drift Remove), Carol is a new member.
+        var aliceValue = new MetaverseObjectAttributeValue
+        {
+            Id = Guid.NewGuid(), MetaverseObject = mvo, Attribute = mvMemberAttr, AttributeId = mvMemberAttr.Id,
+            StringValue = "CN=Alice,DC=test"
+        };
+        var carolValue = new MetaverseObjectAttributeValue
+        {
+            Id = Guid.NewGuid(), MetaverseObject = mvo, Attribute = mvMemberAttr, AttributeId = mvMemberAttr.Id,
+            StringValue = "CN=Carol,DC=test"
+        };
+        mvo.AttributeValues.Add(aliceValue);
+        mvo.AttributeValues.Add(carolValue);
+        var changedAttributes = new List<MetaverseObjectAttributeValue> { aliceValue, carolValue };
+
+        var result = await Jim.ExportEvaluation.EvaluateExportRulesWithNoNetChangeDetectionAsync(
+            mvo, changedAttributes, sourceSystem: null, cache);
+
+        Assert.That(result.PendingExports, Has.Count.EqualTo(1));
+        var merged = result.PendingExports.Single();
+        Assert.That(merged.AttributeValueChanges, Has.Count.EqualTo(3),
+            "Alice (superseded to Add), Carol (new Add) and Bob (untouched drift Remove) are all distinct values.");
+
+        var aliceChange = merged.AttributeValueChanges.Single(c => c.StringValue == "CN=Alice,DC=test");
+        Assert.That(aliceChange.ChangeType, Is.EqualTo(PendingExportAttributeChangeType.Add),
+            "Export eval re-adding Alice must win over the drift Remove for the same value.");
+
+        var bobChange = merged.AttributeValueChanges.Single(c => c.StringValue == "CN=Bob,DC=test");
+        Assert.That(bobChange.ChangeType, Is.EqualTo(PendingExportAttributeChangeType.Remove),
+            "Bob's drift Remove is untouched by this export evaluation and must survive unchanged.");
+
+        var carolChange = merged.AttributeValueChanges.Single(c => c.StringValue == "CN=Carol,DC=test");
+        Assert.That(carolChange.ChangeType, Is.EqualTo(PendingExportAttributeChangeType.Add));
+    }
+
+    /// <summary>
+    /// No existing database Pending Export for the CSO: the create path must be entirely unaffected
+    /// by the merge-fetch change (no merge/delete/replace branch is taken at all).
+    /// </summary>
+    [Test]
+    public async Task EvaluateExportRules_NoExistingDbPendingExport_CreatesNewWithoutMergeAsync()
+    {
+        var (_, mvo, _, targetEmployeeIdAttr, cache) = ArrangeSingleValuedScenario();
+
+        var employeeIdMvAttr = mvo.Type!.Attributes.Single(a => a.Id == (int)MockMetaverseAttributeName.EmployeeId);
+        var newEmployeeIdValue = mvo.AttributeValues.Single(av => av.AttributeId == employeeIdMvAttr.Id);
+        newEmployeeIdValue.StringValue = "E777";
+        var changedAttributes = new List<MetaverseObjectAttributeValue> { newEmployeeIdValue };
+
+        var result = await Jim.ExportEvaluation.EvaluateExportRulesWithNoNetChangeDetectionAsync(
+            mvo, changedAttributes, sourceSystem: null, cache);
+
+        Assert.That(result.PendingExports, Has.Count.EqualTo(1));
+        var created = result.PendingExports.Single();
+        Assert.That(created.ChangeType, Is.EqualTo(PendingExportChangeType.Update));
+        Assert.That(created.AttributeValueChanges, Has.Count.EqualTo(1));
+        Assert.That(created.AttributeValueChanges.Single().AttributeId, Is.EqualTo(targetEmployeeIdAttr.Id));
+        Assert.That(created.AttributeValueChanges.Single().StringValue, Is.EqualTo("E777"));
+    }
+}

--- a/test/JIM.Worker.Tests/Repositories/PendingExportMergeFetchDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Repositories/PendingExportMergeFetchDatabaseTests.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace JIM.Worker.Tests.Repositories;
 
 /// <summary>
-/// Real-PostgreSQL verification of <see cref="JIM.PostgresData.Repositories.ConnectedSystemRepository.GetPendingExportByConnectedSystemObjectIdForMergeAsync"/>,
+/// Real-PostgreSQL verification of <see cref="JIM.PostgresData.Repositories.ConnectedSystemRepository.GetPendingExportLightweightByConnectedSystemObjectIdAsync"/>,
 /// the lean fetch added for the merge-and-replace path in
 /// <c>ExportEvaluationServer.CreateOrUpdatePendingExportWithNoNetChangeAsync</c> (issue #986).
 /// </summary>
@@ -168,14 +168,14 @@ public class PendingExportMergeFetchDatabaseTests
     /// fetch, which loads everything.
     /// </summary>
     [Test]
-    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_DoesNotLoadCsoOrMvoAttributeValueGraphsAsync()
+    public async Task GetPendingExportLightweightByConnectedSystemObjectIdAsync_DoesNotLoadCsoOrMvoAttributeValueGraphsAsync()
     {
         var (csoId, _) = await SeedLargeGroupWithSmallPendingExportAsync();
 
         await using var ctx = NewContext();
         var repository = new PostgresDataRepository(ctx);
 
-        var result = await repository.ConnectedSystems.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId);
+        var result = await repository.ConnectedSystems.GetPendingExportLightweightByConnectedSystemObjectIdAsync(csoId);
 
         Assert.That(result, Is.Not.Null);
         Assert.Multiple(() =>
@@ -200,7 +200,7 @@ public class PendingExportMergeFetchDatabaseTests
     /// swapping the merge call site to the lean method cannot change the merge outcome.
     /// </summary>
     [Test]
-    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_AttributeValueChangesMatchHeavyFetchAsync()
+    public async Task GetPendingExportLightweightByConnectedSystemObjectIdAsync_AttributeValueChangesMatchHeavyFetchAsync()
     {
         var (csoId, _) = await SeedLargeGroupWithSmallPendingExportAsync();
 
@@ -208,7 +208,7 @@ public class PendingExportMergeFetchDatabaseTests
         var heavyResult = await new PostgresDataRepository(heavyCtx).ConnectedSystems.GetPendingExportByConnectedSystemObjectIdAsync(csoId);
 
         await using var leanCtx = NewContext();
-        var leanResult = await new PostgresDataRepository(leanCtx).ConnectedSystems.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId);
+        var leanResult = await new PostgresDataRepository(leanCtx).ConnectedSystems.GetPendingExportLightweightByConnectedSystemObjectIdAsync(csoId);
 
         Assert.That(heavyResult, Is.Not.Null);
         Assert.That(leanResult, Is.Not.Null);

--- a/test/JIM.Worker.Tests/Repositories/PendingExportMergeFetchDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Repositories/PendingExportMergeFetchDatabaseTests.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+using JIM.PostgresData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Repositories;
+
+/// <summary>
+/// Real-PostgreSQL verification of <see cref="JIM.PostgresData.Repositories.ConnectedSystemRepository.GetPendingExportByConnectedSystemObjectIdForMergeAsync"/>,
+/// the lean fetch added for the merge-and-replace path in
+/// <c>ExportEvaluationServer.CreateOrUpdatePendingExportWithNoNetChangeAsync</c> (issue #986).
+/// </summary>
+/// <remarks>
+/// The merge path re-fetches a Pending Export once per removed group member during cohort
+/// deprovisioning. Instrumented capture showed 99.5% of the merge cost is this fetch, because the
+/// pre-existing <see cref="JIM.PostgresData.Repositories.ConnectedSystemRepository.GetPendingExportByConnectedSystemObjectIdAsync"/>
+/// Include chain also loads the target Connected System Object's and source Metaverse Object's full
+/// attribute value graphs, up to ~200,000 rows each for a large group, even though the merge logic
+/// only ever reads AttributeValueChanges. EF Core's in-memory provider (and Moq-backed
+/// <c>IQueryable</c> mocks) cannot distinguish an Include-shaped query from a full one, since every
+/// seeded object is already a fully wired-up graph in memory; this can only be verified against a
+/// real database. Opt-in via the same <c>JIM_TEST_RESET_*</c> environment variables as the other
+/// <c>RequiresPostgres</c> fixtures (see <c>JIM.Worker.Tests.Servers.SystemResetDatabaseTests</c>);
+/// ignored when <c>JIM_TEST_RESET_DB</c> is absent.
+/// </remarks>
+[TestFixture]
+[Category("RequiresPostgres")]
+public class PendingExportMergeFetchDatabaseTests
+{
+    private const int LargeAttributeValueCount = 500;
+
+    private string _connectionString = null!;
+
+    private JimDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseNpgsql(_connectionString)
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new JimDbContext(options);
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var dbName = Environment.GetEnvironmentVariable("JIM_TEST_RESET_DB");
+        if (string.IsNullOrEmpty(dbName))
+            Assert.Ignore("JIM_TEST_RESET_DB not set; skipping real-PostgreSQL Pending Export merge-fetch tests.");
+
+        var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
+        var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
+        var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
+
+        using var ctx = NewContext();
+        ctx.Database.Migrate();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(@"
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+                FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '__EFMigrationsHistory') LOOP
+                    EXECUTE 'TRUNCATE TABLE ""' || r.tablename || '"" RESTART IDENTITY CASCADE';
+                END LOOP;
+            END $$;");
+    }
+
+    /// <summary>
+    /// Seeds a large group-shaped CSO (many attribute values) and source MVO (many attribute values),
+    /// plus a Pending Export for that CSO with a small attribute value change set - mirroring a
+    /// group's Pending Export mid-cohort-deprovisioning: a huge membership graph behind it, but only
+    /// a handful of pending attribute changes.
+    /// </summary>
+    private async Task<(Guid CsoId, Guid PendingExportId)> SeedLargeGroupWithSmallPendingExportAsync()
+    {
+        await using var seed = NewContext();
+
+        var connectorDefinition = new ConnectorDefinition { Name = "Test Connector", BuiltIn = true };
+        var system = new ConnectedSystem { Name = "Glitterband EMEA", ConnectorDefinition = connectorDefinition };
+        var csType = new ConnectedSystemObjectType { Name = "GROUP", ConnectedSystem = system, Selected = true };
+        var memberAttr = new ConnectedSystemObjectTypeAttribute
+        {
+            Name = "member", ConnectedSystemObjectType = csType, Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.MultiValued, Selected = true
+        };
+        var titleAttr = new ConnectedSystemObjectTypeAttribute
+        {
+            Name = "title", ConnectedSystemObjectType = csType, Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.SingleValued, Selected = true
+        };
+        csType.Attributes.Add(memberAttr);
+        csType.Attributes.Add(titleAttr);
+
+        var mvType = new MetaverseObjectType { Name = "Group", PluralName = "Groups", BuiltIn = true };
+        var mvMemberAttr = new MetaverseAttribute
+        {
+            Name = "member", Type = AttributeDataType.Reference, AttributePlurality = AttributePlurality.MultiValued, BuiltIn = true
+        };
+        mvType.Attributes.Add(mvMemberAttr);
+
+        seed.AddRange(connectorDefinition, system, csType, mvType);
+        await seed.SaveChangesAsync();
+
+        var cso = new ConnectedSystemObject { Type = csType, ConnectedSystem = system, Status = ConnectedSystemObjectStatus.Normal };
+        for (var i = 0; i < LargeAttributeValueCount; i++)
+            cso.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Attribute = memberAttr, StringValue = $"CN=User{i:D4},DC=test", ConnectedSystemObject = cso });
+
+        var mvo = new MetaverseObject { Type = mvType };
+        for (var i = 0; i < LargeAttributeValueCount; i++)
+            mvo.AttributeValues.Add(new MetaverseObjectAttributeValue { Attribute = mvMemberAttr, MetaverseObject = mvo, GuidValue = Guid.NewGuid() });
+
+        seed.Add(cso);
+        seed.Add(mvo);
+        await seed.SaveChangesAsync();
+
+        var pendingExport = new PendingExport
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystem = system,
+            ConnectedSystemId = system.Id,
+            ConnectedSystemObject = cso,
+            ConnectedSystemObjectId = cso.Id,
+            SourceMetaverseObject = mvo,
+            SourceMetaverseObjectId = mvo.Id,
+            ChangeType = PendingExportChangeType.Update,
+            Status = PendingExportStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+        pendingExport.AttributeValueChanges.Add(new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), Attribute = titleAttr, AttributeId = titleAttr.Id,
+            StringValue = "Old Title", ChangeType = PendingExportAttributeChangeType.Update
+        });
+        pendingExport.AttributeValueChanges.Add(new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), Attribute = memberAttr, AttributeId = memberAttr.Id,
+            StringValue = "CN=Leaver1,DC=test", ChangeType = PendingExportAttributeChangeType.Remove
+        });
+        pendingExport.AttributeValueChanges.Add(new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(), Attribute = memberAttr, AttributeId = memberAttr.Id,
+            StringValue = "CN=Leaver2,DC=test", ChangeType = PendingExportAttributeChangeType.Remove
+        });
+
+        seed.Add(pendingExport);
+        await seed.SaveChangesAsync();
+
+        return (cso.Id, pendingExport.Id);
+    }
+
+    /// <summary>
+    /// Sharpest red for issue #986: the lean merge fetch must NOT load the target CSO's or source MVO's
+    /// attribute value graphs, only AttributeValueChanges (with Attribute). Before the lean Include
+    /// shape is implemented, this fails because the method under test still delegates to the heavy
+    /// fetch, which loads everything.
+    /// </summary>
+    [Test]
+    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_DoesNotLoadCsoOrMvoAttributeValueGraphsAsync()
+    {
+        var (csoId, _) = await SeedLargeGroupWithSmallPendingExportAsync();
+
+        await using var ctx = NewContext();
+        var repository = new PostgresDataRepository(ctx);
+
+        var result = await repository.ConnectedSystems.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result!.ConnectedSystemObject, Is.Null,
+                "Merge fetch must not load the target CSO navigation - the merge logic never reads it, and for a large group it can be hundreds of thousands of rows.");
+            Assert.That(result!.SourceMetaverseObject, Is.Null,
+                "Merge fetch must not load the source MVO navigation - the merge logic never reads it.");
+            Assert.That(result!.ConnectedSystem, Is.Null,
+                "Merge fetch must not load the ConnectedSystem navigation - the merge logic never reads it.");
+            Assert.That(result!.AttributeValueChanges, Has.Count.EqualTo(3),
+                "Merge fetch must still load AttributeValueChanges - this is the actual merge input.");
+            Assert.That(result!.AttributeValueChanges.All(avc => avc.Attribute != null), Is.True,
+                "Each AttributeValueChange's Attribute must be loaded - GetAttributeChangeMergeKey reads AttributePlurality from it.");
+        });
+    }
+
+    /// <summary>
+    /// Equality-of-merge-result half of the red test: whatever the lean fetch returns for
+    /// AttributeValueChanges must be identical (Id, AttributeId, value columns, ChangeType, and the
+    /// Attribute's AttributePlurality used for merge-key dedup) to what the heavy fetch returns, so
+    /// swapping the merge call site to the lean method cannot change the merge outcome.
+    /// </summary>
+    [Test]
+    public async Task GetPendingExportByConnectedSystemObjectIdForMergeAsync_AttributeValueChangesMatchHeavyFetchAsync()
+    {
+        var (csoId, _) = await SeedLargeGroupWithSmallPendingExportAsync();
+
+        await using var heavyCtx = NewContext();
+        var heavyResult = await new PostgresDataRepository(heavyCtx).ConnectedSystems.GetPendingExportByConnectedSystemObjectIdAsync(csoId);
+
+        await using var leanCtx = NewContext();
+        var leanResult = await new PostgresDataRepository(leanCtx).ConnectedSystems.GetPendingExportByConnectedSystemObjectIdForMergeAsync(csoId);
+
+        Assert.That(heavyResult, Is.Not.Null);
+        Assert.That(leanResult, Is.Not.Null);
+
+        var heavyChanges = heavyResult!.AttributeValueChanges
+            .OrderBy(c => c.Id)
+            .Select(c => (c.Id, c.AttributeId, c.StringValue, c.ChangeType, Plurality: c.Attribute?.AttributePlurality))
+            .ToList();
+        var leanChanges = leanResult!.AttributeValueChanges
+            .OrderBy(c => c.Id)
+            .Select(c => (c.Id, c.AttributeId, c.StringValue, c.ChangeType, Plurality: c.Attribute?.AttributePlurality))
+            .ToList();
+
+        Assert.That(leanChanges, Is.EqualTo(heavyChanges),
+            "The lean fetch's AttributeValueChanges (the actual merge input) must be identical to the heavy fetch's, so the merge-and-replace outcome is unaffected by which fetch method supplied the data.");
+    }
+}


### PR DESCRIPTION
Fixes the cohort-deprovisioning crawl of #986. Note the diagnosis moved during instrumentation: the issue's original delete-and-recreate hypothesis was overturned by span data (posted on the issue); 99.5% of the merge cost was the FETCH of the existing Pending Export, whose Include chain loaded the group CSO's and group MVO's full attribute value graphs (~400k rows for the template's largest group) once per removed member.

## Change

A lean merge fetch, `GetPendingExportByConnectedSystemObjectIdForMergeAsync`, loading only the Pending Export row and its `AttributeValueChanges` (with `Attribute`, needed for single-vs-multi-valued merge dedup). A navigation-consumption trace of the merge-and-replace block (in the commit message) shows the CSO/MVO/Connected System graphs were never read; the change list must stay loaded because child-row disposal on delete relies on EF tracking (no DB-level cascade), and it does. Delete-and-recreate semantics are deliberately unchanged (measured effectively free: 0.4s total across the whole capture).

The heavy `GetPendingExportByConnectedSystemObjectIdAsync` remains for its other callers (UI detail page genuinely needs the full graph). `EnsureDeletePendingExportAsync` (deprovisioning delete path) now uses the same lightweight fetch: it only reads ChangeType/Id/Status and hands the entity to the delete (which needs the loaded change rows for EF-tracked child disposal); a new pinning test covers replaced-PE child-row disposal. With two callers the lean method is renamed `GetPendingExportLightweightByConnectedSystemObjectIdAsync`, matching the existing Lightweight naming precedent. Still flagged, not changed: the plural `GetPendingExportsByConnectedSystemObjectIdsAsync`'s only caller appears to be dead code; noted for follow-up.

## Testing

- Merge-semantics pinning tests (drift-only merge, Create to Update transition, superseding changes, reference add/remove sequences, no-existing-PE) green before and after; all 20 pre-existing merge tests unmodified and green.
- Red-first real-PostgreSQL Include-shape tests (`[Category("RequiresPostgres")]`, EF in-memory cannot distinguish Include shapes): lean fetch proven not to load CSO/MVO graphs while returning identical attribute change sets to the heavy fetch. Red run showed the heavy graphs loading; green after. 37/37 RequiresPostgres tier passing, run twice.
- `dotnet build JIM.sln`: 0 warnings. `dotnet test JIM.sln`: 3,386 passed, 0 failed.

## Runtime verification (live stack, Scale200k10kGroups LeaverCohort re-run on this branch's worker build)

| | Before (2026-07-12 capture) | After |
|---|---|---|
| `GetPendingExportByCsoIdForMerge` | 101 slow spans, avg 4.7s, max 23.7s (99.5% of merge cost) | absent from slow spans entirely (single 275ms merge in the same window) |
| Deprovisioning Full Sync rate | 4 objects/sec, ~14h ETA (killed) | ~13-19 objects/sec, now bounded entirely by a different hotspot (below); merge fetches no longer register |

The re-run exposed a separate, previously-masked hotspot on the deletion path (`FlushPendingMvoDeletions`, avg ~50s per flush) which bounds the sync rate now; that is outside this PR's scope and is written up as a follow-up issue draft for review. This PR's targeted defect (the merge fetch) is verified fixed.

Docs: n/a - performance-only change, no behaviour or configuration change to document (changelog ⚡ entry included).

Closes #986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
