### PR TITLE
Configurable REST API rate limiting via Service Settings (#500)

### DIFF
--- a/.devcontainer/keycloak/jim-realm.json
+++ b/.devcontainer/keycloak/jim-realm.json
@@ -35,7 +35,7 @@
   "duplicateEmailsAllowed": false,
   "resetPasswordAllowed": false,
   "editUsernameAllowed": false,
-  "bruteForceProtected": false,
+  "bruteForceProtected": true,
   "permanentLockout": false,
   "maxTemporaryLockouts": 0,
   "bruteForceStrategy": "MULTIPLE",

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,22 @@ JIM_LOG_REQUESTS=false
 # JIM_INFRASTRUCTURE_API_KEY=jim_ak_your_generated_key_here
 
 # =============================================================================
+# Reverse Proxy (Optional)
+# =============================================================================
+# Comma-separated list of trusted proxy IP addresses and/or CIDR networks
+# (e.g. 10.0.0.1,172.16.0.0/12). When set, JIM trusts X-Forwarded-For /
+# X-Forwarded-Proto headers from these sources only, so the real client IP
+# (used for unauthenticated API rate limiting, logging, HTTPS redirection)
+# is recovered rather than the proxy's own address.
+#
+# Leave unset (the default) when JIM is reached directly: no forwarded
+# headers are trusted and the connecting socket's address is used as-is.
+# Only set this to proxies you control; trusting an untrusted source lets a
+# client spoof its own IP.
+#
+# JIM_TRUSTED_PROXIES=10.0.0.1,172.16.0.0/12
+
+# =============================================================================
 # SSO/OIDC Configuration — Development defaults (bundled Keycloak)
 # =============================================================================
 # The devcontainer ships a pre-configured Keycloak instance that starts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ✨ The REST API is now protected by configurable rate limiting: per-client request limits with sensible defaults, tunable from Service Settings without a restart, returning standard 429 responses with Retry-After guidance.
 - ✨ RFC references in a Connected System's schema attribute descriptions (for example "RFC2256: business category" on an LDAP Connector) are now hyperlinks to the corresponding page on the IETF Datatracker, so you can jump straight to the defining specification.
 
 ### Changed

--- a/docs/administration/configuration.md
+++ b/docs/administration/configuration.md
@@ -101,6 +101,9 @@ The settings listed below are the ones most commonly adjusted; the full list is 
 | `History.RetentionPeriod`    | History retention period  | History         | The duration for which activity and audit history is retained. Format: `d.hh:mm:ss`. Longer periods increase database size and may affect performance. Configuration change history is excluded; it has its own retention period below.                          | `90.00:00:00` (90 days) |
 | `History.ConfigurationChangeRetentionPeriod` | Configuration change retention period | History | The duration for which configuration change history (versioned Connected System, Synchronisation Rule, and Schedule snapshots) is retained. Kept separately from, and typically much longer than, the general history retention period. Format: `d.hh:mm:ss`.     | `3650.00:00:00` (~10 years) |
 | `ChangeTracking.ConfigurationChanges.Enabled` | Track configuration changes | History | Enables or disables capture of Configuration Change History. When `true`, a redacted, versioned snapshot is recorded on the Activity for every configuration create, update, and delete. Set to `false` to stop capturing new history; existing history is not deleted. | `true`        |
+| `Security.RateLimiting.Enabled` | API rate limiting enabled | Security | When `true`, REST API requests are throttled per client. See [Rate Limiting](../api/rate-limiting.md). | `true` |
+| `Security.RateLimiting.AuthenticatedRequestsPerMinute` | Authenticated API requests per minute | Security | The maximum REST API requests per minute for an authenticated client (per signed-in user or API key). | `300` |
+| `Security.RateLimiting.UnauthenticatedRequestsPerMinute` | Unauthenticated API requests per minute | Security | The maximum REST API requests per minute for an unauthenticated client (per IP address). | `30` |
 
 !!! tip "Editing service settings"
     Navigate to **Admin > Service Settings**, use the filter and search box to locate the setting by key or display name, and click the edit icon. Changes are audited: the settings page shows who last modified each value and when.
@@ -135,6 +138,17 @@ JIM encrypts secrets at rest (Connected System credentials, the SSO secret, Sche
 | Variable    | Description                                                                                                    | Default    |
 |-------------|----------------------------------------------------------------------------------------------------------------|------------|
 | `JIM_THEME` | Built-in colour theme for the JIM web interface. Valid values: `purple`, `black`, `blended-nav`, `future-minimal`, `navy-o5`, `navy-o6`. | `navy-o6`  |
+
+---
+
+## Reverse Proxy
+
+| Variable              | Description                                                                                                                                                                                                                     | Default              |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+| `JIM_TRUSTED_PROXIES` | Comma-separated list of trusted proxy IP addresses and/or CIDR networks (e.g. `10.0.0.1,172.16.0.0/12`). When set, JIM trusts `X-Forwarded-For`/`X-Forwarded-Proto` headers from these sources, so the real client IP and scheme are recovered rather than the proxy's own. Used for unauthenticated API [rate limiting](../api/rate-limiting.md), logging, and HTTPS redirection. | *(unset)* -- forwarded headers are not trusted; the connecting socket's address is used as-is |
+
+!!! warning "Only set this behind a trusted reverse proxy"
+    Trusting forwarded headers from an address you do not control lets a client spoof its own IP, defeating IP-based rate limiting and polluting logs. Only list proxies (or the proxy network) that terminate connections in front of JIM.
 
 ---
 

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -606,9 +606,10 @@ Configure appropriate token lifetimes in your identity provider:
 
 ### Brute-Force Protection and MFA
 
-JIM delegates interactive password authentication entirely to your identity provider; it never sees or stores a user's password. That means credential-stuffing and password-guessing defences must be configured **at the identity provider**, not in JIM:
+JIM delegates interactive authentication entirely to your identity provider and never sees or stores user credentials, whichever kind your provider is configured to require: passwords, Kerberos, smart cards or other certificate-based authentication, FIDO2 passkeys, or a combination. Defences against credential attacks therefore belong **at the identity provider**, not in JIM:
 
-- **Enable brute-force/lockout protection**<br /> Entra ID (Smart Lockout), AD FS (the built-in Extranet Lockout Policy), and Keycloak (**Realm settings > Security defenses > Brute force detection**) all offer this. The bundled devcontainer Keycloak realm ships with brute-force detection enabled by default.
+- **Where password authentication is in use, enable brute-force/lockout protection**<br /> Entra ID (Smart Lockout), AD FS (the built-in Extranet Lockout Policy), and Keycloak (**Realm settings > Security defenses > Brute force detection**) all offer this. The bundled devcontainer Keycloak realm ships with brute-force detection enabled by default.
 - **Enable multi-factor authentication where available**<br /> MFA at the identity provider protects every application behind it, including JIM, without any JIM-side configuration.
+- **Prefer phishing-resistant methods where your provider supports them**<br /> Kerberos, certificate-based authentication, and FIDO2 passkeys remove the guessable secret altogether, taking credential-stuffing and password-guessing off the table for those users.
 
-JIM's own [REST API rate limiting](../api/rate-limiting.md) throttles request volume at the application layer (see [Service Settings](../configuration/service-settings.md)); it complements, but does not replace, identity-provider-level brute-force and MFA controls for the interactive sign-in flow.
+JIM's own [REST API rate limiting](../api/rate-limiting.md) throttles request volume at the application layer (see [Service Settings](../configuration/service-settings.md)); it complements, but does not replace, identity-provider-level credential protections for the interactive sign-in flow.

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -603,3 +603,12 @@ Configure appropriate token lifetimes in your identity provider:
 - **Request only the minimum scopes needed**<br /> Follow the principle of least privilege.
 - **Regularly audit which permissions are granted**<br /> Review permissions periodically for security compliance.
 - **Use admin consent for organisation-wide deployments**<br /> For widespread deployments, use organization-level consent mechanisms.
+
+### Brute-Force Protection and MFA
+
+JIM delegates interactive password authentication entirely to your identity provider; it never sees or stores a user's password. That means credential-stuffing and password-guessing defences must be configured **at the identity provider**, not in JIM:
+
+- **Enable brute-force/lockout protection**<br /> Entra ID (Smart Lockout), AD FS (the built-in Extranet Lockout Policy), and Keycloak (**Realm settings > Security defenses > Brute force detection**) all offer this. The bundled devcontainer Keycloak realm ships with brute-force detection enabled by default.
+- **Enable multi-factor authentication where available**<br /> MFA at the identity provider protects every application behind it, including JIM, without any JIM-side configuration.
+
+JIM's own [REST API rate limiting](../api/rate-limiting.md) throttles request volume at the application layer (see [Service Settings](../configuration/service-settings.md)); it complements, but does not replace, identity-provider-level brute-force and MFA controls for the interactive sign-in flow.

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -606,10 +606,10 @@ Configure appropriate token lifetimes in your identity provider:
 
 ### Brute-Force Protection and MFA
 
-JIM delegates interactive authentication entirely to your identity provider and never sees or stores user credentials, whichever kind your provider is configured to require: passwords, Kerberos, smart cards or other certificate-based authentication, FIDO2 passkeys, or a combination. Defences against credential attacks therefore belong **at the identity provider**, not in JIM:
+JIM delegates interactive authentication entirely to your identity provider and never sees or stores user credentials, whichever kind your provider is configured to require, i.e. Kerberos, passwords, smart cards, other certificate-based authentication types, FIDO2 passkeys, etc. Defences against credential attacks therefore belong **at the identity provider**, not in JIM:
 
-- **Where password authentication is in use, enable brute-force/lockout protection**<br /> Entra ID (Smart Lockout), AD FS (the built-in Extranet Lockout Policy), and Keycloak (**Realm settings > Security defenses > Brute force detection**) all offer this. The bundled devcontainer Keycloak realm ships with brute-force detection enabled by default.
+- **Where password authentication is in use, we recommend you enable brute-force/lockout protection**<br /> Entra ID (Smart Lockout), AD FS (the built-in Extranet Lockout Policy), and Keycloak (**Realm settings > Security defences > Brute force detection**) all offer this. The bundled devcontainer Keycloak realm ships with brute-force detection enabled by default.
 - **Enable multi-factor authentication where available**<br /> MFA at the identity provider protects every application behind it, including JIM, without any JIM-side configuration.
-- **Prefer phishing-resistant methods where your provider supports them**<br /> Kerberos, certificate-based authentication, and FIDO2 passkeys remove the guessable secret altogether, taking credential-stuffing and password-guessing off the table for those users.
+- **Prefer phishing-resistant methods where your provider supports them**<br /> Kerberos, certificate-based authentication, and FIDO2 passkeys remove the guessable secret altogether, protecting users against credential-stuffing and password-guessing.
 
 JIM's own [REST API rate limiting](../api/rate-limiting.md) throttles request volume at the application layer (see [Service Settings](../configuration/service-settings.md)); it complements, but does not replace, identity-provider-level credential protections for the interactive sign-in flow.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -47,6 +47,8 @@ These behaviours are common across the API. The interactive API reference is aut
 
 **Asynchronous operations.** Long-running operations (schema import, Run Profile execution, Connected System deletion) return `202 Accepted` with an activity ID; poll [Activities](../configuration/activities.md) to track progress.
 
+**Rate limiting.** Requests are throttled per client (see [Rate Limiting](rate-limiting.md)); an exceeded limit returns `429 Too Many Requests` with a `Retry-After` header.
+
 ## System endpoints
 
 A small set of system-level endpoints (health, readiness, liveness, version, auth config, user info) are useful for orchestrators, load balancers, and client bootstraps rather than identity management workflows. They are documented in the interactive API reference alongside everything else.

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -1,0 +1,65 @@
+---
+title: Rate Limiting
+---
+
+# Rate Limiting
+
+JIM's REST API is protected by configurable rate limiting, so a misbehaving integration, a brute-force credential attempt, or a runaway script cannot exhaust server resources or degrade the service for other clients. This is an application-layer control (OWASP Top 10 A02: Security Misconfiguration); it complements, but does not replace, [brute-force protection and MFA at your identity provider](../administration/sso-setup.md#brute-force-protection-and-mfa).
+
+## What is limited
+
+Only the REST API (paths under `/api/`) is throttled. The Blazor web UI, the SignalR/Blazor Server connection, and static assets are never rate limited.
+
+`/api/v1/health` (and its `/ready`, `/live`, `/version` sub-routes) is exempt: load balancer and orchestrator health probes must never be throttled, and the endpoint is cheap and carries no data.
+
+## How clients are grouped
+
+- **Authenticated requests** are limited per client, identified by a stable ID (the signed-in user's Metaverse Object ID, or the API key's ID), using a **sliding** one-minute window.
+- **Unauthenticated requests**, including a request that failed API key authentication, are limited per client IP address, using a **fixed** one-minute window.
+
+Each client's limit is tracked independently: one integration hitting its limit does not affect any other client.
+
+## Service Settings
+
+Three built-in [Service Settings](../configuration/service-settings.md) (Security category) control rate limiting, and can be changed at runtime by an Administrator without restarting JIM:
+
+| Key | Display name | Type | Default | Description |
+|-----|---------------|------|---------|-------------|
+| `Security.RateLimiting.Enabled` | API rate limiting enabled | Boolean | `true` | When `false`, no limiter is applied to any API request. |
+| `Security.RateLimiting.AuthenticatedRequestsPerMinute` | Authenticated API requests per minute | Integer | `300` | The per-client limit for authenticated requests. |
+| `Security.RateLimiting.UnauthenticatedRequestsPerMinute` | Unauthenticated API requests per minute | Integer | `30` | The per-IP limit for unauthenticated requests. |
+
+!!! info "Settings propagation delay"
+    The rate limiter reads these settings from a short-lived cache (TTL: 30 seconds) rather than the database on every request, so it does not add a database round trip to every API call. A change to any of the three settings above takes effect for new requests within 30 seconds, not instantly.
+
+## When a client is rate limited
+
+A request that exceeds its limit receives:
+
+- **HTTP 429 Too Many Requests**
+- A **`Retry-After`** header, in seconds, indicating how long to wait before retrying
+- A JSON body in JIM's standard API error shape:
+
+```json
+{
+  "code": "TOO_MANY_REQUESTS",
+  "message": "Too many requests. Please retry after the indicated delay.",
+  "details": null,
+  "validationErrors": null,
+  "timestamp": "2026-07-13T12:00:00Z"
+}
+```
+
+Well-behaved clients should back off for the duration given in `Retry-After` before retrying.
+
+## Reverse proxies
+
+If JIM sits behind a reverse proxy or load balancer, the unauthenticated (per-IP) limit needs to see the real client IP address, not the proxy's. By default JIM does **not** trust any forwarded-header information (`X-Forwarded-For`/`X-Forwarded-Proto`) and uses the connecting socket's address as-is, which is correct when JIM is reached directly.
+
+Set the `JIM_TRUSTED_PROXIES` environment variable to a comma-separated list of trusted proxy IP addresses and/or CIDR networks (for example `10.0.0.1,172.16.0.0/12`) to enable forwarded-header trust from those sources only. See [Configuration Reference](../administration/configuration.md) for details.
+
+## See also
+
+- [Authentication](authentication.md): how to authenticate REST API requests
+- [Service Settings](../configuration/service-settings.md): general Service Settings behaviour (defaults, overrides, change history)
+- [Configuration Reference](../administration/configuration.md): the `JIM_TRUSTED_PROXIES` environment variable

--- a/docs/configuration/service-settings.md
+++ b/docs/configuration/service-settings.md
@@ -28,6 +28,7 @@ Settings are grouped by concern:
 - **Synchronisation**<br /> Sync pipeline and change tracking settings.
 - **Maintenance**<br /> Maintenance mode and system health settings.
 - **History**<br /> Audit history retention and cleanup settings.
+- **Security**<br /> Credential encryption and [API rate limiting](../api/rate-limiting.md) settings.
 
 The category is mostly a UI grouping; it does not change semantics.
 

--- a/engineering/plans/OWASP_TOP_10_ASSESSMENT.md
+++ b/engineering/plans/OWASP_TOP_10_ASSESSMENT.md
@@ -1,6 +1,6 @@
 # OWASP Top 10:2025 Assessment
 
-- **Status:** Planned
+- **Status:** Doing (Gap 1, rate limiting, remediated; Gaps 2-5 remain open, see issue for current status)
 - **Issue:** [#500](https://github.com/TetronIO/JIM/issues/500)
 - **Assessed:** 2026-04-09
 - **Standard:** [OWASP Top 10:2025](https://owasp.org/Top10/2025/)
@@ -45,9 +45,11 @@ Core security configuration is sound: HSTS, HTTPS redirection, restricted develo
 | Stack traces suppressed in production | `GlobalExceptionHandler.cs:32` |
 | DbContext pooling prevents connection exhaustion | `Program.cs:76-80` |
 
-**Gap 1: No rate limiting (High priority)**
+**Gap 1: No rate limiting (High priority) - ✅ Remediated**
 
 No `UseRateLimiter()` middleware is configured. Authentication endpoints (`/api/auth`, `/api/apikeys`) are exposed to brute-force attacks with no throttle. This is the highest-priority gap in the assessment.
+
+Remediated: `Microsoft.AspNetCore.RateLimiting` (built-in; no new dependency) now protects the whole REST API with per-client partitioning (authenticated principal or client IP), HTTP 429 with `Retry-After`, and `ForwardedHeaders` handling (`JIM_TRUSTED_PROXIES`) so per-IP partitioning is correct behind a reverse proxy. Limits are runtime-tunable via Service Settings. See [Rate Limiting](../../docs/api/rate-limiting.md).
 
 **Gap 2: No Content Security Policy header (Medium priority)**
 
@@ -209,7 +211,7 @@ A global exception handler catches all unhandled exceptions. Production response
 | # | Category | Rating | Gaps | Priority |
 |---|----------|--------|------|----------|
 | A01 | Broken Access Control | Strong | None | - |
-| A02 | Security Misconfiguration | Good | Rate limiting, CSP header | High, Medium |
+| A02 | Security Misconfiguration | Good | ~~Rate limiting~~ (remediated), CSP header | ~~High~~, Medium |
 | A03 | Software Supply Chain | Good | `packages.lock.json`, DynamicExpresso review | Medium, Low |
 | A04 | Cryptographic Failures | Strong | None | - |
 | A05 | Injection | Strong | None (pending DynamicExpresso) | - |
@@ -221,7 +223,7 @@ A global exception handler catches all unhandled exceptions. Production response
 
 ## Remediation Recommendations
 
-### 1. Rate Limiting Middleware (High)
+### 1. Rate Limiting Middleware (High) - ✅ Remediated
 
 **OWASP:** A02
 **Risk:** Authentication endpoints exposed to brute-force attacks.
@@ -240,6 +242,8 @@ A global exception handler catches all unhandled exceptions. Production response
 **Recommendation:** Option A. It is built-in, requires no new dependency, and works in all deployment topologies including air-gapped.
 
 **Effort:** Low
+
+**Implemented:** Option A, extended to the whole REST API rather than just `/api/auth`/`/api/apikeys` (any endpoint, not just the two named here, is a viable target for API key spraying). Authenticated requests are partitioned per principal (sliding window); unauthenticated requests, including failed API key attempts, per client IP (fixed window). Limits are Service Settings, not hardcoded, per product decision. `/api/health` is excluded (orchestrator probes).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
   - API:
       - api/index.md
       - Authentication: api/authentication.md
+      - Rate Limiting: api/rate-limiting.md
   - PowerShell Module:
       - powershell/index.md
       - System: powershell/system.md

--- a/src/JIM.Application/Servers/SeedingServer.cs
+++ b/src/JIM.Application/Servers/SeedingServer.cs
@@ -1132,6 +1132,45 @@ internal class SeedingServer
             IsReadOnly = true
         });
 
+        // API rate limiting settings (issue #500, OWASP Top 10:2025 A02). Runtime-tunable so administrators can
+        // adjust limits without a restart; JIM.Web's rate limiter reads these through a short-TTL cache rather
+        // than on every request (see RateLimitSettingsCache), so a change here takes effect within that
+        // propagation delay, not instantly.
+        await SeedSettingAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.RateLimitingEnabled,
+            DisplayName = "API rate limiting enabled",
+            Description = "When enabled, REST API requests are throttled per client (see the authenticated and unauthenticated request limits below). When disabled, no limiter is applied to any API request.",
+            Category = ServiceSettingCategory.Security,
+            ValueType = ServiceSettingValueType.Boolean,
+            // Lowercase to match every other boolean setting's stored convention ("true"/"false"); bool.ToString()
+            // would produce "True" instead. bool.Parse accepts either case, but the stored value should be consistent.
+            DefaultValue = Constants.RateLimitDefaults.Enabled ? "true" : "false",
+            IsReadOnly = false
+        });
+
+        await SeedSettingAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute,
+            DisplayName = "Authenticated API requests per minute",
+            Description = "The maximum number of REST API requests an authenticated client (a signed-in user or an API key) may make per rolling minute. Each authenticated principal is limited independently.",
+            Category = ServiceSettingCategory.Security,
+            ValueType = ServiceSettingValueType.Integer,
+            DefaultValue = Constants.RateLimitDefaults.AuthenticatedRequestsPerMinute.ToString(),
+            IsReadOnly = false
+        });
+
+        await SeedSettingAsync(new ServiceSetting
+        {
+            Key = Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute,
+            DisplayName = "Unauthenticated API requests per minute",
+            Description = "The maximum number of REST API requests an unauthenticated client may make per one-minute window, identified by client IP address. Applies to anonymous endpoints and requests that failed API key authentication.",
+            Category = ServiceSettingCategory.Security,
+            ValueType = ServiceSettingValueType.Integer,
+            DefaultValue = Constants.RateLimitDefaults.UnauthenticatedRequestsPerMinute.ToString(),
+            IsReadOnly = false
+        });
+
         // UI Settings
         await SeedSettingAsync(new ServiceSetting
         {

--- a/src/JIM.Models/Core/Constants.cs
+++ b/src/JIM.Models/Core/Constants.cs
@@ -34,6 +34,16 @@ public static class Constants
         // API
         public static string InfrastructureApiKey => "JIM_INFRASTRUCTURE_API_KEY";
 
+        // Reverse proxy
+        /// <summary>
+        /// Optional, comma-separated list of trusted proxy IP addresses and/or CIDR networks (e.g.
+        /// "10.0.0.1,172.16.0.0/12"). When set, JIM trusts X-Forwarded-For/X-Forwarded-Proto headers from these
+        /// sources so client IPs (used for unauthenticated API rate limiting, logging, etc.) reflect the real
+        /// client rather than the reverse proxy. When unset (the default), forwarded headers are not trusted and
+        /// RemoteIpAddress is used as-is.
+        /// </summary>
+        public static string TrustedProxies => "JIM_TRUSTED_PROXIES";
+
         // Encryption
         public static string EncryptionKeyPath => "JIM_ENCRYPTION_KEY_PATH";
 
@@ -288,6 +298,29 @@ public static class Constants
         /// </summary>
         public const string ConfigurationChangeHashKey = "Security.ConfigurationChangeHashKey";
 
+        /// <summary>
+        /// Enables or disables API rate limiting. When enabled, REST API requests are throttled per-client
+        /// (see <see cref="RateLimitingAuthenticatedRequestsPerMinute"/> and
+        /// <see cref="RateLimitingUnauthenticatedRequestsPerMinute"/>). When disabled, no limiter is applied.
+        /// Default: true. Changes take effect within the settings cache propagation delay (see
+        /// <c>RateLimitSettingsCache</c> in JIM.Web), not immediately.
+        /// </summary>
+        public const string RateLimitingEnabled = "Security.RateLimiting.Enabled";
+
+        /// <summary>
+        /// The maximum number of REST API requests an authenticated client (identified by a stable principal ID:
+        /// Metaverse Object ID for SSO/JWT users, API key ID for API key callers) may make per rolling minute.
+        /// Default: 300.
+        /// </summary>
+        public const string RateLimitingAuthenticatedRequestsPerMinute = "Security.RateLimiting.AuthenticatedRequestsPerMinute";
+
+        /// <summary>
+        /// The maximum number of REST API requests an unauthenticated client (identified by client IP address,
+        /// including requests that failed API key authentication) may make per fixed one-minute window.
+        /// Default: 30.
+        /// </summary>
+        public const string RateLimitingUnauthenticatedRequestsPerMinute = "Security.RateLimiting.UnauthenticatedRequestsPerMinute";
+
         // Worker Settings
         /// <summary>
         /// The duration after which a processing task with no heartbeat update is considered stale/abandoned.
@@ -317,5 +350,17 @@ public static class Constants
         /// Generated exactly once on first startup; never changes thereafter.
         /// </summary>
         public const string ServiceId = "Instance.Id";
+    }
+
+    /// <summary>
+    /// The default values for the API rate limiting Service Settings. Shared between the seeded
+    /// <see cref="ServiceSetting"/> defaults (<c>SeedingServer.SyncServiceSettingsAsync</c>) and the settings-cache
+    /// fallback used by JIM.Web's rate limiter (see <c>RateLimitSettingsCache</c>) so the two never drift apart.
+    /// </summary>
+    public static class RateLimitDefaults
+    {
+        public const bool Enabled = true;
+        public const int AuthenticatedRequestsPerMinute = 300;
+        public const int UnauthenticatedRequestsPerMinute = 30;
     }
 }

