### PR TITLE
fix(security): sanitise imported values in sync-path logging (CWE-117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- 🔒 Values imported from connected systems (Distinguished Names, identifiers, CSV fields) can no longer forge or corrupt service log entries via embedded line breaks; all such values are now sanitised before logging across the import, synchronisation, and export paths. Identity display names are no longer written to service logs at all.
 - 🔒 The expression evaluation engine has been security-reviewed and hardened with defence-in-depth guardrails, with no change to expression functionality.
 - 🔒 Every response from JIM now carries defence-in-depth security headers, including a Content Security Policy, clickjacking denial, and MIME-sniffing protection.
 - 🔒 Every NuGet dependency, including transitive packages, is now locked to exact known-good versions, making JIM's builds reproducible and tamper-evident from source through to container image.

--- a/engineering/prd/done/PRD_UNRESOLVED_REFERENCE_HANDLING.md
+++ b/engineering/prd/done/PRD_UNRESOLVED_REFERENCE_HANDLING.md
@@ -1,6 +1,6 @@
 # Unresolved Reference Handling per Connected System
 
-- **Status:** Doing
+- **Status:** Done
 - **Created:** 2026-07-16
 - **Author:** Claude (from issue #873, authored by Jay)
 - **Issue:** [#873](https://github.com/TetronIO/JIM/issues/873)

--- a/src/JIM.Application/Servers/ExportEvaluationServer.cs
+++ b/src/JIM.Application/Servers/ExportEvaluationServer.cs
@@ -701,7 +701,7 @@ public class ExportEvaluationServer
                     });
 
                     Log.Debug("EvaluateMvoDeletionsAsync: Will store secondary external ID '{Value}' (attr {AttrName}) on delete PE for CSO {CsoId}",
-                        secondaryIdAttrValue.StringValue, secondaryIdAttrValue.Attribute.Name, cso.Id);
+                        LogSanitiser.Sanitise(secondaryIdAttrValue.StringValue), secondaryIdAttrValue.Attribute.Name, cso.Id);
                 }
                 else
                 {
@@ -2341,7 +2341,7 @@ public class ExportEvaluationServer
         }
 
         Log.Debug("AddSecondaryExternalIdToCsoAsync: Added secondary external ID value '{SecondaryIdValue}' to CSO {CsoId} for confirming import matching (deferSave={DeferSave})",
-            secondaryIdChange.StringValue ?? secondaryIdChange.IntValue?.ToString() ?? "unknown", cso.Id, deferSave);
+            LogSanitiser.Sanitise(secondaryIdChange.StringValue ?? secondaryIdChange.IntValue?.ToString() ?? "unknown"), cso.Id, deferSave);
     }
 
     /// <summary>
@@ -2924,13 +2924,13 @@ public class ExportEvaluationServer
             // Check if the pending change is also null/empty
             var isEmpty = IsPendingChangeEmpty(pendingChange);
             Log.Debug("IsSingleValueMatch: existingValue is null, pendingChange empty={IsEmpty}, IntValue={IntValue}, StringValue={StringValue}",
-                isEmpty, pendingChange.IntValue, pendingChange.StringValue);
+                isEmpty, pendingChange.IntValue, LogSanitiser.Sanitise(pendingChange.StringValue));
             return isEmpty;
         }
 
         var result = ValuesMatch(pendingChange, existingValue);
         Log.Debug("IsSingleValueMatch: Comparing pendingChange (IntValue={PendingInt}, StringValue={PendingStr}) with existingValue (IntValue={ExistingInt}, StringValue={ExistingStr}). Result={Result}",
-            pendingChange.IntValue, pendingChange.StringValue, existingValue.IntValue, existingValue.StringValue, result);
+            pendingChange.IntValue, LogSanitiser.Sanitise(pendingChange.StringValue), existingValue.IntValue, LogSanitiser.Sanitise(existingValue.StringValue), result);
         return result;
     }
 

--- a/src/JIM.Application/Servers/ExportExecutionServer.cs
+++ b/src/JIM.Application/Servers/ExportExecutionServer.cs
@@ -9,6 +9,7 @@ using JIM.Models.Core;
 using JIM.Models.Interfaces;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
+using JIM.Utilities;
 using Serilog;
 
 namespace JIM.Application.Servers;
@@ -1222,7 +1223,7 @@ public class ExportExecutionServer
 
                 needsUpdate = true;
                 Log.Debug("BatchUpdateCsosAfterSuccessfulExportAsync: Set CSO {CsoId} external ID to {ExternalId} (type: {AttrType})",
-                    cso.Id, exportResult.ExternalId, externalIdAttribute?.Type.ToString() ?? "Unknown");
+                    cso.Id, LogSanitiser.Sanitise(exportResult.ExternalId), externalIdAttribute?.Type.ToString() ?? "Unknown");
             }
 
             // Update secondary external ID if provided
@@ -1254,7 +1255,7 @@ public class ExportExecutionServer
 
                 needsUpdate = true;
                 Log.Debug("BatchUpdateCsosAfterSuccessfulExportAsync: Set CSO {CsoId} secondary external ID to {SecondaryExternalId}",
-                    cso.Id, exportResult.SecondaryExternalId);
+                    cso.Id, LogSanitiser.Sanitise(exportResult.SecondaryExternalId));
             }
 
             if (needsUpdate)
@@ -1305,7 +1306,7 @@ public class ExportExecutionServer
             // Keep as Pending while we're still retrying
             export.Status = PendingExportStatus.Pending;
             Log.Warning("MarkExportFailed: Export {ExportId} failed (attempt {Attempt}/{MaxRetries}). Next retry at {NextRetry}. Error: {Error}",
-                export.Id, export.ErrorCount, export.MaxRetries, export.NextRetryAt, errorMessage);
+                export.Id, export.ErrorCount, export.MaxRetries, export.NextRetryAt, LogSanitiser.Sanitise(errorMessage));
         }
     }
 
@@ -1364,7 +1365,7 @@ public class ExportExecutionServer
 
             needsUpdate = true;
             Log.Information("UpdateCsoAfterSuccessfulExportAsync: Set CSO {CsoId} external ID to {ExternalId} (type: {AttrType})",
-                cso.Id, exportResult.ExternalId, externalIdAttribute?.Type.ToString() ?? "Unknown");
+                cso.Id, LogSanitiser.Sanitise(exportResult.ExternalId), externalIdAttribute?.Type.ToString() ?? "Unknown");
         }
 
         // Update secondary external ID if provided
@@ -1387,7 +1388,7 @@ public class ExportExecutionServer
             secondaryExternalIdAttrValue.StringValue = exportResult.SecondaryExternalId;
             needsUpdate = true;
             Log.Debug("UpdateCsoAfterSuccessfulExportAsync: Set CSO {CsoId} secondary external ID to {SecondaryExternalId}",
-                cso.Id, exportResult.SecondaryExternalId);
+                cso.Id, LogSanitiser.Sanitise(exportResult.SecondaryExternalId));
         }
 
         if (needsUpdate)
@@ -1663,7 +1664,7 @@ public class ExportExecutionServer
 
                     Log.Debug("Resolved reference for MVO {MvoId} to {Value} using {IdType}",
                         referencedMvoId,
-                        attrChange.StringValue,
+                        LogSanitiser.Sanitise(attrChange.StringValue),
                         secondaryExternalIdAttr != null ? "secondary external ID (DN)" : "primary external ID");
                 }
                 else
@@ -1681,7 +1682,7 @@ public class ExportExecutionServer
                     "Attribute: {AttrName}, UnresolvedValue: {UnresolvedValue}",
                     pendingExport.Id, referencedMvoId,
                     attrChange.Attribute?.Name ?? $"AttrId={attrChange.AttributeId}",
-                    attrChange.UnresolvedReferenceValue);
+                    LogSanitiser.Sanitise(attrChange.UnresolvedReferenceValue));
                 allResolved = false;
             }
         }
@@ -1862,7 +1863,7 @@ public class ExportExecutionServer
             // ExportNotConfirmed is for when export succeeded but some values didn't persist
             export.Status = PendingExportStatus.Pending;
             Log.Warning("MarkExportFailedAsync: Export {ExportId} failed (attempt {Attempt}/{MaxRetries}). Next retry at {NextRetry}. Error: {Error}",
-                export.Id, export.ErrorCount, export.MaxRetries, export.NextRetryAt, errorMessage);
+                export.Id, export.ErrorCount, export.MaxRetries, export.NextRetryAt, LogSanitiser.Sanitise(errorMessage));
         }
 
         await SyncRepo.UpdatePendingExportAsync(export);

--- a/src/JIM.Application/Servers/SyncEngine.AttributeFlow.cs
+++ b/src/JIM.Application/Servers/SyncEngine.AttributeFlow.cs
@@ -10,6 +10,7 @@ using JIM.Models.Logic;
 using JIM.Models.Staging;
 using JIM.Models.Sync;
 using JIM.Models.Utility;
