### PR TITLE
docs(sso): split SSO Setup into per-IdP pages and fix client setup

### DIFF
--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -4,13 +4,7 @@ title: Single Sign-On Setup
 
 # Single Sign-On Setup
 
-Step-by-step instructions for configuring Single Sign-On (SSO) with JIM using an external OIDC identity provider.
-
-JIM requires an OIDC-compliant identity provider for authentication. This guide covers setup for three common providers:
-
-- [Microsoft Entra ID](#microsoft-entra-id)
-- [AD FS (Active Directory Federation Services)](#ad-fs)
-- [Keycloak](#keycloak)
+JIM requires an OIDC-compliant identity provider for authentication. This page is the high-level guide to configuring Single Sign-On (SSO): what JIM needs from your identity provider, how the client model works, and how to test and troubleshoot the result. The provider-specific, step-by-step setup lives on its own page per provider (see [Choose your identity provider](#choose-your-identity-provider) below).
 
 !!! info "Before you begin"
     Ensure you have:
@@ -21,429 +15,41 @@ JIM requires an OIDC-compliant identity provider for authentication. This guide 
 
     JIM serves both the web interface and API from a single application. The API is available at `/api/` on the same host.
 
----
+## Choose your identity provider
 
-## Microsoft Entra ID
+JIM works with any OIDC-compliant identity provider. Pick the guide that matches yours for exact, click-by-click setup instructions:
 
-### Step 1: Register the Application
+<div class="grid cards" markdown>
 
-1. Sign in to the [Azure Portal](https://portal.azure.com)
-2. Navigate to **Microsoft Entra ID** > **App registrations**
-3. Click **New registration**
-4. Configure the registration:
-    - **Name**: `JIM Identity Management`
-    - **Supported account types**: Select based on your requirements:
-        - *Single tenant*: Only users in your organisation
-        - *Multitenant*: Users from any Entra ID directory
-    - **Redirect URI**:
-        - Platform: **Web**
-        - URI: `https://your-jim-url/signin-oidc`
-5. Click **Register**
-6. After registration, go to **Authentication** and add a second Web redirect URI for the sign-out callback: `https://your-jim-url/signout-callback-oidc`, then click **Save**. Entra ID validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
+-   :material-microsoft:{ .lg .middle } **[Microsoft Entra ID](sso-setup/microsoft-entra-id.md)**
 
-### Step 2: Note the Application Details
+    ---
 
-After registration, note these values from the **Overview** page:
+    App registration, client secret, exposed API scope, and PowerShell public-client platform, all on a single registration.
 
-- **Application (client) ID**: e.g. `12345678-1234-1234-1234-123456789abc`
-- **Directory (tenant) ID**: e.g. `87654321-4321-4321-4321-cba987654321`
+-   :material-microsoft-windows:{ .lg .middle } **[AD FS](sso-setup/ad-fs.md)**
 
-### Step 3: Create a Client Secret
+    ---
 
-1. Go to **Certificates & secrets**
-2. Click **New client secret**
-3. Add a description (e.g. `JIM Web Client`)
-4. Select an expiry period
-5. Click **Add**
-6. **Copy the secret value immediately** -- it will not be shown again
+    Application Group with a web application, native (PowerShell) application, and Web API, plus the claim rules to emit standard OIDC claims.
 
-### Step 4: Configure API Permissions
+-   :material-account-key:{ .lg .middle } **[Keycloak](sso-setup/keycloak.md)**
 
-1. Go to **API permissions**
-2. Verify `User.Read` (Delegated) is present -- this is added by default and provides the OpenID Connect scopes needed for authentication
+    ---
 
-!!! note
-    The standard OIDC scopes (`openid`, `profile`, `email`, `offline_access`) are requested at runtime and do not need to be added as Graph API permissions.
+    Realm, confidential web client, API client scope, and a separate public client for the PowerShell module.
 
-### Step 5: Expose an API
+</div>
 
-This step creates the API scope that JIM uses for JWT Bearer token validation (for API access).
+Using a different provider? The concepts on this page (a [confidential client](#confidential-vs-public-clients) for the web application, an optional [public client](#confidential-vs-public-clients) for interactive tooling, an API scope for token validation, and the `JIM_SSO_*` environment variables) apply to any OIDC provider. Follow the closest guide above as a template and substitute your provider's terminology.
 
-1. Go to **Expose an API**
-2. Click **Set** next to Application ID URI
-    - Accept the default (`api://{client-id}`) or set a custom URI
-    - Click **Save**
-3. Click **Add a scope**
-4. Configure the scope:
-    - **Scope name**: `access_as_user`
-    - **Who can consent**: Admins and users
-    - **Admin consent display name**: `Access JIM API`
-    - **Admin consent description**: `Allows the app to access JIM API on behalf of the signed-in user`
-    - **User consent display name**: `Access JIM API`
-    - **User consent description**: `Allows this app to access JIM API on your behalf`
-    - **State**: Enabled
-5. Click **Add scope**
-
-### Step 5a: Configure Scalar API Reference Authentication (Development only, Optional)
-
-JIM's interactive [Scalar](https://scalar.com/) API reference is only exposed in development environments (it is disabled in production to reduce the attack surface), so this step is only relevant if you are configuring SSO against a non-production JIM instance where you want to use the Scalar "try it out" flow with OAuth.
-
-To enable OAuth authentication in the Scalar API reference:
-
-1. Go to **Authentication**
-2. Click **Add Redirect URI**
-3. Select **Single-page application**
-4. Add redirect URI: `https://your-jim-dev-url/api/reference` (Scalar uses the API reference page itself as the OAuth redirect target; there is no separate `oauth2-redirect.html` handler)
-5. Click **Configure**
-
-!!! note
-    For production deployments, use the JIM PowerShell module for interactive API testing instead. See Step 5b below.
-
-### Step 5b: Configure PowerShell Module Authentication (Optional but recommended)
-
-Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
-
-Entra ID allows a single app registration to serve both the JIM web application (confidential client with a secret) and the PowerShell module (public client using PKCE with a loopback redirect). You can reuse the same app registration from Step 1; just add a new platform for the PowerShell flow:
-
-1. Go to **Authentication**
-2. Click **Add a platform**
-3. Select **Mobile and desktop applications**
-4. Check the suggested redirect URI: `https://login.microsoftonline.com/common/oauth2/nativeclient`
-5. In **Custom redirect URIs**, add: `http://localhost:8400/callback/`
-6. Click **Configure**
-7. Scroll down to **Advanced settings**
-8. Set **Allow public client flows** to **Yes**
-9. Click **Save**
-
-Because the web and PowerShell platforms share the same **Application (client) ID**, you can either:
-
-- **Share the client ID** (simplest): leave `JIM_SSO_PUBLIC_CLIENT_ID` unset in Step 6 below. The PowerShell module will use `JIM_SSO_CLIENT_ID`, which now has both Web and Mobile/Desktop platforms configured.
-- **Use a separate app registration** for the PowerShell module (stricter isolation): create a second app registration with only the Mobile/Desktop platform, note its Application (client) ID, and set `JIM_SSO_PUBLIC_CLIENT_ID` to that value.
-
-!!! note
-    Entra ID requires exact redirect URI matching. If port 8400 is busy, the module will try ports 8401--8409. You may need to add additional redirect URIs if you encounter port conflicts.
-
-!!! note "Refresh tokens"
-    Setting **Allow public client flows** to **Yes** (step 8 above) is what lets Entra ID return a refresh token to the module. JIM requests the `offline_access` scope at runtime; it is a standard OIDC scope and does not need to be added as an API permission. The refresh token enables silent in-session renewal and optional cross-session token persistence.
-
-### Step 6: Configure JIM Environment Variables
-
-Add these to your `.env` file:
-
-```bash
-# Microsoft Entra ID Configuration
-JIM_SSO_AUTHORITY=https://login.microsoftonline.com/{your-tenant-id}/v2.0
-JIM_SSO_CLIENT_ID={your-application-client-id}
-JIM_SSO_SECRET={your-client-secret}
-JIM_SSO_API_SCOPE=api://{your-application-client-id}/access_as_user
-
-# Optional: only set if you created a separate app registration for the PowerShell
-# module in Step 5b. Leave unset to reuse JIM_SSO_CLIENT_ID.
-# JIM_SSO_PUBLIC_CLIENT_ID={your-powershell-app-client-id}
-
-# User identity mapping
-JIM_SSO_CLAIM_TYPE=sub
-JIM_SSO_MV_ATTRIBUTE=Subject Identifier
-JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
-```
-
-**Example with real values (single app registration, web + PowerShell share client ID):**
-
-```bash
-JIM_SSO_AUTHORITY=https://login.microsoftonline.com/87654321-4321-4321-4321-cba987654321/v2.0
-JIM_SSO_CLIENT_ID=12345678-1234-1234-1234-123456789abc
-JIM_SSO_SECRET=abc123~secretvalue
-JIM_SSO_API_SCOPE=api://12345678-1234-1234-1234-123456789abc/access_as_user
-```
-
-### Step 7: Find Your Admin User's Subject Identifier
-
-1. Start JIM with the configuration above
-2. Log in with your admin account
-3. Navigate to `/claims` in the web interface
-4. Find the `sub` claim value
-5. Update `JIM_SSO_INITIAL_ADMIN` with this value
-
----
-
-## AD FS
-
-### Step 1: Create an Application Group
-
-1. Open **AD FS Management** on your AD FS server
-2. Navigate to **Application Groups**
-3. Right-click and select **Add Application Group**
-4. Enter a name: `JIM Identity Management`
-5. Select **Web browser accessing a web application**
-6. Click **Next**
-
-### Step 2: Configure the Native Application
-
-1. Note the **Client Identifier** (auto-generated GUID)
-2. Add the **Redirect URI**: `https://your-jim-url/signin-oidc`
-3. Add a second **Redirect URI** for the sign-out callback: `https://your-jim-url/signout-callback-oidc`. AD FS validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
-4. Click **Next**
-
-### Step 3: Configure Access Control
-
-1. Select an access control policy (e.g. **Permit everyone**)
-2. Click **Next**
-
-### Step 4: Configure Application Permissions
-
-1. Select **openid** and **profile** scopes
-2. Click **Next** and then **Close**
-
-### Step 4a: Configure PowerShell Module Authentication (Optional but recommended)
-
-Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
-
-The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. AD FS supports this through native applications, which can live in the same Application Group as the web application.
-
-1. Right-click your Application Group and select **Properties**
-2. Click **Add application**
-3. Select **Native application**
-4. Click **Next**
-5. Note the **Client Identifier**. You can either:
-    - **Reuse the web client's identifier** (simplest): use the same value as the web application from Step 2. Leave `JIM_SSO_PUBLIC_CLIENT_ID` unset in Step 7.
-    - **Use a distinct identifier for the native app** (stricter isolation): accept the auto-generated GUID, and set `JIM_SSO_PUBLIC_CLIENT_ID` to that value in Step 7.
-6. Add the **Redirect URI**: `http://localhost:8400/callback/`
-7. Click **Next** and then **Close**
-
-!!! note
-    The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). AD FS native applications support PKCE, which the PowerShell module uses for security. If port 8400 is busy, you may need to add additional redirect URIs for ports 8401--8409.
-
-### Step 5: Create the Web API
-
-This step creates the API configuration for JWT Bearer token validation.
-
-1. Right-click your Application Group and select **Properties**
-2. Click **Add application**
-3. Select **Web API**
-4. Click **Next**
-5. Set the **Identifier**: `api://{client-identifier}` (use the client ID from Step 2)
-6. Click **Next**
-7. Select an access control policy
-8. Click **Next**
-9. Under **Permitted scopes**, add:
-    - `openid`
-    - `profile`
-    - `email`
-    - `offline_access` (required for refresh-token issuance; enables PowerShell silent renewal and token persistence)
-10. Click **Next** and then **Close**
-
-### Step 6: Generate a Client Secret
-
-1. In your Application Group properties, select the **Native application**
-2. Click **Edit**
-3. Under **Secrets**, click **Generate**
-4. **Copy the secret value** -- store it securely
-
-### Step 7: Configure JIM Environment Variables
-
-```bash
-# AD FS Configuration
-JIM_SSO_AUTHORITY=https://{your-adfs-server}/adfs
-JIM_SSO_CLIENT_ID={your-client-identifier}
-JIM_SSO_SECRET={your-client-secret}
-JIM_SSO_API_SCOPE=api://{your-client-identifier}
-
-# Optional: only set if Step 4a used a distinct Client Identifier for the native
-# (PowerShell) application. Leave unset to reuse JIM_SSO_CLIENT_ID.
-# JIM_SSO_PUBLIC_CLIENT_ID={your-native-app-client-identifier}
-
-# User identity mapping
-JIM_SSO_CLAIM_TYPE=sub
-JIM_SSO_MV_ATTRIBUTE=Subject Identifier
-JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
-```
-
-**Example (native app reuses the web client identifier):**
-
-```bash
-JIM_SSO_AUTHORITY=https://adfs.example.com/adfs
-JIM_SSO_CLIENT_ID=e1234567-89ab-cdef-0123-456789abcdef
-JIM_SSO_SECRET=generatedSecretValue123
-JIM_SSO_API_SCOPE=api://e1234567-89ab-cdef-0123-456789abcdef
-```
-
-### AD FS Claim Rules
-
-AD FS may need claim rules to emit standard OIDC claims (`sub`, `email`, `name`). In your Web API's **Issuance Transform Rules**, add rules to map AD claims to OIDC claims:
-
-```text
-# Rule: Send User Principal Name as sub
-c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
- => issue(Type = "sub", Value = c.Value);
-
-# Rule: Send Display Name as name
-c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]
- => issue(Type = "name", Value = c.Value);
-
-# Rule: Send Email
-c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
- => issue(Type = "email", Value = c.Value);
-```
-
-### AD FS Troubleshooting
-
-- **Token signing certificate**: Ensure your AD FS token signing certificate is trusted by the JIM server
-- **Claim rules**: AD FS may need claim rules to emit standard OIDC claims (see above)
-- **CORS**: If JIM and AD FS are on different domains, configure CORS in AD FS
-
----
-
-## Keycloak
-
-### Step 1: Create a Realm (if needed)
-
-1. Log in to the Keycloak Admin Console
-2. Hover over the realm dropdown and click **Create Realm**
-3. Enter a **Realm name** (e.g. `jim`)
-4. Click **Create**
-
-### Step 2: Create a Client for JIM
-
-1. Navigate to **Clients**
-2. Click **Create client**
-3. Configure the client:
-    - **Client type**: OpenID Connect
-    - **Client ID**: `jim`
-4. Click **Next**
-5. Configure capability:
-    - **Client authentication**: ON
-    - **Authorisation**: OFF
-    - **Authentication flow**: Check **Standard flow** (Authorisation Code)
-6. Click **Next**
-7. Configure login settings:
-    - **Root URL**: `https://your-jim-url`
-    - **Valid redirect URIs**: `https://your-jim-url/signin-oidc`
-    - **Valid post logout redirect URIs**: `https://your-jim-url/signout-callback-oidc`
-    - **Web origins**: `https://your-jim-url`
-8. Click **Save**
-
-### Step 3: Get the Client Secret
-
-1. Go to the **Credentials** tab
-2. Copy the **Client secret**
-
-### Step 4: Create a Service Account Client (Optional)
-
-If you need separate API clients for service-to-service communication:
-
-1. Click **Create client**
-2. Configure:
-    - **Client type**: OpenID Connect
-    - **Client ID**: `jim-service`
-3. Click **Next**
-4. Configure capability:
-    - **Client authentication**: ON
-    - **Authentication flow**: Check **Service accounts roles** (Client Credentials)
-5. Click **Save**
-
-### Step 5: Create Client Scopes (for API access)
-
-1. Navigate to **Client scopes**
-2. Click **Create client scope**
-3. Configure:
-    - **Name**: `jim-api`
-    - **Type**: Optional
-    - **Protocol**: OpenID Connect
-4. Click **Save**
-5. Go to the **Mappers** tab
-6. Click **Configure a new mapper**
-7. Select **Audience**
-8. Configure:
-    - **Name**: `jim-api-audience`
-    - **Included Client Audience**: `jim` (or `jim-service` if created)
-    - **Add to access token**: ON
-9. Click **Save**
-
-### Step 6: Assign the Scope to the Client
-
-1. Navigate to **Clients** > **jim**
-2. Go to the **Client scopes** tab
-3. Click **Add client scope**
-4. Select `jim-api` and add as **Optional**
-
-### Step 6a: Configure PowerShell Module Authentication (Recommended)
-
-Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys.
-
-The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. **Keycloak requires this to be a separate client** from the confidential web client: a single Keycloak client cannot be both confidential (with a secret) and public (PKCE/loopback). You must create a second, public client and tell JIM about it via `JIM_SSO_PUBLIC_CLIENT_ID` in Step 7.
-
-1. Navigate to **Clients**
-2. Click **Create client**
-3. Configure the client:
-    - **Client type**: OpenID Connect
-    - **Client ID**: `jim-powershell` (this exact value is what you'll set `JIM_SSO_PUBLIC_CLIENT_ID` to in Step 7)
-4. Click **Next**
-5. Configure capability:
-    - **Client authentication**: OFF (this makes it a public client)
-    - **Authorisation**: OFF
-    - **Authentication flow**: Check **Standard flow** (Authorisation Code)
-6. Click **Next**
-7. Configure login settings:
-    - **Root URL**: Leave empty
-    - **Valid redirect URIs**: `http://localhost:8400/callback/`
-    - **Web origins**: `+` (allows all origins from redirect URIs)
-8. Click **Save**
-9. Go to the **Client scopes** tab
-10. Click **Add client scope**
-11. Select `jim-api` and add as **Optional**
-12. Confirm `offline_access` is listed (Keycloak adds it as a default optional scope on new clients). If it is missing, click **Add client scope**, select `offline_access`, and add it as **Optional**. This lets the module receive a refresh token for silent renewal and token persistence.
-
-!!! note
-    The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). If port 8400 is busy, the module will try ports 8401--8409. Add the corresponding redirect URIs (e.g. `http://localhost:8401/callback/` through `http://localhost:8409/callback/`) if port conflicts are likely in your environment.
-
-### Step 7: Configure JIM Environment Variables
-
-```bash
-# Keycloak Configuration
-JIM_SSO_AUTHORITY=https://{your-keycloak-server}/realms/{realm-name}
-JIM_SSO_CLIENT_ID=jim
-JIM_SSO_SECRET={your-client-secret}
-JIM_SSO_API_SCOPE=jim-api
-
-# Client ID for the public client you created in Step 6a for the PowerShell
-# module. Required if you want interactive (SSO) PowerShell authentication;
-# omit if you only plan to use API keys.
-JIM_SSO_PUBLIC_CLIENT_ID=jim-powershell
-
-# User identity mapping
-JIM_SSO_CLAIM_TYPE=sub
-JIM_SSO_MV_ATTRIBUTE=Subject Identifier
-JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
-```
-
-**Example:**
-
-```bash
-JIM_SSO_AUTHORITY=https://keycloak.example.com/realms/jim
-JIM_SSO_CLIENT_ID=jim
-JIM_SSO_SECRET=AbCdEfGhIjKlMnOpQrStUvWxYz123456
-JIM_SSO_API_SCOPE=jim-api
-JIM_SSO_PUBLIC_CLIENT_ID=jim-powershell
-```
-
-### Keycloak Troubleshooting
-
-- **Realm name**: Ensure the realm name in `JIM_SSO_AUTHORITY` matches exactly (case-sensitive)
-- **Client scopes**: Verify `openid`, `profile`, and `email` scopes are included
-- **Token mapper**: If the `sub` claim is missing, add a mapper in Client Scopes > openid > Mappers
-
-**Checking claim values:**
-
-1. Navigate to **Clients** > **jim** > **Client scopes**
-2. Click **Evaluate**
-3. Select a user and click **Evaluate**
-4. Check the **Generated access token** to see claim values
+Whichever provider you use, JIM is configured through a small set of `JIM_SSO_*` environment variables; the per-provider guides show the exact values to set. For the full list and defaults, see the [Configuration Reference](configuration.md).
 
 ---
 
 ## Confidential vs Public Clients
 
-JIM uses two kinds of OAuth 2.0 clients, and depending on your identity provider they may be the same registration or two separate ones. Understanding which is which makes the per-provider steps above easier to follow.
+JIM uses two kinds of OAuth 2.0 clients, and depending on your identity provider they may be the same registration or two separate ones. Understanding which is which makes the per-provider steps easier to follow.
 
 | Client | Used by | Authentication | Configured via |
 |--------|---------|----------------|----------------|
@@ -471,11 +77,13 @@ The JIM server exposes `/api/v1/auth/config`, an unauthenticated discovery endpo
 Backend token validation (the JWT bearer middleware that protects `/api/**` endpoints) always uses `JIM_SSO_AUTHORITY` for issuer and JWKS, and `JIM_SSO_API_SCOPE` for the audience, regardless of which public client issued the token. As long as the public and confidential clients belong to the same realm/tenant and both request the same API scope, tokens from either are valid.
 
 !!! info "Why `offline_access`?"
-    JIM requests the `offline_access` scope so the identity provider issues a **refresh token**. The PowerShell module uses this for two things: silent in-session token renewal (so long-running sessions don't expire mid-task), and optional cross-session token persistence (so opening a new terminal doesn't require re-authenticating in the browser). The refresh token is the only credential persisted, and it is stored in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux); never in plain text. Your public client must be permitted to receive `offline_access`. Most identity providers grant it to public clients by default; the per-provider steps above note where it must be enabled explicitly.
+    JIM requests the `offline_access` scope so the identity provider issues a **refresh token**. The PowerShell module uses this for two things: silent in-session token renewal (so long-running sessions don't expire mid-task), and optional cross-session token persistence (so opening a new terminal doesn't require re-authenticating in the browser). The refresh token is the only credential persisted, and it is stored in the operating system's credential store (Credential Manager on Windows, login Keychain on macOS, libsecret on Linux); never in plain text. Your public client must be permitted to receive `offline_access`. Most identity providers grant it to public clients by default; the per-provider guides note where it must be enabled explicitly.
 
 ---
 
 ## Testing Your Configuration
+
+Once you have completed the setup for your provider, use these steps to verify sign-in, claims, sign-out, and API access.
 
 ### 1. Verify OIDC Discovery
 
@@ -518,9 +126,9 @@ You should see a JSON response with endpoints for `authorization_endpoint`, `tok
 
 ### 5. Test the API
 
-In production, the recommended way to test API access with SSO is via the JIM PowerShell module (see Step 6 below), which supports interactive browser-based authentication.
+In production, the recommended way to test API access with SSO is via the JIM PowerShell module (see step 6 below), which supports interactive browser-based authentication.
 
-If you are configuring SSO against a non-production JIM instance and completed Step 5a above, you can also test the API interactively via the Scalar API reference:
+If you are configuring SSO against a non-production JIM instance and configured a Scalar single-page-application redirect URI on your identity provider (see [Microsoft Entra ID Step 5a](sso-setup/microsoft-entra-id.md#step-5a-configure-scalar-api-reference-authentication-development-only-optional) for an example), you can also test the API interactively via the Scalar API reference:
 
 1. Navigate to `https://your-jim-dev-url/api/reference`
 2. Select an endpoint and choose the **OAuth2** security scheme
@@ -559,10 +167,10 @@ Sign-out uses OIDC [RP-initiated logout](https://openid.net/specs/openid-connect
 The most common failure modes and how to fix them:
 
 **"AADSTS50011: The reply URL specified in the request does not match..."** (Entra ID)
-: The post-logout URI (`https://your-jim-url/signout-callback-oidc`) is not registered against the app. Add it to **Authentication** > **Platform configurations** > **Web** > **Redirect URIs** and save. See [Entra ID Step 1](#step-1-register-the-application).
+: The post-logout URI (`https://your-jim-url/signout-callback-oidc`) is not registered against the app. Add it to **Authentication** > **Platform configurations** > **Web** > **Redirect URIs** and save. See [Entra ID Step 1](sso-setup/microsoft-entra-id.md#step-1-register-the-application).
 
 **"Invalid post_logout_redirect_uri"** or similar (AD FS, Keycloak)
-: Same root cause as above: the URI is not in the application's registered redirect URI list. For AD FS, add `https://your-jim-url/signout-callback-oidc` to the Web Application's Redirect URIs (see [AD FS Step 2](#step-2-configure-the-native-application)). For Keycloak, add it to **Valid post logout redirect URIs** on the client (see [Keycloak Step 2](#step-2-create-a-client-for-jim)).
+: Same root cause as above: the URI is not in the application's registered redirect URI list. For AD FS, add `https://your-jim-url/signout-callback-oidc` to the Web Application's Redirect URIs (see [AD FS Step 2](sso-setup/ad-fs.md#step-2-configure-the-native-application)). For Keycloak, add it to **Valid post logout redirect URIs** on the client (see [Keycloak Step 2](sso-setup/keycloak.md#step-2-create-a-client-for-jim)).
 
 **"Missing parameters: id_token_hint"** (Keycloak and other strict providers)
 : Keycloak and other strict OIDC providers require `id_token_hint` on the end-session request per the OIDC specification. JIM persists the ID token during sign-in automatically so the middleware can include it on sign-out. If you see this error, verify your identity provider is actually issuing an ID token (the `openid` scope must be requested, which JIM does by default) and that your client configuration is not stripping it.

--- a/docs/administration/sso-setup.md
+++ b/docs/administration/sso-setup.md
@@ -59,10 +59,10 @@ JIM uses two kinds of OAuth 2.0 clients, and depending on your identity provider
 **When are these the same registration?**
 
 - **Microsoft Entra ID**: One app registration can have both a Web platform (for the confidential flow) and a Mobile/Desktop platform (for the public flow). In this case, leave `JIM_SSO_PUBLIC_CLIENT_ID` unset; the PowerShell module uses the same Application (client) ID as the web application.
-- **AD FS**: A single Application Group can include both a web application and a native application that share a Client Identifier. Leave `JIM_SSO_PUBLIC_CLIENT_ID` unset in that case.
 
 **When must they be different?**
 
+- **AD FS**: A Server application (confidential) and a Native application (public) are distinct applications with their own Client Identifiers, even inside a single Application Group. Create both and set `JIM_SSO_PUBLIC_CLIENT_ID` to the Native application's identifier.
 - **Keycloak**: A single Keycloak client cannot be both confidential and public. You must create two clients (e.g. `jim` and `jim-powershell`) and set `JIM_SSO_PUBLIC_CLIENT_ID` to the public one.
 - **Any IdP where your security policy forbids adding loopback redirects to a confidential client**: create a dedicated public client and point `JIM_SSO_PUBLIC_CLIENT_ID` at it.
 
@@ -170,7 +170,7 @@ The most common failure modes and how to fix them:
 : The post-logout URI (`https://your-jim-url/signout-callback-oidc`) is not registered against the app. Add it to **Authentication** > **Platform configurations** > **Web** > **Redirect URIs** and save. See [Entra ID Step 1](sso-setup/microsoft-entra-id.md#step-1-register-the-application).
 
 **"Invalid post_logout_redirect_uri"** or similar (AD FS, Keycloak)
-: Same root cause as above: the URI is not in the application's registered redirect URI list. For AD FS, add `https://your-jim-url/signout-callback-oidc` to the Web Application's Redirect URIs (see [AD FS Step 2](sso-setup/ad-fs.md#step-2-configure-the-native-application)). For Keycloak, add it to **Valid post logout redirect URIs** on the client (see [Keycloak Step 2](sso-setup/keycloak.md#step-2-create-a-client-for-jim)).
+: Same root cause as above: the URI is not in the application's registered redirect URI list. For AD FS, add `https://your-jim-url/signout-callback-oidc` to the Server application's Redirect URIs (see [AD FS Step 2](sso-setup/ad-fs.md#step-2-configure-the-server-application)). For Keycloak, add it to **Valid post logout redirect URIs** on the client (see [Keycloak Step 2](sso-setup/keycloak.md#step-2-create-a-client-for-jim)).
 
 **"Missing parameters: id_token_hint"** (Keycloak and other strict providers)
 : Keycloak and other strict OIDC providers require `id_token_hint` on the end-session request per the OIDC specification. JIM persists the ID token during sign-in automatically so the middleware can include it on sign-out. If you see this error, verify your identity provider is actually issuing an ID token (the `openid` scope must be requested, which JIM does by default) and that your client configuration is not stripping it.

--- a/docs/administration/sso-setup/ad-fs.md
+++ b/docs/administration/sso-setup/ad-fs.md
@@ -1,0 +1,137 @@
+---
+title: SSO Setup - AD FS
+---
+
+# SSO Setup: AD FS
+
+Step-by-step instructions for configuring Single Sign-On with JIM using AD FS (Active Directory Federation Services) as the OIDC identity provider.
+
+!!! info "Read the overview first"
+    This page is one of the provider-specific guides linked from the [SSO Setup overview](../sso-setup.md). The overview covers the prerequisites, the [confidential vs public client](../sso-setup.md#confidential-vs-public-clients) model these steps rely on, and the [testing steps](../sso-setup.md#testing-your-configuration) you run once configuration is complete.
+
+## Step 1: Create an Application Group
+
+1. Open **AD FS Management** on your AD FS server
+2. Navigate to **Application Groups**
+3. Right-click and select **Add Application Group**
+4. Enter a name: `JIM Identity Management`
+5. Select **Web browser accessing a web application**
+6. Click **Next**
+
+## Step 2: Configure the Native Application
+
+1. Note the **Client Identifier** (auto-generated GUID)
+2. Add the **Redirect URI**: `https://your-jim-url/signin-oidc`
+3. Add a second **Redirect URI** for the sign-out callback: `https://your-jim-url/signout-callback-oidc`. AD FS validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
+4. Click **Next**
+
+## Step 3: Configure Access Control
+
+1. Select an access control policy (e.g. **Permit everyone**)
+2. Click **Next**
+
+## Step 4: Configure Application Permissions
+
+1. Select **openid** and **profile** scopes
+2. Click **Next** and then **Close**
+
+## Step 4a: Configure PowerShell Module Authentication (Optional but recommended)
+
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
+
+The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. AD FS supports this through native applications, which can live in the same Application Group as the web application.
+
+1. Right-click your Application Group and select **Properties**
+2. Click **Add application**
+3. Select **Native application**
+4. Click **Next**
+5. Note the **Client Identifier**. You can either:
+    - **Reuse the web client's identifier** (simplest): use the same value as the web application from Step 2. Leave `JIM_SSO_PUBLIC_CLIENT_ID` unset in Step 7.
+    - **Use a distinct identifier for the native app** (stricter isolation): accept the auto-generated GUID, and set `JIM_SSO_PUBLIC_CLIENT_ID` to that value in Step 7.
+6. Add the **Redirect URI**: `http://localhost:8400/callback/`
+7. Click **Next** and then **Close**
+
+!!! note
+    The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). AD FS native applications support PKCE, which the PowerShell module uses for security. If port 8400 is busy, you may need to add additional redirect URIs for ports 8401--8409.
+
+## Step 5: Create the Web API
+
+This step creates the API configuration for JWT Bearer token validation.
+
+1. Right-click your Application Group and select **Properties**
+2. Click **Add application**
+3. Select **Web API**
+4. Click **Next**
+5. Set the **Identifier**: `api://{client-identifier}` (use the client ID from Step 2)
+6. Click **Next**
+7. Select an access control policy
+8. Click **Next**
+9. Under **Permitted scopes**, add:
+    - `openid`
+    - `profile`
+    - `email`
+    - `offline_access` (required for refresh-token issuance; enables PowerShell silent renewal and token persistence)
+10. Click **Next** and then **Close**
+
+## Step 6: Generate a Client Secret
+
+1. In your Application Group properties, select the **Native application**
+2. Click **Edit**
+3. Under **Secrets**, click **Generate**
+4. **Copy the secret value** -- store it securely
+
+## Step 7: Configure JIM Environment Variables
+
+```bash
+# AD FS Configuration
+JIM_SSO_AUTHORITY=https://{your-adfs-server}/adfs
+JIM_SSO_CLIENT_ID={your-client-identifier}
+JIM_SSO_SECRET={your-client-secret}
+JIM_SSO_API_SCOPE=api://{your-client-identifier}
+
+# Optional: only set if Step 4a used a distinct Client Identifier for the native
+# (PowerShell) application. Leave unset to reuse JIM_SSO_CLIENT_ID.
+# JIM_SSO_PUBLIC_CLIENT_ID={your-native-app-client-identifier}
+
+# User identity mapping
+JIM_SSO_CLAIM_TYPE=sub
+JIM_SSO_MV_ATTRIBUTE=Subject Identifier
+JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
+```
+
+**Example (native app reuses the web client identifier):**
+
+```bash
+JIM_SSO_AUTHORITY=https://adfs.example.com/adfs
+JIM_SSO_CLIENT_ID=e1234567-89ab-cdef-0123-456789abcdef
+JIM_SSO_SECRET=generatedSecretValue123
+JIM_SSO_API_SCOPE=api://e1234567-89ab-cdef-0123-456789abcdef
+```
+
+## AD FS Claim Rules
+
+AD FS may need claim rules to emit standard OIDC claims (`sub`, `email`, `name`). In your Web API's **Issuance Transform Rules**, add rules to map AD claims to OIDC claims:
+
+```text
+# Rule: Send User Principal Name as sub
+c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+ => issue(Type = "sub", Value = c.Value);
+
+# Rule: Send Display Name as name
+c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"]
+ => issue(Type = "name", Value = c.Value);
+
+# Rule: Send Email
+c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
+ => issue(Type = "email", Value = c.Value);
+```
+
+## AD FS Troubleshooting
+
+- **Token signing certificate**: Ensure your AD FS token signing certificate is trusted by the JIM server
+- **Claim rules**: AD FS may need claim rules to emit standard OIDC claims (see above)
+- **CORS**: If JIM and AD FS are on different domains, configure CORS in AD FS
+
+## Next steps
+
+With the configuration in place, [test your configuration](../sso-setup.md#testing-your-configuration) to verify sign-in, claims, sign-out, and API access. If sign-out fails, see [Sign-Out Troubleshooting](../sso-setup.md#sign-out-troubleshooting).

--- a/docs/administration/sso-setup/ad-fs.md
+++ b/docs/administration/sso-setup/ad-fs.md
@@ -4,94 +4,91 @@ title: SSO Setup - AD FS
 
 # SSO Setup: AD FS
 
-Step-by-step instructions for configuring Single Sign-On with JIM using AD FS (Active Directory Federation Services) as the OIDC identity provider.
+Step-by-step instructions for configuring Single Sign-On with JIM using AD FS (Active Directory Federation Services) as the OIDC identity provider. Requires **AD FS on Windows Server 2019 or later** (earlier versions do not support PKCE, which the PowerShell module relies on).
 
 !!! info "Read the overview first"
     This page is one of the provider-specific guides linked from the [SSO Setup overview](../sso-setup.md). The overview covers the prerequisites, the [confidential vs public client](../sso-setup.md#confidential-vs-public-clients) model these steps rely on, and the [testing steps](../sso-setup.md#testing-your-configuration) you run once configuration is complete.
 
+!!! note "Two client types, two AD FS applications"
+    The JIM web application is a **confidential client**: it runs on a server and authenticates to AD FS with a shared secret, so it is registered as an AD FS **Server application**. The optional PowerShell module is a **public client**: it runs on an administrator's machine and uses PKCE with a loopback redirect instead of a secret, so it is registered as a separate AD FS **Native application**. Both live in the same Application Group. Steps 1--6 configure the confidential web application; Step 7 adds the public client for the PowerShell module.
+
 ## Step 1: Create an Application Group
 
 1. Open **AD FS Management** on your AD FS server
-2. Navigate to **Application Groups**
-3. Right-click and select **Add Application Group**
-4. Enter a name: `JIM Identity Management`
-5. Select **Web browser accessing a web application**
-6. Click **Next**
+2. Right-click **Application Groups** and select **Add Application Group**
+3. Enter a name: `JIM Identity Management`
+4. Under **Client-Server applications**, select **Server application accessing a web API**
+5. Click **Next**
 
-## Step 2: Configure the Native Application
+This template creates a **Server application** (the confidential web client) and a **Web API** (the resource used for JWT Bearer token validation) in one group.
 
-1. Note the **Client Identifier** (auto-generated GUID)
-2. Add the **Redirect URI**: `https://your-jim-url/signin-oidc`
-3. Add a second **Redirect URI** for the sign-out callback: `https://your-jim-url/signout-callback-oidc`. AD FS validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
+## Step 2: Configure the Server Application
+
+1. Note the **Client Identifier** (auto-generated GUID) -- this becomes `JIM_SSO_CLIENT_ID`
+2. Add the **Redirect URI**: `https://your-jim-url/signin-oidc`, then click **Add**
+3. Add a second **Redirect URI** for the sign-out callback: `https://your-jim-url/signout-callback-oidc`, then click **Add**. AD FS validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
 4. Click **Next**
 
-## Step 3: Configure Access Control
+## Step 3: Configure Application Credentials
+
+1. Check **Generate a shared secret**
+2. **Copy the secret value** -- store it securely; this becomes `JIM_SSO_SECRET`
+3. Click **Next**
+
+!!! note
+    The shared secret belongs to the confidential Server application only. The Native application you add in Step 7 for the PowerShell module is a public client and does **not** have a secret; it uses PKCE instead.
+
+## Step 4: Configure the Web API
+
+1. Set the **Identifier**: `api://{client-identifier}` (use the Client Identifier from Step 2), then click **Add**. This becomes `JIM_SSO_API_SCOPE`.
+2. Click **Next**
+
+## Step 5: Apply an Access Control Policy
 
 1. Select an access control policy (e.g. **Permit everyone**)
 2. Click **Next**
 
-## Step 4: Configure Application Permissions
+## Step 6: Configure Application Permissions
 
-1. Select **openid** and **profile** scopes
-2. Click **Next** and then **Close**
-
-## Step 4a: Configure PowerShell Module Authentication (Optional but recommended)
-
-Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
-
-The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. AD FS supports this through native applications, which can live in the same Application Group as the web application.
-
-1. Right-click your Application Group and select **Properties**
-2. Click **Add application**
-3. Select **Native application**
-4. Click **Next**
-5. Note the **Client Identifier**. You can either:
-    - **Reuse the web client's identifier** (simplest): use the same value as the web application from Step 2. Leave `JIM_SSO_PUBLIC_CLIENT_ID` unset in Step 7.
-    - **Use a distinct identifier for the native app** (stricter isolation): accept the auto-generated GUID, and set `JIM_SSO_PUBLIC_CLIENT_ID` to that value in Step 7.
-6. Add the **Redirect URI**: `http://localhost:8400/callback/`
-7. Click **Next** and then **Close**
-
-!!! note
-    The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). AD FS native applications support PKCE, which the PowerShell module uses for security. If port 8400 is busy, you may need to add additional redirect URIs for ports 8401--8409.
-
-## Step 5: Create the Web API
-
-This step creates the API configuration for JWT Bearer token validation.
-
-1. Right-click your Application Group and select **Properties**
-2. Click **Add application**
-3. Select **Web API**
-4. Click **Next**
-5. Set the **Identifier**: `api://{client-identifier}` (use the client ID from Step 2)
-6. Click **Next**
-7. Select an access control policy
-8. Click **Next**
-9. Under **Permitted scopes**, add:
+1. Under **Permitted scopes**, select:
     - `openid`
     - `profile`
     - `email`
     - `offline_access` (required for refresh-token issuance; enables PowerShell silent renewal and token persistence)
-10. Click **Next** and then **Close**
+2. Click **Next**, then **Next** again on the Summary screen, and **Close**
 
-## Step 6: Generate a Client Secret
+The confidential web application is now configured. If you do not need interactive PowerShell authentication, skip to Step 8.
 
-1. In your Application Group properties, select the **Native application**
-2. Click **Edit**
-3. Under **Secrets**, click **Generate**
-4. **Copy the secret value** -- store it securely
+## Step 7: Configure PowerShell Module Authentication (Optional but recommended)
 
-## Step 7: Configure JIM Environment Variables
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module.
+
+The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. This is a **public client**, so it must be a separate **Native application** (a native/public application in AD FS cannot hold a shared secret). Add it to the same Application Group:
+
+1. Right-click your Application Group and select **Properties**
+2. Click **Add application**
+3. Select **Native application**, then click **Next**
+4. Note the **Client Identifier** (auto-generated GUID) -- this becomes `JIM_SSO_PUBLIC_CLIENT_ID`
+5. Add the **Redirect URI**: `http://localhost:8400/callback/`, then click **Add**
+6. Click **Next**, then **Close**
+7. Grant the native application access to the Web API: back in the Application Group properties, select the **Web API**, click **Edit**, and on the **Client Permissions** tab ensure the native application is permitted the `openid`, `profile`, `email` and `offline_access` scopes
+
+!!! note
+    The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). AD FS 2019 and later support PKCE for native applications, which the module uses for security. If port 8400 is busy, the module will try ports 8401--8409; add the corresponding redirect URIs (e.g. `http://localhost:8401/callback/` through `http://localhost:8409/callback/`) if port conflicts are likely in your environment.
+
+## Step 8: Configure JIM Environment Variables
 
 ```bash
 # AD FS Configuration
 JIM_SSO_AUTHORITY=https://{your-adfs-server}/adfs
-JIM_SSO_CLIENT_ID={your-client-identifier}
-JIM_SSO_SECRET={your-client-secret}
-JIM_SSO_API_SCOPE=api://{your-client-identifier}
+JIM_SSO_CLIENT_ID={your-server-application-client-identifier}
+JIM_SSO_SECRET={your-shared-secret}
+JIM_SSO_API_SCOPE=api://{your-server-application-client-identifier}
 
-# Optional: only set if Step 4a used a distinct Client Identifier for the native
-# (PowerShell) application. Leave unset to reuse JIM_SSO_CLIENT_ID.
-# JIM_SSO_PUBLIC_CLIENT_ID={your-native-app-client-identifier}
+# Client ID of the Native application created in Step 7 for the PowerShell
+# module. Required for interactive (SSO) PowerShell authentication; omit if
+# you only plan to use API keys.
+JIM_SSO_PUBLIC_CLIENT_ID={your-native-application-client-identifier}
 
 # User identity mapping
 JIM_SSO_CLAIM_TYPE=sub
@@ -99,13 +96,14 @@ JIM_SSO_MV_ATTRIBUTE=Subject Identifier
 JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
 ```
 
-**Example (native app reuses the web client identifier):**
+**Example:**
 
 ```bash
 JIM_SSO_AUTHORITY=https://adfs.example.com/adfs
 JIM_SSO_CLIENT_ID=e1234567-89ab-cdef-0123-456789abcdef
 JIM_SSO_SECRET=generatedSecretValue123
 JIM_SSO_API_SCOPE=api://e1234567-89ab-cdef-0123-456789abcdef
+JIM_SSO_PUBLIC_CLIENT_ID=a9876543-21fe-dcba-3210-fedcba987654
 ```
 
 ## AD FS Claim Rules
@@ -131,6 +129,7 @@ c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
 - **Token signing certificate**: Ensure your AD FS token signing certificate is trusted by the JIM server
 - **Claim rules**: AD FS may need claim rules to emit standard OIDC claims (see above)
 - **CORS**: If JIM and AD FS are on different domains, configure CORS in AD FS
+- **PKCE / PowerShell sign-in fails**: Confirm AD FS is Windows Server 2019 or later; earlier versions do not support PKCE and cannot authenticate the PowerShell module's public client
 
 ## Next steps
 

--- a/docs/administration/sso-setup/keycloak.md
+++ b/docs/administration/sso-setup/keycloak.md
@@ -1,0 +1,158 @@
+---
+title: SSO Setup - Keycloak
+---
+
+# SSO Setup: Keycloak
+
+Step-by-step instructions for configuring Single Sign-On with JIM using Keycloak as the OIDC identity provider.
+
+!!! info "Read the overview first"
+    This page is one of the provider-specific guides linked from the [SSO Setup overview](../sso-setup.md). The overview covers the prerequisites, the [confidential vs public client](../sso-setup.md#confidential-vs-public-clients) model these steps rely on, and the [testing steps](../sso-setup.md#testing-your-configuration) you run once configuration is complete.
+
+## Step 1: Create a Realm (if needed)
+
+1. Log in to the Keycloak Admin Console
+2. Hover over the realm dropdown and click **Create Realm**
+3. Enter a **Realm name** (e.g. `jim`)
+4. Click **Create**
+
+## Step 2: Create a Client for JIM
+
+1. Navigate to **Clients**
+2. Click **Create client**
+3. Configure the client:
+    - **Client type**: OpenID Connect
+    - **Client ID**: `jim`
+4. Click **Next**
+5. Configure capability:
+    - **Client authentication**: ON
+    - **Authorisation**: OFF
+    - **Authentication flow**: Check **Standard flow** (Authorisation Code)
+6. Click **Next**
+7. Configure login settings:
+    - **Root URL**: `https://your-jim-url`
+    - **Valid redirect URIs**: `https://your-jim-url/signin-oidc`
+    - **Valid post logout redirect URIs**: `https://your-jim-url/signout-callback-oidc`
+    - **Web origins**: `https://your-jim-url`
+8. Click **Save**
+
+## Step 3: Get the Client Secret
+
+1. Go to the **Credentials** tab
+2. Copy the **Client secret**
+
+## Step 4: Create a Service Account Client (Optional)
+
+If you need separate API clients for service-to-service communication:
+
+1. Click **Create client**
+2. Configure:
+    - **Client type**: OpenID Connect
+    - **Client ID**: `jim-service`
+3. Click **Next**
+4. Configure capability:
+    - **Client authentication**: ON
+    - **Authentication flow**: Check **Service accounts roles** (Client Credentials)
+5. Click **Save**
+
+## Step 5: Create Client Scopes (for API access)
+
+1. Navigate to **Client scopes**
+2. Click **Create client scope**
+3. Configure:
+    - **Name**: `jim-api`
+    - **Type**: Optional
+    - **Protocol**: OpenID Connect
+4. Click **Save**
+5. Go to the **Mappers** tab
+6. Click **Configure a new mapper**
+7. Select **Audience**
+8. Configure:
+    - **Name**: `jim-api-audience`
+    - **Included Client Audience**: `jim` (or `jim-service` if created)
+    - **Add to access token**: ON
+9. Click **Save**
+
+## Step 6: Assign the Scope to the Client
+
+1. Navigate to **Clients** > **jim**
+2. Go to the **Client scopes** tab
+3. Click **Add client scope**
+4. Select `jim-api` and add as **Optional**
+
+## Step 6a: Configure PowerShell Module Authentication (Recommended)
+
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys.
+
+The JIM PowerShell module uses OAuth 2.0 with PKCE for interactive browser-based authentication. **Keycloak requires this to be a separate client** from the confidential web client: a single Keycloak client cannot be both confidential (with a secret) and public (PKCE/loopback). You must create a second, public client and tell JIM about it via `JIM_SSO_PUBLIC_CLIENT_ID` in Step 7.
+
+1. Navigate to **Clients**
+2. Click **Create client**
+3. Configure the client:
+    - **Client type**: OpenID Connect
+    - **Client ID**: `jim-powershell` (this exact value is what you'll set `JIM_SSO_PUBLIC_CLIENT_ID` to in Step 7)
+4. Click **Next**
+5. Configure capability:
+    - **Client authentication**: OFF (this makes it a public client)
+    - **Authorisation**: OFF
+    - **Authentication flow**: Check **Standard flow** (Authorisation Code)
+6. Click **Next**
+7. Configure login settings:
+    - **Root URL**: Leave empty
+    - **Valid redirect URIs**: `http://localhost:8400/callback/`
+    - **Web origins**: `+` (allows all origins from redirect URIs)
+8. Click **Save**
+9. Go to the **Client scopes** tab
+10. Click **Add client scope**
+11. Select `jim-api` and add as **Optional**
+12. Confirm `offline_access` is listed (Keycloak adds it as a default optional scope on new clients). If it is missing, click **Add client scope**, select `offline_access`, and add it as **Optional**. This lets the module receive a refresh token for silent renewal and token persistence.
+
+!!! note
+    The PowerShell module uses loopback redirect URIs per [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252). If port 8400 is busy, the module will try ports 8401--8409. Add the corresponding redirect URIs (e.g. `http://localhost:8401/callback/` through `http://localhost:8409/callback/`) if port conflicts are likely in your environment.
+
+## Step 7: Configure JIM Environment Variables
+
+```bash
+# Keycloak Configuration
+JIM_SSO_AUTHORITY=https://{your-keycloak-server}/realms/{realm-name}
+JIM_SSO_CLIENT_ID=jim
+JIM_SSO_SECRET={your-client-secret}
+JIM_SSO_API_SCOPE=jim-api
+
+# Client ID for the public client you created in Step 6a for the PowerShell
+# module. Required if you want interactive (SSO) PowerShell authentication;
+# omit if you only plan to use API keys.
+JIM_SSO_PUBLIC_CLIENT_ID=jim-powershell
+
+# User identity mapping
+JIM_SSO_CLAIM_TYPE=sub
+JIM_SSO_MV_ATTRIBUTE=Subject Identifier
+JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
+```
+
+**Example:**
+
+```bash
+JIM_SSO_AUTHORITY=https://keycloak.example.com/realms/jim
+JIM_SSO_CLIENT_ID=jim
+JIM_SSO_SECRET=AbCdEfGhIjKlMnOpQrStUvWxYz123456
+JIM_SSO_API_SCOPE=jim-api
+JIM_SSO_PUBLIC_CLIENT_ID=jim-powershell
+```
+
+## Keycloak Troubleshooting
+
+- **Realm name**: Ensure the realm name in `JIM_SSO_AUTHORITY` matches exactly (case-sensitive)
+- **Client scopes**: Verify `openid`, `profile`, and `email` scopes are included
+- **Token mapper**: If the `sub` claim is missing, add a mapper in Client Scopes > openid > Mappers
+
+**Checking claim values:**
+
+1. Navigate to **Clients** > **jim** > **Client scopes**
+2. Click **Evaluate**
+3. Select a user and click **Evaluate**
+4. Check the **Generated access token** to see claim values
+
+## Next steps
+
+With the configuration in place, [test your configuration](../sso-setup.md#testing-your-configuration) to verify sign-in, claims, sign-out, and API access. If sign-out fails, see [Sign-Out Troubleshooting](../sso-setup.md#sign-out-troubleshooting).

--- a/docs/administration/sso-setup/microsoft-entra-id.md
+++ b/docs/administration/sso-setup/microsoft-entra-id.md
@@ -1,0 +1,153 @@
+---
+title: SSO Setup - Microsoft Entra ID
+---
+
+# SSO Setup: Microsoft Entra ID
+
+Step-by-step instructions for configuring Single Sign-On with JIM using Microsoft Entra ID as the OIDC identity provider.
+
+!!! info "Read the overview first"
+    This page is one of the provider-specific guides linked from the [SSO Setup overview](../sso-setup.md). The overview covers the prerequisites, the [confidential vs public client](../sso-setup.md#confidential-vs-public-clients) model these steps rely on, and the [testing steps](../sso-setup.md#testing-your-configuration) you run once configuration is complete.
+
+## Step 1: Register the Application
+
+1. Sign in to the [Azure Portal](https://portal.azure.com)
+2. Navigate to **Microsoft Entra ID** > **App registrations**
+3. Click **New registration**
+4. Configure the registration:
+    - **Name**: `JIM Identity Management`
+    - **Supported account types**: Select based on your requirements:
+        - *Single tenant*: Only users in your organisation
+        - *Multitenant*: Users from any Entra ID directory
+    - **Redirect URI**:
+        - Platform: **Web**
+        - URI: `https://your-jim-url/signin-oidc`
+5. Click **Register**
+6. After registration, go to **Authentication** and add a second Web redirect URI for the sign-out callback: `https://your-jim-url/signout-callback-oidc`, then click **Save**. Entra ID validates the `post_logout_redirect_uri` parameter against the same Redirect URIs list as sign-in, so this entry is required for sign-out to work.
+
+## Step 2: Note the Application Details
+
+After registration, note these values from the **Overview** page:
+
+- **Application (client) ID**: e.g. `12345678-1234-1234-1234-123456789abc`
+- **Directory (tenant) ID**: e.g. `87654321-4321-4321-4321-cba987654321`
+
+## Step 3: Create a Client Secret
+
+1. Go to **Certificates & secrets**
+2. Click **New client secret**
+3. Add a description (e.g. `JIM Web Client`)
+4. Select an expiry period
+5. Click **Add**
+6. **Copy the secret value immediately** -- it will not be shown again
+
+## Step 4: Configure API Permissions
+
+1. Go to **API permissions**
+2. Verify `User.Read` (Delegated) is present -- this is added by default and provides the OpenID Connect scopes needed for authentication
+
+!!! note
+    The standard OIDC scopes (`openid`, `profile`, `email`, `offline_access`) are requested at runtime and do not need to be added as Graph API permissions.
+
+## Step 5: Expose an API
+
+This step creates the API scope that JIM uses for JWT Bearer token validation (for API access).
+
+1. Go to **Expose an API**
+2. Click **Set** next to Application ID URI
+    - Accept the default (`api://{client-id}`) or set a custom URI
+    - Click **Save**
+3. Click **Add a scope**
+4. Configure the scope:
+    - **Scope name**: `access_as_user`
+    - **Who can consent**: Admins and users
+    - **Admin consent display name**: `Access JIM API`
+    - **Admin consent description**: `Allows the app to access JIM API on behalf of the signed-in user`
+    - **User consent display name**: `Access JIM API`
+    - **User consent description**: `Allows this app to access JIM API on your behalf`
+    - **State**: Enabled
+5. Click **Add scope**
+
+## Step 5a: Configure Scalar API Reference Authentication (Development only, Optional)
+
+JIM's interactive [Scalar](https://scalar.com/) API reference is only exposed in development environments (it is disabled in production to reduce the attack surface), so this step is only relevant if you are configuring SSO against a non-production JIM instance where you want to use the Scalar "try it out" flow with OAuth.
+
+To enable OAuth authentication in the Scalar API reference:
+
+1. Go to **Authentication**
+2. Click **Add Redirect URI**
+3. Select **Single-page application**
+4. Add redirect URI: `https://your-jim-dev-url/api/reference` (Scalar uses the API reference page itself as the OAuth redirect target; there is no separate `oauth2-redirect.html` handler)
+5. Click **Configure**
+
+!!! note
+    For production deployments, use the JIM PowerShell module for interactive API testing instead. See Step 5b below.
+
+## Step 5b: Configure PowerShell Module Authentication (Optional but recommended)
+
+Configuring the PowerShell module now means administrators and automation scripts can connect to JIM interactively with their SSO account, without needing to issue or manage API keys. You can skip this step if you don't plan to use the PowerShell module, but it only takes a moment and is worth doing up front.
+
+Entra ID allows a single app registration to serve both the JIM web application (confidential client with a secret) and the PowerShell module (public client using PKCE with a loopback redirect). You can reuse the same app registration from Step 1; just add a new platform for the PowerShell flow:
+
+1. Go to **Authentication**
+2. Click **Add a platform**
+3. Select **Mobile and desktop applications**
+4. Check the suggested redirect URI: `https://login.microsoftonline.com/common/oauth2/nativeclient`
+5. In **Custom redirect URIs**, add: `http://localhost:8400/callback/`
+6. Click **Configure**
+7. Scroll down to **Advanced settings**
+8. Set **Allow public client flows** to **Yes**
+9. Click **Save**
+
+Because the web and PowerShell platforms share the same **Application (client) ID**, you can either:
+
+- **Share the client ID** (simplest): leave `JIM_SSO_PUBLIC_CLIENT_ID` unset in Step 6 below. The PowerShell module will use `JIM_SSO_CLIENT_ID`, which now has both Web and Mobile/Desktop platforms configured.
+- **Use a separate app registration** for the PowerShell module (stricter isolation): create a second app registration with only the Mobile/Desktop platform, note its Application (client) ID, and set `JIM_SSO_PUBLIC_CLIENT_ID` to that value.
+
+!!! note
+    Entra ID requires exact redirect URI matching. If port 8400 is busy, the module will try ports 8401--8409. You may need to add additional redirect URIs if you encounter port conflicts.
+
+!!! note "Refresh tokens"
+    Setting **Allow public client flows** to **Yes** (step 8 above) is what lets Entra ID return a refresh token to the module. JIM requests the `offline_access` scope at runtime; it is a standard OIDC scope and does not need to be added as an API permission. The refresh token enables silent in-session renewal and optional cross-session token persistence.
+
+## Step 6: Configure JIM Environment Variables
+
+Add these to your `.env` file:
+
+```bash
+# Microsoft Entra ID Configuration
+JIM_SSO_AUTHORITY=https://login.microsoftonline.com/{your-tenant-id}/v2.0
+JIM_SSO_CLIENT_ID={your-application-client-id}
+JIM_SSO_SECRET={your-client-secret}
+JIM_SSO_API_SCOPE=api://{your-application-client-id}/access_as_user
+
+# Optional: only set if you created a separate app registration for the PowerShell
+# module in Step 5b. Leave unset to reuse JIM_SSO_CLIENT_ID.
+# JIM_SSO_PUBLIC_CLIENT_ID={your-powershell-app-client-id}
+
+# User identity mapping
+JIM_SSO_CLAIM_TYPE=sub
+JIM_SSO_MV_ATTRIBUTE=Subject Identifier
+JIM_SSO_INITIAL_ADMIN={your-admin-sub-value}
+```
+
+**Example with real values (single app registration, web + PowerShell share client ID):**
+
+```bash
+JIM_SSO_AUTHORITY=https://login.microsoftonline.com/87654321-4321-4321-4321-cba987654321/v2.0
+JIM_SSO_CLIENT_ID=12345678-1234-1234-1234-123456789abc
+JIM_SSO_SECRET=abc123~secretvalue
+JIM_SSO_API_SCOPE=api://12345678-1234-1234-1234-123456789abc/access_as_user
+```
+
+## Step 7: Find Your Admin User's Subject Identifier
+
+1. Start JIM with the configuration above
+2. Log in with your admin account
+3. Navigate to `/claims` in the web interface
+4. Find the `sub` claim value
+5. Update `JIM_SSO_INITIAL_ADMIN` with this value
+
+## Next steps
+
+With the configuration in place, [test your configuration](../sso-setup.md#testing-your-configuration) to verify sign-in, claims, sign-out, and API access. If sign-out fails, see [Sign-Out Troubleshooting](../sso-setup.md#sign-out-troubleshooting).

--- a/docs/administration/sso-setup/microsoft-entra-id.md
+++ b/docs/administration/sso-setup/microsoft-entra-id.md
@@ -108,7 +108,7 @@ Because the web and PowerShell platforms share the same **Application (client) I
     Entra ID requires exact redirect URI matching. If port 8400 is busy, the module will try ports 8401--8409. You may need to add additional redirect URIs if you encounter port conflicts.
 
 !!! note "Refresh tokens"
-    Setting **Allow public client flows** to **Yes** (step 8 above) is what lets Entra ID return a refresh token to the module. JIM requests the `offline_access` scope at runtime; it is a standard OIDC scope and does not need to be added as an API permission. The refresh token enables silent in-session renewal and optional cross-session token persistence.
+    The refresh token is issued because JIM requests the `offline_access` scope at runtime; it is a standard OIDC scope and does not need to be added as an API permission. Setting **Allow public client flows** to **Yes** (step 8 above) is a separate requirement: it marks the registration as a public client so the module can redeem the authorization code via PKCE without a client secret. This matters when the module shares the web application's registration, which already has a secret and would otherwise be treated as confidential. The refresh token enables silent in-session renewal and optional cross-session token persistence.
 
 ## Step 6: Configure JIM Environment Variables
 

--- a/docs/administration/troubleshooting.md
+++ b/docs/administration/troubleshooting.md
@@ -19,7 +19,7 @@ You clicked **Login** (or let `Connect-JIM` open your browser) and the identity 
 
 **How to fix.**
 
-1. Confirm your identity provider has a public client registered with at least the redirect URI `http://localhost:8400/callback/`. The [SSO Setup Guide](sso-setup.md) has per-provider instructions (Entra ID Step 5b, AD FS Step 4a, Keycloak Step 6a).
+1. Confirm your identity provider has a public client registered with at least the redirect URI `http://localhost:8400/callback/`. The per-provider guides cover this: [Entra ID Step 5b](sso-setup/microsoft-entra-id.md#step-5b-configure-powershell-module-authentication-optional-but-recommended), [AD FS Step 4a](sso-setup/ad-fs.md#step-4a-configure-powershell-module-authentication-optional-but-recommended), [Keycloak Step 6a](sso-setup/keycloak.md#step-6a-configure-powershell-module-authentication-recommended).
 2. If the public client is a **separate registration** from the web application (always the case for Keycloak), set `JIM_SSO_PUBLIC_CLIENT_ID` on the JIM server to the public client's client ID and restart JIM.
 3. If the public client **shares a registration** with the web application (Entra ID or AD FS with both platforms added to one app), you do not need to set `JIM_SSO_PUBLIC_CLIENT_ID`; just ensure the web app registration has the loopback redirect URI added under its native/mobile platform.
 

--- a/docs/administration/troubleshooting.md
+++ b/docs/administration/troubleshooting.md
@@ -19,7 +19,7 @@ You clicked **Login** (or let `Connect-JIM` open your browser) and the identity 
 
 **How to fix.**
 
-1. Confirm your identity provider has a public client registered with at least the redirect URI `http://localhost:8400/callback/`. The per-provider guides cover this: [Entra ID Step 5b](sso-setup/microsoft-entra-id.md#step-5b-configure-powershell-module-authentication-optional-but-recommended), [AD FS Step 4a](sso-setup/ad-fs.md#step-4a-configure-powershell-module-authentication-optional-but-recommended), [Keycloak Step 6a](sso-setup/keycloak.md#step-6a-configure-powershell-module-authentication-recommended).
+1. Confirm your identity provider has a public client registered with at least the redirect URI `http://localhost:8400/callback/`. The per-provider guides cover this: [Entra ID Step 5b](sso-setup/microsoft-entra-id.md#step-5b-configure-powershell-module-authentication-optional-but-recommended), [AD FS Step 7](sso-setup/ad-fs.md#step-7-configure-powershell-module-authentication-optional-but-recommended), [Keycloak Step 6a](sso-setup/keycloak.md#step-6a-configure-powershell-module-authentication-recommended).
 2. If the public client is a **separate registration** from the web application (always the case for Keycloak), set `JIM_SSO_PUBLIC_CLIENT_ID` on the JIM server to the public client's client ID and restart JIM.
 3. If the public client **shares a registration** with the web application (Entra ID or AD FS with both platforms added to one app), you do not need to set `JIM_SSO_PUBLIC_CLIENT_ID`; just ensure the web app registration has the loopback redirect URI added under its native/mobile platform.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,11 @@ nav:
   - Administration:
       - administration/index.md
       - Deployment: administration/deployment.md
-      - SSO Setup: administration/sso-setup.md
+      - SSO Setup:
+          - administration/sso-setup.md
+          - Microsoft Entra ID: administration/sso-setup/microsoft-entra-id.md
+          - AD FS: administration/sso-setup/ad-fs.md
+          - Keycloak: administration/sso-setup/keycloak.md
       - Security Headers: administration/security-headers.md
       - Security Audit Events: administration/security-audit-events.md
       - Configuration Reference: administration/configuration.md


### PR DESCRIPTION
## Summary
- Split the long SSO Setup page into a high-level hub plus one page per identity provider (Microsoft Entra ID, AD FS, Keycloak), so the overview delivers guidance and links out to vendor-specific step-by-step instructions. The hub keeps the provider-agnostic material: Confidential vs Public Clients, Testing, Sign-Out Troubleshooting, Security Considerations. Public URL `/administration/sso-setup/` is preserved.
- Corrected the Entra refresh-token note: the refresh token is issued by the `offline_access` scope, not by the "Allow public client flows" setting (that setting is a separate requirement, marking the app as a public client for PKCE). Verified against Microsoft docs.
- Fixed a genuine AD FS defect: the guide conflated the confidential web client with a public native client (it generated a shared secret on a Native application, which contradicts the AD FS model and is not executable as written). Now registers JIM.Web as a confidential Server application with a secret + Web API, and the PowerShell module as a separate public Native application (PKCE, loopback, no secret).
- Reconciled the hub's Confidential vs Public Clients note (AD FS moves from "same registration" to "must be different") and the AD FS deep links in the sign-out and general troubleshooting sections.

## Test plan
- [x] Docs-only change (pages under `docs/` plus `mkdocs.yml` nav); skips `dotnet build`/`test` per the CLAUDE.md exception list
- [x] All intra-doc anchors and inbound links verified to resolve by inspection
- [ ] Not runtime-tested against live AD FS/Entra/Keycloak; AD FS rewrite is grounded in Microsoft's documented Server (confidential) vs Native (public) model

🤖 Generated with [Claude Code](https://claude.com/claude-code)