### PR TITLE
chore(devcontainer): alias bat to batcat

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,6 +69,13 @@ RUN printf 'Package: moby-containerd\nPin: version 2.2.*\nPin-Priority: 1001\n' 
 # during setup silently fails without this. (Regression from the bookworm->noble
 # base image bump; bookworm shipped pip by default.)
 #
+# Install bat (a syntax-highlighting cat, used via the `bat` alias in
+# jim-aliases.sh). The base image happens to ship it today, but base image
+# contents are not a contract and can change under a digest bump; naming it here
+# keeps the alias from breaking silently. Debian/Ubuntu install the binary as
+# `batcat`, not `bat`, to avoid clashing with bacula-console's `bat` - hence the
+# alias.
+#
 # Install ripgrep so Claude Code can use the distro binary instead of its
 # bundled vendor/ripgrep/arm64-linux/rg. The bundled binary assumes a 4K
 # memory page size and SIGABRTs on hosts running a 16K page-size kernel
@@ -81,6 +88,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     socat \
     python3-pip \
+    bat \
     ripgrep \
     libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -219,6 +219,11 @@ jim-reset          # Full reset (containers, images, volumes)
 jim-wipe           # Wipe JIM data (reset CSOs/MVOs/config, keep schema)
 ```
 
+### Tooling
+```bash
+bat <file>         # Syntax-highlighting cat (Ubuntu packages it as batcat)
+```
+
 ### Help
 ```bash
 jim                # Show all available aliases

--- a/.devcontainer/jim-aliases.sh
+++ b/.devcontainer/jim-aliases.sh
@@ -71,6 +71,9 @@ Developer Setup:
   jim-setup-signing   - (Re)configure git commit signing for this environment
   jim-signing-status  - Show current commit signing state and readiness
 
+Tooling:
+  bat                - Syntax-highlighting cat (Ubuntu ships it as batcat)
+
 Help:
   jim                - Show this help message
 "'
@@ -548,6 +551,11 @@ jim-reset() {
 # Documentation preview (MkDocs Material)
 alias jim-docs='mkdocs serve --dev-addr 0.0.0.0:8000'
 alias jim-docs-build='mkdocs build'
+
+# bat (syntax-highlighting cat). Debian and Ubuntu package the binary as `batcat`
+# because bacula-console already owns the `bat` name, so restore the upstream
+# name everyone actually types.
+alias bat='batcat'
 
 # Create a new PRD from template
 jim-prd() {


### PR DESCRIPTION
## Summary
- Adds `alias bat='batcat'` to `.devcontainer/jim-aliases.sh`. Debian and Ubuntu package bat's binary as `batcat` because bacula-console already owns the `bat` name, so the command everyone actually types does not exist in the container.
- Names `bat` explicitly in the devcontainer Dockerfile's apt install list. The base image ships it today, but base image contents are not a contract; naming it here stops the alias breaking silently under a future digest bump. Left unpinned, consistent with the neighbouring `socat` / `ripgrep` / `python3-pip` (this Dockerfile is not tagged `# jim-compliance: production-image`, so `apt-pin-check` does not scan it).
- Documents it in the `jim` help output and `.devcontainer/README.md` under a new Tooling heading.

## Test plan
- [x] Verified `bat --version` resolves to bat 0.24.0 in both bash and zsh after sourcing `jim-aliases.sh`
- [x] Verified `bat -p <file>` renders correctly
- [x] `dotnet build` / `dotnet test` skipped per the CLAUDE.md non-code exception list (Dockerfile, shell script, and Markdown only)

Docs: n/a - developer tooling alias, no user-facing behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)