### PR TITLE
docs: clarify FlushRpeisAsync description in delta sync flow

### DIFF
--- a/docs/developer/diagrams/DELTA_SYNC_FLOW.md
+++ b/docs/developer/diagrams/DELTA_SYNC_FLOW.md
@@ -42,7 +42,7 @@ flowchart TD
     Pass1 --> Pass2[Pass 2: non-obsolete CSOs<br/>ProcessActiveConnectedSystemObjectAsync<br/>Identical to Full Sync:<br/>join, project, Attribute Flow, drift]
     Pass2 --> CsoLoop
 
-    CsoLoop -->|No| PageFlush[Page flush pipeline:<br/>1. Deferred reference attributes<br/>2. PersistPendingMetaverseObjectsAsync<br/>3. CreatePendingMvoChangeObjectsAsync<br/>4. EvaluatePendingExportsAsync<br/>5. FlushPendingExportOperationsAsync<br/>6. ResolvePendingExportReferenceSnapshotsAsync<br/>7. FlushObsoleteCsoOperationsAsync<br/>8. FlushPendingMvoDeletionsAsync<br/>9. FlushRpeisAsync (bulk-insert via raw SQL)<br/>10. FlushPendingMvoChangesAsync<br/>11. Clear change tracker, update progress]
+    CsoLoop -->|No| PageFlush[Page flush pipeline:<br/>1. Deferred reference attributes<br/>2. PersistPendingMetaverseObjectsAsync<br/>3. CreatePendingMvoChangeObjectsAsync<br/>4. EvaluatePendingExportsAsync<br/>5. FlushPendingExportOperationsAsync<br/>6. ResolvePendingExportReferenceSnapshotsAsync<br/>7. FlushObsoleteCsoOperationsAsync<br/>8. FlushPendingMvoDeletionsAsync<br/>9. FlushRpeisAsync: bulk-insert via raw SQL<br/>10. FlushPendingMvoChangesAsync<br/>11. Clear change tracker, update progress]
     PageFlush --> PageLoop
 
     PageLoop -->|No| CrossPage[Cross-page reference resolution<br/>Reload CSOs with unresolved references<br/>Merge reference-attribute changes under<br/>the existing MvoChange parent RPEI<br/>Re-run persist/flush pipeline]


### PR DESCRIPTION
## Description

Minor documentation clarification in the delta sync flow diagram. Changed the description of step 9 (FlushRpeisAsync) from "(bulk-insert via raw SQL)" to ": bulk-insert via raw SQL" for consistency with the formatting style used elsewhere in the pipeline steps.

This is a purely cosmetic change to improve readability and visual consistency of the diagram.

## Type of change

- [x] Documentation update

## Testing

- [x] No testing needed

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale

The change is in `docs/developer/diagrams/DELTA_SYNC_FLOW.md`, which is developer reference documentation.

## Checklist

- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

https://claude.ai/code/session_01MUGgttWjQFTw57MTrTtvuH