--- a/src/JIM.Web/Middleware/Api/IRateLimitSettingsCache.cs
+++ b/src/JIM.Web/Middleware/Api/IRateLimitSettingsCache.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// A short-TTL cache over the API rate limiting Service Settings, so the rate limiter (which runs on every
+/// REST API request) does not hit the database per request. See <see cref="RateLimitSettingsCache"/>.
+/// </summary>
+public interface IRateLimitSettingsCache
+{
+    /// <summary>
+    /// Returns the current settings snapshot, refreshing from the database if the cached value has expired.
+    /// </summary>
+    Task<RateLimitSettingsSnapshot> GetSnapshotAsync();
+}

--- a/src/JIM.Web/Middleware/Api/RateLimitDecision.cs
+++ b/src/JIM.Web/Middleware/Api/RateLimitDecision.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// The outcome of <see cref="RateLimitPartitionResolver.Resolve"/>: which kind of limiter (if any) applies to a
+/// request, the partition key that isolates it from other clients, and the permit/window parameters.
+/// </summary>
+/// <remarks>
+/// A plain result type (rather than the real <c>System.Threading.RateLimiting.RateLimitPartition&lt;string&gt;</c>)
+/// so partition selection can be unit tested by inspecting a value, without spinning up a
+/// <c>PartitionedRateLimiter</c> or the ASP.NET Core pipeline. <see cref="RateLimitingExtensions"/> maps this to
+/// the real partition type used by <c>PartitionedRateLimiter.Create</c>.
+/// </remarks>
+/// <param name="Kind">Which limiter (if any) applies.</param>
+/// <param name="PartitionKey">
+/// The key isolating this client from others. Deliberately includes the permit limit (e.g. "auth:{id}:{limit}"),
+/// because <c>PartitionedRateLimiter.Create</c> caches limiter instances per partition key: without the limit baked
+/// into the key, a Service Setting change would not affect a partition that already has a cached limiter instance.
+/// </param>
+/// <param name="PermitLimit">The maximum number of requests allowed per window. Ignored when <see cref="Kind"/> is <see cref="RateLimitPartitionKind.NoLimiter"/>.</param>
+/// <param name="Window">The rate limiting window duration. Ignored when <see cref="Kind"/> is <see cref="RateLimitPartitionKind.NoLimiter"/>.</param>
+public sealed record RateLimitDecision(RateLimitPartitionKind Kind, string PartitionKey, int PermitLimit, TimeSpan Window)
+{
+    /// <summary>
+    /// Builds a "no limiter applies" decision. The partition key is irrelevant to behaviour (no throttling occurs)
+    /// but a constant is used so every unlimited request shares one partition rather than growing the limiter's
+    /// internal partition table unboundedly.
+    /// </summary>
+    public static RateLimitDecision NoLimiter() => new(RateLimitPartitionKind.NoLimiter, "no-limit", 0, TimeSpan.Zero);
+}