+using JIM.Utilities;
 using Serilog;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -40,7 +41,7 @@ public partial class SyncEngine
     {
         if (cso.MetaverseObject == null)
         {
-            Log.Error("ProcessMapping: CSO ({Cso}) is not joined to an MVO!", cso);
+            Log.Error("ProcessMapping: CSO ({CsoId}) is not joined to an MVO!", cso.Id);
             return;
         }
 
@@ -113,7 +114,7 @@ public partial class SyncEngine
                                 "ProcessMapping: Multi-valued source attribute '{SourceAttr}' has {ValueCount} values but target " +
                                 "attribute '{TargetAttr}' is single-valued. Using first value: '{SelectedValue}'. CSO {CsoId}",
                                 csotAttribute.Name, csoAttributeValues.Count,
-                                syncRuleMapping.TargetMetaverseAttribute.Name, selectedValueDescription, cso.Id);
+                                syncRuleMapping.TargetMetaverseAttribute.Name, LogSanitiser.Sanitise(selectedValueDescription), cso.Id);
 
                             warnings?.Add(new AttributeFlowWarning
                             {
@@ -404,7 +405,7 @@ public partial class SyncEngine
                 {
                     mvo.PendingAttributeValueAdditions.Add(newMvoValue);
                     Log.Debug("ProcessExpressionMapping: Expression-based mapping set {AttributeName} to '{Value}' on MVO {MvoId}",
-                        syncRuleMapping.TargetMetaverseAttribute!.Name, resultString, mvo.Id);
+                        syncRuleMapping.TargetMetaverseAttribute!.Name, LogSanitiser.Sanitise(resultString), mvo.Id);
                 }
             }
         }
@@ -950,7 +951,7 @@ public partial class SyncEngine
                     newMvoValue.IntValue = parsedInt;
                 else
                 {
-                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to Number", result);
+                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to Number", LogSanitiser.Sanitise(result?.ToString()));
                     return null;
                 }
                 break;
@@ -961,7 +962,7 @@ public partial class SyncEngine
                     newMvoValue.DateTimeValue = parsedDt;
                 else
                 {
-                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to DateTime", result);
+                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to DateTime", LogSanitiser.Sanitise(result?.ToString()));
                     return null;
                 }
                 break;
@@ -972,7 +973,7 @@ public partial class SyncEngine
                     newMvoValue.BoolValue = parsedBool;
                 else
                 {
-                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to Boolean", result);
+                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to Boolean", LogSanitiser.Sanitise(result?.ToString()));
                     return null;
                 }
                 break;
@@ -983,7 +984,7 @@ public partial class SyncEngine
                     newMvoValue.GuidValue = parsedGuid;
                 else
                 {
-                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to Guid", result);
+                    Log.Warning("CreateMvoAttributeValueFromExpressionResult: Could not convert expression result '{Result}' to Guid", LogSanitiser.Sanitise(result?.ToString()));
                     return null;
                 }
                 break;

--- a/src/JIM.Application/Servers/SyncEngine.Reconciliation.cs
+++ b/src/JIM.Application/Servers/SyncEngine.Reconciliation.cs
@@ -4,6 +4,7 @@
 using JIM.Models.Core;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
+using JIM.Utilities;
 using Serilog;
 
 namespace JIM.Application.Servers;
@@ -87,8 +88,8 @@ public partial class SyncEngine
                     attrChange.Attribute?.Name ?? "unknown",
                     attrChange.ChangeType,
                     connectedSystemObject.Id,
-                    GetExpectedValueAsString(attrChange),
-                    GetImportedValueAsString(attrValuesByAttrId, attrChange),
+                    LogSanitiser.Sanitise(GetExpectedValueAsString(attrChange)),
+                    LogSanitiser.Sanitise(GetImportedValueAsString(attrValuesByAttrId, attrChange)),
                     confirmed);
             }
 
@@ -113,7 +114,7 @@ public partial class SyncEngine
                     Log.Warning("ReconcileCsoAgainstPendingExport: Attribute change {AttrChangeId} (Attr: {AttrName}) failed after {Attempts} attempts. " +
                         "Expected: '{ExpectedValue}', Actual: '{ImportedValue}'",
                         attrChange.Id, attrChange.Attribute?.Name ?? "unknown", attrChange.ExportAttemptCount,
-                        expectedValue, attrChange.LastImportedValue);
+                        LogSanitiser.Sanitise(expectedValue), LogSanitiser.Sanitise(attrChange.LastImportedValue));
                 }
                 else
                 {
@@ -121,7 +122,7 @@ public partial class SyncEngine
                     Log.Debug("ReconcileCsoAgainstPendingExport: Attribute change {AttrChangeId} (Attr: {AttrName}) not confirmed, will retry (attempt {Attempt}). " +
                         "Expected: '{ExpectedValue}', Actual: '{ImportedValue}'",
                         attrChange.Id, attrChange.Attribute?.Name ?? "unknown", attrChange.ExportAttemptCount,
-                        expectedValue, attrChange.LastImportedValue);
+                        LogSanitiser.Sanitise(expectedValue), LogSanitiser.Sanitise(attrChange.LastImportedValue));
                 }
             }
         }

--- a/src/JIM.Application/Servers/SyncEngine.cs
+++ b/src/JIM.Application/Servers/SyncEngine.cs
@@ -50,7 +50,7 @@ public partial class SyncEngine : ISyncEngine
 
         if (cso.MetaverseObject == null)
         {
-            Log.Error("FlowInboundAttributes: CSO ({Cso}) has no MVO!", cso);
+            Log.Error("FlowInboundAttributes: CSO ({CsoId}) has no MVO!", cso.Id);
             return warnings;
         }
 

--- a/src/JIM.Application/Services/DriftDetectionService.cs
+++ b/src/JIM.Application/Services/DriftDetectionService.cs
@@ -8,6 +8,7 @@ using JIM.Models.Core;
 using JIM.Models.Logic;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
+using JIM.Utilities;
 using Serilog;
 
 namespace JIM.Application.Services;
@@ -868,13 +869,13 @@ public class DriftDetectionService
             if (hashSet.Count == 0)
                 return "(empty set)";
 
-            var formattedValues = hashSet.Select(v => v?.ToString() ?? "(null)").Take(5);
+            var formattedValues = hashSet.Select(v => LogSanitiser.Sanitise(v?.ToString()) ?? "(null)").Take(5);
             var result = string.Join(", ", formattedValues);
             if (hashSet.Count > 5)
                 result += $"... (+{hashSet.Count - 5} more)";
             return $"[{result}] ({hashSet.Count} values)";
         }
 
-        return value.ToString() ?? "(null)";
+        return LogSanitiser.Sanitise(value.ToString()) ?? "(null)";
     }
 }

--- a/src/JIM.Connectors/File/FileConnectorExport.cs
+++ b/src/JIM.Connectors/File/FileConnectorExport.cs
@@ -7,6 +7,7 @@ using JIM.Models.Core;
 using JIM.Models.Exceptions;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
+using JIM.Utilities;
 using Serilog;
 using System.Globalization;
 namespace JIM.Connectors.File;
@@ -290,7 +291,7 @@ internal class FileConnectorExport
                 if (existingRows.ContainsKey(externalId))
                 {
                     _logger.Warning("FileConnectorExport.ProcessPendingExport: Create export for '{ExternalId}' but row already exists. Treating as update.",
-                        externalId);
+                        LogSanitiser.Sanitise(externalId));
                 }
 
                 // Build the row from attribute changes
@@ -316,7 +317,7 @@ internal class FileConnectorExport
                 if (!existingRows.TryGetValue(externalId, out var existingRow))
                 {
                     _logger.Warning("FileConnectorExport.ProcessPendingExport: Update for '{ExternalId}' but no existing row found. Creating new row.",
-                        externalId);
+                        LogSanitiser.Sanitise(externalId));
                     existingRow = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     existingRows[externalId] = existingRow;
                 }
@@ -339,12 +340,12 @@ internal class FileConnectorExport
 
                 if (existingRows.Remove(externalId))
                 {
-                    _logger.Debug("FileConnectorExport.ProcessPendingExport: Removed row for '{ExternalId}'", externalId);
+                    _logger.Debug("FileConnectorExport.ProcessPendingExport: Removed row for '{ExternalId}'", LogSanitiser.Sanitise(externalId));
                 }
                 else
                 {
                     _logger.Debug("FileConnectorExport.ProcessPendingExport: Delete for '{ExternalId}' but row not found in file (already removed or never exported)",
-                        externalId);
+                        LogSanitiser.Sanitise(externalId));
                 }
 
                 return ConnectedSystemExportResult.Succeeded(externalId);

--- a/src/JIM.Connectors/File/FileConnectorImport.cs
+++ b/src/JIM.Connectors/File/FileConnectorImport.cs
@@ -3,6 +3,7 @@
 
 using JIM.Models.Core;
 using JIM.Models.Staging;
+using JIM.Utilities;
 using Serilog;
 using System.Diagnostics;
 namespace JIM.Connectors.File;
@@ -234,7 +235,7 @@ internal class FileConnectorImport
                     var rowNumber = _reader.CsvReader.Context.Parser?.Row ?? 0;
                     var rawValue = _reader.CsvReader.GetField(attribute.Name);
                     _logger.Warning(ex, "Failed to parse attribute '{AttributeName}' as {AttributeType} at row {Row}. Raw value: '{RawValue}'",
-                        attribute.Name, attribute.Type, rowNumber, rawValue);
+                        attribute.Name, attribute.Type, rowNumber, LogSanitiser.Sanitise(rawValue));
 
                     importObject.ErrorType = ConnectedSystemImportObjectError.AttributeValueError;
                     importObject.ErrorMessage = $"Failed to parse '{attribute.Name}' as {attribute.Type}: {ex.Message}";

