### PR TITLE
fix(export): persist deferred reference resolutions before parallel batch execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- 🐛 Exports running with Max Export Parallelism above one no longer send unresolved reference values (raw internal identifiers) to the target system. Reference resolution results are now persisted before parallel export batches execute, so every batch sees the resolved values; previously group memberships could be exported as invalid values and fail (for example "invalid per syntax" from an LDAP directory).
 - 🐛 Closing the browser or navigating away while an admin page with tabs (such as Operations) was open no longer records spurious Error-level "Navigation failed" and "Unhandled exception in circuit" entries in the JIM.Web log. Any remaining browser-disconnect noise from the framework is now logged at Warning, so Error entries once again indicate genuine problems.
 
 ### Performance

--- a/src/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/src/JIM.Application/Servers/ExportExecutionServer.cs
@@ -726,6 +726,23 @@ public class ExportExecutionServer
         // Batch-export resolved deferred exports
         if (resolvedExports.Count > 0)
         {
+            // Persist the in-memory reference resolutions BEFORE executing the deferred batches.
+            // The parallel path (ProcessBatchesInParallelAsync) re-loads each batch by ID on a
+            // fresh per-batch repository/DbContext, which only sees persisted state; without
+            // persisting first, those contexts read the still-unresolved rows and send raw
+            // Metaverse Object identifiers to the target system (observed against OpenLDAP as
+            // "member: value #0 invalid per syntax" when Max Export Parallelism first defaulted
+            // above 1). The sequential path passes these in-memory instances straight to the
+            // connector and does not strictly need the persist, but doing it unconditionally
+            // also means a worker crash mid-export no longer loses completed resolution work.
+            // UpdatePendingExportsAsync persists both the parent rows and the attribute value
+            // change rows (StringValue/UnresolvedReferenceValue) via raw SQL.
+            using (Diagnostics.Diagnostics.Database.StartSpan("PersistResolvedDeferredExports")
+                .SetTag("count", resolvedExports.Count))
+            {
+                await SyncRepo.UpdatePendingExportsAsync(resolvedExports);
+            }
+
             // Clear the change tracker before exporting deferred batches.
             // The CSO lookup query above re-loaded entities into the tracker, which causes
             // identity conflicts when the EF fallback paths (used in tests with in-memory DB)

--- a/src/JIM.InMemoryData/SyncRepository.cs
+++ b/src/JIM.InMemoryData/SyncRepository.cs
@@ -971,7 +971,9 @@ public class SyncRepository : ISyncRepository
         return Task.CompletedTask;
     }
 
-    public Task UpdatePendingExportsAsync(IEnumerable<PendingExport> pendingExports)
+    // Virtual for test-support subclasses (see GetPendingExportsByIdsAsync): persisting is the
+    // event that makes state visible to fresh per-batch contexts in the parallel export path.
+    public virtual Task UpdatePendingExportsAsync(IEnumerable<PendingExport> pendingExports)
     {
         foreach (var pe in pendingExports)
             _pendingExports[pe.Id] = pe;
@@ -1768,7 +1770,10 @@ public class SyncRepository : ISyncRepository
         return Task.CompletedTask;
     }
 
-    public Task<List<PendingExport>> GetPendingExportsByIdsAsync(IList<Guid> pendingExportIds)
+    // Virtual for test-support subclasses: the parallel export batch path re-loads Pending
+    // Exports by ID on a fresh per-batch context, and tests need to simulate that database
+    // isolation (returning last-persisted state rather than live in-memory references).
+    public virtual Task<List<PendingExport>> GetPendingExportsByIdsAsync(IList<Guid> pendingExportIds)
     {
         var result = pendingExportIds
             .Where(id => _pendingExports.ContainsKey(id))

--- a/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
+++ b/test/JIM.Worker.Tests/OutboundSync/ExportExecutionTests.cs
@@ -1918,6 +1918,91 @@ public class ExportExecutionTests
         }
     }
 
