### PR TITLE
fix(ci): skip claude-review for bot-authored PRs and serialise the Dependabot merge train

### DIFF
--- a/.claude/skills/review-dependabot/SKILL.md
+++ b/.claude/skills/review-dependabot/SKILL.md
@@ -110,29 +110,29 @@ Recommendations should be one of:
 - **Hold** - Needs investigation (explain why)
 - **Reject** - Fails assessment (explain why)
 
-## Step 6: Merge
+## Step 6: Merge (serial merge train)
 
-Unless running in review-only mode:
+Unless running in review-only mode. Assessment (Steps 1 to 5) is batched because reading diffs costs no CI; merging is **strictly serial**: one PR at a time, in order. Branch protection requires every PR to be up to date with `main`, so each merge invalidates the rest of the batch; updating or triggering CI on any PR other than the next in the queue wastes CI minutes (a rebase-everything-after-every-merge pattern costs roughly N-squared/2 CI runs per batch of N, against a floor of N).
 
-1. **Check branch is up to date**: Before merging, check whether the PR branch is behind `main` (`gh pr view <number> --json mergeStateStatus`). Branch protection requires the branch to be current. If the branch is behind:
-   - Comment `@dependabot rebase` on the PR and wait — do not use any other mechanism
-   - **Never use `update_pull_request_branch` (the API "Update branch" endpoint) or the GitHub "Update branch" button.** This creates a *merge commit* instead of a proper git rebase. Merge commits on Dependabot branches cause cascading conflicts when multiple PRs share the same files (e.g. `JIM.Web.csproj` is referenced by several grouped NuGet update PRs), and — critically — once an external merge commit is on the branch, Dependabot ignores all subsequent `@dependabot rebase` and `@dependabot recreate` commands, leaving the PR permanently stuck.
-   - `@dependabot rebase` is the only safe mechanism: it replays the Dependabot commit cleanly on top of current `main` without these side-effects.
-   - Accept the wait: multiple CI rounds are normal when merging a batch of PRs that share files. After each merge, comment `@dependabot rebase` on the remaining PRs and let CI run.
-   - Once Dependabot rebases and CI passes, the merge can proceed (the user can re-run this skill or merge manually)
-2. Identify any merge ordering constraints (multiple PRs touching the same file)
-3. Merge approved PRs in the correct order using `gh pr merge <number> --merge`
-4. Include a merge comment noting what was verified (pinning, security advisory, etc.)
-5. If a PR has merge conflicts after earlier merges, comment `@dependabot rebase` and wait for the rebase before merging
-6. **Recovery if a PR is `dirty`**: If a branch ended up `dirty` because an external merge commit was added (e.g. via `update_pull_request_branch`), Dependabot will not respond to any further commands. The only fix is a manual rebase from a local clone:
+1. **Pick the next PR only.** Order: security fixes first, then any ordering constraint from the assessment (PRs sharing files), then oldest first. Do not comment on, update, or otherwise trigger CI on any other PR in the batch.
+2. **Bring it up to date and fix lock files in ONE push** (each push costs a full CI run, so never push a lock-file fix and a branch update separately):
+   - If the branch carries only Dependabot's own commits, comment `@dependabot rebase` and wait up to ~5 minutes (it normally responds in under a minute). If it responds, lock files may still need regenerating (see below) - do that on the rebased head in the same pass as any further update.
+   - If the branch has external commits (lock-file regeneration, an earlier update), or Dependabot does not respond within the timeout: update locally instead. `git fetch origin`, `git checkout <branch>`, `git pull --no-rebase` (absorbs any remote drift, e.g. a stray "Update branch" click), `git merge origin/main --no-edit`. **Merge, don't rebase**: `main` squash-merges so branch history is discarded anyway, and a merge needs only a plain push (root `CLAUDE.md`). Dependabot stops maintaining a branch once it has external commits; that is expected - the train owns the branch from that point.
+   - **Conflicts**: resolve conflicted `.csproj` files manually, keeping BOTH sides' version bumps (`git diff HEAD origin/main -- <file>` shows what each side changed). Never hand-merge a `packages.lock.json` conflict - lock content derives from the csproj set, so regenerate instead.
+   - **Regenerate and verify before committing**: run `dotnet restore JIM.sln --force-evaluate` as its own command and check its exit status directly - do not bury it in a `&&`/pipe chain where a piped `tail` masks the exit code. Then `grep -rln '<<<<<<<' src/ test/` must return nothing (a marker-laden csproj otherwise gets committed silently; this happened). Then `git add -A`, commit, plain push.
+3. **Arm auto-merge**: `gh pr merge <number> --squash --auto`. Include a merge comment noting what was verified (pinning, security advisory) where the assessment found anything noteworthy.
+4. **Wait for the merge before touching the next PR** (background until-loop on the merge state per root `CLAUDE.md`, or a PR-activity subscription). Investigate red required checks on the current PR only; checks on queued PRs are stale by construction and not worth reading.
+5. **Advance** to the next PR and repeat from step 2.
+6. **Avoid the API "Update branch" endpoint (`update_pull_request_branch`) on branches Dependabot still maintains**: the merge commit it creates makes Dependabot ignore all subsequent `@dependabot rebase`/`recreate` commands. On a branch that already has external commits it is functionally equivalent to the local merge in step 2, but prefer the local merge for conflict control and the single-push discipline.
+7. **Recovery (last resort)**: for a branch that is truly wedged, a manual rebase replays only the version-bump commit on top of current `main`:
    ```bash
    git fetch origin
    git checkout <dependabot-branch-name>
    git rebase origin/main
    git push --force-with-lease origin <dependabot-branch-name>
    ```