--- a/src/JIM.Connectors/LDAP/LdapConnectorExport.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorExport.cs
@@ -196,7 +196,7 @@ internal class LdapConnectorExport
                 $"Cannot create object: Distinguished Name '{dn}' contains empty RDN components.",
                 ConnectedSystemExportErrorType.InvalidGeneratedExternalId);
 
-        _logger.Debug("LdapConnectorExport.ProcessCreate: Creating object at DN '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessCreate: Creating object at DN '{Dn}'", LogSanitiser.Sanitise(dn));
 
         // Ensure parent containers exist if the setting is enabled
         var createContainersAsNeeded = GetSettingBoolValue(SettingCreateContainersAsNeeded) ?? false;
@@ -232,14 +232,14 @@ internal class LdapConnectorExport
                     $"Overflow modify failed for '{dn}': {modifyResponse.ErrorMessage}");
         }
 
-        _logger.Debug("LdapConnectorExport.ProcessCreate: Successfully created object at '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessCreate: Successfully created object at '{Dn}'", LogSanitiser.Sanitise(dn));
 
         // After successful create, fetch the system-assigned external ID (objectGUID for AD, entryUUID for OpenLDAP)
         var rootDse = new LdapConnectorRootDse { DirectoryType = _directoryType };
         var externalId = FetchExternalId(dn, rootDse);
         if (externalId != null)
         {
-            _logger.Debug("LdapConnectorExport.ProcessCreate: Retrieved external ID {ExternalId} for '{Dn}'", externalId, dn);
+            _logger.Debug("LdapConnectorExport.ProcessCreate: Retrieved external ID {ExternalId} for '{Dn}'", LogSanitiser.Sanitise(externalId), LogSanitiser.Sanitise(dn));
             return ConnectedSystemExportResult.Succeeded(externalId, dn);
         }
 
@@ -267,7 +267,7 @@ internal class LdapConnectorExport
         }
         catch (Exception ex)
         {
-            _logger.Warning(ex, "LdapConnectorExport.FetchExternalId: Error fetching external ID for '{Dn}'", dn);
+            _logger.Warning(ex, "LdapConnectorExport.FetchExternalId: Error fetching external ID for '{Dn}'", LogSanitiser.Sanitise(dn));
             return null;
         }
     }
@@ -278,7 +278,7 @@ internal class LdapConnectorExport
         if (string.IsNullOrEmpty(currentDn))
             throw new InvalidOperationException("Cannot update object: Distinguished Name (DN) could not be determined.");
 
-        _logger.Debug("LdapConnectorExport.ProcessUpdate: Updating object at DN '{Dn}'", currentDn);
+        _logger.Debug("LdapConnectorExport.ProcessUpdate: Updating object at DN '{Dn}'", LogSanitiser.Sanitise(currentDn));
 
         // Check if a rename is needed (DN has changed)
         var newDn = GetNewDistinguishedName(pendingExport);
@@ -307,7 +307,7 @@ internal class LdapConnectorExport
 
         if (modifyRequests.Count == 0)
         {
-            _logger.Debug("LdapConnectorExport.ProcessUpdate: No attribute modifications to apply for '{Dn}'", workingDn);
+            _logger.Debug("LdapConnectorExport.ProcessUpdate: No attribute modifications to apply for '{Dn}'", LogSanitiser.Sanitise(workingDn));
             return wasRenamed ? ConnectedSystemExportResult.Succeeded(null, workingDn) : ConnectedSystemExportResult.Succeeded();
         }
 
@@ -319,7 +319,7 @@ internal class LdapConnectorExport
             if (modifyRequests.Count > 1)
             {
                 _logger.Debug("LdapConnectorExport.ProcessUpdate: Sending modify request chunk {Chunk}/{Total} with {Count} modifications for '{Dn}'",
-                    i + 1, modifyRequests.Count, request.Modifications.Count, workingDn);
+                    i + 1, modifyRequests.Count, request.Modifications.Count, LogSanitiser.Sanitise(workingDn));
             }
 
             try
@@ -342,7 +342,7 @@ internal class LdapConnectorExport
     /// </summary>
     private string ProcessRename(string currentDn, string newDn)
     {
-        _logger.Debug("LdapConnectorExport.ProcessRename: Renaming object from '{OldDn}' to '{NewDn}'", currentDn, newDn);
+        _logger.Debug("LdapConnectorExport.ProcessRename: Renaming object from '{OldDn}' to '{NewDn}'", LogSanitiser.Sanitise(currentDn), LogSanitiser.Sanitise(newDn));
 
         var modifyDnRequest = BuildModifyDnRequest(currentDn, newDn);
 
@@ -353,7 +353,7 @@ internal class LdapConnectorExport
         }
 
         _logger.Information("LdapConnectorExport.ProcessRename: Successfully renamed object from '{OldDn}' to '{NewDn}'",
-            currentDn, newDn);
+            LogSanitiser.Sanitise(currentDn), LogSanitiser.Sanitise(newDn));
 
         return newDn;
     }
@@ -386,7 +386,7 @@ internal class LdapConnectorExport
 
     private void ProcessHardDelete(string dn)
     {
-        _logger.Debug("LdapConnectorExport.ProcessHardDelete: Deleting object at DN '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessHardDelete: Deleting object at DN '{Dn}'", LogSanitiser.Sanitise(dn));
 
         try
         {
@@ -395,7 +395,7 @@ internal class LdapConnectorExport
 
             if (IsNoSuchObjectResult(response.ResultCode, response.ErrorMessage))
             {
-                _logger.Information("LdapConnectorExport.ProcessHardDelete: Object at '{Dn}' does not exist (already deleted), treating as success", dn);
+                _logger.Information("LdapConnectorExport.ProcessHardDelete: Object at '{Dn}' does not exist (already deleted), treating as success", LogSanitiser.Sanitise(dn));
                 return;
             }
 
@@ -404,19 +404,19 @@ internal class LdapConnectorExport
                 throw new LdapException((int)response.ResultCode, response.ErrorMessage);
             }
 
-            _logger.Information("LdapConnectorExport.ProcessHardDelete: Successfully deleted object at '{Dn}'", dn);
+            _logger.Information("LdapConnectorExport.ProcessHardDelete: Successfully deleted object at '{Dn}'", LogSanitiser.Sanitise(dn));
         }
         catch (DirectoryOperationException ex) when (IsNoSuchObjectResult(ex.Response?.ResultCode, ex.Message))
         {
             // Samba AD and some directory implementations throw DirectoryOperationException
             // instead of returning the error code in the response. Treat as idempotent success.
-            _logger.Information("LdapConnectorExport.ProcessHardDelete: Object at '{Dn}' does not exist (already deleted), treating as success", dn);
+            _logger.Information("LdapConnectorExport.ProcessHardDelete: Object at '{Dn}' does not exist (already deleted), treating as success", LogSanitiser.Sanitise(dn));
         }
     }
 
     private void ProcessDisable(PendingExport pendingExport, string dn)
     {
-        _logger.Debug("LdapConnectorExport.ProcessDisable: Disabling object at DN '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessDisable: Disabling object at DN '{Dn}'", LogSanitiser.Sanitise(dn));
 
         var disableAttribute = GetSettingValue(SettingDisableAttribute) ?? "userAccountControl";
 
@@ -441,7 +441,7 @@ internal class LdapConnectorExport
             }
         }
 
-        _logger.Information("LdapConnectorExport.ProcessDisable: Successfully disabled object at '{Dn}'", dn);
+        _logger.Information("LdapConnectorExport.ProcessDisable: Successfully disabled object at '{Dn}'", LogSanitiser.Sanitise(dn));
     }
 
     private void DisableUsingUserAccountControl(string dn)
@@ -546,7 +546,7 @@ internal class LdapConnectorExport
         // Track the created container for auto-selection
         _createdContainerExternalIds.Add(containerDn);
 
-        _logger.Information("LdapConnectorExport.CreateContainer: Successfully created container '{ContainerDn}'", containerDn);
+        _logger.Information("LdapConnectorExport.CreateContainer: Successfully created container '{ContainerDn}'", LogSanitiser.Sanitise(containerDn));
     }
 
     #endregion
@@ -656,7 +656,7 @@ internal class LdapConnectorExport
                 $"Cannot create object: Distinguished Name '{dn}' contains empty RDN components.",
                 ConnectedSystemExportErrorType.InvalidGeneratedExternalId);
 
-        _logger.Debug("LdapConnectorExport.ProcessCreateAsync: Creating object at DN '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessCreateAsync: Creating object at DN '{Dn}'", LogSanitiser.Sanitise(dn));
 
         var createContainersAsNeeded = GetSettingBoolValue(SettingCreateContainersAsNeeded) ?? false;
         if (createContainersAsNeeded)
@@ -682,13 +682,13 @@ internal class LdapConnectorExport
                     $"Overflow modify failed for '{dn}': {modifyResponse.ErrorMessage}");
         }
 
-        _logger.Debug("LdapConnectorExport.ProcessCreateAsync: Successfully created object at '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessCreateAsync: Successfully created object at '{Dn}'", LogSanitiser.Sanitise(dn));
 
         var rootDse = new LdapConnectorRootDse { DirectoryType = _directoryType };
         var externalId = await FetchExternalIdAsync(dn, rootDse);
         if (externalId != null)
         {
-            _logger.Debug("LdapConnectorExport.ProcessCreateAsync: Retrieved external ID {ExternalId} for '{Dn}'", externalId, dn);
+            _logger.Debug("LdapConnectorExport.ProcessCreateAsync: Retrieved external ID {ExternalId} for '{Dn}'", LogSanitiser.Sanitise(externalId), LogSanitiser.Sanitise(dn));
             return ConnectedSystemExportResult.Succeeded(externalId, dn);
         }
 