+    /// <summary>
+    /// Simulates database persistence isolation for the parallel export batch path: the real
+    /// ProcessBatchesInParallelAsync re-loads each batch's Pending Exports by ID on a FRESH
+    /// per-batch DbContext, which only sees state that has been persisted. The plain in-memory
+    /// repository returns live object references, so in-memory mutations (such as reference
+    /// resolution) are visible to "re-loads" even when nothing was persisted; that masks exactly
+    /// the class of bug this fake exists to expose. Here, GetPendingExportsByIdsAsync returns
+    /// deep clones of the last-PERSISTED state, and only UpdatePendingExportsAsync (the persist
+    /// event) refreshes that state.
+    /// </summary>
+    private sealed class PersistenceIsolatingSyncRepository : SyncRepository
+    {
+        private readonly Dictionary<Guid, PendingExport> _persistedState = new();
+        private readonly object _persistLock = new();
+
+        /// <summary>
+        /// Seeds a Pending Export into the store AND snapshots it as the persisted (committed)
+        /// state, as a real database row would be after the sync run that created it.
+        /// </summary>
+        public void SeedPendingExportAsPersisted(PendingExport pendingExport)
+        {
+            SeedPendingExport(pendingExport);
+            lock (_persistLock)
+                _persistedState[pendingExport.Id] = ClonePendingExport(pendingExport);
+        }
+
+        public override Task UpdatePendingExportsAsync(IEnumerable<PendingExport> pendingExports)
+        {
+            var list = pendingExports.ToList();
+            lock (_persistLock)
+            {
+                foreach (var pe in list)
+                    _persistedState[pe.Id] = ClonePendingExport(pe);
+            }
+            return base.UpdatePendingExportsAsync(list);
+        }
+
+        public override Task<List<PendingExport>> GetPendingExportsByIdsAsync(IList<Guid> pendingExportIds)
+        {
+            lock (_persistLock)
+            {
+                var result = pendingExportIds
+                    .Where(id => _persistedState.ContainsKey(id))
+                    .Select(id => ClonePendingExport(_persistedState[id]))
+                    .ToList();
+                return Task.FromResult(result);
+            }
+        }
+
+        private static PendingExport ClonePendingExport(PendingExport source)
+        {
+            return new PendingExport
+            {
+                Id = source.Id,
+                ConnectedSystemId = source.ConnectedSystemId,
+                ConnectedSystem = source.ConnectedSystem,
+                ConnectedSystemObject = source.ConnectedSystemObject,
+                ConnectedSystemObjectId = source.ConnectedSystemObjectId,
+                SourceMetaverseObjectId = source.SourceMetaverseObjectId,
+                Status = source.Status,
+                ChangeType = source.ChangeType,
+                CreatedAt = source.CreatedAt,
+                HasUnresolvedReferences = source.HasUnresolvedReferences,
+                MaxRetries = source.MaxRetries,
+                ErrorCount = source.ErrorCount,
+                NextRetryAt = source.NextRetryAt,
+                LastAttemptedAt = source.LastAttemptedAt,
+                AttributeValueChanges = source.AttributeValueChanges.Select(avc => new PendingExportAttributeValueChange
+                {
+                    Id = avc.Id,
+                    PendingExportId = avc.PendingExportId,
+                    AttributeId = avc.AttributeId,
+                    Attribute = avc.Attribute,
+                    ChangeType = avc.ChangeType,
+                    Status = avc.Status,
+                    StringValue = avc.StringValue,
+                    UnresolvedReferenceValue = avc.UnresolvedReferenceValue,
+                    GuidValue = avc.GuidValue,
+                    IntValue = avc.IntValue,
+                    ExportAttemptCount = avc.ExportAttemptCount
+                }).ToList()
+            };
+        }
+    }
+
     private static Mock<IConnector> CreateSucceedingCallsConnector()
     {
         var mockConnector = new Mock<IConnector>();
@@ -2204,6 +2289,128 @@ public class ExportExecutionTests
             "The deferred bulk-collect must not fire while executable exports remain beyond the cursor.");
         Assert.That(countingRepo.ExecutableProbeCalls, Is.GreaterThanOrEqualTo(1),
             "Expected the all-deferred page 1 to trigger the executable-exports existence probe.");