--- a/src/JIM.Web/Middleware/Api/RateLimitPartitionKind.cs
+++ b/src/JIM.Web/Middleware/Api/RateLimitPartitionKind.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// The kind of rate limiting partition <see cref="RateLimitPartitionResolver"/> selected for a request.
+/// </summary>
+public enum RateLimitPartitionKind
+{
+    /// <summary>
+    /// No limiter applies: the request is outside the REST API, is a health check, or rate limiting is disabled.
+    /// </summary>
+    NoLimiter,
+
+    /// <summary>
+    /// An authenticated request, partitioned per principal, throttled with a sliding window.
+    /// </summary>
+    AuthenticatedSlidingWindow,
+
+    /// <summary>
+    /// An unauthenticated request (including one that failed API key authentication), partitioned per client IP,
+    /// throttled with a fixed window.
+    /// </summary>
+    UnauthenticatedFixedWindow
+}

--- a/src/JIM.Web/Middleware/Api/RateLimitPartitionResolver.cs
+++ b/src/JIM.Web/Middleware/Api/RateLimitPartitionResolver.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Security.Claims;
+using JIM.Models.Core;
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// Decides which rate limiting partition a request belongs to. Extracted from the <c>AddRateLimiter</c> global
+/// limiter factory in <see cref="RateLimitingExtensions"/> so the selection logic can be unit tested against a
+/// plain <see cref="HttpContext"/> (e.g. <c>DefaultHttpContext</c>) without spinning up the ASP.NET Core pipeline
+/// or a real <c>PartitionedRateLimiter</c>.
+/// </summary>
+public static class RateLimitPartitionResolver
+{
+    /// <summary>Both limiter kinds use a one-minute window; only the permit count is configurable.</summary>
+    public static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Resolves the rate limiting decision for a request.
+    /// </summary>
+    /// <param name="context">The current request's <see cref="HttpContext"/>. Identity (<see cref="HttpContext.User"/>)
+    /// must already be resolved (i.e. this must run after authentication) for principal partitioning to work.</param>
+    /// <param name="settings">The current rate limiting Service Settings, as served by <see cref="IRateLimitSettingsCache"/>.</param>
+    public static RateLimitDecision Resolve(HttpContext context, RateLimitSettingsSnapshot settings)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        // The Blazor UI, the SignalR hub, and static assets are untouched by this feature.
+        if (!context.Request.Path.StartsWithSegments("/api"))
+            return RateLimitDecision.NoLimiter();
+
+        // Load balancer and orchestrator probes must never be throttled; the endpoint is cheap and carries no data.
+        if (IsHealthCheckPath(context.Request.Path))
+            return RateLimitDecision.NoLimiter();
+
+        if (!settings.Enabled)
+            return RateLimitDecision.NoLimiter();
+
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var principalId = ResolvePrincipalId(context.User);
+            // The limit is baked into the partition key: PartitionedRateLimiter.Create caches limiter instances
+            // per key, so without this a Service Settings change would not affect an already-cached partition.
+            return new RateLimitDecision(
+                RateLimitPartitionKind.AuthenticatedSlidingWindow,
+                $"auth:{principalId}:{settings.AuthenticatedRequestsPerMinute}",
+                settings.AuthenticatedRequestsPerMinute,
+                Window);
+        }
+
+        // Unauthenticated /api requests, including requests that failed API key authentication (a failed
+        // ApiKeyAuthenticationHandler result leaves HttpContext.User unauthenticated, not throwing), fall here.
+        var clientIp = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return new RateLimitDecision(
+            RateLimitPartitionKind.UnauthenticatedFixedWindow,
+            $"unauth:{clientIp}:{settings.UnauthenticatedRequestsPerMinute}",
+            settings.UnauthenticatedRequestsPerMinute,
+            Window);
+    }
+
+    /// <summary>
+    /// Matches the versioned health controller's routes (<c>/api/v{version}/health</c> and its sub-routes such as
+    /// <c>/ready</c>, <c>/live</c>, <c>/version</c>), per the <c>api/v{version:apiVersion}/[controller]</c>
+    /// convention every JIM API controller uses.
+    /// </summary>
+    private static bool IsHealthCheckPath(PathString path)
+    {
+        var segments = path.Value?.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments == null || segments.Length < 3)
+            return false;
+
+        return string.Equals(segments[0], "api", StringComparison.OrdinalIgnoreCase) &&
+               segments[1].Length > 1 && (segments[1][0] == 'v' || segments[1][0] == 'V') &&
+               string.Equals(segments[2], "health", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Picks a stable identifier to partition an authenticated principal by. Preference order: the Metaverse
+    /// Object ID claim JIM attaches to SSO/JWT Bearer principals (<see cref="Constants.BuiltInClaims.MetaverseObjectId"/>,
+    /// via <c>Program.ResolveAndAttachJimIdentityAsync</c>), then the API key ID claim
+    /// <see cref="ApiKeyAuthenticationHandler"/> attaches to API-key principals (<see cref="ClaimTypes.NameIdentifier"/>),
+    /// then <see cref="ClaimsIdentity.Name"/> as a last resort so an authenticated request is never accidentally
+    /// treated as anonymous.
+    /// </summary>
+    private static string ResolvePrincipalId(ClaimsPrincipal user)
+    {
+        var metaverseObjectId = user.FindFirstValue(Constants.BuiltInClaims.MetaverseObjectId);
+        if (!string.IsNullOrEmpty(metaverseObjectId))
+            return metaverseObjectId;
+
+        var nameIdentifier = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrEmpty(nameIdentifier))
+            return nameIdentifier;
+
+        return user.Identity?.Name ?? "unknown";
+    }
+}

