### PR TITLE
Add filtering to Synchronisation Rules list across portal, API and PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ The Synchronisation Rules list can now be filtered by Connected System, Direction, Action (Projects, Provisions or Flow Only) and Status. The filters combine with the existing search box, which narrows whatever the filters left.
+- ✨ The same filters are available to automation: `Get-JIMSyncRule` gains `-Direction`, `-ActionType` and `-Status`, and the Synchronisation Rules REST endpoint gains matching query parameters.
+
+### Fixed
+
+- 🐛 `Get-JIMSyncRule` now returns every Synchronisation Rule rather than only the first 25, paging through the full result set.
+
 ## [0.14.0] - 2026-07-25
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 `Get-JIMSyncRule` now returns every Synchronisation Rule rather than only the first 25, paging through the full result set.
+- 🐛 Piping a Connected System into `Get-JIMSyncRule`, as its documentation has always shown, now works instead of failing to bind.
 
 ## [0.14.0] - 2026-07-25
 

--- a/docs/configuration/synchronisation-rules.md
+++ b/docs/configuration/synchronisation-rules.md
@@ -302,6 +302,23 @@ A complete import rule for an HR system might look like:
 
 This rule imports full-time employees from the HR system, joins them to existing Metaverse Objects by employee ID, creates new Metaverse Objects for new starters, and flows their attributes into the metaverse.
 
+## Finding a Synchronisation Rule
+
+Once a deployment has more than a handful of rules, the Synchronisation Rules list carries filters above the table so you can narrow it to the rules you care about:
+
+| Filter | Narrows to |
+|--------|------------|
+| **Connected System** | Rules belonging to the systems you pick. Only systems that actually have rules are offered. |
+| **Direction** | Inbound (Import) or Outbound (Export) rules. |
+| **Action** | **Projects** (Import rules that create Metaverse Objects), **Provisions** (Export rules that create Connected System Objects), or **Flow Only** (rules that create nothing and only flow attribute values). |
+| **Status** | Enabled or Disabled rules. |
+
+Each filter accepts several values, and the filters combine: picking two Connected Systems and the Outbound direction shows the outbound rules of either system. Leaving a filter empty means "all".
+
+The search box in the table's toolbar narrows whatever the filters left, matching on the rule name. Clearing the search box returns the filtered list rather than the full one, so you can keep a filter in place while searching within it.
+
+The same filters are available to automation: see `Get-JIMSyncRule`'s `-Direction`, `-ActionType` and `-Status` parameters, and the matching query parameters on the Synchronisation Rules list endpoint in the REST API.
+
 ## Manage Synchronisation Rules
 
 - **JIM portal**<br /> Synchronisation Rules area of the admin UI

--- a/docs/powershell/synchronisation-rules.md
+++ b/docs/powershell/synchronisation-rules.md
@@ -23,9 +23,9 @@ The filters combine with AND, and each of `-Direction`, `-ActionType` and `-Stat
 ### Syntax
 
 ```powershell
-# List all Synchronisation Rules (default)
-Get-JIMSyncRule [-Name <string>] [-Direction <string[]>] [-ActionType <string[]>]
-    [-Status <string[]>]
+# List all Synchronisation Rules (default), optionally with a piped Connected System
+Get-JIMSyncRule [-InputObject <PSCustomObject>] [-Name <string>] [-Direction <string[]>]
+    [-ActionType <string[]>] [-Status <string[]>]
 
 # By Synchronisation Rule ID
 Get-JIMSyncRule -Id <int>