+    }
+
+    /// <summary>
+    /// Regression guard for the parallel deferred-export path: ProcessBatchesInParallelAsync
+    /// re-loads each batch's Pending Exports by ID on a fresh per-batch repository/DbContext,
+    /// which only sees PERSISTED state. Reference resolution happens in memory before dispatch,
+    /// so the resolutions must be persisted BEFORE the parallel batches execute; otherwise each
+    /// batch re-loads the stale unresolved rows and sends raw Metaverse Object identifiers to
+    /// the target directory ("member: value #0 invalid per syntax" against OpenLDAP; observed
+    /// 2026-07-13 when the Max Export Parallelism default first exceeded 1). The sequential path
+    /// masks this by passing the in-memory objects straight to the connector.
+    /// </summary>
+    [Test]
+    public async Task ExecuteExportsAsync_ParallelDeferredExports_ConnectorReceivesResolvedReferencesAsync()
+    {
+        // Arrange: an application wired to a persistence-isolating repository, so per-batch
+        // re-loads behave like a real fresh DbContext (persisted state only).
+        var isolatingRepo = new PersistenceIsolatingSyncRepository();
+        var syncRepo = TestUtilities.CreateSyncRepository(activity: ActivitiesData.First(), repository: isolatingRepo);
+        using var jim = new JimApplication(new PostgresDataRepository(MockJimDbContext.Object), syncRepository: syncRepo);
+
+        var targetSystem = ConnectedSystemsData.Single(s => s.Name == "Dummy Target System");
+        var targetUserType = ConnectedSystemObjectTypesData.Single(t => t.Name == "TARGET_USER");
+        var managerAttr = targetUserType.Attributes.Single(a => a.Name == MockTargetSystemAttributeNames.Manager.ToString());
+        var objectGuidAttr = targetUserType.Attributes.Single(a => a.Name == MockTargetSystemAttributeNames.ObjectGuid.ToString());
+
+        // Referenced MVOs with target CSOs so every deferred reference resolves in this run.
+        var referencedMvoIds = new List<Guid>();
+        for (var i = 0; i < 6; i++)
+        {
+            var mvoId = Guid.NewGuid();
+            referencedMvoIds.Add(mvoId);
+            isolatingRepo.SeedMetaverseObject(new MetaverseObject { Id = mvoId });
+
+            var referencedCso = new ConnectedSystemObject
+            {
+                Id = Guid.NewGuid(),
+                ConnectedSystemId = targetSystem.Id,
+                Type = targetUserType,
+                TypeId = targetUserType.Id,
+                MetaverseObjectId = mvoId,
+                AttributeValues = new List<ConnectedSystemObjectAttributeValue>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Attribute = objectGuidAttr,
+                        AttributeId = objectGuidAttr.Id,
+                        GuidValue = Guid.NewGuid()
+                    }
+                }
+            };
+            isolatingRepo.SeedConnectedSystemObject(referencedCso);
+        }
+
+        // Six deferred reference-bearing exports at batch size 2 = three deferred batches,
+        // which is what routes execution through ProcessBatchesInParallelAsync (it requires
+        // more than one batch) when MaxParallelism > 1 and both factories are supplied.
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        for (var i = 0; i < 6; i++)
+        {
+            var pe = CreateSeededCreateExport(targetSystem, targetUserType,
+                baseTime.AddMilliseconds(i), hasUnresolvedReferences: true);
+            pe.AttributeValueChanges.Add(new PendingExportAttributeValueChange
+            {
+                Id = Guid.NewGuid(),
+                PendingExportId = pe.Id,
+                ChangeType = PendingExportAttributeChangeType.Add,
+                AttributeId = managerAttr.Id,
+                Attribute = managerAttr,
+                UnresolvedReferenceValue = referencedMvoIds[i].ToString(),
+                Status = PendingExportAttributeChangeStatus.Pending
+            });
+            isolatingRepo.SeedPendingExportAsPersisted(pe);
+        }
+
+        // Recording connectors: capture the reference values each batch's connector actually
+        // receives, cloned AT CALL TIME so later in-memory mutations cannot mask staleness.
+        var receivedReferenceValues = new System.Collections.Concurrent.ConcurrentBag<(Guid PeId, string? StringValue, string? UnresolvedReferenceValue)>();
+        Mock<IConnector> CreateRecordingConnector()
+        {
+            var mock = new Mock<IConnector>();
+            var export = mock.As<IConnectorExportUsingCalls>();
+            mock.Setup(c => c.Name).Returns("Recording Test Connector");
+            export.Setup(c => c.ExportAsync(It.IsAny<IList<PendingExport>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IList<PendingExport> exports, CancellationToken _) =>
+                {
+                    foreach (var pe in exports)
+                        foreach (var avc in pe.AttributeValueChanges.Where(a => a.AttributeId == managerAttr.Id))
+                            receivedReferenceValues.Add((pe.Id, avc.StringValue, avc.UnresolvedReferenceValue));
+                    return exports.Select(_ => ConnectedSystemExportResult.Succeeded()).ToList();
+                });
+            return mock;
+        }
+
+        var primaryConnector = CreateRecordingConnector();
+        var options = new ExportExecutionOptions { BatchSize = 2, MaxParallelism = 2 };
+
+        // Act
+        var result = await jim.ExportExecution.ExecuteExportsAsync(
+            targetSystem,
+            primaryConnector.Object,
+            SyncRunMode.PreviewAndSync,
+            options,
+            CancellationToken.None,
+            progressCallback: null,
+            connectorFactory: () => CreateRecordingConnector().Object,
+            repositoryFactory: () => isolatingRepo);
+
+        // Assert: every deferred export reached a connector, and every reference the connectors
+        // received was RESOLVED (StringValue populated, unresolved marker cleared). Before the
+        // fix, the parallel batches re-loaded pre-resolution rows and received raw MVO GUIDs.
+        Assert.That(receivedReferenceValues.Count, Is.EqualTo(6),
+            "All six deferred exports should have been executed via connector batches.");
+        var unresolvedReceived = receivedReferenceValues
+            .Where(v => string.IsNullOrEmpty(v.StringValue) || !string.IsNullOrEmpty(v.UnresolvedReferenceValue))
+            .ToList();
+        Assert.That(unresolvedReceived, Is.Empty,
+            "Connector received unresolved reference values; in-memory resolutions must be persisted " +
+            "before parallel deferred batches re-load their exports from fresh contexts. Received: " +
+            string.Join("; ", unresolvedReceived.Select(v => $"PE {v.PeId}: StringValue='{v.StringValue}', Unresolved='{v.UnresolvedReferenceValue}'")));
+        Assert.That(result.FailedCount, Is.EqualTo(0), "No deferred export should fail in this scenario.");
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes the mass group Create failures ("member: value #0 invalid per syntax") seen on the first Scenario 8 run after #990 merged.

