### PR TITLE
fix(security): bump .NET base images to 10.0.10 servicing release

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -33,7 +33,41 @@
 #
 # JIM also does not use EncryptedXml (the affected class) at runtime.
 #
-# Review by: 2026-07-15 (re-check whether Microsoft has re-rolled the SDK
+# Review by: 2026-10-21 (re-check whether Microsoft has re-rolled the SDK
 # image or Trivy's matching has been corrected).
+# Re-evaluated 2026-07-21: situation unchanged. The current sdk:10.0-noble
+# digest (ed034a8, runtime 10.0.10 / SDK 10.0.302) is the newest available
+# and the file-version matching gotcha persists (see the July 2026 entry
+# below, which is the same failure mode for the next servicing wave).
 CVE-2026-26171
 CVE-2026-33116
+
+# ----------------------------------------------------------------------------
+# CVE-2026-47302 / CVE-2026-47304 / CVE-2026-50525 / CVE-2026-50648
+# (.NET July 2026 servicing wave, flagged only in the SDK build-stage image)
+# ----------------------------------------------------------------------------
+# All four are part of the July 2026 .NET security release (Ubuntu advisory
+# USN-8553-1, published 2026-07-15) and are fixed in .NET runtime 10.0.10 /
+# SDK 10.0.302: XML-encryption resource-exhaustion DoS and SMTP header
+# handling in the runtime, plus SDK tooling variants.
+#
+# The production images (aspnet/runtime 10.0-noble) were bumped to the
+# 10.0.10 digests (1fa23fc / ed5d539) in the same commit as this entry; their
+# scans pass, so shipped JIM containers carry the fixes.
+#
+# The sdk:10.0-noble image digest ed034a8 IS the patched build (runtime
+# 10.0.10, SDK 10.0.302 - verified via the image config's DOTNET_VERSION),
+# yet Trivy still flags these CVEs against components bundled inside the SDK
+# image. This is the same in-box assembly file-version matching gotcha
+# documented in the entry above; no newer SDK image exists to pull.
+#
+# The SDK image is a build stage only: no SDK-image content ships in the
+# final runtime images beyond JIM's own published output, so there is no
+# exploit surface in deployed containers.
+#
+# Review by: 2026-10-21 (re-check whether Microsoft has re-rolled the SDK
+# image; remove once a clean sdk:10.0-noble digest exists).
+CVE-2026-47302
+CVE-2026-47304
+CVE-2026-50525
+CVE-2026-50648

--- a/src/JIM.Scheduler/Dockerfile
+++ b/src/JIM.Scheduler/Dockerfile
@@ -7,7 +7,7 @@
 
 ARG VERSION=dev
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:58318ab0733b63d3ac0d7609c46f2718244e623a176f45991ee01fad46fbf880 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:ed5d539b27842d656a06a5984dbcb5114d3e885fbada612a49a5a7c3c3a44e1c AS base
 ARG VERSION
 
 LABEL org.opencontainers.image.title="JIM Scheduler"
@@ -27,7 +27,7 @@ RUN mkdir -p /data/keys /var/log/jim \
 # Run as non-root for security (built-in 'app' user, UID 1654)
 USER app
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "./"]
 COPY ["VERSION", "./"]

--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -11,7 +11,7 @@ ARG VERSION=dev
 # to skip the expensive generation step in local dev builds.
 ARG OPENAPI_STAGE=openapi-gen
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:1fa23fc4872d95fd71c2833ebe65d7e84a43b2d51a31d119516852f13d9505a7 AS base
 ARG VERSION
 
 LABEL org.opencontainers.image.title="JIM Web"
@@ -105,7 +105,7 @@ RUN dotnet publish "JIM.Web.csproj" -c Release -o /app/publish /p:UseAppHost=fal
 #
 # The output is written under /app/publish so that the final stage can pull
 # from either openapi-gen or publish using the same path.
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:ddcf70ad1ab963a4fcd41fbd722a6b660e404e87567cfbd46fd2809c21b02088 AS openapi-gen
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble@sha256:1fa23fc4872d95fd71c2833ebe65d7e84a43b2d51a31d119516852f13d9505a7 AS openapi-gen
 WORKDIR /app/publish
 COPY --from=publish /app/publish .
 ENV JIM_OPENAPI_GENERATE=true \

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -7,7 +7,7 @@
 
 ARG VERSION=dev
 
-FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:58318ab0733b63d3ac0d7609c46f2718244e623a176f45991ee01fad46fbf880 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0-noble@sha256:ed5d539b27842d656a06a5984dbcb5114d3e885fbada612a49a5a7c3c3a44e1c AS base
 ARG VERSION
 
 LABEL org.opencontainers.image.title="JIM Worker"
@@ -43,7 +43,7 @@ RUN mkdir -p /data/keys /var/log/jim /connector-files \
 # Run as non-root for security (built-in 'app' user, UID 1654)
 USER app
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "./"]
 COPY ["VERSION", "./"]


### PR DESCRIPTION
## Description

Trivy's overnight vulnerability DB update began flagging the pinned 10.0.9-era .NET base image digests with five HIGH CVEs from the July 2026 .NET servicing wave ([USN-8553-1](https://ubuntu.com/security/notices/USN-8553-1): XML-encryption resource-exhaustion DoS and SMTP client spoofing), failing the required `scan-base-images-summary` check on every open PR.

- Bump `aspnet`/`runtime` 10.0-noble pins to the current 10.0.10 digests (`1fa23fc` / `ed5d539`), which contain the fixes (verified via the image configs' `DOTNET_VERSION`).
- Align JIM.Worker/JIM.Scheduler `sdk` pins with JIM.Web's current 10.0.302 digest (`ed034a8`).
- Suppress CVE-2026-47302/47304/50525/50648 for the SDK build-stage image in `.trivyignore`: the patched SDK image still trips Trivy's in-box assembly file-version matching (the same documented gotcha as the existing Cryptography.Xml entry), and no SDK-stage content ships in production images. Review date 2026-10-21.
- Re-evaluated the expired Cryptography.Xml suppression review date per policy; situation unchanged, extended to 2026-10-21.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] Digest/config-only change: no `.cs` touched, so no local build/test applies (per repo build/test exceptions)
- [x] Verified the new digests are the current `10.0-noble` manifests on MCR and contain .NET 10.0.10 via the registry API image configs
- [x] CI `scan-base-images` on this PR exercises the change directly

## Documentation

- [x] No documentation needed

Docs: n/a - dependency pin bump and CVE suppression housekeeping; no user-facing behaviour change

## Screenshots / output (if applicable)

Blocking CVEs from the failing scans: CVE-2026-47302, CVE-2026-50524, CVE-2026-50528 (8.2), CVE-2026-50651, CVE-2026-57108 (runtime images, fixed by the digest bumps); CVE-2026-47302/47304/50525/50648 (SDK image, suppressed with rationale).

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

Unblocks the Dependabot merge train (#1071, #1072, #1074, #1075, #1076, #1077), which is currently stuck on the scan gate. The suppressions are time-boxed; remove once Microsoft re-rolls a clean `sdk:10.0-noble` digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmxijKgLk22PXG2benH2i4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmxijKgLk22PXG2benH2i4)_