-   This replays only the Dependabot version-bump commit on top of current `main`. CI will then run cleanly and the PR can be merged normally.
-7. Report final status of all PRs
+   Prefer the merge path in step 2; force-push only when a plain push cannot represent the fix, and expect the harness to require explicit user approval for it.
+8. Report final status of all PRs
 
 ## Reference: JIM's Supply Chain Security Requirements
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,25 +25,42 @@ jobs:
       # job-level `if` skip causes the check to be absent/failed, which blocks
       # merge when claude-review is a required check.
       #
-      # Two actors are exempt:
+      # Two bots are exempt, matched on BOTH the actor (who triggered the run)
+      # and the PR author (who opened the PR):
       #   - dependabot[bot]: NuGet/Docker/Actions version bumps.
       #   - jim-automation[bot]: the App that opens the apt-pin-check and
       #     tooling-pin-check version-bump PRs. These are mechanical pin bumps
       #     that do not warrant an AI review, and the review action cannot
-      #     authenticate on a bot-authored PR anyway (it dies trying to mint an
+      #     authenticate on a bot-actored run anyway (it dies trying to mint an
       #     installation token), so it must be skipped, not merely allowed to run.
+      # The author check matters because maintenance pushes to a bot's PR branch
+      # (lock-file regeneration, update-with-main) make the human pusher the
+      # actor, which previously un-skipped the review on PRs it was designed to
+      # skip (July 2026 Dependabot batch).
       - name: Skip review for automation bots
-        if: github.actor == 'dependabot[bot]' || github.actor == 'jim-automation[bot]'
-        run: echo "Skipping automated review for ${{ github.actor }} PRs"
+        if: >-
+          github.actor == 'dependabot[bot]' ||
+          github.actor == 'jim-automation[bot]' ||
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
+          github.event.pull_request.user.login == 'jim-automation[bot]'
+        run: echo "Skipping automated review for bot PR (actor ${{ github.actor }}, author ${{ github.event.pull_request.user.login }})"
 
       - name: Checkout repository
-        if: github.actor != 'dependabot[bot]' && github.actor != 'jim-automation[bot]'
+        if: >-
+          github.actor != 'dependabot[bot]' &&
+          github.actor != 'jim-automation[bot]' &&
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.user.login != 'jim-automation[bot]'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        if: github.actor != 'dependabot[bot]' && github.actor != 'jim-automation[bot]'
+        if: >-
+          github.actor != 'dependabot[bot]' &&
+          github.actor != 'jim-automation[bot]' &&
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.user.login != 'jim-automation[bot]'
         id: claude-review
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e  # v1.0.178
         with:


### PR DESCRIPTION
## Description

Retrospective fixes from the July 2026 Dependabot batch (nine PRs merged over ~24 hours):

- **`claude-code-review.yml`**: skip the AI review when the PR *author* is `dependabot[bot]` or `jim-automation[bot]`, not just when the *actor* is. Maintenance pushes to a bot's PR branch (lock-file regeneration, update-with-main) make the human pusher the actor, which un-skipped the review on PRs it was designed to skip and burned a doomed review run per push.
- **`review-dependabot` skill, Step 6**: rewritten as a serial merge train; one PR at a time, branch update and lock-file regeneration combined into a single push, auto-merge (squash), wait for merge before touching the next PR. Deletes the "after each merge, comment `·@·d·ependabot r·ebase` on the remaining PRs" guidance (roughly N²/2 CI runs per batch of N, against a floor of N). Adds a merge-from-main fallback for branches with external commits or an unresponsive Dependabot, plus update hygiene learned the hard way: verify `dotnet restore` exit status as its own command, and grep for leftover conflict markers before committing.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [x] Other (describe below): CI workflow and dev-tooling (skill) optimisation

## Testing

- [x] Workflow YAML and Markdown only; no build/test applies (per repo build/test exceptions)
- [x] Workflow condition logic mirrors the existing actor checks with the author term added to each expression

## Documentation

- [x] No documentation needed

Docs: n/a - CI workflow and internal skill tooling; no user-facing behaviour change

## Screenshots / output (if applicable)

n/a

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

The `claude-review` check is currently removed from the ruleset's required checks (its `CLAUDE_CODE_OAUTH_TOKEN` is dead); once the token is refreshed and the check re-added, this change ensures Dependabot PRs satisfy it via the skip path regardless of who pushes to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmxijKgLk22PXG2benH2i4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmxijKgLk22PXG2benH2i4)_