@@ -46,6 +46,7 @@ Get-JIMSyncRule -ConnectedSystemName <string> [-Name <string>] [-Direction <stri
 | `Id` | `int` | Yes (ById set) | | The ID of a specific Synchronisation Rule to retrieve |
 | `ConnectedSystemId` | `int` | No | | Filter Synchronisation Rules by Connected System ID. Accepts pipeline input. |
 | `ConnectedSystemName` | `string` | No | | Filter Synchronisation Rules by Connected System name. Must be an exact match. |
+| `InputObject` | `PSCustomObject` | No | | A Connected System object from the pipeline (for example from `Get-JIMConnectedSystem`). Its `Id` filters the rules, equivalent to `-ConnectedSystemId`. |
 | `Name` | `string` | No | | Filter Synchronisation Rules by name. Supports wildcards (e.g., `"Inbound*"`). |
 | `Direction` | `string[]` | No | | Filter by direction: `Import` (inbound) or `Export` (outbound). |
 | `ActionType` | `string[]` | No | | Filter by the action the rule performs: `Projects`, `Provisions`, or `FlowOnly`. |
@@ -90,6 +91,10 @@ Get-JIMSyncRule -ConnectedSystemName "Active Directory" -Direction Export -Statu
 ```powershell title="Pipeline from Connected System ID"
 $cs = Get-JIMConnectedSystem -Name "HR System"
 Get-JIMSyncRule -ConnectedSystemId $cs.Id
+```
+
+```powershell title="Pipe Connected Systems straight in, and filter them"
+Get-JIMConnectedSystem -Name "HR*" | Get-JIMSyncRule -Direction Import -Status Enabled
 ```
 
 ---

--- a/docs/powershell/synchronisation-rules.md
+++ b/docs/powershell/synchronisation-rules.md
@@ -16,22 +16,27 @@ Create, retrieve, update, and delete Synchronisation Rules.
 
 ## Get-JIMSyncRule
 
-Retrieves one or more Synchronisation Rules. When called without parameters, returns all Synchronisation Rules. Use the parameter sets to filter by ID, Connected System ID, or Connected System name.
+Retrieves one or more Synchronisation Rules. When called without parameters, returns all Synchronisation Rules. Use the parameter sets to filter by ID, Connected System ID, or Connected System name, and the `-Direction`, `-ActionType` and `-Status` filters to narrow the list further.
+
+The filters combine with AND, and each of `-Direction`, `-ActionType` and `-Status` accepts several values, which combine with OR. `-Name` narrows whatever the other filters left, so removing it returns those results. These are the same filters offered on the Synchronisation Rules page of the JIM portal.
 
 ### Syntax
 
 ```powershell
 # List all Synchronisation Rules (default)
-Get-JIMSyncRule [-Name <string>]
+Get-JIMSyncRule [-Name <string>] [-Direction <string[]>] [-ActionType <string[]>]
+    [-Status <string[]>]
 
 # By Synchronisation Rule ID
 Get-JIMSyncRule -Id <int>
 
 # By Connected System ID
-Get-JIMSyncRule -ConnectedSystemId <int> [-Name <string>]
+Get-JIMSyncRule -ConnectedSystemId <int> [-Name <string>] [-Direction <string[]>]
+    [-ActionType <string[]>] [-Status <string[]>]
 
 # By Connected System name
-Get-JIMSyncRule -ConnectedSystemName <string> [-Name <string>]
+Get-JIMSyncRule -ConnectedSystemName <string> [-Name <string>] [-Direction <string[]>]
+    [-ActionType <string[]>] [-Status <string[]>]
 ```
 
 ### Parameters
@@ -42,6 +47,11 @@ Get-JIMSyncRule -ConnectedSystemName <string> [-Name <string>]
 | `ConnectedSystemId` | `int` | No | | Filter Synchronisation Rules by Connected System ID. Accepts pipeline input. |
 | `ConnectedSystemName` | `string` | No | | Filter Synchronisation Rules by Connected System name. Must be an exact match. |
 | `Name` | `string` | No | | Filter Synchronisation Rules by name. Supports wildcards (e.g., `"Inbound*"`). |
+| `Direction` | `string[]` | No | | Filter by direction: `Import` (inbound) or `Export` (outbound). |
+| `ActionType` | `string[]` | No | | Filter by the action the rule performs: `Projects`, `Provisions`, or `FlowOnly`. |
+| `Status` | `string[]` | No | | Filter by state: `Enabled` or `Disabled`. |
+
+`ActionType` values map to what a rule creates: `Projects` for Import rules that project new Metaverse Objects, `Provisions` for Export rules that provision new Connected System Objects, and `FlowOnly` for rules that create no objects and only flow attribute values.
 
 ### Output
 
@@ -63,6 +73,18 @@ Get-JIMSyncRule -Name "Inbound*"
 
 ```powershell title="Get Synchronisation Rules for a Connected System"
 Get-JIMSyncRule -ConnectedSystemName "Active Directory"
+```
+
+```powershell title="Find enabled outbound rules"
+Get-JIMSyncRule -Direction Export -Status Enabled
+```
+
+```powershell title="Find the rules that create objects"
+Get-JIMSyncRule -ActionType Projects, Provisions
+```
+
+```powershell title="Combine filters to audit one system"
+Get-JIMSyncRule -ConnectedSystemName "Active Directory" -Direction Export -Status Disabled
 ```
 
 ```powershell title="Pipeline from Connected System ID"

--- a/src/JIM.Models/Logic/DTOs/SyncRuleFilter.cs
+++ b/src/JIM.Models/Logic/DTOs/SyncRuleFilter.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Logic.DTOs;
+
+/// <summary>
+/// The facets an administrator can narrow a list of Synchronisation Rules by, plus an optional
+/// free-text search term.
+/// <para>
+/// Facets combine with AND, values within a facet combine with OR, and an unset or empty facet
+/// matches everything. The search term narrows whatever the facets left, so clearing it returns the
+/// facet results rather than the full list.
+/// </para>
+/// <para>
+/// This is the single definition of what "matching" means for a Synchronisation Rule list; the
+/// portal, the REST API and PowerShell all filter through <see cref="Matches"/> so the three
+/// surfaces cannot drift apart.
+/// </para>
+/// </summary>
+public class SyncRuleFilter
+{
+    /// <summary>
+    /// Match only Synchronisation Rules belonging to these Connected Systems.
+    /// </summary>
+    public IReadOnlyCollection<int>? ConnectedSystemIds { get; set; }
+
+    /// <summary>
+    /// Match only Synchronisation Rules flowing in these directions.
+    /// </summary>
+    public IReadOnlyCollection<SyncRuleDirection>? Directions { get; set; }
+
+    /// <summary>
+    /// Match only Synchronisation Rules performing these actions.
+    /// </summary>
+    public IReadOnlyCollection<SyncRuleActionType>? ActionTypes { get; set; }
+
+    /// <summary>
+    /// Match only Synchronisation Rules in these states.
+    /// </summary>
+    public IReadOnlyCollection<SyncRuleStatus>? Statuses { get; set; }
+
+    /// <summary>
+    /// Free-text term matched case-insensitively against the Synchronisation Rule name. Null,
+    /// empty or whitespace-only terms are ignored.
+    /// </summary>
+    public string? Search { get; set; }
+
+    /// <summary>
+    /// True when no facet and no search term has been supplied, so every Synchronisation Rule
+    /// matches. Callers can use this to skip filtering work entirely.
+    /// </summary>
+    public bool IsEmpty =>
+        ConnectedSystemIds is not { Count: > 0 } &&
+        Directions is not { Count: > 0 } &&
+        ActionTypes is not { Count: > 0 } &&
+        Statuses is not { Count: > 0 } &&
+        string.IsNullOrWhiteSpace(Search);
+
+    /// <summary>
+    /// Determines the action a Synchronisation Rule performs from its direction and its
+    /// projection/provisioning settings. Projection only applies to Import rules and provisioning
+    /// only to Export rules, so a value set on the wrong direction is ignored.
+    /// </summary>
+    public static SyncRuleActionType GetActionType(SyncRuleHeader header)
+    {
+        ArgumentNullException.ThrowIfNull(header);
+
+        if (header.Direction == SyncRuleDirection.Import && header.ProjectToMetaverse == true)
+            return SyncRuleActionType.Projects;
+
+        if (header.Direction == SyncRuleDirection.Export && header.ProvisionToConnectedSystem == true)
+            return SyncRuleActionType.Provisions;
+
+        return SyncRuleActionType.FlowOnly;
+    }
+
+    /// <summary>
+    /// Expresses a Synchronisation Rule's enabled flag as a <see cref="SyncRuleStatus"/>.
+    /// </summary>
+    public static SyncRuleStatus GetStatus(SyncRuleHeader header)
+    {
+        ArgumentNullException.ThrowIfNull(header);
+        return header.Enabled ? SyncRuleStatus.Enabled : SyncRuleStatus.Disabled;
+    }
+
+    /// <summary>
+    /// Determines whether a Synchronisation Rule satisfies every facet and the search term.
+    /// </summary>
+    public bool Matches(SyncRuleHeader header)
+    {
+        ArgumentNullException.ThrowIfNull(header);
+
+        if (ConnectedSystemIds is { Count: > 0 } connectedSystemIds && !connectedSystemIds.Contains(header.ConnectedSystemId))
+            return false;
+
+        if (Directions is { Count: > 0 } directions && !directions.Contains(header.Direction))
+            return false;
+
+        if (ActionTypes is { Count: > 0 } actionTypes && !actionTypes.Contains(GetActionType(header)))
+            return false;
+
+        if (Statuses is { Count: > 0 } statuses && !statuses.Contains(GetStatus(header)))
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(Search) && !header.Name.Contains(Search, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return true;
+    }
+}

--- a/src/JIM.Models/Logic/SyncRuleEnums.cs
+++ b/src/JIM.Models/Logic/SyncRuleEnums.cs
@@ -10,6 +10,46 @@ public enum SyncRuleDirection
     Export = 2
 }
 
+/// <summary>
+/// The object-creating action a Synchronisation Rule performs, derived from its direction and its
+/// projection/provisioning settings. Used to filter and describe rules in list views; the three
+/// values are mutually exclusive and exhaustive.
+/// </summary>
+public enum SyncRuleActionType
+{
+    /// <summary>
+    /// The Synchronisation Rule creates no objects; it only flows attribute values.
+    /// </summary>
+    FlowOnly = 0,
+
+    /// <summary>
+    /// An Import rule that projects new Metaverse Objects.
+    /// </summary>
+    Projects = 1,
+
+    /// <summary>
+    /// An Export rule that provisions new Connected System Objects.
+    /// </summary>
+    Provisions = 2
+}
+
+/// <summary>
+/// Whether a Synchronisation Rule is enabled, expressed as an enumeration so that it can be used as
+/// a filter facet alongside the other Synchronisation Rule facets.
+/// </summary>
+public enum SyncRuleStatus
+{
+    /// <summary>
+    /// The Synchronisation Rule is disabled and is skipped by the synchronisation engine.
+    /// </summary>
+    Disabled = 0,
+
+    /// <summary>
+    /// The Synchronisation Rule is enabled and is evaluated by the synchronisation engine.
+    /// </summary>
+    Enabled = 1
+}
+
 
 /// <summary>
 /// Used to provide some context to the user on what type of sources configuration has been used in a Synchronisation Rule mapping.

--- a/src/JIM.PowerShell/Public/SyncRules/Get-JIMSyncRule.ps1
+++ b/src/JIM.PowerShell/Public/SyncRules/Get-JIMSyncRule.ps1
@@ -22,6 +22,10 @@ function Get-JIMSyncRule {
     .PARAMETER ConnectedSystemName
         Filter Synchronisation Rules by Connected System name. Must be an exact match.
 
+    .PARAMETER InputObject
+        A Connected System object from the pipeline (e.g., from Get-JIMConnectedSystem). Its Id is
+        used to filter Synchronisation Rules, equivalent to specifying -ConnectedSystemId directly.
+
     .PARAMETER Name
         Filter Synchronisation Rules by name. Supports wildcards (e.g., "Inbound*").
 
@@ -105,6 +109,16 @@ function Get-JIMSyncRule {
         [Parameter(ParameterSetName = 'ByConnectedSystemName')]
         [string]$ConnectedSystemName,
 
+        # A Connected System object (e.g. from Get-JIMConnectedSystem) exposes Id, not
+        # ConnectedSystemId, so it cannot bind to -ConnectedSystemId by property name. Binding the
+        # whole object here and reading its Id below is the fix: ConnectedSystemId cannot carry an
+        # [Alias('Id')] to cover this, because the -Id parameter above is itself literally named
+        # "Id" in this cmdlet and PowerShell rejects a parameter alias that collides with another
+        # parameter's own name, even across mutually exclusive parameter sets. Same shape and same
+        # reasoning as Get-JIMScheduleExecution.
+        [Parameter(ParameterSetName = 'List', ValueFromPipeline)]
+        [PSCustomObject]$InputObject,
+
         [Parameter(ParameterSetName = 'List')]
         [Parameter(ParameterSetName = 'ByConnectedSystemId')]
         [Parameter(ParameterSetName = 'ByConnectedSystemName')]
@@ -143,6 +157,14 @@ function Get-JIMSyncRule {
             $ConnectedSystemId = $connectedSystem.id
         }
 
+        # -ConnectedSystemId (direct or bound by property name) takes precedence; otherwise fall
+        # back to the piped Connected System object's Id (see -InputObject above).
+        $filterByConnectedSystem = $ConnectedSystemId -gt 0
+        if (-not $filterByConnectedSystem -and $InputObject -and $InputObject.PSObject.Properties['Id']) {
+            $ConnectedSystemId = [int]$InputObject.Id
+            $filterByConnectedSystem = $ConnectedSystemId -gt 0
+        }
+
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 Write-Verbose "Getting Synchronisation Rule with ID: $Id"
@@ -156,7 +178,7 @@ function Get-JIMSyncRule {
                 # same filters. -Name stays client-side because it supports PowerShell wildcards.
                 $baseQueryParams = @('pageSize=100')
 
-                if ($PSBoundParameters.ContainsKey('ConnectedSystemId') -or $PSBoundParameters.ContainsKey('ConnectedSystemName')) {
+                if ($filterByConnectedSystem) {
                     Write-Verbose "Filtering by Connected System ID: $ConnectedSystemId"
                     $baseQueryParams += "connectedSystemIds=$ConnectedSystemId"
                 }

--- a/src/JIM.PowerShell/Public/SyncRules/Get-JIMSyncRule.ps1
+++ b/src/JIM.PowerShell/Public/SyncRules/Get-JIMSyncRule.ps1
@@ -7,8 +7,11 @@ function Get-JIMSyncRule {
         Gets Synchronisation Rules from JIM.
 
     .DESCRIPTION
-        Retrieves Synchronisation Rule configurations from JIM. Can retrieve all rules,
-        a specific rule by ID, or filter by Connected System.
+        Retrieves Synchronisation Rule configurations from JIM. Can retrieve all rules, a specific
+        rule by ID, or narrow the list by Connected System, Direction, Action type and Status.
+
+        The filters combine with AND and each accepts several values, which combine with OR. The
+        -Name filter narrows whatever the other filters left, so removing it returns those results.
 
     .PARAMETER Id
         The unique identifier of a specific Synchronisation Rule to retrieve.
@@ -21,6 +24,19 @@ function Get-JIMSyncRule {
 
     .PARAMETER Name
         Filter Synchronisation Rules by name. Supports wildcards (e.g., "Inbound*").
+
+    .PARAMETER Direction
+        Filter Synchronisation Rules by direction: Import for inbound rules, Export for outbound
+        rules. Accepts several values.
+
+    .PARAMETER ActionType
+        Filter Synchronisation Rules by the action they perform: Projects for Import rules that
+        project new Metaverse Objects, Provisions for Export rules that provision new Connected
+        System Objects, and FlowOnly for rules that create no objects and only flow attribute
+        values. Accepts several values.
+
+    .PARAMETER Status
+        Filter Synchronisation Rules by state: Enabled or Disabled. Accepts several values.
 
     .OUTPUTS
         PSCustomObject representing Synchronisation Rule(s).
@@ -51,6 +67,22 @@ function Get-JIMSyncRule {
         Gets all Synchronisation Rules with names starting with "Inbound".
 
     .EXAMPLE
+        Get-JIMSyncRule -Direction Export -Status Enabled
+
+        Gets every enabled outbound Synchronisation Rule.
+
+    .EXAMPLE
+        Get-JIMSyncRule -ActionType Projects, Provisions
+
+        Gets the Synchronisation Rules that create objects, either by projecting them into the
+        Metaverse or by provisioning them into a Connected System.
+
+    .EXAMPLE
+        Get-JIMSyncRule -ConnectedSystemName 'Contoso AD' -Direction Export -Status Disabled
+
+        Gets the disabled outbound Synchronisation Rules for the 'Contoso AD' Connected System.
+
+    .EXAMPLE
         Get-JIMConnectedSystem -Name "HR*" | Get-JIMSyncRule
 
         Gets all Synchronisation Rules for Connected Systems with names starting with "HR".
@@ -77,7 +109,25 @@ function Get-JIMSyncRule {
         [Parameter(ParameterSetName = 'ByConnectedSystemId')]
         [Parameter(ParameterSetName = 'ByConnectedSystemName')]
         [SupportsWildcards()]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ByConnectedSystemId')]
+        [Parameter(ParameterSetName = 'ByConnectedSystemName')]
+        [ValidateSet('Import', 'Export')]
+        [string[]]$Direction,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ByConnectedSystemId')]
+        [Parameter(ParameterSetName = 'ByConnectedSystemName')]
+        [ValidateSet('Projects', 'Provisions', 'FlowOnly')]
+        [string[]]$ActionType,
+
+        [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'ByConnectedSystemId')]
+        [Parameter(ParameterSetName = 'ByConnectedSystemName')]
+        [ValidateSet('Enabled', 'Disabled')]
+        [string[]]$Status
     )
 
     process {
@@ -101,28 +151,63 @@ function Get-JIMSyncRule {
             }
 
             default {
-                Write-Verbose "Getting all Synchronisation Rules"
-                $response = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/sync-rules"
+                # The facets are evaluated by the API, which narrows the list through the same
+                # SyncRuleFilter the portal uses, so both surfaces return the same rules for the
+                # same filters. -Name stays client-side because it supports PowerShell wildcards.
+                $baseQueryParams = @('pageSize=100')
 
-                # Handle paginated response - check if 'items' property exists (not if it's truthy)
-                $rules = if ($null -ne $response.items) { $response.items } else { $response }
-
-                # Filter by Connected System if specified
                 if ($PSBoundParameters.ContainsKey('ConnectedSystemId') -or $PSBoundParameters.ContainsKey('ConnectedSystemName')) {
                     Write-Verbose "Filtering by Connected System ID: $ConnectedSystemId"
-                    $rules = $rules | Where-Object { $_.connectedSystemId -eq $ConnectedSystemId }
+                    $baseQueryParams += "connectedSystemIds=$ConnectedSystemId"
                 }
 
-                # Filter by name if specified
-                if ($Name) {
-                    Write-Verbose "Filtering by name pattern: $Name"
-                    $rules = $rules | Where-Object { $_.name -like $Name }
+                foreach ($directionValue in $Direction) {
+                    $baseQueryParams += "directions=$directionValue"
                 }
 
-                # Output each rule individually for pipeline support
-                foreach ($rule in $rules) {
-                    $rule
+                foreach ($actionTypeValue in $ActionType) {
+                    $baseQueryParams += "actionTypes=$actionTypeValue"
                 }
+
+                foreach ($statusValue in $Status) {
+                    $baseQueryParams += "statuses=$statusValue"
+                }
+
+                Write-Verbose "Getting Synchronisation Rules"
+
+                # Page through the whole result set. Synchronisation Rules are configuration rather
+                # than object data, so the set is small, but stopping at the first page would
+                # silently truncate the list and make the filters look as though they had excluded
+                # rules they did not.
+                $currentPage = 1
+                $pagesFetched = 0
+                do {
+                    $queryString = (@("page=$currentPage") + $baseQueryParams) -join '&'
+                    $response = Invoke-JIMApi -Endpoint "/api/v1/synchronisation/sync-rules?$queryString"
+                    $pagesFetched++
+
+                    # Handle paginated response - check if 'items' property exists (not if it's truthy)
+                    $rules = if ($null -ne $response.items) { $response.items } else { $response }
+
+                    # Output each rule individually for pipeline support
+                    foreach ($rule in $rules) {
+                        if (-not $Name -or $rule.name -like $Name) {
+                            $rule
+                        }
+                    }
+
+                    $hasMore = $response.hasNextPage -eq $true
+
+                    if ($hasMore -and $pagesFetched -ge $script:JIMMaxAllPages) {
+                        Write-Warning "Get-JIMSyncRule stopped after $script:JIMMaxAllPages pages; more results remain (total pages: $($response.totalPages)). Narrow the query with -ConnectedSystemId, -Direction, -ActionType or -Status."
+                        break
+                    }
+
+                    if ($hasMore) {
+                        $currentPage++
+                        Write-Verbose "Fetching page $currentPage of $($response.totalPages)..."
+                    }
+                } while ($hasMore)
             }
         }
     }

--- a/src/JIM.PowerShell/Tests/SyncRules.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/SyncRules.Tests.ps1
@@ -54,6 +54,150 @@ Describe 'Get-JIMSyncRule' {
         It 'Should have ConnectedSystemName parameter' {
             $command.Parameters['ConnectedSystemName'] | Should -Not -BeNullOrEmpty
         }
+
+        It 'Should have a Direction parameter with ValidateSet' {
+            $param = $command.Parameters['Direction']
+            $param | Should -Not -BeNullOrEmpty
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet | Should -Not -BeNullOrEmpty
+            $validateSet.ValidValues | Should -Contain 'Import'
+            $validateSet.ValidValues | Should -Contain 'Export'
+        }
+
+        It 'Should have an ActionType parameter with ValidateSet' {
+            $param = $command.Parameters['ActionType']
+            $param | Should -Not -BeNullOrEmpty
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet | Should -Not -BeNullOrEmpty
+            $validateSet.ValidValues | Should -Contain 'Projects'
+            $validateSet.ValidValues | Should -Contain 'Provisions'
+            $validateSet.ValidValues | Should -Contain 'FlowOnly'
+        }
+
+        It 'Should have a Status parameter with ValidateSet' {
+            $param = $command.Parameters['Status']
+            $param | Should -Not -BeNullOrEmpty
+            $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet | Should -Not -BeNullOrEmpty
+            $validateSet.ValidValues | Should -Contain 'Enabled'
+            $validateSet.ValidValues | Should -Contain 'Disabled'
+        }
+
+        It 'Should accept multiple values for Direction, ActionType and Status' {
+            $command.Parameters['Direction'].ParameterType | Should -Be ([string[]])
+            $command.Parameters['ActionType'].ParameterType | Should -Be ([string[]])
+            $command.Parameters['Status'].ParameterType | Should -Be ([string[]])
+        }
+    }
+
+    Context 'Filter composition' {
+
+        It 'Sends no filter facets in the query string when none are specified' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                Get-JIMSyncRule | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -notmatch 'directions=' -and
+                    $Endpoint -notmatch 'actionTypes=' -and
+                    $Endpoint -notmatch 'statuses=' -and
+                    $Endpoint -notmatch 'connectedSystemIds=' -and
+                    $Endpoint -notmatch 'search='
+                }
+            }
+        }
+
+        It 'Sends the Direction facet as a repeated query parameter' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                Get-JIMSyncRule -Direction Import, Export | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'directions=Import' -and $Endpoint -match 'directions=Export'
+                }
+            }
+        }
+
+        It 'Sends the ActionType facet in the query string' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                Get-JIMSyncRule -ActionType Provisions | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'actionTypes=Provisions'
+                }
+            }
+        }
+
+        It 'Sends the Status facet in the query string' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                Get-JIMSyncRule -Status Disabled | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'statuses=Disabled'
+                }
+            }
+        }
+
+        It 'Sends the Connected System facet in the query string rather than filtering client-side' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                Get-JIMSyncRule -ConnectedSystemId 7 | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'connectedSystemIds=7'
+                }
+            }
+        }
+
+        It 'Combines facets with the name filter, which stays client-side for wildcard support' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                $rules = @(
+                    [PSCustomObject]@{ id = 1; name = 'HR Inbound'; connectedSystemId = 1 },
+                    [PSCustomObject]@{ id = 2; name = 'Payroll Inbound'; connectedSystemId = 1 }
+                )
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = $rules; hasNextPage = $false; totalPages = 1 } }
+
+                $result = @(Get-JIMSyncRule -Direction Import -Name 'HR*')
+
+                $result.Count | Should -Be 1
+                $result[0].name | Should -Be 'HR Inbound'
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'directions=Import'
+                }
+            }
+        }
+
+        It 'Pages through every result so a filtered list is never silently truncated' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi {
+                    if ($Endpoint -match 'page=1') {
+                        [PSCustomObject]@{ items = @([PSCustomObject]@{ id = 1; name = 'Rule 1' }); hasNextPage = $true; totalPages = 2 }
+                    }
+                    else {
+                        [PSCustomObject]@{ items = @([PSCustomObject]@{ id = 2; name = 'Rule 2' }); hasNextPage = $false; totalPages = 2 }
+                    }
+                }
+
+                $result = @(Get-JIMSyncRule)
+
+                $result.Count | Should -Be 2
+                Should -Invoke Invoke-JIMApi -Times 2 -Exactly
+            }
+        }
     }
 
     Context 'Requires Connection' {

--- a/src/JIM.PowerShell/Tests/SyncRules.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/SyncRules.Tests.ps1
@@ -200,6 +200,68 @@ Describe 'Get-JIMSyncRule' {
         }
     }
 
+    Context 'Pipeline binding' {
+
+        It 'Binds a piped Connected System (which exposes Id, not ConnectedSystemId), as documented' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                # As returned by Get-JIMConnectedSystem: a PSCustomObject exposing Id.
+                $connectedSystem = [PSCustomObject]@{ Id = 4; Name = 'HR System' }
+                $connectedSystem | Get-JIMSyncRule | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'connectedSystemIds=4'
+                }
+            }
+        }
+
+        It 'Prefers an explicit ConnectedSystemId over the piped object' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                $connectedSystem = [PSCustomObject]@{ Id = 4; Name = 'HR System' }
+                $connectedSystem | Get-JIMSyncRule -ConnectedSystemId 9 | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'connectedSystemIds=9'
+                }
+            }
+        }
+
+        It 'Still binds an object exposing ConnectedSystemId by property name' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                $syncRule = [PSCustomObject]@{ Id = 1; ConnectedSystemId = 6 }
+                $syncRule | Get-JIMSyncRule | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'connectedSystemIds=6'
+                }
+            }
+        }
+
+        It 'Applies the facet filters to a piped Connected System' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                Mock Invoke-JIMApi { [PSCustomObject]@{ items = @(); hasNextPage = $false; totalPages = 1 } }
+
+                $connectedSystem = [PSCustomObject]@{ Id = 4; Name = 'HR System' }
+                $connectedSystem | Get-JIMSyncRule -Direction Export -Status Enabled | Out-Null
+
+                Should -Invoke Invoke-JIMApi -Times 1 -Exactly -ParameterFilter {
+                    $Endpoint -match 'connectedSystemIds=4' -and
+                    $Endpoint -match 'directions=Export' -and
+                    $Endpoint -match 'statuses=Enabled'
+                }
+            }
+        }
+    }
+
     Context 'Requires Connection' {
 
         BeforeEach {

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -1654,18 +1654,29 @@ public class SynchronisationController(
     /// <summary>
     /// List Synchronisation Rules
     /// </summary>
+    /// <remarks>
+    /// Narrow the list with the <c>connectedSystemIds</c>, <c>directions</c>, <c>actionTypes</c> and
+    /// <c>statuses</c> facets, each of which is repeatable. Facets combine with AND, values within a
+    /// facet combine with OR, and <c>search</c> narrows whatever the facets left.
+    /// </remarks>
     /// <param name="pagination">Pagination parameters (page, pageSize, sortBy, sortDirection, filter).</param>
+    /// <param name="filter">Connected System, Direction, Action type, Status and free-text filters.</param>
     /// <returns>A paginated list of Synchronisation Rule headers.</returns>
     [HttpGet("sync-rules", Name = "GetSyncRules")]
     [ProducesResponseType(typeof(PaginatedResponse<SyncRuleHeader>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetSyncRulesAsync([FromQuery] PaginationRequest pagination)
+    public async Task<IActionResult> GetSyncRulesAsync([FromQuery] PaginationRequest pagination, [FromQuery] SyncRuleFilterRequest filter)
     {
         _logger.LogTrace("Requested Synchronisation Rules (Page: {Page}, PageSize: {PageSize})", pagination.Page, pagination.PageSize);
-        var rules = await _application.ConnectedSystems.GetSyncRulesAsync();
-        var headers = rules.Select(SyncRuleHeader.FromEntity).AsQueryable();
 
-        var result = headers
+        // Header tier: a list endpoint has no use for each rule's Attribute Flows, Object Matching
+        // Rules and schema graph, and the Synchronisation Rule set is small enough to filter in
+        // memory through the shared SyncRuleFilter every JIM surface uses.
+        var headers = await _application.ConnectedSystems.GetSyncRuleHeadersAsync();
+        var syncRuleFilter = filter.ToFilter();
+        var filtered = (syncRuleFilter.IsEmpty ? headers : headers.Where(syncRuleFilter.Matches)).AsQueryable();
+
+        var result = filtered
             .ApplySortAndFilter(pagination)
             .ToPaginatedResponse(pagination);
 

--- a/src/JIM.Web/Models/Api/SyncRuleFilterRequest.cs
+++ b/src/JIM.Web/Models/Api/SyncRuleFilterRequest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Logic;
+using JIM.Models.Logic.DTOs;
+
+namespace JIM.Web.Models.Api;
+
+/// <summary>
+/// Query-string filters for the Synchronisation Rules list endpoint.
+/// <para>
+/// Each facet is repeatable (for example <c>?directions=Import&amp;directions=Export</c>). Facets
+/// combine with AND, values within a facet combine with OR, and an omitted facet matches
+/// everything. <see cref="Search"/> narrows whatever the facets left.
+/// </para>
+/// </summary>
+public class SyncRuleFilterRequest
+{
+    /// <summary>
+    /// Return only Synchronisation Rules belonging to these Connected Systems.
+    /// </summary>
+    public List<int>? ConnectedSystemIds { get; set; }
+
+    /// <summary>
+    /// Return only Synchronisation Rules flowing in these directions (<c>Import</c> for inbound,
+    /// <c>Export</c> for outbound).
+    /// </summary>
+    public List<SyncRuleDirection>? Directions { get; set; }
+
+    /// <summary>
+    /// Return only Synchronisation Rules performing these actions (<c>Projects</c>,
+    /// <c>Provisions</c>, or <c>FlowOnly</c> for rules that create no objects).
+    /// </summary>
+    public List<SyncRuleActionType>? ActionTypes { get; set; }
+
+    /// <summary>
+    /// Return only Synchronisation Rules in these states (<c>Enabled</c> or <c>Disabled</c>).
+    /// </summary>
+    public List<SyncRuleStatus>? Statuses { get; set; }
+
+    /// <summary>
+    /// Free-text term matched case-insensitively against the Synchronisation Rule name.
+    /// </summary>
+    public string? Search { get; set; }
+
+    /// <summary>
+    /// Converts the request into the shared filter that every JIM surface evaluates rules against.
+    /// </summary>
+    public SyncRuleFilter ToFilter()
+    {
+        return new SyncRuleFilter
+        {
+            ConnectedSystemIds = ConnectedSystemIds,
+            Directions = Directions,
+            ActionTypes = ActionTypes,
+            Statuses = Statuses,
+            Search = Search
+        };
+    }
+}

--- a/src/JIM.Web/Pages/Admin/SyncRuleList.razor
+++ b/src/JIM.Web/Pages/Admin/SyncRuleList.razor
@@ -20,10 +20,60 @@
 {
     <MudAlert Class="mt-5" Severity="Severity.Warning" Variant="Variant.Outlined">Please create a <MudLink Href="/admin/connected-systems/">Connected
         System</MudLink> first.</MudAlert>
-    }
+}
+
+@* ─── Filters ─── *@
+@if (_syncRuleHeaders is { Count: > 0 })
+{
+    <MudStack Row="true" Spacing="3" Class="mt-4 flex-wrap" AlignItems="AlignItems.End">
+        <MudItem Class="flex-grow-1">
+            <MudSelect T="int" Label="Connected System" Variant="Variant.Outlined"
+                       Dense="true" Clearable="true" MultiSelection="true"
+                       SelectedValues="SelectedConnectedSystemIds"
+                       SelectedValuesChanged="OnConnectedSystemFilterChanged"
+                       MultiSelectionTextFunc="@(new Func<IReadOnlyList<string>, string>(GetConnectedSystemFilterText))">
+                @foreach (var connectedSystemId in _connectedSystemFilterOptionIds)
+                {
+                    <MudSelectItem T="int" Value="@connectedSystemId">@_connectedSystemNames[connectedSystemId]</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem Class="flex-grow-1">
+            <MudSelect T="SyncRuleDirection" Label="Direction" Variant="Variant.Outlined"
+                       Dense="true" Clearable="true" MultiSelection="true"
+                       SelectedValues="SelectedDirections"
+                       SelectedValuesChanged="OnDirectionFilterChanged"
+                       MultiSelectionTextFunc="@(new Func<IReadOnlyList<string>, string>(GetDirectionFilterText))">
+                <MudSelectItem T="SyncRuleDirection" Value="SyncRuleDirection.Import">Inbound</MudSelectItem>
+                <MudSelectItem T="SyncRuleDirection" Value="SyncRuleDirection.Export">Outbound</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+        <MudItem Class="flex-grow-1">
+            <MudSelect T="SyncRuleActionType" Label="Action" Variant="Variant.Outlined"
+                       Dense="true" Clearable="true" MultiSelection="true"
+                       SelectedValues="SelectedActionTypes"
+                       SelectedValuesChanged="OnActionTypeFilterChanged"
+                       MultiSelectionTextFunc="@(new Func<IReadOnlyList<string>, string>(GetActionTypeFilterText))">
+                <MudSelectItem T="SyncRuleActionType" Value="SyncRuleActionType.Projects">Projects</MudSelectItem>
+                <MudSelectItem T="SyncRuleActionType" Value="SyncRuleActionType.Provisions">Provisions</MudSelectItem>
+                <MudSelectItem T="SyncRuleActionType" Value="SyncRuleActionType.FlowOnly">Flow Only</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+        <MudItem Class="flex-grow-1">
+            <MudSelect T="SyncRuleStatus" Label="Status" Variant="Variant.Outlined"
+                       Dense="true" Clearable="true" MultiSelection="true"
+                       SelectedValues="SelectedStatuses"
+                       SelectedValuesChanged="OnStatusFilterChanged"
+                       MultiSelectionTextFunc="@(new Func<IReadOnlyList<string>, string>(GetStatusFilterText))">
+                <MudSelectItem T="SyncRuleStatus" Value="SyncRuleStatus.Enabled">Enabled</MudSelectItem>
+                <MudSelectItem T="SyncRuleStatus" Value="SyncRuleStatus.Disabled">Disabled</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+    </MudStack>
+}
 
     <MudTable Items="@_syncRuleHeaders" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By"
-              Filter="new Func<SyncRuleHeader, bool>(FilterFunc1)" Outlined="true" Elevation="0">
+              Filter="new Func<SyncRuleHeader, bool>(_filter.Matches)" Outlined="true" Elevation="0">
         <ToolBarContent>
             <TableDensityToggle @bind-Dense="_dense" />
             <MudText Class="mx-2 mud-text-disabled">|</MudText>
@@ -31,9 +81,9 @@
                        Color="Color.Primary" Disabled="@(!_canCreateSyncRules)" DropShadow="false">Create Synchronisation Rule
             </MudButton>
             <MudSpacer />
-            <MudTextField @bind-Value="_searchString" Variant="Variant.Outlined" Placeholder="Search" Margin="Margin.Dense"
+            <MudTextField @bind-Value="SearchString" Variant="Variant.Outlined" Placeholder="Search" Margin="Margin.Dense"
                           Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium"
-                          Class="mt-0"></MudTextField>
+                          Immediate="true" DebounceInterval="300" Class="mt-0"></MudTextField>
         </ToolBarContent>
         <HeaderContent>
             <MudTh>
@@ -57,7 +107,7 @@
                 </MudTableSortLabel>
             </MudTh>
             <MudTh>
-                <MudTableSortLabel SortBy="new Func<SyncRuleHeader, object>(x => GetCapabilityText(x))">
+                <MudTableSortLabel SortBy="new Func<SyncRuleHeader, object>(x => SyncRuleFilter.GetActionType(x))">
                     <MudText Typo="Typo.button">Actions</MudText>
                 </MudTableSortLabel>
             </MudTh>
@@ -135,23 +185,22 @@
             </MudTd>
             <MudTd DataLabel="Actions">
                 <div class="d-flex align-center gap-1 flex-wrap">
-                    @if (context.Direction == SyncRuleDirection.Import && context.ProjectToMetaverse == true)
+                    @switch (SyncRuleFilter.GetActionType(context))
                     {
-                        <MudTooltip Text="Projects new objects to the Metaverse" Arrow="true" Placement="Placement.Top">
-                            <MudChip T="string" Variant="Variant.Text" Color="Color.Info">Projects</MudChip>
-                        </MudTooltip>
-                    }
-                    @if (context.Direction == SyncRuleDirection.Export && context.ProvisionToConnectedSystem == true)
-                    {
-                        <MudTooltip Text="Provisions new objects to the Connected System" Arrow="true"
-                                    Placement="Placement.Top">
-                            <MudChip T="string" Variant="Variant.Text" Color="Color.Warning">Provisions</MudChip>
-                        </MudTooltip>
-                    }
-                    @if (!((context.Direction == SyncRuleDirection.Import && context.ProjectToMetaverse == true) ||
-                                                                                                                           (context.Direction == SyncRuleDirection.Export && context.ProvisionToConnectedSystem == true)))
-                    {
-                        <MudText Typo="Typo.body2" Class="mud-text-secondary">-</MudText>
+                        case SyncRuleActionType.Projects:
+                            <MudTooltip Text="Projects new objects to the Metaverse" Arrow="true" Placement="Placement.Top">
+                                <MudChip T="string" Variant="Variant.Text" Color="Color.Info">Projects</MudChip>
+                            </MudTooltip>
+                            break;
+                        case SyncRuleActionType.Provisions:
+                            <MudTooltip Text="Provisions new objects to the Connected System" Arrow="true"
+                                        Placement="Placement.Top">
+                                <MudChip T="string" Variant="Variant.Text" Color="Color.Warning">Provisions</MudChip>
+                            </MudTooltip>
+                            break;
+                        default:
+                            <EmptyValue />
+                            break;
                     }
                 </div>
             </MudTd>
@@ -172,15 +221,28 @@
             </MudTd>
         </RowTemplate>
         <NoRecordsContent>
-            There are no Synchronisation Rules
+            @if (_filter.IsEmpty)
+            {
+                <MudText>There are no Synchronisation Rules</MudText>
+            }
+            else
+            {
+                <MudText>No Synchronisation Rules match the current filters</MudText>
+            }
         </NoRecordsContent>
     </MudTable>
 
 @code {
     private IList<SyncRuleHeader>? _syncRuleHeaders;
-    private string _searchString = "";
     private bool _canCreateSyncRules;
     private bool _dense;
+
+    // The single holder of filter state. SyncRuleFilter.Matches is the same predicate the REST API
+    // filters through, so every surface narrows a Synchronisation Rule list identically.
+    private readonly SyncRuleFilter _filter = new();
+
+    private Dictionary<int, string> _connectedSystemNames = new();
+    private List<int> _connectedSystemFilterOptionIds = [];
 
     private readonly List<BreadcrumbItem> _breadcrumbs = new List<BreadcrumbItem>
     {
@@ -203,27 +265,69 @@
         using var jim = JimFactory.Create();
         _canCreateSyncRules = jim.ConnectedSystems.GetConnectedSystemCount() > 0;
         _syncRuleHeaders = await jim.ConnectedSystems.GetSyncRuleHeadersAsync();
+
+        // Offer only the Connected Systems that actually have Synchronisation Rules; filtering by a
+        // system with none would just empty the table.
+        _connectedSystemNames = _syncRuleHeaders
+            .GroupBy(h => h.ConnectedSystemId)
+            .ToDictionary(g => g.Key, g => g.First().ConnectedSystemName);
+        _connectedSystemFilterOptionIds = _connectedSystemNames.OrderBy(n => n.Value).Select(n => n.Key).ToList();
     }
 
-    private bool FilterFunc1(SyncRuleHeader element) => FilterFunc(element, _searchString);
-
-    private static string GetCapabilityText(SyncRuleHeader element)
+    private string SearchString
     {
-        if (element.Direction == SyncRuleDirection.Import && element.ProjectToMetaverse == true)
-            return "Projects";
-        if (element.Direction == SyncRuleDirection.Export && element.ProvisionToConnectedSystem == true)
-            return "Provisions";
-        return "";
+        get => _filter.Search ?? string.Empty;
+        set => _filter.Search = value;
     }
 
-    private static bool FilterFunc(SyncRuleHeader element, string searchString)
+    private IReadOnlyCollection<int> SelectedConnectedSystemIds => _filter.ConnectedSystemIds ?? [];
+
+    private IReadOnlyCollection<SyncRuleDirection> SelectedDirections => _filter.Directions ?? [];
+
+    private IReadOnlyCollection<SyncRuleActionType> SelectedActionTypes => _filter.ActionTypes ?? [];
+
+    private IReadOnlyCollection<SyncRuleStatus> SelectedStatuses => _filter.Statuses ?? [];
+
+    private void OnConnectedSystemFilterChanged(IReadOnlyCollection<int> selected) => _filter.ConnectedSystemIds = selected;
+
+    private void OnDirectionFilterChanged(IReadOnlyCollection<SyncRuleDirection> selected) => _filter.Directions = selected;
+
+    private void OnActionTypeFilterChanged(IReadOnlyCollection<SyncRuleActionType> selected) => _filter.ActionTypes = selected;
+
+    private void OnStatusFilterChanged(IReadOnlyCollection<SyncRuleStatus> selected) => _filter.Statuses = selected;
+
+    private string GetConnectedSystemFilterText(IReadOnlyList<string> selectedValues)
     {
-        if (string.IsNullOrWhiteSpace(searchString))
-            return true;
+        if (selectedValues.Count == 1 &&
+            int.TryParse(selectedValues[0], out var connectedSystemId) &&
+            _connectedSystemNames.TryGetValue(connectedSystemId, out var connectedSystemName))
+        {
+            return connectedSystemName;
+        }
 
-        if (element.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase))
-            return true;
+        return GetMultiSelectText(selectedValues);
+    }
 
-        return false;
+    private static string GetDirectionFilterText(IReadOnlyList<string> selectedValues) =>
+        GetMultiSelectText(selectedValues, value => value == nameof(SyncRuleDirection.Import) ? "Inbound" : "Outbound");
+
+    private static string GetActionTypeFilterText(IReadOnlyList<string> selectedValues) =>
+        GetMultiSelectText(selectedValues, value => value == nameof(SyncRuleActionType.FlowOnly) ? "Flow Only" : value);
+
+    private static string GetStatusFilterText(IReadOnlyList<string> selectedValues) => GetMultiSelectText(selectedValues);
+
+    /// <summary>
+    /// Renders a multi-select's summary text: blank when nothing is selected (so the label's
+    /// placeholder shows through), the single selection's display label when one is selected, and a
+    /// count otherwise. Matches the convention used by the Activities and Operations filter bars.
+    /// </summary>
+    private static string GetMultiSelectText(IReadOnlyList<string> selectedValues, Func<string, string>? displayLabel = null)
+    {
+        return selectedValues.Count switch
+        {
+            0 => string.Empty,
+            1 => displayLabel == null ? selectedValues[0] : displayLabel(selectedValues[0]),
+            _ => $"{selectedValues.Count} selected"
+        };
     }
 }

--- a/test/JIM.Models.Tests/Logic/SyncRuleFilterTests.cs
+++ b/test/JIM.Models.Tests/Logic/SyncRuleFilterTests.cs
@@ -1,0 +1,284 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Logic;
+using JIM.Models.Logic.DTOs;
+using NUnit.Framework;
+
+namespace JIM.Models.Tests.Logic;
+
+[TestFixture]
+public class SyncRuleFilterTests
+{
+    private static SyncRuleHeader ImportRule(
+        int id = 1,
+        string name = "HR Inbound",
+        int connectedSystemId = 1,
+        bool projectToMetaverse = true,
+        bool enabled = true,
+        string? description = null)
+    {
+        return new SyncRuleHeader
+        {
+            Id = id,
+            Name = name,
+            Description = description,
+            ConnectedSystemId = connectedSystemId,
+            ConnectedSystemName = "HR System",
+            ConnectedSystemObjectTypeName = "Employee",
+            MetaverseObjectTypeName = "Person",
+            Direction = SyncRuleDirection.Import,
+            ProjectToMetaverse = projectToMetaverse,
+            ProvisionToConnectedSystem = null,
+            Enabled = enabled
+        };
+    }
+
+    private static SyncRuleHeader ExportRule(
+        int id = 2,
+        string name = "AD Outbound",
+        int connectedSystemId = 2,
+        bool provisionToConnectedSystem = true,
+        bool enabled = true,
+        string? description = null)
+    {
+        return new SyncRuleHeader
+        {
+            Id = id,
+            Name = name,
+            Description = description,
+            ConnectedSystemId = connectedSystemId,
+            ConnectedSystemName = "Contoso AD",
+            ConnectedSystemObjectTypeName = "user",
+            MetaverseObjectTypeName = "Person",
+            Direction = SyncRuleDirection.Export,
+            ProjectToMetaverse = null,
+            ProvisionToConnectedSystem = provisionToConnectedSystem,
+            Enabled = enabled
+        };
+    }
+
+    #region Action type derivation
+
+    [Test]
+    public void GetActionType_ImportRuleThatProjects_ReturnsProjects()
+    {
+        Assert.That(SyncRuleFilter.GetActionType(ImportRule(projectToMetaverse: true)), Is.EqualTo(SyncRuleActionType.Projects));
+    }
+
+    [Test]
+    public void GetActionType_ExportRuleThatProvisions_ReturnsProvisions()
+    {
+        Assert.That(SyncRuleFilter.GetActionType(ExportRule(provisionToConnectedSystem: true)), Is.EqualTo(SyncRuleActionType.Provisions));
+    }
+
+    [Test]
+    public void GetActionType_ImportRuleThatDoesNotProject_ReturnsFlowOnly()
+    {
+        Assert.That(SyncRuleFilter.GetActionType(ImportRule(projectToMetaverse: false)), Is.EqualTo(SyncRuleActionType.FlowOnly));
+    }
+
+    [Test]
+    public void GetActionType_ExportRuleThatDoesNotProvision_ReturnsFlowOnly()
+    {
+        Assert.That(SyncRuleFilter.GetActionType(ExportRule(provisionToConnectedSystem: false)), Is.EqualTo(SyncRuleActionType.FlowOnly));
+    }
+
+    [Test]
+    public void GetActionType_ImportRuleWithNullProjectToMetaverse_ReturnsFlowOnly()
+    {
+        var header = ImportRule();
+        header.ProjectToMetaverse = null;
+
+        Assert.That(SyncRuleFilter.GetActionType(header), Is.EqualTo(SyncRuleActionType.FlowOnly));
+    }
+
+    [Test]
+    public void GetActionType_ExportRuleWithProjectToMetaverseSet_ReturnsFlowOnly()
+    {
+        // ProjectToMetaverse is only meaningful for Import rules; an Export rule carrying a stale
+        // value must not be reported as projecting.
+        var header = ExportRule(provisionToConnectedSystem: false);
+        header.ProjectToMetaverse = true;
+
+        Assert.That(SyncRuleFilter.GetActionType(header), Is.EqualTo(SyncRuleActionType.FlowOnly));
+    }
+
+    #endregion
+
+    #region Empty filter
+
+    [Test]
+    public void Matches_EmptyFilter_MatchesEverything()
+    {
+        var filter = new SyncRuleFilter();
+
+        Assert.That(filter.Matches(ImportRule()), Is.True);
+        Assert.That(filter.Matches(ExportRule(enabled: false)), Is.True);
+    }
+
+    [Test]
+    public void IsEmpty_NoFacetsOrSearch_ReturnsTrue()
+    {
+        Assert.That(new SyncRuleFilter().IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void IsEmpty_WithEmptyCollections_ReturnsTrue()
+    {
+        var filter = new SyncRuleFilter
+        {
+            ConnectedSystemIds = [],
+            Directions = [],
+            ActionTypes = [],
+            Statuses = [],
+            Search = "   "
+        };
+
+        Assert.That(filter.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void IsEmpty_WithASingleFacetValue_ReturnsFalse()
+    {
+        var filter = new SyncRuleFilter { Directions = [SyncRuleDirection.Import] };
+
+        Assert.That(filter.IsEmpty, Is.False);
+    }
+
+    #endregion
+
+    #region Individual facets
+
+    [Test]
+    public void Matches_ConnectedSystemFilter_OnlyMatchesRulesForThoseSystems()
+    {
+        var filter = new SyncRuleFilter { ConnectedSystemIds = [1] };
+
+        Assert.That(filter.Matches(ImportRule(connectedSystemId: 1)), Is.True);
+        Assert.That(filter.Matches(ExportRule(connectedSystemId: 2)), Is.False);
+    }
+
+    [Test]
+    public void Matches_MultipleConnectedSystems_MatchesAnyOfThem()
+    {
+        var filter = new SyncRuleFilter { ConnectedSystemIds = [1, 2] };
+
+        Assert.That(filter.Matches(ImportRule(connectedSystemId: 1)), Is.True);
+        Assert.That(filter.Matches(ExportRule(connectedSystemId: 2)), Is.True);
+        Assert.That(filter.Matches(ImportRule(connectedSystemId: 3)), Is.False);
+    }
+
+    [Test]
+    public void Matches_DirectionFilter_OnlyMatchesThatDirection()
+    {
+        var filter = new SyncRuleFilter { Directions = [SyncRuleDirection.Export] };
+
+        Assert.That(filter.Matches(ExportRule()), Is.True);
+        Assert.That(filter.Matches(ImportRule()), Is.False);
+    }
+
+    [Test]
+    public void Matches_ActionTypeFilter_OnlyMatchesThatActionType()
+    {
+        var filter = new SyncRuleFilter { ActionTypes = [SyncRuleActionType.Provisions] };
+
+        Assert.That(filter.Matches(ExportRule(provisionToConnectedSystem: true)), Is.True);
+        Assert.That(filter.Matches(ImportRule(projectToMetaverse: true)), Is.False);
+        Assert.That(filter.Matches(ExportRule(provisionToConnectedSystem: false)), Is.False);
+    }
+
+    [Test]
+    public void Matches_FlowOnlyActionTypeFilter_MatchesRulesThatNeitherProjectNorProvision()
+    {
+        var filter = new SyncRuleFilter { ActionTypes = [SyncRuleActionType.FlowOnly] };
+
+        Assert.That(filter.Matches(ImportRule(projectToMetaverse: false)), Is.True);
+        Assert.That(filter.Matches(ExportRule(provisionToConnectedSystem: false)), Is.True);
+        Assert.That(filter.Matches(ImportRule(projectToMetaverse: true)), Is.False);
+    }
+
+    [Test]
+    public void Matches_StatusFilter_OnlyMatchesThatStatus()
+    {
+        var filter = new SyncRuleFilter { Statuses = [SyncRuleStatus.Disabled] };
+
+        Assert.That(filter.Matches(ImportRule(enabled: false)), Is.True);
+        Assert.That(filter.Matches(ImportRule(enabled: true)), Is.False);
+    }
+
+    [Test]
+    public void Matches_BothStatuses_MatchesEnabledAndDisabled()
+    {
+        var filter = new SyncRuleFilter { Statuses = [SyncRuleStatus.Enabled, SyncRuleStatus.Disabled] };
+
+        Assert.That(filter.Matches(ImportRule(enabled: true)), Is.True);
+        Assert.That(filter.Matches(ImportRule(enabled: false)), Is.True);
+    }
+
+    #endregion
+
+    #region Free-text search
+
+    [Test]
+    public void Matches_Search_MatchesOnNameCaseInsensitively()
+    {
+        var filter = new SyncRuleFilter { Search = "inbound" };
+
+        Assert.That(filter.Matches(ImportRule(name: "HR Inbound")), Is.True);
+        Assert.That(filter.Matches(ExportRule(name: "AD Outbound")), Is.False);
+    }
+
+    [Test]
+    public void Matches_WhitespaceOnlySearch_MatchesEverything()
+    {
+        var filter = new SyncRuleFilter { Search = "   " };
+
+        Assert.That(filter.Matches(ImportRule(name: "HR Inbound")), Is.True);
+    }
+
+    #endregion
+
+    #region Composition
+
+    [Test]
+    public void Matches_FacetsCombineWithAnd()
+    {
+        var filter = new SyncRuleFilter
+        {
+            Directions = [SyncRuleDirection.Import],
+            Statuses = [SyncRuleStatus.Enabled]
+        };
+
+        Assert.That(filter.Matches(ImportRule(enabled: true)), Is.True);
+        Assert.That(filter.Matches(ImportRule(enabled: false)), Is.False);
+        Assert.That(filter.Matches(ExportRule(enabled: true)), Is.False);
+    }
+
+    [Test]
+    public void Matches_SearchNarrowsWithinTheFacetResults()
+    {
+        var filter = new SyncRuleFilter
+        {
+            Directions = [SyncRuleDirection.Import],
+            Search = "HR"
+        };
+
+        Assert.That(filter.Matches(ImportRule(name: "HR Inbound")), Is.True);
+        Assert.That(filter.Matches(ImportRule(name: "Payroll Inbound")), Is.False);
+        // The search term alone must not pull in a rule the facets exclude.
+        Assert.That(filter.Matches(ExportRule(name: "HR Outbound")), Is.False);
+    }
+
+    [Test]
+    public void Matches_RemovingTheSearchLeavesTheFacetResults()
+    {
+        var facetsOnly = new SyncRuleFilter { Directions = [SyncRuleDirection.Import] };
+
+        Assert.That(facetsOnly.Matches(ImportRule(name: "HR Inbound")), Is.True);
+        Assert.That(facetsOnly.Matches(ImportRule(name: "Payroll Inbound")), Is.True);
+        Assert.That(facetsOnly.Matches(ExportRule(name: "HR Outbound")), Is.False);
+    }
+
+    #endregion
+}

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerGetSyncRulesTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerGetSyncRulesTests.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using JIM.Application;
+using JIM.Application.Expressions;
+using JIM.Application.Interfaces;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Interfaces;
+using JIM.Models.Logic;
+using JIM.Models.Logic.DTOs;
+using JIM.Web.Controllers.Api;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for SynchronisationController.GetSyncRulesAsync. Verifies the list endpoint reads the
+/// lightweight Header tier and honours the Connected System, Direction, Action type, Status and
+/// search filters, so the REST surface narrows a Synchronisation Rule list exactly as the portal does.
+/// </summary>
+[TestFixture]
+public class SynchronisationControllerGetSyncRulesTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IConnectedSystemRepository> _mockConnectedSystemRepo = null!;
+    private Mock<IApiKeyRepository> _mockApiKeyRepo = null!;
+    private Mock<ILogger<SynchronisationController>> _mockLogger = null!;
+    private Mock<ICredentialProtectionService> _mockCredentialProtection = null!;
+    private IExpressionEvaluator _expressionEvaluator = null!;
+    private JimApplication _application = null!;
+    private SynchronisationController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockRepository = new Mock<IRepository>();
+        _mockConnectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _mockApiKeyRepo = new Mock<IApiKeyRepository>();
+        _mockRepository.Setup(r => r.ConnectedSystems).Returns(_mockConnectedSystemRepo.Object);
+        _mockRepository.Setup(r => r.ApiKeys).Returns(_mockApiKeyRepo.Object);
+        _mockLogger = new Mock<ILogger<SynchronisationController>>();
+        _mockCredentialProtection = new Mock<ICredentialProtectionService>();
+        _expressionEvaluator = new DynamicExpressoEvaluator();
+        _application = new JimApplication(_mockRepository.Object);
+        _controller = new SynchronisationController(_mockLogger.Object, _application, _expressionEvaluator, _mockCredentialProtection.Object);
+
+        var claims = new List<Claim>
+        {
+            new("sub", Guid.NewGuid().ToString()),
+            new(ClaimTypes.Role, "Administrator")
+        };
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+            }
+        };
+
+        _mockConnectedSystemRepo
+            .Setup(r => r.GetSyncRuleHeadersAsync(null, null))
+            .ReturnsAsync(BuildHeaders());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application.Dispose();
+    }
+
+    /// <summary>
+    /// Four rules spanning both directions, two Connected Systems, all three action types and both
+    /// statuses, so every facet has something to include and something to exclude.
+    /// </summary>
+    private static IList<SyncRuleHeader> BuildHeaders()
+    {
+        return
+        [
+            new SyncRuleHeader
+            {
+                Id = 1, Name = "HR Inbound", ConnectedSystemId = 1, ConnectedSystemName = "HR System",
+                ConnectedSystemObjectTypeName = "Employee", MetaverseObjectTypeName = "Person",
+                Direction = SyncRuleDirection.Import, ProjectToMetaverse = true, Enabled = true
+            },
+            new SyncRuleHeader
+            {
+                Id = 2, Name = "HR Inbound Contractors", ConnectedSystemId = 1, ConnectedSystemName = "HR System",
+                ConnectedSystemObjectTypeName = "Contractor", MetaverseObjectTypeName = "Person",
+                Direction = SyncRuleDirection.Import, ProjectToMetaverse = false, Enabled = false
+            },
+            new SyncRuleHeader
+            {
+                Id = 3, Name = "AD Outbound", ConnectedSystemId = 2, ConnectedSystemName = "Contoso AD",
+                ConnectedSystemObjectTypeName = "user", MetaverseObjectTypeName = "Person",
+                Direction = SyncRuleDirection.Export, ProvisionToConnectedSystem = true, Enabled = true
+            },
+            new SyncRuleHeader
+            {
+                Id = 4, Name = "AD Outbound Groups", ConnectedSystemId = 2, ConnectedSystemName = "Contoso AD",
+                ConnectedSystemObjectTypeName = "group", MetaverseObjectTypeName = "Group",
+                Direction = SyncRuleDirection.Export, ProvisionToConnectedSystem = false, Enabled = true
+            }
+        ];
+    }
+
+    private static List<int> IdsFrom(IActionResult result)
+    {
+        var ok = result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null, "Expected a 200 OK result.");
+        var response = ok!.Value as PaginatedResponse<SyncRuleHeader>;
+        Assert.That(response, Is.Not.Null, "Expected a paginated Synchronisation Rule header response.");
+        return response!.Items.Select(i => i.Id).ToList();
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_NoFilters_ReturnsEveryRuleAsync()
+    {
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), new SyncRuleFilterRequest());
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    /// <summary>
+    /// The list endpoint must read the Header tier rather than materialising every rule's full
+    /// object graph; loading Attribute Flows and Object Matching Rules to render a list is wasted work.
+    /// </summary>
+    [Test]
+    public async Task GetSyncRulesAsync_ReadsHeaderTierNotFullEntityGraphAsync()
+    {
+        await _controller.GetSyncRulesAsync(new PaginationRequest(), new SyncRuleFilterRequest());
+
+        _mockConnectedSystemRepo.Verify(r => r.GetSyncRuleHeadersAsync(null, null), Times.Once);
+        _mockConnectedSystemRepo.Verify(r => r.GetSyncRulesAsync(It.IsAny<bool>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_ConnectedSystemIdsFilter_ReturnsOnlyThoseSystemsRulesAsync()
+    {
+        var filter = new SyncRuleFilterRequest { ConnectedSystemIds = [2] };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 3, 4 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_DirectionsFilter_ReturnsOnlyThatDirectionAsync()
+    {
+        var filter = new SyncRuleFilterRequest { Directions = [SyncRuleDirection.Import] };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 1, 2 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_ActionTypesFilter_ReturnsOnlyThatActionAsync()
+    {
+        var filter = new SyncRuleFilterRequest { ActionTypes = [SyncRuleActionType.Provisions] };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 3 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_FlowOnlyActionTypeFilter_ReturnsRulesThatNeitherProjectNorProvisionAsync()
+    {
+        var filter = new SyncRuleFilterRequest { ActionTypes = [SyncRuleActionType.FlowOnly] };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 2, 4 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_StatusesFilter_ReturnsOnlyThatStatusAsync()
+    {
+        var filter = new SyncRuleFilterRequest { Statuses = [SyncRuleStatus.Disabled] };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 2 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_SearchNarrowsWithinTheFacetResultsAsync()
+    {
+        var filter = new SyncRuleFilterRequest
+        {
+            Directions = [SyncRuleDirection.Export],
+            Search = "groups"
+        };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 4 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_FacetsCombineWithAndAsync()
+    {
+        var filter = new SyncRuleFilterRequest
+        {
+            ConnectedSystemIds = [1],
+            Statuses = [SyncRuleStatus.Enabled]
+        };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        Assert.That(IdsFrom(result), Is.EquivalentTo(new[] { 1 }));
+    }
+
+    [Test]
+    public async Task GetSyncRulesAsync_FilterExcludingEverything_ReturnsAnEmptyPageAsync()
+    {
+        var filter = new SyncRuleFilterRequest { ConnectedSystemIds = [99] };
+
+        var result = await _controller.GetSyncRulesAsync(new PaginationRequest(), filter);
+
+        var ok = result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        var response = ok!.Value as PaginatedResponse<SyncRuleHeader>;
+        Assert.That(response, Is.Not.Null);
+        Assert.That(response!.Items, Is.Empty);
+        Assert.That(response.TotalCount, Is.Zero);
+    }
+}

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerGetSyncRulesTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerGetSyncRulesTests.cs
@@ -234,6 +234,6 @@ public class SynchronisationControllerGetSyncRulesTests
         var response = ok!.Value as PaginatedResponse<SyncRuleHeader>;
         Assert.That(response, Is.Not.Null);
         Assert.That(response!.Items, Is.Empty);
-        Assert.That(response.TotalCount, Is.Zero);
+        Assert.That(response!.TotalCount, Is.Zero);
     }
 }


### PR DESCRIPTION
## Description

Adds comprehensive filtering to the Synchronisation Rules list, allowing administrators to narrow results by Connected System, Direction (Import/Export), Action type (Projects/Provisions/Flow Only), and Status (Enabled/Disabled). The filters are implemented consistently across three surfaces: the Blazor portal, the REST API, and PowerShell.

Introduces `SyncRuleFilter` as a single source of truth for filtering logic, ensuring the portal, API, and PowerShell cmdlets all evaluate rules identically. Filters combine with AND; values within a facet combine with OR; search narrows whatever the facets left.

Closes #

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
  - Added `SyncRuleFilterTests` (284 lines) covering action type derivation, empty filter, individual facets, free-text search, and filter composition
  - Added `SynchronisationControllerGetSyncRulesTests` (239 lines) verifying the REST endpoint honours all filters and reads the Header tier (not full entity graph)
  - Added PowerShell Pester tests verifying Direction, ActionType, Status parameters and filter composition

## Documentation

- [x] Public documentation updated (`docs/`); pages:
  - `docs/configuration/synchronisation-rules.md` – new "Finding a Synchronisation Rule" section documenting the four filter facets
  - `docs/powershell/synchronisation-rules.md` – updated `Get-JIMSyncRule` syntax, parameters, and examples
- [x] CHANGELOG.md updated

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in `docs/DEVELOPER_GUIDE.md`
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information

## Additional context

**Key design decisions:**

1. **Single source of truth:** `SyncRuleFilter.Matches()` is the only place filtering logic lives; portal, API, and PowerShell all call it, preventing drift.

2. **Action type derivation:** `SyncRuleActionType` (Projects/Provisions/FlowOnly) is computed from direction and projection/provisioning flags, not stored. This handles stale data gracefully (e.g., an Export rule with a leftover ProjectToMetaverse value is correctly reported as FlowOnly).

3. **Header tier only:** The REST endpoint calls `GetSyncRuleHeadersAsync()` rather than materialising full rule objects, avoiding wasted work loading Attribute Flows and Object Matching Rules for a list view.

4. **Filter composition:** Facets combine with AND (all must match); values within a facet combine with OR (any can match); search narrows whatever the facets left. This is the same model as the portal and is now enforced consistently.

5. **PowerShell pipeline binding:** Added `-InputObject` parameter to accept piped Connected System objects (which expose `Id`, not `ConnectedSystemId`), matching the pattern used in `Get-JIMScheduleExecution`.

https://claude.ai/code/session_01NSwZDEZG9WdAjECXZXriDR