--- a/src/JIM.Web/Middleware/Api/RateLimitSettingsCache.cs
+++ b/src/JIM.Web/Middleware/Api/RateLimitSettingsCache.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Application.Interfaces;
+using JIM.Models.Core;
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// A thread-safe, short-TTL cache of the API rate limiting Service Settings. The global rate limiter's partition
+/// factory runs on every REST API request and cannot be async-friendly about it (<c>PartitionedRateLimiter.Create</c>
+/// takes a synchronous factory), so settings are read from the database in the background at most once per
+/// <see cref="DefaultCacheDuration"/> rather than on the hot path. A Service Settings change is therefore visible to new
+/// requests within this TTL, not instantly; that propagation delay is documented for administrators in the rate
+/// limiting docs page.
+/// </summary>
+/// <remarks>
+/// No existing generic settings cache covers this (JimApplication's optional <c>IMemoryCache</c> is wired up for
+/// the Worker only; JIM.Web's <c>JimApplication</c> registration does not pass one, and
+/// <c>ServiceSettingsServer.GetSettingValueAsync</c> always reads through to the repository). This is a small,
+/// purpose-built cache rather than an attempt to retrofit generic caching onto every Service Setting read.
+/// </remarks>
+public sealed class RateLimitSettingsCache : IRateLimitSettingsCache
+{
+    /// <summary>The default cache TTL.</summary>
+    public static readonly TimeSpan DefaultCacheDuration = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The active cache TTL. Defaults to <see cref="DefaultCacheDuration"/>; settable so tests can verify
+    /// expiry behaviour without a real 30-second wait. A single constructor (matching DI's expectations exactly)
+    /// is kept deliberately, rather than an overload taking the TTL, to avoid any risk of the DI container
+    /// selecting the wrong one.
+    /// </summary>
+    public TimeSpan CacheDuration { get; set; } = DefaultCacheDuration;
+
+    private readonly IJimApplicationFactory _applicationFactory;
+    private readonly ILogger<RateLimitSettingsCache> _logger;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private RateLimitSettingsSnapshot _snapshot = RateLimitSettingsSnapshot.Defaults;
+
+    public RateLimitSettingsCache(IJimApplicationFactory applicationFactory, ILogger<RateLimitSettingsCache> logger)
+    {
+        _applicationFactory = applicationFactory;
+        _logger = logger;
+    }
+
+    public async Task<RateLimitSettingsSnapshot> GetSnapshotAsync()
+    {
+        var current = Volatile.Read(ref _snapshot);
+        if (DateTime.UtcNow - current.RetrievedUtc < CacheDuration)
+            return current;
+
+        // Only one caller refreshes at a time; everyone else keeps serving the (briefly) stale snapshot rather
+        // than piling concurrent requests onto the database the instant the cache expires.
+        if (!await _refreshGate.WaitAsync(0))
+            return current;
+
+        try
+        {
+            // Re-check: another request may have refreshed while this one waited for the gate.
+            current = Volatile.Read(ref _snapshot);
+            if (DateTime.UtcNow - current.RetrievedUtc < CacheDuration)
+                return current;
+
+            var refreshed = await LoadFromDatabaseAsync(current);
+            Volatile.Write(ref _snapshot, refreshed);
+            return refreshed;
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
+    private async Task<RateLimitSettingsSnapshot> LoadFromDatabaseAsync(RateLimitSettingsSnapshot previous)
+    {
+        try
+        {
+            using var jim = _applicationFactory.Create();
+            var enabled = await jim.ServiceSettings.GetSettingValueAsync(
+                Constants.SettingKeys.RateLimitingEnabled, Constants.RateLimitDefaults.Enabled);
+            var authenticatedLimit = await jim.ServiceSettings.GetSettingValueAsync(
+                Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute, Constants.RateLimitDefaults.AuthenticatedRequestsPerMinute);
+            var unauthenticatedLimit = await jim.ServiceSettings.GetSettingValueAsync(
+                Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute, Constants.RateLimitDefaults.UnauthenticatedRequestsPerMinute);
+
+            return new RateLimitSettingsSnapshot(enabled, authenticatedLimit, unauthenticatedLimit, DateTime.UtcNow);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Fallback-dispatcher catch: a settings read failure (e.g. transient database outage) must not take
+            // down every REST API request, so fall back to the last known-good snapshot (or the compiled-in
+            // defaults, before any successful read has ever happened). The timestamp is refreshed so a prolonged
+            // outage retries at most once per cache window rather than on every request.
+            _logger.LogWarning(ex, "RateLimitSettingsCache: failed to refresh rate limiting settings from the database; continuing with the last known values.");
+            return previous with { RetrievedUtc = DateTime.UtcNow };
+        }
+    }
+}

--- a/src/JIM.Web/Middleware/Api/RateLimitSettingsSnapshot.cs
+++ b/src/JIM.Web/Middleware/Api/RateLimitSettingsSnapshot.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// An immutable, point-in-time read of the API rate limiting Service Settings, as served by
+/// <see cref="IRateLimitSettingsCache"/>.
+/// </summary>
+/// <param name="Enabled">Whether API rate limiting is enabled at all.</param>
+/// <param name="AuthenticatedRequestsPerMinute">The per-principal limit for authenticated requests.</param>
+/// <param name="UnauthenticatedRequestsPerMinute">The per-IP limit for unauthenticated requests.</param>
+/// <param name="RetrievedUtc">When this snapshot was read (or deemed unreadable and defaulted), used by the cache to decide when to refresh.</param>
+public sealed record RateLimitSettingsSnapshot(
+    bool Enabled,
+    int AuthenticatedRequestsPerMinute,
+    int UnauthenticatedRequestsPerMinute,
+    DateTime RetrievedUtc)
+{
+    /// <summary>
+    /// The compiled-in defaults, used before the database has ever been read (for example the very first
+    /// request after startup, or a database outage on the first attempt). <see cref="RetrievedUtc"/> is
+    /// <see cref="DateTime.MinValue"/> so this value is always treated as stale, forcing a real read at the
+    /// first opportunity rather than being cached for a full TTL window.
+    /// </summary>
+    public static readonly RateLimitSettingsSnapshot Defaults = new(
+        Constants.RateLimitDefaults.Enabled,
+        Constants.RateLimitDefaults.AuthenticatedRequestsPerMinute,
+        Constants.RateLimitDefaults.UnauthenticatedRequestsPerMinute,
+        DateTime.MinValue);
+}

--- a/src/JIM.Web/Middleware/Api/RateLimitingExtensions.cs
+++ b/src/JIM.Web/Middleware/Api/RateLimitingExtensions.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Threading.RateLimiting;
+using JIM.Utilities;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// Wires up REST API rate limiting: a single global <see cref="PartitionedRateLimiter{TResource}"/> whose
+/// partitioning decision comes from <see cref="RateLimitPartitionResolver"/>, and a rejection handler that
+/// returns a 429 with a Retry-After header and a body matching the API's standard error shape
+/// (<see cref="ApiErrorResponse"/>, mirroring <see cref="GlobalExceptionHandler"/>).
+/// </summary>
+/// <remarks>
+/// Built entirely on <c>Microsoft.AspNetCore.RateLimiting</c> / <c>System.Threading.RateLimiting</c>, part of the
+/// ASP.NET Core shared framework; no new NuGet package is required.
+/// </remarks>
+public static class RateLimitingExtensions
+{
+    /// <summary>10-second segments across the one-minute sliding window used for authenticated requests.</summary>
+    private const int SlidingWindowSegmentsPerWindow = 6;
+
+    private static readonly JsonSerializerOptions RejectionBodyJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Registers the settings cache and the global rate limiter. Call once during service configuration; pair
+    /// with the built-in <c>app.UseRateLimiter()</c> in the request pipeline.
+    /// </summary>
+    public static IServiceCollection AddApiRateLimiting(this IServiceCollection services)
+    {
+        services.AddSingleton<IRateLimitSettingsCache, RateLimitSettingsCache>();
+
+        services.AddRateLimiter(options =>
+        {
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+            {
+                var cache = context.RequestServices.GetRequiredService<IRateLimitSettingsCache>();
+
+                // PartitionedRateLimiter.Create requires a synchronous factory; there is no async overload.
+                // IRateLimitSettingsCache.GetSnapshotAsync only ever awaits the database on a cache miss (at
+                // most once per its TTL, and concurrent misses fall back to the stale value rather than all
+                // awaiting), so in the overwhelming majority of calls this Task is already complete and
+                // GetAwaiter().GetResult() does not block.
+                var settings = cache.GetSnapshotAsync().GetAwaiter().GetResult();
+                var decision = RateLimitPartitionResolver.Resolve(context, settings);
+                return ToPartition(decision);
+            });
+
+            options.OnRejected = OnRejectedAsync;
+        });
+
+        return services;
+    }
+
+    private static RateLimitPartition<string> ToPartition(RateLimitDecision decision)
+    {
+        return decision.Kind switch
+        {
+            RateLimitPartitionKind.AuthenticatedSlidingWindow => RateLimitPartition.GetSlidingWindowLimiter(
+                decision.PartitionKey,
+                _ => new SlidingWindowRateLimiterOptions
+                {
+                    // A permit limit of 0 or less (an administrator misconfiguring the Service Setting) would
+                    // otherwise throw from inside the limiter factory and take down every request in the
+                    // partition; clamp to a minimum of 1 rather than fail closed on every API call.
+                    PermitLimit = Math.Max(1, decision.PermitLimit),
+                    Window = decision.Window,
+                    SegmentsPerWindow = SlidingWindowSegmentsPerWindow,
+                    QueueLimit = 0
+                }),
+
+            RateLimitPartitionKind.UnauthenticatedFixedWindow => RateLimitPartition.GetFixedWindowLimiter(
+                decision.PartitionKey,
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = Math.Max(1, decision.PermitLimit),
+                    Window = decision.Window,
+                    QueueLimit = 0
+                }),
+
+            _ => RateLimitPartition.GetNoLimiter(decision.PartitionKey)
+        };
+    }
+
+    private static async ValueTask OnRejectedAsync(OnRejectedContext rejectedContext, CancellationToken cancellationToken)
+    {
+        var httpContext = rejectedContext.HttpContext;
+
+        // Both limiter kinds populate this metadata on rejection; the fallback covers the (currently unreachable,
+        // but non-throwing) case where a future limiter kind does not.
+        var retryAfterSeconds = rejectedContext.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+            ? (int)Math.Ceiling(retryAfter.TotalSeconds)
+            : (int)RateLimitPartitionResolver.Window.TotalSeconds;
+
+        httpContext.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+        httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        httpContext.Response.ContentType = "application/json";
+
+        var logger = httpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("JIM.Web.Middleware.Api.RateLimiting");
+        logger.LogWarning(
+            "Rate limit exceeded for {Method} {Path} from {RemoteIp}; Retry-After {RetryAfterSeconds}s",
+            LogSanitiser.Sanitise(httpContext.Request.Method),
+            LogSanitiser.Sanitise(httpContext.Request.Path.ToString()),
+            httpContext.Connection.RemoteIpAddress,
+            retryAfterSeconds);
+
+        var errorResponse = new ApiErrorResponse
+        {
+            Code = ApiErrorCodes.TooManyRequests,
+            Message = "Too many requests. Please retry after the indicated delay."
+        };
+
+        await httpContext.Response.WriteAsync(JsonSerializer.Serialize(errorResponse, RejectionBodyJsonOptions), cancellationToken);
+    }
+}

--- a/src/JIM.Web/Middleware/Api/TrustedProxyConfiguration.cs
+++ b/src/JIM.Web/Middleware/Api/TrustedProxyConfiguration.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Net;
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// The parsed result of <see cref="TrustedProxyParser.Parse"/>: the exact proxy IP addresses and/or CIDR networks
+/// JIM should trust to supply forwarded headers (X-Forwarded-For / X-Forwarded-Proto).
+/// </summary>
+public sealed record TrustedProxyConfiguration(IReadOnlyList<IPAddress> KnownProxies, IReadOnlyList<IPNetwork> KnownNetworks)
+{
+    public static readonly TrustedProxyConfiguration Empty = new([], []);
+
+    /// <summary>True when no proxies or networks were configured (nothing to trust).</summary>
+    public bool IsEmpty => KnownProxies.Count == 0 && KnownNetworks.Count == 0;
+}