@@ -711,7 +711,7 @@ internal class LdapConnectorExport
         }
         catch (Exception ex)
         {
-            _logger.Warning(ex, "LdapConnectorExport.FetchExternalIdAsync: Error fetching external ID for '{Dn}'", dn);
+            _logger.Warning(ex, "LdapConnectorExport.FetchExternalIdAsync: Error fetching external ID for '{Dn}'", LogSanitiser.Sanitise(dn));
             return null;
         }
     }
@@ -722,7 +722,7 @@ internal class LdapConnectorExport
         if (string.IsNullOrEmpty(currentDn))
             throw new InvalidOperationException("Cannot update object: Distinguished Name (DN) could not be determined.");
 
-        _logger.Debug("LdapConnectorExport.ProcessUpdateAsync: Updating object at DN '{Dn}'", currentDn);
+        _logger.Debug("LdapConnectorExport.ProcessUpdateAsync: Updating object at DN '{Dn}'", LogSanitiser.Sanitise(currentDn));
 
         var newDn = GetNewDistinguishedName(pendingExport);
         var workingDn = currentDn;
@@ -747,7 +747,7 @@ internal class LdapConnectorExport
 
         if (modifyRequests.Count == 0)
         {
-            _logger.Debug("LdapConnectorExport.ProcessUpdateAsync: No attribute modifications to apply for '{Dn}'", workingDn);
+            _logger.Debug("LdapConnectorExport.ProcessUpdateAsync: No attribute modifications to apply for '{Dn}'", LogSanitiser.Sanitise(workingDn));
             return wasRenamed ? ConnectedSystemExportResult.Succeeded(null, workingDn) : ConnectedSystemExportResult.Succeeded();
         }
 
@@ -759,7 +759,7 @@ internal class LdapConnectorExport
             if (modifyRequests.Count > 1)
             {
                 _logger.Debug("LdapConnectorExport.ProcessUpdateAsync: Sending modify request chunk {Chunk}/{Total} with {Count} modifications for '{Dn}'",
-                    i + 1, modifyRequests.Count, request.Modifications.Count, workingDn);
+                    i + 1, modifyRequests.Count, request.Modifications.Count, LogSanitiser.Sanitise(workingDn));
             }
 
             var response = (ModifyResponse)await _executor.SendRequestAsync(request);
@@ -771,7 +771,7 @@ internal class LdapConnectorExport
 
     private async Task<string> ProcessRenameAsync(string currentDn, string newDn)
     {
-        _logger.Debug("LdapConnectorExport.ProcessRenameAsync: Renaming object from '{OldDn}' to '{NewDn}'", currentDn, newDn);
+        _logger.Debug("LdapConnectorExport.ProcessRenameAsync: Renaming object from '{OldDn}' to '{NewDn}'", LogSanitiser.Sanitise(currentDn), LogSanitiser.Sanitise(newDn));
 
         var modifyDnRequest = BuildModifyDnRequest(currentDn, newDn);
 
@@ -782,7 +782,7 @@ internal class LdapConnectorExport
         }
 
         _logger.Information("LdapConnectorExport.ProcessRenameAsync: Successfully renamed object from '{OldDn}' to '{NewDn}'",
-            currentDn, newDn);
+            LogSanitiser.Sanitise(currentDn), LogSanitiser.Sanitise(newDn));
 
         return newDn;
     }
@@ -815,7 +815,7 @@ internal class LdapConnectorExport
 
     private async Task ProcessHardDeleteAsync(string dn)
     {
-        _logger.Debug("LdapConnectorExport.ProcessHardDeleteAsync: Deleting object at DN '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessHardDeleteAsync: Deleting object at DN '{Dn}'", LogSanitiser.Sanitise(dn));
 
         try
         {
@@ -824,7 +824,7 @@ internal class LdapConnectorExport
 
             if (IsNoSuchObjectResult(response.ResultCode, response.ErrorMessage))
             {
-                _logger.Information("LdapConnectorExport.ProcessHardDeleteAsync: Object at '{Dn}' does not exist (already deleted), treating as success", dn);
+                _logger.Information("LdapConnectorExport.ProcessHardDeleteAsync: Object at '{Dn}' does not exist (already deleted), treating as success", LogSanitiser.Sanitise(dn));
                 return;
             }
 
@@ -833,17 +833,17 @@ internal class LdapConnectorExport
                 throw new LdapException((int)response.ResultCode, response.ErrorMessage);
             }
 
-            _logger.Information("LdapConnectorExport.ProcessHardDeleteAsync: Successfully deleted object at '{Dn}'", dn);
+            _logger.Information("LdapConnectorExport.ProcessHardDeleteAsync: Successfully deleted object at '{Dn}'", LogSanitiser.Sanitise(dn));
         }
         catch (DirectoryOperationException ex) when (IsNoSuchObjectResult(ex.Response?.ResultCode, ex.Message))
         {
-            _logger.Information("LdapConnectorExport.ProcessHardDeleteAsync: Object at '{Dn}' does not exist (already deleted), treating as success", dn);
+            _logger.Information("LdapConnectorExport.ProcessHardDeleteAsync: Object at '{Dn}' does not exist (already deleted), treating as success", LogSanitiser.Sanitise(dn));
         }
     }
 
     private async Task ProcessDisableAsync(PendingExport pendingExport, string dn)
     {
-        _logger.Debug("LdapConnectorExport.ProcessDisableAsync: Disabling object at DN '{Dn}'", dn);
+        _logger.Debug("LdapConnectorExport.ProcessDisableAsync: Disabling object at DN '{Dn}'", LogSanitiser.Sanitise(dn));
 
         var disableAttribute = GetSettingValue(SettingDisableAttribute) ?? "userAccountControl";
 
@@ -865,7 +865,7 @@ internal class LdapConnectorExport
             }
         }
 
-        _logger.Information("LdapConnectorExport.ProcessDisableAsync: Successfully disabled object at '{Dn}'", dn);
+        _logger.Information("LdapConnectorExport.ProcessDisableAsync: Successfully disabled object at '{Dn}'", LogSanitiser.Sanitise(dn));
     }
 
     private async Task DisableUsingUserAccountControlAsync(string dn)
@@ -973,7 +973,7 @@ internal class LdapConnectorExport
 
         _createdContainerExternalIds.Add(containerDn);
 
-        _logger.Information("LdapConnectorExport.CreateContainerAsync: Successfully created container '{ContainerDn}'", containerDn);
+        _logger.Information("LdapConnectorExport.CreateContainerAsync: Successfully created container '{ContainerDn}'", LogSanitiser.Sanitise(containerDn));
     }
 
     #endregion
@@ -1038,7 +1038,7 @@ internal class LdapConnectorExport
                 _logger.Information(
                     "LdapConnectorExport.BuildAddRequestWithOverflow: Object class '{ObjectClass}' requires at least one member. " +
                     "Injecting placeholder member '{Placeholder}' for '{Dn}'.",
-                    objectClass, _placeholderMemberDn, dn);
+                    objectClass, LogSanitiser.Sanitise(_placeholderMemberDn), LogSanitiser.Sanitise(dn));
                 attributeGroups[memberAttrName] = new List<object> { _placeholderMemberDn };
             }
         }
@@ -1065,7 +1065,7 @@ internal class LdapConnectorExport
             // Attribute exceeds batch size: put first batch in the AddRequest, remainder in ModifyRequests
             _logger.Information("LdapConnectorExport.BuildAddRequestWithOverflow: Attribute '{AttrName}' has {Count} values " +
                 "exceeding batch size {BatchSize} for '{Dn}'. First {BatchSize} values in AddRequest; remainder in overflow ModifyRequests.",
-                attrName, values.Count, _modifyBatchSize, dn);
+                attrName, values.Count, _modifyBatchSize, LogSanitiser.Sanitise(dn));
 
             var firstBatch = new DirectoryAttribute(attrName);
             for (var i = 0; i < _modifyBatchSize; i++)
@@ -1124,7 +1124,7 @@ internal class LdapConnectorExport
     {
         if (searchResponse.ResultCode != ResultCode.Success || searchResponse.Entries.Count == 0)
         {
-            _logger.Warning("LdapConnectorExport.ParseExternalIdFromResponse: Failed to fetch external ID for '{Dn}'", dn);
+            _logger.Warning("LdapConnectorExport.ParseExternalIdFromResponse: Failed to fetch external ID for '{Dn}'", LogSanitiser.Sanitise(dn));
             return null;
         }
 
@@ -1294,7 +1294,7 @@ internal class LdapConnectorExport
         if (requests.Count > 1)
         {
             _logger.Information("LdapConnectorExport.ChunkModifyRequests: Split modifications for '{Dn}' into {RequestCount} " +
-                "LDAP requests (batch size: {BatchSize})", workingDn, requests.Count, _modifyBatchSize);
+                "LDAP requests (batch size: {BatchSize})", LogSanitiser.Sanitise(workingDn), requests.Count, _modifyBatchSize);
         }
 
         return requests;
