### PR TITLE
docs(prd): redact author surname to first name only

### DIFF
--- a/engineering/prd/PRD_PARALLEL_INTEGRATION_TESTS.md
+++ b/engineering/prd/PRD_PARALLEL_INTEGRATION_TESTS.md
@@ -2,7 +2,7 @@
 
 - **Status:** Planned
 - **Created:** 2026-04-22
-- **Author:** Jay Van der Zant
+- **Author:** Jay
 - **Issue:** #636
 
 ## Problem Statement

--- a/engineering/prd/PRD_RELATIVE_DATE_SEARCH_CRITERIA.md
+++ b/engineering/prd/PRD_RELATIVE_DATE_SEARCH_CRITERIA.md
@@ -2,7 +2,7 @@
 
 - **Status:** Done
 - **Created:** 2026-06-21
-- **Author:** Jay Van der Zant
+- **Author:** Jay
 - **Issue:** [#85](https://github.com/TetronIO/JIM/issues/85)
 - **Implementation plan:** [`engineering/plans/done/RELATIVE_DATE_SEARCH_CRITERIA.md`](../plans/done/RELATIVE_DATE_SEARCH_CRITERIA.md) and [`engineering/plans/done/TEMPORAL_SCOPE_REEVALUATION.md`](../plans/done/TEMPORAL_SCOPE_REEVALUATION.md) (#892)
 

--- a/engineering/prd/PRD_SCOPING_CRITERIA_EVALUATION_MATRIX.md
+++ b/engineering/prd/PRD_SCOPING_CRITERIA_EVALUATION_MATRIX.md
@@ -2,7 +2,7 @@
 
 - **Status:** Planned
 - **Created:** 2026-05-22
-- **Author:** Jay Van der Zant
+- **Author:** Jay
 - **Issue:** #[number] *(to be filed after PRD review)*
 
 ## Problem Statement

--- a/engineering/prd/PRD_WORKER_PIPELINE_ARCHITECTURE.md
+++ b/engineering/prd/PRD_WORKER_PIPELINE_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 - **Status:** Planned
 - **Created:** 2026-04-02
-- **Author:** Jay Van der Zant
+- **Author:** Jay
 - **Issue:** [#451](https://github.com/TetronIO/JIM/issues/451)
 
 ## Problem Statement


### PR DESCRIPTION
## Summary
- Redacts four PRD `Author:` lines from the full name to first name only (`Jay`), per the author's preference not to have their surname committed to the repository:
  - `PRD_PARALLEL_INTEGRATION_TESTS.md`
  - `PRD_RELATIVE_DATE_SEARCH_CRITERIA.md`
  - `PRD_SCOPING_CRITERIA_EVALUATION_MATRIX.md`
  - `PRD_WORKER_PIPELINE_ARCHITECTURE.md`
- `PRD_SQL_DATABASE_CONNECTOR.md` is deliberately **excluded**: it is under active refinement on another branch and its author line is being handled there.
- Docs-only change (PRD planning docs); no code, changelog, or public-docs impact. Note: the surname remains in git history; only the current tree is redacted.

## Test plan
- [x] Docs-only change (per CLAUDE.md, no build/test required)
- [x] `git grep "Van der Zant"` on the branch returns only the intentionally-excluded SQL Connector PRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)