--- a/src/JIM.Web/Middleware/Api/TrustedProxyParser.cs
+++ b/src/JIM.Web/Middleware/Api/TrustedProxyParser.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Net;
+using JIM.Utilities;
+using Serilog;
+
+namespace JIM.Web.Middleware.Api;
+
+/// <summary>
+/// Parses the optional <c>JIM_TRUSTED_PROXIES</c> environment variable (a comma-separated list of IP addresses
+/// and/or CIDR networks, e.g. <c>"10.0.0.1,172.16.0.0/12"</c>) into the collections
+/// <c>ForwardedHeadersOptions.KnownProxies</c>/<c>KnownIPNetworks</c> need. A bare address is trusted as an exact
+/// match (<see cref="TrustedProxyConfiguration.KnownProxies"/>); an entry containing <c>/</c> is parsed as a CIDR
+/// network (<see cref="TrustedProxyConfiguration.KnownNetworks"/>). Unparsable entries are logged and skipped
+/// rather than failing startup, since a single typo in a deployment's proxy list should not prevent JIM starting.
+/// </summary>
+public static class TrustedProxyParser
+{
+    public static TrustedProxyConfiguration Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return TrustedProxyConfiguration.Empty;
+
+        var proxies = new List<IPAddress>();
+        var networks = new List<IPNetwork>();
+
+        foreach (var entry in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (entry.Contains('/'))
+            {
+                if (IPNetwork.TryParse(entry, out var network))
+                    networks.Add(network);
+                else
+                    Log.Warning("TrustedProxyParser: Could not parse '{Entry}' as a CIDR network; ignoring.", LogSanitiser.Sanitise(entry));
+            }
+            else if (IPAddress.TryParse(entry, out var address))
+            {
+                proxies.Add(address);
+            }
+            else
+            {
+                Log.Warning("TrustedProxyParser: Could not parse '{Entry}' as an IP address; ignoring.", LogSanitiser.Sanitise(entry));
+            }
+        }
+
+        return new TrustedProxyConfiguration(proxies, networks);
+    }
+}

--- a/src/JIM.Web/Models/Api/ApiErrorResponse.cs
+++ b/src/JIM.Web/Models/Api/ApiErrorResponse.cs
@@ -118,6 +118,18 @@ public class ApiErrorResponse
             Message = message
         };
     }
+
+    /// <summary>
+    /// Creates a too-many-requests (rate limited) error response.
+    /// </summary>
+    public static ApiErrorResponse TooManyRequests(string message)
+    {
+        return new ApiErrorResponse
+        {
+            Code = ApiErrorCodes.TooManyRequests,
+            Message = message
+        };
+    }
 }
 
 /// <summary>
@@ -133,4 +145,5 @@ public static class ApiErrorCodes
     public const string InternalError = "INTERNAL_ERROR";
     public const string BadRequest = "BAD_REQUEST";
     public const string ServiceUnavailable = "SERVICE_UNAVAILABLE";
+    public const string TooManyRequests = "TOO_MANY_REQUESTS";
 }

--- a/src/JIM.Web/Program.cs
+++ b/src/JIM.Web/Program.cs
@@ -27,6 +27,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using Microsoft.AspNetCore.OpenApi;
@@ -61,6 +62,7 @@ using System.Security.Claims;
 // JIM_INFRASTRUCTURE_API_KEY - Creates an infrastructure API key on startup for CI/CD automation (24hr expiry)
 // JIM_ENCRYPTION_KEY_PATH - Custom path for encryption key storage (default: /data/keys or app data directory)
 // JIM_THEME - Built-in colour theme name (default: refined)
+// JIM_TRUSTED_PROXIES - Comma-separated trusted proxy IPs/CIDR networks; enables X-Forwarded-For/-Proto (default: none trusted)
 
 // initial logging setup for when the application has not yet been created (bootstrapping)...
 InitialiseLogging(new LoggerConfiguration(), true);
@@ -88,6 +90,32 @@ try
     }
 
     var builder = WebApplication.CreateBuilder(args);
+
+    // Reverse proxy trust (optional; container orchestration override, per CLAUDE.md's environment-variable
+    // design principle). Unset by default: no forwarded headers are trusted and RemoteIpAddress is used as-is,
+    // which is correct when JIM is reached directly. Set JIM_TRUSTED_PROXIES to a comma-separated list of proxy
+    // IPs and/or CIDR networks when JIM sits behind a reverse proxy/load balancer, so X-Forwarded-For/-Proto are
+    // trusted only from those sources and the real client IP (used for unauthenticated API rate limiting,
+    // logging, HTTPS redirection, etc.) is recovered rather than the proxy's own address. Deliberately not part
+    // of ValidateSsoConfiguration's fail-fast checks: it is an optional deployment-topology override, not
+    // required configuration.
+    var trustedProxiesValue = Environment.GetEnvironmentVariable(Constants.Config.TrustedProxies);
+    var trustedProxies = TrustedProxyParser.Parse(trustedProxiesValue);
+    if (!trustedProxies.IsEmpty)
+    {
+        builder.Services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            options.KnownProxies.Clear();
+            options.KnownIPNetworks.Clear();
+            foreach (var proxy in trustedProxies.KnownProxies)
+                options.KnownProxies.Add(proxy);
+            foreach (var network in trustedProxies.KnownNetworks)
+                options.KnownIPNetworks.Add(network);
+        });
+        Log.Information("Trusting forwarded headers from {ProxyCount} known proxy address(es) and {NetworkCount} known network(s)",
+            trustedProxies.KnownProxies.Count, trustedProxies.KnownNetworks.Count);
+    }
 
     // Configure database connection
     var connectionString = JimDbContext.BuildConnectionString();
@@ -359,6 +387,11 @@ try
 
     // setup authorisation policies
     builder.Services.AddAuthorization();
+
+    // REST API rate limiting (issue #500, OWASP Top 10:2025 A02). Registers the settings cache and the global
+    // limiter; UseRateLimiter() below wires it into the pipeline. Not needed in OpenAPI generation mode, which
+    // never accepts requests.
+    builder.Services.AddApiRateLimiting();
     } // end of !isOpenApiGenerateMode auth block
 
     // Add services to the container.
@@ -598,6 +631,12 @@ try
         app.Logger.LogInformation("No static OpenAPI document found; using runtime generation (development only)");
     }
 
+    // Forwarded headers (X-Forwarded-For / X-Forwarded-Proto) must be processed before anything that reads the
+    // client IP or scheme: HTTPS redirection, authentication, and rate limiting all depend on it. A no-op unless
+    // JIM_TRUSTED_PROXIES was set above (the common case: JIM reached directly, no proxy to trust).
+    if (!trustedProxies.IsEmpty)
+        app.UseForwardedHeaders();
+
     app.UseHttpsRedirection();
     app.UseStaticFiles();
     app.UseRouting();
@@ -615,6 +654,20 @@ try
         context => context.Request.Path.StartsWithSegments("/api"),
         appBuilder => appBuilder.UseJimRoleEnrichment()
     );
+
+    // REST API rate limiting (issue #500). Must run after authentication and role enrichment so the
+    // GlobalLimiter's partition factory sees a fully-resolved identity (roles, the Metaverse Object ID claim),
+    // and BEFORE authorisation: a request that will fail authorisation (missing/invalid credentials, insufficient
+    // role) must still be counted and throttled per client IP, otherwise unauthenticated brute-force/credential
+    // probing against protected endpoints would bypass the limiter entirely via authorisation's 401/403
+    // short-circuit. Applied pipeline-wide (not UseWhen-scoped to /api) because the GlobalLimiter itself already
+    // returns a no-op limiter for non-API paths; a single registration keeps that decision in one place
+    // (RateLimitPartitionResolver) instead of splitting it between the pipeline and the partition factory.
+    // Skipped in OpenAPI generation mode, matching the AddApiRateLimiting registration above: that mode never
+    // serves requests, and UseRateLimiter verifies its services are registered at pipeline-build time, so an
+    // ungated call crashes the openapi-gen Docker build stage at startup.
+    if (!isOpenApiGenerateMode)
+        app.UseRateLimiter();
 
     app.UseAuthorization();
 