## Root cause (pre-existing, exposed by #990's parallelism default)

`ProcessDeferredExportsAsync` resolves reference values in memory and, on the sequential path, hands those instances straight to the connector. The parallel path (`ProcessBatchesInParallelAsync`) re-loads each batch by ID on a fresh per-batch repository/DbContext (required for EF thread safety), which only sees persisted state; the resolutions were never persisted before execution, so every parallel deferred batch exported raw Metaverse Object GUIDs as reference values, which the directory rejects. Reachable in released versions by any administrator setting Max Export Parallelism above 1; the path had zero test coverage (the suite's only `MaxParallelism` reference was `= 1`), so #990's conservative default of 2 was the first thing ever to execute it.

## Fix

Bulk-persist the resolved exports (parent rows and attribute value change rows; `UpdatePendingExportsAsync` covers both via raw SQL) before deferred batches dispatch, on both paths, under a new `PersistResolvedDeferredExports` span. Side benefit: a worker crash mid-export no longer loses completed resolution work.

## Testing

- Red-first regression test `ExecuteExportsAsync_ParallelDeferredExports_ConnectorReceivesResolvedReferencesAsync`. The plain in-memory repository returns live object references, which masks exactly this bug (in-memory mutations are visible to "re-loads" without any persist), so the test introduces a persistence-isolating repository fake: per-batch fetches return deep clones of last-persisted state, like a real fresh DbContext, and recording connectors clone received values at call time. Red run: connectors received raw MVO GUIDs. Green after the fix.
- `dotnet build JIM.sln`: 0 warnings. `dotnet test JIM.sln`: 3,429 passed, 0 failed.

## Runtime verification

The exact failing command (`Scenario8-CrossDomainEntitlementSync`, Medium, OpenLDAP, `-ExportConcurrency 16`) re-run on this branch's images: all tests passed, zero Error/Fatal log lines, 9m49s. Worker log confirms the parallel deferred path executed (`ProcessBatchesInParallelAsync`, recommendation 2) and the previously 100%-failing group Creates succeeded.

Docs: n/a - bug fix, no behaviour or configuration change to document (changelog 🐛 entry included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