@@ -1470,7 +1470,7 @@ internal class LdapConnectorExport
             {
                 _logger.Warning("LdapConnectorExport.HandleModifyResponse: Some attribute values already exist at '{Dn}'. " +
                     "This typically means a group member was already present. Treating as success. Error: {Error}",
-                    workingDn, response.ErrorMessage);
+                    LogSanitiser.Sanitise(workingDn), LogSanitiser.Sanitise(response.ErrorMessage));
                 return wasRenamed ? ConnectedSystemExportResult.Succeeded(null, workingDn) : ConnectedSystemExportResult.Succeeded();
             }
 
@@ -1486,7 +1486,7 @@ internal class LdapConnectorExport
         }
 
         _logger.Debug("LdapConnectorExport.HandleModifyResponse: Successfully updated object at '{Dn}' with {Count} modifications",
-            workingDn, modifyRequest.Modifications.Count);
+            LogSanitiser.Sanitise(workingDn), modifyRequest.Modifications.Count);
 
         return wasRenamed ? ConnectedSystemExportResult.Succeeded(null, workingDn) : ConnectedSystemExportResult.Succeeded();
     }
@@ -1508,7 +1508,7 @@ internal class LdapConnectorExport
                      !newParentDn.Equals(currentParentDn, StringComparison.OrdinalIgnoreCase);
 
         _logger.Debug("LdapConnectorExport.BuildModifyDnRequest: NewRdn: '{NewRdn}', NewParent: '{NewParent}', IsMove: {IsMove}",
-            newRdn, newParentDn ?? "(same)", isMove);
+            LogSanitiser.Sanitise(newRdn), LogSanitiser.Sanitise(newParentDn) ?? "(same)", isMove);
 
         return new ModifyDNRequest(
             currentDn,
@@ -1548,7 +1548,7 @@ internal class LdapConnectorExport
             throw new InvalidOperationException($"Cannot create container: Unable to parse RDN from DN '{containerDn}'");
         }
 
-        _logger.Information("LdapConnectorExport.BuildContainerAddRequest: Creating missing container '{ContainerDn}'", containerDn);
+        _logger.Information("LdapConnectorExport.BuildContainerAddRequest: Creating missing container '{ContainerDn}'", LogSanitiser.Sanitise(containerDn));
 
         var addRequest = new AddRequest(containerDn);
 
@@ -1761,14 +1761,14 @@ internal class LdapConnectorExport
                 foreach (var av in matchingAttrValues)
                 {
                     Log.Verbose("GetDistinguishedNameForUpdate: AttrValue Id={Id}, AttributeId={AttrId}, StringValue='{StringValue}'",
-                        av.Id, av.AttributeId, av.StringValue);
+                        av.Id, av.AttributeId, LogSanitiser.Sanitise(av.StringValue));
                 }
             }
 
             if (cso.SecondaryExternalIdAttributeValue?.StringValue != null)
             {
                 Log.Debug("GetDistinguishedNameForUpdate: Using CSO SecondaryExternalIdAttributeValue: '{DN}'",
-                    cso.SecondaryExternalIdAttributeValue.StringValue);
+                    LogSanitiser.Sanitise(cso.SecondaryExternalIdAttributeValue.StringValue));
                 return cso.SecondaryExternalIdAttributeValue.StringValue;
             }
 
@@ -1784,7 +1784,7 @@ internal class LdapConnectorExport
         var dnFromAttrChanges = GetDistinguishedNameForCreate(pendingExport);
         if (dnFromAttrChanges != null)
         {
-            Log.Debug("GetDistinguishedNameForUpdate: Using DN from attribute changes: '{DN}'", dnFromAttrChanges);
+            Log.Debug("GetDistinguishedNameForUpdate: Using DN from attribute changes: '{DN}'", LogSanitiser.Sanitise(dnFromAttrChanges));
         }
         else
         {
@@ -1838,7 +1838,7 @@ internal class LdapConnectorExport
             "LdapConnectorExport: Placeholder member '{Placeholder}' was rejected by the directory for '{Dn}'. " +
             "The directory may have referential integrity enabled. " +
             "Update the '{Setting}' connector setting to point to an existing entry.",
-            _placeholderMemberDn, dn, LdapConnectorConstants.SETTING_GROUP_PLACEHOLDER_MEMBER_DN);
+            LogSanitiser.Sanitise(_placeholderMemberDn), LogSanitiser.Sanitise(dn), LdapConnectorConstants.SETTING_GROUP_PLACEHOLDER_MEMBER_DN);
 
         return ConnectedSystemExportResult.Failed(
             $"Failed to add placeholder member '{_placeholderMemberDn}' to group '{dn}' — " +
@@ -1892,7 +1892,7 @@ internal class LdapConnectorExport
                 _logger.Information(
                     "LdapConnectorExport.InjectPlaceholderModificationsIfNeeded: Removing all members from '{ObjectClass}' group. " +
                     "Injecting placeholder member '{Placeholder}' to satisfy MUST constraint.",
-                    objectClass, _placeholderMemberDn);
+                    objectClass, LogSanitiser.Sanitise(_placeholderMemberDn));
 
                 var placeholderAttr = new ConnectedSystemObjectTypeAttribute
                 {
@@ -1920,7 +1920,7 @@ internal class LdapConnectorExport
             _logger.Information(
                 "LdapConnectorExport.InjectPlaceholderModificationsIfNeeded: Adding real members to placeholder-only '{ObjectClass}' group. " +
                 "Removing placeholder member '{Placeholder}'.",
-                objectClass, _placeholderMemberDn);
+                objectClass, LogSanitiser.Sanitise(_placeholderMemberDn));
 
             var placeholderAttr = new ConnectedSystemObjectTypeAttribute
             {

--- a/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
@@ -855,7 +855,7 @@ internal class LdapConnectorImport
         {
             // Server returned a cookie on first page but doesn't actually support paging (e.g., Samba AD)
             // Retry without paging control - results should have already been returned on first page
-            _logger.Warning("GetFisoResults: Server rejected paging cookie, assuming all results were returned on first page. Error: {Message}", ex.Message);
+            _logger.Warning("GetFisoResults: Server rejected paging cookie, assuming all results were returned on first page. Error: {Message}", LogSanitiser.Sanitise(ex.Message));
             return;
         }
 
@@ -933,7 +933,7 @@ internal class LdapConnectorImport
         {
             // Server returned a cookie on first page but doesn't actually support paging (e.g., Samba AD)
             // Retry without paging control - results should have already been returned on first page
-            _logger.Warning("GetDeltaResultsUsingUsn: Server rejected paging cookie, assuming all results were returned on first page. Error: {Message}", ex.Message);
+            _logger.Warning("GetDeltaResultsUsingUsn: Server rejected paging cookie, assuming all results were returned on first page. Error: {Message}", LogSanitiser.Sanitise(ex.Message));
             return;
         }
 
@@ -1022,13 +1022,13 @@ internal class LdapConnectorImport
             // The Show Deleted Objects control may not be supported by all directories
             // (e.g., some Samba AD configurations). Log and continue without failing the import.
             _logger.Warning("GetDeletedObjectsUsingUsn: Failed to query Deleted Objects container. " +
-                "The directory may not support the Show Deleted Objects control. Error: {Message}", ex.Message);
+                "The directory may not support the Show Deleted Objects control. Error: {Message}", LogSanitiser.Sanitise(ex.Message));
             return;
         }
         catch (LdapException ex) when (ex.ErrorCode == 32) // NoSuchObject
         {
             // The Deleted Objects container may not exist in some configurations
-            _logger.Debug("GetDeletedObjectsUsingUsn: Deleted Objects container not found at {Dn}. Skipping deletion detection.", deletedObjectsDn);
+            _logger.Debug("GetDeletedObjectsUsingUsn: Deleted Objects container not found at {Dn}. Skipping deletion detection.", LogSanitiser.Sanitise(deletedObjectsDn));
             return;
         }
 
@@ -1052,7 +1052,7 @@ internal class LdapConnectorImport
             var objectGuid = LdapConnectorUtilities.GetEntryAttributeGuidValues(entry, "objectGUID")?.FirstOrDefault();
             if (objectGuid == null || objectGuid == Guid.Empty)
             {
-                _logger.Warning("GetDeletedObjectsUsingUsn: Deleted object has no objectGUID. DN: {Dn}", entry.DistinguishedName);
+                _logger.Warning("GetDeletedObjectsUsingUsn: Deleted object has no objectGUID. DN: {Dn}", LogSanitiser.Sanitise(entry.DistinguishedName));
                 continue;
             }
 
@@ -1061,7 +1061,7 @@ internal class LdapConnectorImport
             var objectClasses = LdapConnectorUtilities.GetEntryAttributeStringValues(entry, "objectClass");
             if (objectClasses == null || objectClasses.Count == 0)
             {
-                _logger.Warning("GetDeletedObjectsUsingUsn: Deleted object has no objectClass. DN: {Dn}", entry.DistinguishedName);
+                _logger.Warning("GetDeletedObjectsUsingUsn: Deleted object has no objectClass. DN: {Dn}", LogSanitiser.Sanitise(entry.DistinguishedName));
                 continue;
             }
 
@@ -1375,7 +1375,7 @@ internal class LdapConnectorImport
                     {
                         _logger.Warning("GetDeltaResultsUsingAccesslog: GetObjectByDn returned null for DN '{ReqDn}' " +
                             "(change type: {ChangeType}). The object may have been deleted or moved since the accesslog " +
-                            "entry was recorded. Entry skipped.", reqDn, objectChangeType);
+                            "entry was recorded. Entry skipped.", LogSanitiser.Sanitise(reqDn), objectChangeType);
                     }
                 }
             }