--- a/test/JIM.Web.Api.Tests/RateLimitPartitionResolverTests.cs
+++ b/test/JIM.Web.Api.Tests/RateLimitPartitionResolverTests.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using JIM.Models.Core;
+using JIM.Web.Middleware.Api;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for <see cref="RateLimitPartitionResolver"/>: the pure partition-selection logic behind JIM's REST API
+/// rate limiting (issue #500). Drives the resolver with a plain <see cref="DefaultHttpContext"/> so the pipeline
+/// and the real ASP.NET Core rate limiter are never involved.
+/// </summary>
+[TestFixture]
+public class RateLimitPartitionResolverTests
+{
+    private static readonly RateLimitSettingsSnapshot EnabledSettings =
+        new(Enabled: true, AuthenticatedRequestsPerMinute: 300, UnauthenticatedRequestsPerMinute: 30, DateTime.UtcNow);
+
+    private static readonly RateLimitSettingsSnapshot DisabledSettings =
+        new(Enabled: false, AuthenticatedRequestsPerMinute: 300, UnauthenticatedRequestsPerMinute: 30, DateTime.UtcNow);
+
+    [Test]
+    public void Resolve_NonApiPath_ReturnsNoLimiter()
+    {
+        var context = BuildContext("/admin/settings");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.NoLimiter));
+    }
+
+    [Test]
+    public void Resolve_BlazorHubPath_ReturnsNoLimiter()
+    {
+        var context = BuildContext("/_blazor");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.NoLimiter));
+    }
+
+    [TestCase("/api/v1/health")]
+    [TestCase("/api/v1/health/ready")]
+    [TestCase("/api/v1/health/live")]
+    [TestCase("/api/v2/health")]
+    public void Resolve_HealthCheckPath_ReturnsNoLimiter(string path)
+    {
+        var context = BuildContext(path);
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.NoLimiter));
+    }
+
+    [Test]
+    public void Resolve_HealthLookalikePath_IsNotExemptedAsHealthCheck()
+    {
+        // "healthreport" is a different controller/resource to "health"; only an exact "health" segment counts.
+        var context = BuildContext("/api/v1/healthreport");
+        SetAuthenticated(context, metaverseObjectId: null, nameIdentifier: null, name: null);
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.Not.EqualTo(RateLimitPartitionKind.NoLimiter));
+    }
+
+    [Test]
+    public void Resolve_RateLimitingDisabled_ReturnsNoLimiterEvenForApiPath()
+    {
+        var context = BuildContext("/api/v1/connected-systems");
+        SetAuthenticated(context, metaverseObjectId: Guid.NewGuid().ToString(), nameIdentifier: null, name: null);
+
+        var decision = RateLimitPartitionResolver.Resolve(context, DisabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.NoLimiter));
+    }
+
+    [Test]
+    public void Resolve_RateLimitingDisabled_ReturnsNoLimiterForUnauthenticatedApiPath()
+    {
+        var context = BuildContext("/api/v1/connected-systems");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, DisabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.NoLimiter));
+    }
+
+    [Test]
+    public void Resolve_AuthenticatedRequestWithMetaverseObjectIdClaim_UsesSlidingWindowKeyedByMvoId()
+    {
+        var mvoId = Guid.NewGuid().ToString();
+        var context = BuildContext("/api/v1/connected-systems");
+        SetAuthenticated(context, metaverseObjectId: mvoId, nameIdentifier: "should-not-be-used", name: "should-not-be-used");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.AuthenticatedSlidingWindow));
+        Assert.That(decision.PartitionKey, Is.EqualTo($"auth:{mvoId}:300"));
+        Assert.That(decision.PermitLimit, Is.EqualTo(300));
+        Assert.That(decision.Window, Is.EqualTo(RateLimitPartitionResolver.Window));
+    }
+
+    [Test]
+    public void Resolve_AuthenticatedRequestWithoutMvoIdClaim_FallsBackToNameIdentifierClaim()
+    {
+        // Mirrors an API-key-authenticated principal: ApiKeyAuthenticationHandler sets ClaimTypes.NameIdentifier
+        // to the API key's id, but never a Metaverse Object ID claim (that is only attached for SSO/JWT users).
+        var apiKeyId = Guid.NewGuid().ToString();
+        var context = BuildContext("/api/v1/connected-systems");
+        SetAuthenticated(context, metaverseObjectId: null, nameIdentifier: apiKeyId, name: "My API Key");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.AuthenticatedSlidingWindow));
+        Assert.That(decision.PartitionKey, Is.EqualTo($"auth:{apiKeyId}:300"));
+    }
+
+    [Test]
+    public void Resolve_AuthenticatedRequestWithNoStableIdClaims_FallsBackToIdentityName()
+    {
+        var context = BuildContext("/api/v1/connected-systems");
+        SetAuthenticated(context, metaverseObjectId: null, nameIdentifier: null, name: "someone");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.AuthenticatedSlidingWindow));
+        Assert.That(decision.PartitionKey, Is.EqualTo("auth:someone:300"));
+    }
+
+    [Test]
+    public void Resolve_UnauthenticatedApiRequest_UsesFixedWindowKeyedByClientIp()
+    {
+        var context = BuildContext("/api/v1/connected-systems");
+        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.7");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.UnauthenticatedFixedWindow));
+        Assert.That(decision.PartitionKey, Is.EqualTo("unauth:203.0.113.7:30"));
+        Assert.That(decision.PermitLimit, Is.EqualTo(30));
+        Assert.That(decision.Window, Is.EqualTo(RateLimitPartitionResolver.Window));
+    }
+
+    [Test]
+    public void Resolve_FailedApiKeyAuthentication_IsTreatedAsUnauthenticated()
+    {
+        // A failed ApiKeyAuthenticationHandler result leaves HttpContext.User unauthenticated (AuthenticateResult.Fail
+        // does not throw); such requests must still be throttled per-IP, not skipped entirely.
+        var context = BuildContext("/api/v1/connected-systems");
+        context.User = new ClaimsPrincipal(new ClaimsIdentity()); // unauthenticated: no authenticationType
+        context.Connection.RemoteIpAddress = IPAddress.Parse("198.51.100.9");
+
+        var decision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+
+        Assert.That(decision.Kind, Is.EqualTo(RateLimitPartitionKind.UnauthenticatedFixedWindow));
+        Assert.That(decision.PartitionKey, Does.StartWith("unauth:198.51.100.9:"));
+    }
+
+    [Test]
+    public void Resolve_PartitionKey_ChangesWhenConfiguredAuthenticatedLimitChanges()
+    {
+        var mvoId = Guid.NewGuid().ToString();
+        var context = BuildContext("/api/v1/connected-systems");
+        SetAuthenticated(context, metaverseObjectId: mvoId, nameIdentifier: null, name: null);
+        var higherLimitSettings = EnabledSettings with { AuthenticatedRequestsPerMinute = 500 };
+
+        var originalDecision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+        var changedDecision = RateLimitPartitionResolver.Resolve(context, higherLimitSettings);
+
+        // PartitionedRateLimiter.Create caches limiter instances per key; a settings change must produce a
+        // different key so a stale cached limiter is never reused with the old limit.
+        Assert.That(originalDecision.PartitionKey, Is.Not.EqualTo(changedDecision.PartitionKey));
+    }
+
+    [Test]
+    public void Resolve_PartitionKey_ChangesWhenConfiguredUnauthenticatedLimitChanges()
+    {
+        var context = BuildContext("/api/v1/connected-systems");
+        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.7");
+        var higherLimitSettings = EnabledSettings with { UnauthenticatedRequestsPerMinute = 60 };
+
+        var originalDecision = RateLimitPartitionResolver.Resolve(context, EnabledSettings);
+        var changedDecision = RateLimitPartitionResolver.Resolve(context, higherLimitSettings);
+
+        Assert.That(originalDecision.PartitionKey, Is.Not.EqualTo(changedDecision.PartitionKey));
+    }
+
+    // -- helpers -------------------------------------------------------------------------------------------------------
+
+    private static DefaultHttpContext BuildContext(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        return context;
+    }
+
+    private static void SetAuthenticated(HttpContext context, string? metaverseObjectId, string? nameIdentifier, string? name)
+    {
+        var claims = new List<Claim>();
+        if (metaverseObjectId != null)
+            claims.Add(new Claim(Constants.BuiltInClaims.MetaverseObjectId, metaverseObjectId));
+        if (nameIdentifier != null)
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, nameIdentifier));
+        if (name != null)
+            claims.Add(new Claim(ClaimTypes.Name, name));
+
+        // A non-null authenticationType is what makes ClaimsIdentity.IsAuthenticated true.
+        var identity = new ClaimsIdentity(claims, authenticationType: "Test", nameType: ClaimTypes.Name, roleType: null);
+        context.User = new ClaimsPrincipal(identity);
+    }
+}

--- a/test/JIM.Web.Api.Tests/RateLimitSettingsCacheTests.cs
+++ b/test/JIM.Web.Api.Tests/RateLimitSettingsCacheTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Application.Interfaces;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using JIM.Web.Middleware.Api;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for <see cref="RateLimitSettingsCache"/>: the short-TTL cache that keeps JIM's REST API rate limiter
+/// (which runs on every request) off the database hot path, while still picking up a Service Settings change
+/// within a bounded delay. Covers TTL behaviour and the pre-seeding/database-failure fallback to defaults.
+/// </summary>
+[TestFixture]
+public class RateLimitSettingsCacheTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockSettingsRepo = null!;
+    private Mock<IJimApplicationFactory> _mockFactory = null!;
+    private int _createCallCount;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockSettingsRepo.Object);
+
+        _createCallCount = 0;
+        _mockFactory = new Mock<IJimApplicationFactory>();
+        _mockFactory.Setup(f => f.Create()).Returns(() =>
+        {
+            _createCallCount++;
+            return new JimApplication(_mockRepository.Object);
+        });
+    }
+
+    [Test]
+    public async Task GetSnapshotAsync_SettingsNotYetSeeded_FallsBackToCompiledInDefaultsAsync()
+    {
+        // GetSettingAsync returning null for every key mirrors a fresh database before SeedingServer has run.
+        _mockSettingsRepo.Setup(r => r.GetSettingAsync(It.IsAny<string>())).ReturnsAsync((ServiceSetting?)null);
+        var cache = new RateLimitSettingsCache(_mockFactory.Object, NullLogger());
+
+        var snapshot = await cache.GetSnapshotAsync();
+
+        Assert.That(snapshot.Enabled, Is.EqualTo(Constants.RateLimitDefaults.Enabled));
+        Assert.That(snapshot.AuthenticatedRequestsPerMinute, Is.EqualTo(Constants.RateLimitDefaults.AuthenticatedRequestsPerMinute));
+        Assert.That(snapshot.UnauthenticatedRequestsPerMinute, Is.EqualTo(Constants.RateLimitDefaults.UnauthenticatedRequestsPerMinute));
+    }
+
+    [Test]
+    public async Task GetSnapshotAsync_SettingsPersisted_ReturnsPersistedValuesAsync()
+    {
+        SetupSetting(Constants.SettingKeys.RateLimitingEnabled, ServiceSettingValueType.Boolean, "false");
+        SetupSetting(Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute, ServiceSettingValueType.Integer, "150");
+        SetupSetting(Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute, ServiceSettingValueType.Integer, "15");
+        var cache = new RateLimitSettingsCache(_mockFactory.Object, NullLogger());
+
+        var snapshot = await cache.GetSnapshotAsync();
+
+        Assert.That(snapshot.Enabled, Is.False);
+        Assert.That(snapshot.AuthenticatedRequestsPerMinute, Is.EqualTo(150));
+        Assert.That(snapshot.UnauthenticatedRequestsPerMinute, Is.EqualTo(15));
+    }
+
+    [Test]
+    public async Task GetSnapshotAsync_CalledTwiceWithinTtl_ReadsTheDatabaseOnlyOnceAsync()
+    {
+        _mockSettingsRepo.Setup(r => r.GetSettingAsync(It.IsAny<string>())).ReturnsAsync((ServiceSetting?)null);
+        var cache = new RateLimitSettingsCache(_mockFactory.Object, NullLogger()) { CacheDuration = TimeSpan.FromMinutes(1) };
+
+        await cache.GetSnapshotAsync();
+        await cache.GetSnapshotAsync();
+
+        Assert.That(_createCallCount, Is.EqualTo(1), "a second call within the TTL must be served from cache, not the database");
+    }
+
+    [Test]
+    public async Task GetSnapshotAsync_CalledAfterTtlExpires_RefreshesFromDatabaseAsync()
+    {
+        _mockSettingsRepo.Setup(r => r.GetSettingAsync(It.IsAny<string>())).ReturnsAsync((ServiceSetting?)null);
+        var cache = new RateLimitSettingsCache(_mockFactory.Object, NullLogger()) { CacheDuration = TimeSpan.FromMilliseconds(20) };
+
+        await cache.GetSnapshotAsync();
+        await Task.Delay(60);
+        await cache.GetSnapshotAsync();
+
+        Assert.That(_createCallCount, Is.EqualTo(2), "a call after the TTL has elapsed must refresh from the database");
+    }
+
+    [Test]
+    public async Task GetSnapshotAsync_DatabaseThrows_FallsBackToLastKnownValuesInsteadOfThrowingAsync()
+    {
+        _mockFactory.Setup(f => f.Create()).Throws(new InvalidOperationException("database unavailable"));
+        var cache = new RateLimitSettingsCache(_mockFactory.Object, NullLogger());
+
+        var snapshot = await cache.GetSnapshotAsync();
+
+        // First-ever read failed, so the "last known" value is the compiled-in Defaults.
+        Assert.That(snapshot.Enabled, Is.EqualTo(Constants.RateLimitDefaults.Enabled));
+        Assert.That(snapshot.AuthenticatedRequestsPerMinute, Is.EqualTo(Constants.RateLimitDefaults.AuthenticatedRequestsPerMinute));
+        Assert.That(snapshot.UnauthenticatedRequestsPerMinute, Is.EqualTo(Constants.RateLimitDefaults.UnauthenticatedRequestsPerMinute));
+    }
+
+    [Test]
+    public async Task GetSnapshotAsync_DatabaseThrowsAfterAGoodRead_KeepsServingThePreviousGoodValuesAsync()
+    {
+        SetupSetting(Constants.SettingKeys.RateLimitingEnabled, ServiceSettingValueType.Boolean, "true");
+        SetupSetting(Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute, ServiceSettingValueType.Integer, "42");
+        SetupSetting(Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute, ServiceSettingValueType.Integer, "7");
+        var cache = new RateLimitSettingsCache(_mockFactory.Object, NullLogger()) { CacheDuration = TimeSpan.FromMilliseconds(20) };
+        await cache.GetSnapshotAsync();
+
+        // The database now fails on the next refresh.
+        _mockFactory.Setup(f => f.Create()).Throws(new InvalidOperationException("database unavailable"));
+        await Task.Delay(60);
+        var snapshot = await cache.GetSnapshotAsync();
+
+        Assert.That(snapshot.AuthenticatedRequestsPerMinute, Is.EqualTo(42), "a failed refresh must keep serving the last successfully-read value, not the compiled-in default");
+        Assert.That(snapshot.UnauthenticatedRequestsPerMinute, Is.EqualTo(7));
+    }
+
+    // -- helpers -------------------------------------------------------------------------------------------------------
+
+    private void SetupSetting(string key, ServiceSettingValueType valueType, string value) =>
+        _mockSettingsRepo.Setup(r => r.GetSettingAsync(key)).ReturnsAsync(new ServiceSetting
+        {
+            Key = key,
+            DisplayName = key,
+            ValueType = valueType,
+            Value = value
+        });
+
+    private static ILogger<RateLimitSettingsCache> NullLogger() =>
+        Mock.Of<ILogger<RateLimitSettingsCache>>();
+}