@@ -1449,7 +1449,7 @@ internal class LdapConnectorImport
         {
             var reqDn = LdapConnectorUtilities.GetEntryAttributeStringValue(accesslogEntry, "reqDN");
             _logger.Warning("BuildDeleteImportObjectFromAccesslog: Could not determine object type for deleted object. " +
-                "DN: {Dn}. The accesslog entry may not contain reqOld attributes.", reqDn);
+                "DN: {Dn}. The accesslog entry may not contain reqOld attributes.", LogSanitiser.Sanitise(reqDn));
             return null;
         }
 
@@ -1457,7 +1457,7 @@ internal class LdapConnectorImport
         {
             var reqDn = LdapConnectorUtilities.GetEntryAttributeStringValue(accesslogEntry, "reqDN");
             _logger.Warning("BuildDeleteImportObjectFromAccesslog: Could not determine entryUUID for deleted object. " +
-                "DN: {Dn}. The accesslog entry may not contain reqEntryUUID or reqOld entryUUID.", reqDn);
+                "DN: {Dn}. The accesslog entry may not contain reqEntryUUID or reqOld entryUUID.", LogSanitiser.Sanitise(reqDn));
             return null;
         }
 
@@ -1493,7 +1493,7 @@ internal class LdapConnectorImport
         }
 
         _logger.Debug("BuildDeleteImportObjectFromAccesslog: Built delete import for {ObjectType} with entryUUID {Uuid}, DN: {Dn}",
-            objectClassName, entryUuid, reqDnValue);
+            objectClassName, LogSanitiser.Sanitise(entryUuid), LogSanitiser.Sanitise(reqDnValue));
         return importObject;
     }
 
@@ -1517,7 +1517,7 @@ internal class LdapConnectorImport
 
             if (searchResponse.Entries.Count == 0)
             {
-                _logger.Verbose("GetObjectByDn: Object not found at DN {Dn}", dn);
+                _logger.Verbose("GetObjectByDn: Object not found at DN {Dn}", LogSanitiser.Sanitise(dn));
                 return null;
             }
 
@@ -1526,7 +1526,7 @@ internal class LdapConnectorImport
         }
         catch (Exception ex)
         {
-            _logger.Warning(ex, "GetObjectByDn: Error fetching object at DN {Dn}", dn);
+            _logger.Warning(ex, "GetObjectByDn: Error fetching object at DN {Dn}", LogSanitiser.Sanitise(dn));
             return null;
         }
     }
@@ -1664,7 +1664,7 @@ internal class LdapConnectorImport
                                 importObjectAttribute.ReferenceValues.AddRange(filteredValues);
                             else if (referenceValues.Count > filteredValues.Count)
                                 _logger.Debug("LdapConnectorImport: Filtered placeholder member '{Placeholder}' from attribute '{Attr}' on '{Dn}'",
-                                    _placeholderMemberDn, attributeName, searchResult.DistinguishedName);
+                                    LogSanitiser.Sanitise(_placeholderMemberDn), attributeName, LogSanitiser.Sanitise(searchResult.DistinguishedName));
                         }
                         break;
                     case AttributeDataType.NotSet:

--- a/src/JIM.Connectors/LDAP/LdapConnectorUtilities.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorUtilities.cs
@@ -85,7 +85,7 @@ internal static class LdapConnectorUtilities
             var duplicateCount = guidValues.Count - uniqueValues.Count;
             Log.Warning("GetEntryAttributeGuidValues: Detected and removed {DuplicateCount} duplicate value(s) from attribute '{AttributeName}' on entry '{EntryDn}'. " +
                 "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                duplicateCount, attributeName, entry.DistinguishedName, guidValues.Count, uniqueValues.Count);
+                duplicateCount, attributeName, LogSanitiser.Sanitise(entry.DistinguishedName), guidValues.Count, uniqueValues.Count);
         }
 
         return uniqueValues;
@@ -267,7 +267,7 @@ internal static class LdapConnectorUtilities
             var duplicateCount = values.Count - uniqueValues.Count;
             Log.Warning("GetEntryAttributeStringValues: Detected and removed {DuplicateCount} duplicate value(s) from attribute '{AttributeName}' on entry '{EntryDn}'. " +
                 "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                duplicateCount, attributeName, entry.DistinguishedName, values.Count, uniqueValues.Count);
+                duplicateCount, attributeName, LogSanitiser.Sanitise(entry.DistinguishedName), values.Count, uniqueValues.Count);
         }
 
         return uniqueValues;
@@ -293,7 +293,7 @@ internal static class LdapConnectorUtilities
             var duplicateCount = binaryValues.Count - uniqueValues.Count;
             Log.Warning("GetEntryAttributeBinaryValues: Detected and removed {DuplicateCount} duplicate value(s) from attribute '{AttributeName}' on entry '{EntryDn}'. " +
                 "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                duplicateCount, attributeName, entry.DistinguishedName, binaryValues.Count, uniqueValues.Count);
+                duplicateCount, attributeName, LogSanitiser.Sanitise(entry.DistinguishedName), binaryValues.Count, uniqueValues.Count);
         }
 
         return uniqueValues;
@@ -351,7 +351,7 @@ internal static class LdapConnectorUtilities
             var duplicateCount = result.Count - uniqueValues.Count;
             Log.Warning("GetEntryAttributeIntValues: Detected and removed {DuplicateCount} duplicate value(s) from attribute '{AttributeName}' on entry '{EntryDn}'. " +
                 "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                duplicateCount, attributeName, entry.DistinguishedName, result.Count, uniqueValues.Count);
+                duplicateCount, attributeName, LogSanitiser.Sanitise(entry.DistinguishedName), result.Count, uniqueValues.Count);
         }
 
         return uniqueValues;
@@ -383,7 +383,7 @@ internal static class LdapConnectorUtilities
             var duplicateCount = result.Count - uniqueValues.Count;
             Log.Warning("GetEntryAttributeLongValues: Detected and removed {DuplicateCount} duplicate value(s) from attribute '{AttributeName}' on entry '{EntryDn}'. " +
                 "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                duplicateCount, attributeName, entry.DistinguishedName, result.Count, uniqueValues.Count);
+                duplicateCount, attributeName, LogSanitiser.Sanitise(entry.DistinguishedName), result.Count, uniqueValues.Count);
         }
 
         return uniqueValues;

--- a/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
@@ -281,7 +281,7 @@ public class SyncImportTaskProcessor
                     // queries on subsequent pages.
                     if (result.PersistedConnectorData != null && newPersistedData == null)
                     {
-                        Log.Debug($"ExecuteAsync: captured new persisted connector data from page {pageNumber}. old value: '{originalPersistedData}', new value: '{result.PersistedConnectorData}'");
+                        Log.Debug($"ExecuteAsync: captured new persisted connector data from page {pageNumber}. old value: '{LogSanitiser.Sanitise(originalPersistedData)}', new value: '{LogSanitiser.Sanitise(result.PersistedConnectorData)}'");
                         newPersistedData = result.PersistedConnectorData;
                     }
 
@@ -311,7 +311,7 @@ public class SyncImportTaskProcessor
                 // with the new watermark captured from the first page.
                 if (newPersistedData != null && newPersistedData != originalPersistedData)
                 {
-                    Log.Debug($"ExecuteAsync: updating persisted connector data after all pages. old value: '{originalPersistedData}', new value: '{newPersistedData}'");
+                    Log.Debug($"ExecuteAsync: updating persisted connector data after all pages. old value: '{LogSanitiser.Sanitise(originalPersistedData)}', new value: '{LogSanitiser.Sanitise(newPersistedData)}'");
                     await _syncServer.UpdateConnectedSystemPersistedConnectorDataAsync(_connectedSystem, newPersistedData);
                 }
 
@@ -322,7 +322,7 @@ public class SyncImportTaskProcessor
                 if (connectorWarningMessage != null)
                 {
                     _activity.WarningMessage = connectorWarningMessage;
-                    Log.Warning("PerformImportAsync: Connector reported warning: {WarningMessage}", connectorWarningMessage);
+                    Log.Warning("PerformImportAsync: Connector reported warning: {WarningMessage}", LogSanitiser.Sanitise(connectorWarningMessage));
                 }
 
                 using (Diagnostics.Connector.StartSpan("CloseImportConnection"))
@@ -759,7 +759,7 @@ public class SyncImportTaskProcessor
                 var extId = orphanedRpei.ConnectedSystemObject?.ExternalIdAttributeValue?.StringValue ?? "[unknown]";
                 var hasCsoRef = orphanedRpei.ConnectedSystemObject != null;
                 Log.Error("VALIDATION FAILURE: RPEI has ObjectChangeType=Create but no ConnectedSystemObjectId and no error. HasCsoRef={HasCsoRef}, ExtId={ExtId}. This is a bug! Setting error type.",
-                    hasCsoRef, extId);
+                    hasCsoRef, LogSanitiser.Sanitise(extId));
                 orphanedRpei.ErrorType = ActivityRunProfileExecutionItemErrorType.CsoCreationFailed;
                 orphanedRpei.ErrorMessage = $"Internal error: RPEI was created for import (ExtId={extId}) but CSO was not persisted. CSO reference exists={hasCsoRef}. This indicates a bug in the persistence layer.";
             }