--- a/test/JIM.Web.Api.Tests/TrustedProxyParserTests.cs
+++ b/test/JIM.Web.Api.Tests/TrustedProxyParserTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Net;
+using JIM.Web.Middleware.Api;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for <see cref="TrustedProxyParser"/>, which parses the optional <c>JIM_TRUSTED_PROXIES</c> environment
+/// variable into the proxy/network collections <c>ForwardedHeadersOptions</c> needs.
+/// </summary>
+[TestFixture]
+public class TrustedProxyParserTests
+{
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Parse_UnsetOrBlank_ReturnsEmpty(string? value)
+    {
+        var result = TrustedProxyParser.Parse(value);
+
+        Assert.That(result.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Parse_SingleIpAddress_AddsToKnownProxies()
+    {
+        var result = TrustedProxyParser.Parse("10.0.0.1");
+
+        Assert.That(result.KnownProxies, Is.EqualTo(new[] { IPAddress.Parse("10.0.0.1") }));
+        Assert.That(result.KnownNetworks, Is.Empty);
+    }
+
+    [Test]
+    public void Parse_CidrNetwork_AddsToKnownNetworks()
+    {
+        var result = TrustedProxyParser.Parse("172.16.0.0/12");
+
+        Assert.That(result.KnownNetworks, Has.Count.EqualTo(1));
+        Assert.That(result.KnownProxies, Is.Empty);
+    }
+
+    [Test]
+    public void Parse_MixedCommaSeparatedList_PopulatesBothCollections()
+    {
+        var result = TrustedProxyParser.Parse("10.0.0.1, 172.16.0.0/12 ,192.168.1.5");
+
+        Assert.That(result.KnownProxies, Has.Count.EqualTo(2));
+        Assert.That(result.KnownNetworks, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Parse_UnparsableEntry_IsSkippedWithoutThrowing()
+    {
+        Assert.DoesNotThrow(() =>
+        {
+            var result = TrustedProxyParser.Parse("not-an-ip, 10.0.0.1");
+            Assert.That(result.KnownProxies, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Parse_UnparsableCidrEntry_IsSkippedWithoutThrowing()
+    {
+        var result = TrustedProxyParser.Parse("10.0.0.0/999");
+
+        Assert.That(result.KnownNetworks, Is.Empty);
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/SeedingServerRateLimitingSettingsTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SeedingServerRateLimitingSettingsTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Tests that the three built-in API rate limiting Service Settings (issue #500, OWASP Top 10:2025 A02) are
+/// seeded with the expected key, category, type, and default on first run. Mirrors
+/// <see cref="SeedingServerInstanceSettingsTests"/>'s mock pattern.
+/// </summary>
+[TestFixture]
+public class SeedingServerRateLimitingSettingsTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepo = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockServiceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepo.Object);
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(It.IsAny<string>())).ReturnsAsync(false);
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.IsAny<ServiceSetting>())).Returns(Task.CompletedTask);
+        // SyncServiceSettingsAsync diffs the setting keys before and after its loop to baseline newly-created settings;
+        // these tests do not exercise that path, so return an empty set (no baselines recorded).
+        _mockServiceSettingsRepo.Setup(r => r.GetAllSettingsAsync()).ReturnsAsync(new List<ServiceSetting>());
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_SeedsRateLimitingEnabledDefaultTrueAsync()
+    {
+        var captured = await CaptureSeededSettingAsync(Constants.SettingKeys.RateLimitingEnabled);
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Security));
+        Assert.That(captured!.ValueType, Is.EqualTo(ServiceSettingValueType.Boolean));
+        Assert.That(captured!.DefaultValue, Is.EqualTo("true"));
+        Assert.That(captured!.IsReadOnly, Is.False);
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_SeedsAuthenticatedRequestsPerMinuteDefault300Async()
+    {
+        var captured = await CaptureSeededSettingAsync(Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute);
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Security));
+        Assert.That(captured!.ValueType, Is.EqualTo(ServiceSettingValueType.Integer));
+        Assert.That(captured!.DefaultValue, Is.EqualTo("300"));
+        Assert.That(captured!.IsReadOnly, Is.False);
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_FirstRun_SeedsUnauthenticatedRequestsPerMinuteDefault30Async()
+    {
+        var captured = await CaptureSeededSettingAsync(Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute);
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.Category, Is.EqualTo(ServiceSettingCategory.Security));
+        Assert.That(captured!.ValueType, Is.EqualTo(ServiceSettingValueType.Integer));
+        Assert.That(captured!.DefaultValue, Is.EqualTo("30"));
+        Assert.That(captured!.IsReadOnly, Is.False);
+    }
+
+    [Test]
+    public async Task SyncServiceSettings_RateLimitingSettingsAlreadyExist_AreNotRecreatedAsync()
+    {
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(Constants.SettingKeys.RateLimitingEnabled)).ReturnsAsync(true);
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute)).ReturnsAsync(true);
+        _mockServiceSettingsRepo.Setup(r => r.SettingExistsAsync(Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute)).ReturnsAsync(true);
+        // CreateOrUpdateSettingAsync only updates existing settings when they are IsReadOnly; these are not, so no
+        // GetSettingAsync/UpdateSettingAsync call is expected for them either.
+        _mockServiceSettingsRepo.Setup(r => r.GetSettingAsync(It.IsAny<string>())).ReturnsAsync((ServiceSetting?)null);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        _mockServiceSettingsRepo.Verify(
+            r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.RateLimitingEnabled)),
+            Times.Never);
+        _mockServiceSettingsRepo.Verify(
+            r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute)),
+            Times.Never);
+        _mockServiceSettingsRepo.Verify(
+            r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute)),
+            Times.Never);
+    }
+
+    // -- helpers -------------------------------------------------------------------------------------------------------
+
+    private async Task<ServiceSetting?> CaptureSeededSettingAsync(string key)
+    {
+        ServiceSetting? captured = null;
+        _mockServiceSettingsRepo.Setup(r => r.CreateSettingAsync(It.Is<ServiceSetting>(s => s.Key == key)))
+            .Callback<ServiceSetting>(s => captured = s)
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncServiceSettingsAsync();
+
+        return captured;
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/SystemResetServiceSettingBaselineTests.cs
+++ b/test/JIM.Worker.Tests/Servers/SystemResetServiceSettingBaselineTests.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Text;
+using JIM.Application;
+using JIM.Application.Interfaces;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.ExampleData;
+using JIM.Models.Scheduling;
+using JIM.Models.Utility;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Tests that a factory reset restores the provenance of the built-in API rate limiting Service Settings
+/// (issue #500). Service Setting rows themselves are never truncated by <c>SystemRepository.ResetSystemAsync</c>
+/// (they are not customer data), but the Activities table is, which loses the Create Activity and version-1
+/// configuration snapshot that show they were created by JIM rather than an administrator. Without
+/// <see cref="JIM.Application.Servers.SeedingServer.RebaselineBuiltInConfigurationAsync"/>, that provenance
+/// would be permanently lost after a reset. Mirrors <c>SystemResetBuiltInScheduleTests</c>'s mock pattern,
+/// extended with the repositories <c>RebaselineBuiltInConfigurationAsync</c> also reads.
+/// </summary>
+[TestFixture]
+public class SystemResetServiceSettingBaselineTests
+{
+    private Mock<IRepository> _repo = null!;
+    private Mock<IActivityRepository> _activityRepo = null!;
+    private Mock<IServiceSettingsRepository> _settingsRepo = null!;
+    private Mock<ISchedulingRepository> _schedulingRepo = null!;
+    private Mock<ISystemRepository> _systemRepo = null!;
+    private Mock<IExampleDataRepository> _exampleDataRepo = null!;
+    private Mock<IMetaverseRepository> _metaverseRepo = null!;
+    private Mock<ISearchRepository> _searchRepo = null!;
+    private Mock<IConnectedSystemRepository> _connectedSystemRepo = null!;
+    private Mock<ISecurityRepository> _securityRepo = null!;
+    private FakeProtection _protection = null!;
+    private JimApplication _jim = null!;
+    private List<Activity> _createdActivities = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        // NUnit reuses a single fixture instance across every [Test] method by default, so this must be
+        // (re)assigned here rather than via a field initialiser, or activities from one test would still be
+        // present when the next test's CreateActivityAsync callback starts appending to it.
+        _createdActivities = new List<Activity>();
+
+        _repo = new Mock<IRepository>();
+        _activityRepo = new Mock<IActivityRepository>();
+        _settingsRepo = new Mock<IServiceSettingsRepository>();
+        _schedulingRepo = new Mock<ISchedulingRepository>();
+        _systemRepo = new Mock<ISystemRepository>();
+        _exampleDataRepo = new Mock<IExampleDataRepository>();
+        _metaverseRepo = new Mock<IMetaverseRepository>();
+        _searchRepo = new Mock<ISearchRepository>();
+        _connectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _securityRepo = new Mock<ISecurityRepository>();
+        _repo.Setup(r => r.Activity).Returns(_activityRepo.Object);
+        _repo.Setup(r => r.ServiceSettings).Returns(_settingsRepo.Object);
+        _repo.Setup(r => r.Scheduling).Returns(_schedulingRepo.Object);
+        _repo.Setup(r => r.System).Returns(_systemRepo.Object);
+        _repo.Setup(r => r.ExampleData).Returns(_exampleDataRepo.Object);
+        _repo.Setup(r => r.Metaverse).Returns(_metaverseRepo.Object);
+        _repo.Setup(r => r.Search).Returns(_searchRepo.Object);
+        _repo.Setup(r => r.ConnectedSystems).Returns(_connectedSystemRepo.Object);
+        _repo.Setup(r => r.Security).Returns(_securityRepo.Object);
+
+        // No activities in progress, so the reset's integrity guard passes.
+        _activityRepo.Setup(r => r.GetActivitiesAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<Guid?>(), It.IsAny<IEnumerable<ActivityTargetOperationType>?>(),
+                It.IsAny<IEnumerable<ActivityOutcomeType>?>(), It.IsAny<IEnumerable<ActivityTargetType>?>(),
+                It.IsAny<IEnumerable<ActivityStatus>?>(), It.IsAny<bool?>()))
+            .ReturnsAsync(new PagedResultSet<Activity> { Results = new List<Activity>(), TotalResults = 0, PageSize = 1, CurrentPage = 1 });
+        _activityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<Activity>()))
+            .Callback<Activity>(a => _createdActivities.Add(a))
+            .Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<Activity>())).Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.GetMaxConfigurationChangeVersionAsync(ActivityTargetType.ServiceSetting, It.IsAny<string>())).ReturnsAsync(0);
+        _activityRepo.Setup(r => r.GetLatestConfigurationChangeSnapshotAsync(It.IsAny<ActivityTargetType>(), It.IsAny<string>())).ReturnsAsync((string?)null);
+
+        _systemRepo.Setup(r => r.ResetSystemAsync(It.IsAny<bool>())).ReturnsAsync(new SystemResetResult());
+
+        // The built-in example data template is intact, so EnsureBuiltInExampleDataTemplateAsync's repair path is a no-op.
+        var intactTemplate = new ExampleDataTemplate { Name = "Users & Groups", BuiltIn = true };
+        var objectType = new ExampleDataObjectType { MetaverseObjectType = new MetaverseObjectType { Name = "User" } };
+        objectType.TemplateAttributes.Add(new ExampleDataTemplateAttribute());
+        intactTemplate.ObjectTypes.Add(objectType);
+        _exampleDataRepo.Setup(r => r.GetTemplateAsync("Users & Groups")).ReturnsAsync(intactTemplate);
+
+        // The built-in schedule already exists post-wipe (not the focus of this test), so SeedBuiltInSchedulesAsync no-ops.
+        _schedulingRepo.Setup(r => r.GetAllSchedulesAsync()).ReturnsAsync(new List<Schedule>
+        {
+            new()
+            {
+                BuiltIn = true,
+                Steps = new List<ScheduleStep> { new() { StepType = ScheduleStepType.TemporalScopeReconciliation } }
+            }
+        });
+
+        // Empty for every other rebaselined configuration type: this test's focus is Service Settings.
+        _metaverseRepo.Setup(r => r.GetMetaverseObjectTypesAsync(It.IsAny<bool>())).ReturnsAsync(new List<MetaverseObjectType>());
+        _metaverseRepo.Setup(r => r.GetMetaverseAttributesAsync()).ReturnsAsync(new List<MetaverseAttribute>());
+        _searchRepo.Setup(r => r.GetPredefinedSearchHeadersAsync()).ReturnsAsync(new List<JIM.Models.Search.DTOs.PredefinedSearchHeader>());
+        _connectedSystemRepo.Setup(r => r.GetConnectorDefinitionHeadersAsync()).ReturnsAsync(new List<JIM.Models.Staging.DTOs.ConnectorDefinitionHeader>());
+        _exampleDataRepo.Setup(r => r.GetExampleDataSetsAsync()).ReturnsAsync(new List<ExampleDataSet>());
+        _exampleDataRepo.Setup(r => r.GetTemplatesAsync()).ReturnsAsync(new List<ExampleDataTemplate>());
+        _securityRepo.Setup(r => r.GetRolesAsync()).ReturnsAsync(new List<JIM.Models.Security.Role>());
+
+        // Configuration change tracking must be enabled for RebaselineBuiltInConfigurationAsync to do anything.
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled,
+                DisplayName = "Track configuration changes",
+                ValueType = ServiceSettingValueType.Boolean,
+                Value = "true"
+            });
+
+        // The three rate limiting settings, as they would exist post-wipe (rows preserved; not truncated).
+        var rateLimitingEnabled = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.RateLimitingEnabled,
+            DisplayName = "API rate limiting enabled",
+            Category = ServiceSettingCategory.Security,
+            ValueType = ServiceSettingValueType.Boolean,
+            DefaultValue = "true"
+        };
+        var authenticatedLimit = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute,
+            DisplayName = "Authenticated API requests per minute",
+            Category = ServiceSettingCategory.Security,
+            ValueType = ServiceSettingValueType.Integer,
+            DefaultValue = "300"
+        };
+        var unauthenticatedLimit = new ServiceSetting
+        {
+            Key = Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute,
+            DisplayName = "Unauthenticated API requests per minute",
+            Category = ServiceSettingCategory.Security,
+            ValueType = ServiceSettingValueType.Integer,
+            DefaultValue = "30"
+        };
+        _settingsRepo.Setup(r => r.GetAllSettingsAsync())
+            .ReturnsAsync(new List<ServiceSetting> { rateLimitingEnabled, authenticatedLimit, unauthenticatedLimit });
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.RateLimitingEnabled)).ReturnsAsync(rateLimitingEnabled);
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute)).ReturnsAsync(authenticatedLimit);
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute)).ReturnsAsync(unauthenticatedLimit);
+        _settingsRepo.Setup(r => r.GetServiceSettingsAsync()).ReturnsAsync(new ServiceSettings());
+        _settingsRepo.Setup(r => r.UpdateServiceSettingsAsync(It.IsAny<ServiceSettings>())).Returns(Task.CompletedTask);
+
+        // The configuration change hash key setting: RecordSeededServiceSettingBaselineAsync's capture path reads
+        // (and, on first use, generates and persists) this to compute keyed hashes of secret values in snapshots.
+        _protection = new FakeProtection();
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ConfigurationChangeHashKey))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ConfigurationChangeHashKey,
+                DisplayName = "Configuration change hash key",
+                ValueType = ServiceSettingValueType.StringEncrypted,
+                Value = _protection.Protect(Convert.ToBase64String(new byte[32]))
+            });
+
+        _jim = new JimApplication(_repo.Object) { CredentialProtection = _protection };
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    [Test]
+    public async Task ResetSystemAsync_RestoresCreateActivityAndVersionOneBaselineForRateLimitingSettingsAsync()
+    {
+        await _jim.System.ResetSystemAsync(
+            ActivityInitiatorType.ApiKey, Guid.NewGuid(), "Infrastructure Key", includeAdministrators: false);
+
+        foreach (var key in new[]
+                 {
+                     Constants.SettingKeys.RateLimitingEnabled,
+                     Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute,
+                     Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute
+                 })
+        {
+            var activity = _createdActivities.SingleOrDefault(a =>
+                a.TargetType == ActivityTargetType.ServiceSetting && a.ServiceSettingKey == key);
+
+            Assert.That(activity, Is.Not.Null, $"a factory reset must re-record the Create Activity for '{key}'");
+            Assert.That(activity!.TargetOperationType, Is.EqualTo(ActivityTargetOperationType.Create));
+            Assert.That(activity!.InitiatedByType, Is.EqualTo(ActivityInitiatorType.System));
+        }
+    }
+
+    [Test]
+    public async Task ResetSystemAsync_RateLimitingSettingBaselines_AreGroupedUnderTheSystemInitialisationParentAsync()
+    {
+        await _jim.System.ResetSystemAsync(
+            ActivityInitiatorType.ApiKey, Guid.NewGuid(), "Infrastructure Key", includeAdministrators: false);
+
+        var parentActivity = _createdActivities.SingleOrDefault(a => a.TargetType == ActivityTargetType.SystemInitialisation);
+        Assert.That(parentActivity, Is.Not.Null, "the reseed must record a System Initialisation parent Activity");
+
+        var rateLimitingActivity = _createdActivities.Single(a =>
+            a.TargetType == ActivityTargetType.ServiceSetting && a.ServiceSettingKey == Constants.SettingKeys.RateLimitingEnabled);
+        Assert.That(rateLimitingActivity.ParentActivityId, Is.EqualTo(parentActivity!.Id));
+    }
+
+    /// <summary>A round-trip credential-protection test double using a recognisable encrypted-value prefix.</summary>
+    private sealed class FakeProtection : ICredentialProtectionService
+    {
+        private const string Prefix = "$JIM$v1$";
+
+        public string? Protect(string? plainText) =>
+            string.IsNullOrEmpty(plainText) ? plainText : Prefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText));
+
+        public string? Unprotect(string? protectedData) =>
+            string.IsNullOrEmpty(protectedData) || !IsProtected(protectedData)
+                ? protectedData
+                : Encoding.UTF8.GetString(Convert.FromBase64String(protectedData[Prefix.Length..]));
+
+        public bool IsProtected(string? value) =>
+            !string.IsNullOrEmpty(value) && value.StartsWith(Prefix, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the highest-priority gap from the OWASP Top 10:2025 assessment (A02): the REST API now has configurable rate limiting via the built-in ASP.NET Core rate limiter (no new dependency), with limits tunable at runtime through Service Settings. Part of #500.

## Design

- **Scope:** `/api/*` only. The Blazor UI, SignalR circuit, and static assets are never limited; `/api/v{n}/health` is exempt (probes must never throttle).
- **Partitioning:** authenticated requests per principal (Metaverse Object ID claim, else API key ID, else identity name) on a sliding one-minute window; unauthenticated requests, including failed API key attempts, per client IP on a fixed window.
- **Pipeline placement:** after authentication and role enrichment (identity available for partitioning) and deliberately **before** authorisation, so credential-spraying traffic that would 401 still gets counted and throttled rather than bypassing the limiter via authorisation's short-circuit.
- **Service Settings (Security category, seeded through the audited path):** `Security.RateLimiting.Enabled` (default true), `...AuthenticatedRequestsPerMinute` (300), `...UnauthenticatedRequestsPerMinute` (30). A 30-second-TTL single-flight cache keeps settings reads off the per-request path; the limit value is baked into the partition key so a change takes effect within the TTL without a restart.
- **Rejection:** HTTP 429 + `Retry-After` (seconds) + JIM's standard JSON error shape; misconfigured limits (≤0) clamp to 1 rather than failing every request in the partition.
- **Forwarded headers:** optional `JIM_TRUSTED_PROXIES` (comma-separated IPs/CIDRs) enables X-Forwarded-For/-Proto trust from those sources only; default trusts nothing, correct for direct exposure.
- **IdP guidance:** dev Keycloak realm now ships `bruteForceProtected: true`, and the SSO setup guide recommends brute-force protection and MFA at the identity provider (interactive password auth is delegated there).

## Runtime verification (full stack, rebuilt images)

- Unauthenticated hammer against `/api/v1/auth/config`: exactly 30 × 200 then 429s; the 429 carries `Retry-After: 60` and the standard JSON error body.
- Health exemption: 45/45 requests to `/api/v1/health` returned 200. Blazor UI unaffected (200).
- Runtime tunability: setting the unauthenticated limit to 5 via the Service Setting took effect within the cache TTL with no restart (exactly 5 × 200 then 429); setting restored afterwards.
- **Validator-found fix:** the sub-agent implementation called `UseRateLimiter()` unconditionally, but `AddApiRateLimiting()` is (correctly) skipped in OpenAPI generation mode, and `UseRateLimiter` verifies service registration at pipeline-build time; generation mode therefore crashed at startup. This would have broken every CI/release Docker build of `jim-web` (the openapi-gen stage boots the app) while being invisible to local `jim-build` (which skips that stage via `OPENAPI_STAGE=publish`). Fixed by gating `UseRateLimiter()` on the same mode flag; OpenAPI generation re-verified end-to-end (document generated, 162 paths, exit 0).

## Tests

36 new tests (red-first for behavioural changes): partition resolution (paths, health exemption, enabled flag, principal/IP partitioning, limit-in-key), settings cache (TTL, single-flight, database-failure fallback), trusted proxy parsing, Service Setting seeding through the audited path, and factory-reset restoration. Full solution: 0 warnings, all tests green.

No integration-level 429 test: the repo has no WebApplicationFactory/TestServer infrastructure to build on; runtime verification above covers the end-to-end path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