@@ -998,7 +998,7 @@ public class SyncImportTaskProcessor
 
         if (cso == null)
         {
-            Log.Information($"ObsoleteConnectedSystemObjectAsync: CSO with external id '{connectedSystemObjectExternalId}' not found. No work to do.");
+            Log.Information($"ObsoleteConnectedSystemObjectAsync: CSO with external id '{LogSanitiser.Sanitise(connectedSystemObjectExternalId?.ToString())}' not found. No work to do.");
             return;
         }
 
@@ -1272,7 +1272,7 @@ public class SyncImportTaskProcessor
 
                         // DEBUG: Log the external ID value extracted
                         Log.Debug("ProcessImportObjectsAsync: Extracted external ID value '{ExternalIdValue}' from import object at index {Index}. Duplicate key: {DuplicateKey}",
-                            externalIdValue, importIndex, duplicateKey);
+                            LogSanitiser.Sanitise(externalIdValue), importIndex, LogSanitiser.Sanitise(duplicateKey));
 
                         // Snapshot the external ID for error reporting
                         activityRunProfileExecutionItem.ExternalIdSnapshot = externalIdValue;
@@ -1286,7 +1286,7 @@ public class SyncImportTaskProcessor
                             activityRunProfileExecutionItem.ErrorType = ActivityRunProfileExecutionItemErrorType.DuplicateObject;
                             activityRunProfileExecutionItem.ErrorMessage = $"Duplicate external ID '{externalIdValue}' found across import pages. This object was already processed on a previous page. This may indicate a directory server paging issue.";
                             Log.Warning("ProcessImportObjectsAsync: Cross-page duplicate external ID '{ExternalId}' at index {Index}. Object was already imported on a previous page. Skipping.",
-                                externalIdValue, importIndex);
+                                LogSanitiser.Sanitise(externalIdValue), importIndex);
                             continue;
                         }
 
@@ -1296,7 +1296,7 @@ public class SyncImportTaskProcessor
                             activityRunProfileExecutionItem.ErrorType = ActivityRunProfileExecutionItemErrorType.DuplicateObject;
                             activityRunProfileExecutionItem.ErrorMessage = $"Duplicate external ID '{externalIdValue}' found in the same import batch. All objects with this external ID have been rejected. Fix the source data to ensure unique external IDs.";
                             Log.Warning("ProcessImportObjectsAsync: Duplicate external ID '{ExternalId}' (3rd+ occurrence) at index {Index}. Marking as error.",
-                                externalIdValue, importIndex);
+                                LogSanitiser.Sanitise(externalIdValue), importIndex);
                             continue;
                         }
 
@@ -1304,7 +1304,7 @@ public class SyncImportTaskProcessor
                         {
                             // Duplicate found! Error BOTH objects.
                             Log.Warning("ProcessImportObjectsAsync: Duplicate external ID '{ExternalId}' found at index {CurrentIndex}. First occurrence was at index {FirstIndex}. Erroring BOTH objects.",
-                                externalIdValue, importIndex, firstOccurrence.index);
+                                LogSanitiser.Sanitise(externalIdValue), importIndex, firstOccurrence.index);
 
                             // Mark THIS object as duplicate
                             activityRunProfileExecutionItem.ErrorType = ActivityRunProfileExecutionItemErrorType.DuplicateObject;
@@ -1323,7 +1323,7 @@ public class SyncImportTaskProcessor
                                 if (removed)
                                 {
                                     Log.Debug("ProcessImportObjectsAsync: Removed CSO for first occurrence of duplicate external ID '{ExternalId}' from create list.",
-                                        externalIdValue);
+                                        LogSanitiser.Sanitise(externalIdValue));
                                 }
                                 // Clear the CSO reference from the RPEI since we're not persisting it
                                 firstOccurrence.rpei.ConnectedSystemObject = null;
@@ -1458,7 +1458,7 @@ public class SyncImportTaskProcessor
                             var extIdForError = activityRunProfileExecutionItem.ExternalIdSnapshot ?? "[unknown]";
                             activityRunProfileExecutionItem.ErrorMessage = $"Failed to create Connected System Object for import object with external ID '{extIdForError}'. No specific error was recorded.";
                             Log.Error("ProcessImportObjectsAsync: CSO creation failed for external ID '{ExternalId}' with no specific error. This indicates a bug in import processing.",
-                                extIdForError);
+                                LogSanitiser.Sanitise(extIdForError));
                         }
                     }
                 }
@@ -1728,7 +1728,7 @@ public class SyncImportTaskProcessor
         if (secondaryCso != null && secondaryCso.Status == ConnectedSystemObjectStatus.PendingProvisioning)
         {
             Log.Information("HydrateCsoAsync: Found PendingProvisioning CSO {CsoId} by secondary external ID '{SecondaryId}'. This confirms a provisioned object.",
-                secondaryCso.Id, secondaryIdImportAttr.StringValues[0]);
+                secondaryCso.Id, LogSanitiser.Sanitise(secondaryIdImportAttr.StringValues[0]));
             return secondaryCso;
         }
 
@@ -1918,7 +1918,7 @@ public class SyncImportTaskProcessor
         activityRunProfileExecutionItem.ConnectedSystemObject = connectedSystemObject;
 
         stopwatch.Stop();
-        Log.Debug($"CreateConnectedSystemObjectFromImportObject: completed for {connectedSystemObject.Type.Name} ExtId: '{connectedSystemObject.ExternalIdAttributeValue}', SecExtId: '{connectedSystemObject.SecondaryExternalIdAttributeValue}' in {stopwatch.Elapsed}");
+        Log.Debug($"CreateConnectedSystemObjectFromImportObject: completed for {connectedSystemObject.Type.Name} ExtId: '{LogSanitiser.Sanitise(connectedSystemObject.ExternalIdAttributeValue?.ToString())}', SecExtId: '{LogSanitiser.Sanitise(connectedSystemObject.SecondaryExternalIdAttributeValue?.ToString())}' in {stopwatch.Elapsed}");
 
         return connectedSystemObject;
     }
@@ -2248,7 +2248,7 @@ public class SyncImportTaskProcessor
                 {
                     Log.Warning("DeduplicateImportObjectAttributes: Detected and removed {DuplicateCount} duplicate string value(s) from attribute '{AttributeName}' on import object '{ExternalId}'. " +
                         "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                        originalStringCount - uniqueStrings.Count, attr.Name, csoExternalId ?? "(unknown)", originalStringCount, uniqueStrings.Count);
+                        originalStringCount - uniqueStrings.Count, attr.Name, LogSanitiser.Sanitise(csoExternalId) ?? "(unknown)", originalStringCount, uniqueStrings.Count);
                     attr.StringValues.Clear();
                     attr.StringValues.AddRange(uniqueStrings);
                 }
@@ -2263,7 +2263,7 @@ public class SyncImportTaskProcessor
                 {
                     Log.Warning("DeduplicateImportObjectAttributes: Detected and removed {DuplicateCount} duplicate int value(s) from attribute '{AttributeName}' on import object '{ExternalId}'. " +
                         "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                        originalIntCount - uniqueInts.Count, attr.Name, csoExternalId ?? "(unknown)", originalIntCount, uniqueInts.Count);
+                        originalIntCount - uniqueInts.Count, attr.Name, LogSanitiser.Sanitise(csoExternalId) ?? "(unknown)", originalIntCount, uniqueInts.Count);
                     attr.IntValues.Clear();
                     attr.IntValues.AddRange(uniqueInts);
                 }
@@ -2278,7 +2278,7 @@ public class SyncImportTaskProcessor
                 {
                     Log.Warning("DeduplicateImportObjectAttributes: Detected and removed {DuplicateCount} duplicate long value(s) from attribute '{AttributeName}' on import object '{ExternalId}'. " +
                         "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                        originalLongCount - uniqueLongs.Count, attr.Name, csoExternalId ?? "(unknown)", originalLongCount, uniqueLongs.Count);
+                        originalLongCount - uniqueLongs.Count, attr.Name, LogSanitiser.Sanitise(csoExternalId) ?? "(unknown)", originalLongCount, uniqueLongs.Count);
                     attr.LongValues.Clear();
                     attr.LongValues.AddRange(uniqueLongs);
                 }
@@ -2293,7 +2293,7 @@ public class SyncImportTaskProcessor
                 {
                     Log.Warning("DeduplicateImportObjectAttributes: Detected and removed {DuplicateCount} duplicate GUID value(s) from attribute '{AttributeName}' on import object '{ExternalId}'. " +
                         "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                        originalGuidCount - uniqueGuids.Count, attr.Name, csoExternalId ?? "(unknown)", originalGuidCount, uniqueGuids.Count);
+                        originalGuidCount - uniqueGuids.Count, attr.Name, LogSanitiser.Sanitise(csoExternalId) ?? "(unknown)", originalGuidCount, uniqueGuids.Count);
                     attr.GuidValues.Clear();
                     attr.GuidValues.AddRange(uniqueGuids);
                 }
@@ -2308,7 +2308,7 @@ public class SyncImportTaskProcessor
                 {
                     Log.Warning("DeduplicateImportObjectAttributes: Detected and removed {DuplicateCount} duplicate reference value(s) from attribute '{AttributeName}' on import object '{ExternalId}'. " +
                         "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                        originalRefCount - uniqueRefs.Count, attr.Name, csoExternalId ?? "(unknown)", originalRefCount, uniqueRefs.Count);
+                        originalRefCount - uniqueRefs.Count, attr.Name, LogSanitiser.Sanitise(csoExternalId) ?? "(unknown)", originalRefCount, uniqueRefs.Count);
                     attr.ReferenceValues.Clear();
                     attr.ReferenceValues.AddRange(uniqueRefs);
                 }
@@ -2323,7 +2323,7 @@ public class SyncImportTaskProcessor
                 {
                     Log.Warning("DeduplicateImportObjectAttributes: Detected and removed {DuplicateCount} duplicate binary value(s) from attribute '{AttributeName}' on import object '{ExternalId}'. " +
                         "Original count: {OriginalCount}, Unique count: {UniqueCount}",
-                        originalBinaryCount - uniqueBinaries.Count, attr.Name, csoExternalId ?? "(unknown)", originalBinaryCount, uniqueBinaries.Count);
+                        originalBinaryCount - uniqueBinaries.Count, attr.Name, LogSanitiser.Sanitise(csoExternalId) ?? "(unknown)", originalBinaryCount, uniqueBinaries.Count);
                     attr.ByteValues.Clear();
                     attr.ByteValues.AddRange(uniqueBinaries);
                 }

--- a/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
+++ b/src/JIM.Worker/Processors/SyncTaskProcessorBase.cs
@@ -404,7 +404,7 @@ public abstract class SyncTaskProcessorBase
     /// </summary>
     protected async Task ProcessObsoleteAndExportConfirmationAsync(List<SyncRule> activeSyncRules, ConnectedSystemObject connectedSystemObject)
     {
-        Log.Verbose($"ProcessObsoleteAndExportConfirmationAsync: Pass 1 for CSO: {connectedSystemObject}.");
+        Log.Verbose($"ProcessObsoleteAndExportConfirmationAsync: Pass 1 for CSO: {connectedSystemObject.Id}.");
 
         try
         {
@@ -440,8 +440,8 @@ public abstract class SyncTaskProcessorBase
             runProfileExecutionItem.ErrorStackTrace = e.StackTrace;
             _activity.RunProfileExecutionItems.Add(runProfileExecutionItem);
 
-            Log.Error(e, "ProcessObsoleteAndExportConfirmationAsync: Unhandled error during pass 1 for {Cso}.",
-                connectedSystemObject);
+            Log.Error(e, "ProcessObsoleteAndExportConfirmationAsync: Unhandled error during pass 1 for {CsoId}.",
+                connectedSystemObject.Id);
         }
     }
 
@@ -471,7 +471,7 @@ public abstract class SyncTaskProcessorBase
         if (activeSyncRules.Count == 0 && _connectedSystem.ObjectMatchingRuleMode != ObjectMatchingRuleMode.ConnectedSystem)
             return;
 
-        Log.Verbose($"ProcessActiveConnectedSystemObjectAsync: Pass 2 for CSO: {connectedSystemObject}.");
+        Log.Verbose($"ProcessActiveConnectedSystemObjectAsync: Pass 2 for CSO: {connectedSystemObject.Id}.");
 
         try
         {
@@ -609,8 +609,8 @@ public abstract class SyncTaskProcessorBase
             runProfileExecutionItem.ErrorMessage = joinEx.Message;
             _activity.RunProfileExecutionItems.Add(runProfileExecutionItem);
 
-            Log.Warning("ProcessActiveConnectedSystemObjectAsync: Join error for {Cso}: {Message}",
-                connectedSystemObject, joinEx.Message);
+            Log.Warning("ProcessActiveConnectedSystemObjectAsync: Join error for {CsoId}: {Message}",
+                connectedSystemObject.Id, LogSanitiser.Sanitise(joinEx.Message));
         }
         catch (SyncExpressionEvaluationException expressionEx)
         {
@@ -626,8 +626,8 @@ public abstract class SyncTaskProcessorBase
             runProfileExecutionItem.ErrorStackTrace = expressionEx.StackTrace;
             _activity.RunProfileExecutionItems.Add(runProfileExecutionItem);
 
-            Log.Error(expressionEx, "ProcessActiveConnectedSystemObjectAsync: Expression evaluation error during pass 2 for {Cso}. Target attribute '{Attribute}', expression '{Expression}'.",
-                connectedSystemObject, LogSanitiser.Sanitise(expressionEx.TargetAttributeName), LogSanitiser.Sanitise(expressionEx.Expression));
+            Log.Error(expressionEx, "ProcessActiveConnectedSystemObjectAsync: Expression evaluation error during pass 2 for {CsoId}. Target attribute '{Attribute}', expression '{Expression}'.",
+                connectedSystemObject.Id, LogSanitiser.Sanitise(expressionEx.TargetAttributeName), LogSanitiser.Sanitise(expressionEx.Expression));
         }
         catch (Exception e)
         {
@@ -640,8 +640,8 @@ public abstract class SyncTaskProcessorBase
             runProfileExecutionItem.ErrorStackTrace = e.StackTrace;
             _activity.RunProfileExecutionItems.Add(runProfileExecutionItem);
 
-            Log.Error(e, "ProcessActiveConnectedSystemObjectAsync: Unhandled error during pass 2 for {Cso}.",
-                connectedSystemObject);
+            Log.Error(e, "ProcessActiveConnectedSystemObjectAsync: Unhandled error during pass 2 for {CsoId}.",
+                connectedSystemObject.Id);
         }
     }
 
@@ -1088,7 +1088,7 @@ public abstract class SyncTaskProcessorBase
     /// <returns>A result indicating what MVO changes occurred (projection, join, Attribute Flow).</returns>
     protected async Task<MetaverseObjectChangeResult> ProcessMetaverseObjectChangesAsync(List<SyncRule> activeSyncRules, ConnectedSystemObject connectedSystemObject)
     {
-        Log.Verbose($"ProcessMetaverseObjectChangesAsync: Executing for: {connectedSystemObject}.");
+        Log.Verbose($"ProcessMetaverseObjectChangesAsync: Executing for: {connectedSystemObject.Id}.");
         if (connectedSystemObject.Status == ConnectedSystemObjectStatus.Obsolete)
             return MetaverseObjectChangeResult.NoChanges();
 
@@ -3005,8 +3005,8 @@ public abstract class SyncTaskProcessorBase
                     finalAttributeValues);
                 deletedMvoIds.Add(mvo.Id);
                 Log.Information(
-                    "ProcessMvoDeletionsIndividuallyAsync: Deleted MVO {MvoId} ({DisplayName})",
-                    mvo.Id, mvo.DisplayName ?? "No display name");
+                    "ProcessMvoDeletionsIndividuallyAsync: Deleted MVO {MvoId}",
+                    mvo.Id);
             }
             catch (Exception ex)
             {

--- a/src/JIM.Worker/Worker.cs
+++ b/src/JIM.Worker/Worker.cs
@@ -715,8 +715,8 @@ public class Worker : BackgroundService
             {
                 try
                 {
-                    Log.Information("PerformMetaverseObjectHousekeepingAsync: Deleting MVO {MvoId} ({DisplayName}) - disconnected at {DisconnectedDate}, rule: {DeletionRule}",
-                        mvo.Id, mvo.DisplayName ?? "No display name", mvo.LastConnectorDisconnectedDate, mvo.Type?.DeletionRule);
+                    Log.Information("PerformMetaverseObjectHousekeepingAsync: Deleting MVO {MvoId} - disconnected at {DisconnectedDate}, rule: {DeletionRule}",
+                        mvo.Id, mvo.LastConnectorDisconnectedDate, mvo.Type?.DeletionRule);
 
                     // Evaluate export rules for the MVO deletion: delete Pending Exports are created for
                     // CSOs whose export Synchronisation Rule's OutboundDeprovisionAction is Delete (issue #655).


### PR DESCRIPTION
## Summary
- Sweeps the full import, synchronisation, and export paths for log calls rendering externally-sourced strings unsanitised, and wraps them with `LogSanitiser.Sanitise()`: LDAP Distinguished Names (~65 sites in the LDAP connector, which previously had no sanitisation), external IDs and duplicate-detection values in the import processor, expression and reconciliation values in the sync engine, export values and directory error messages in the export servers, drift detection values (fixed once inside `FormatValueForLog`), and CSV field values in the File connector; roughly one hundred call sites across 13 files.
- Removes identity display names from service logs entirely (11 call sites logging `ConnectedSystemObject`/`MetaverseObject.ToString()` or `mvo.DisplayName` now log the object Id), per the no-personal-data logging rule.
- The injection risk is real, not theoretical: during #873's integration validation, a reference value carrying an embedded newline and forged log text rendered verbatim into the worker's live log.
- Also completes the #873 PRD lifecycle: `PRD_UNRESOLVED_REFERENCE_HANDLING.md` moves to `engineering/prd/done/` with `Status: Done` (issue closed via #1063).
- Changelog: one 🔒 entry covering the hardening.

Docs: n/a - security hardening of log output and an internal PRD lifecycle move; no administrator-observable behaviour change beyond log content.

## Test plan
- [x] `dotnet build JIM.sln` clean (0 warnings, 0 errors)
- [x] `dotnet test JIM.sln` clean (3,752 passed, 0 failed; 86 pre-existing RequiresPostgres skips)
- [x] Injection vector previously reproduced live (newline-bearing reference value forging a log line); the affected sites are now wrapped
- [x] Double-wrap and leftover-DisplayName sweeps clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Punb6DbxCR4kbBvnfAVkt

---
_Generated by [Claude Code](https://claude.ai/code/session_019Punb6DbxCR4kbBvnfAVkt)_