### PR TITLE
Configuration change classification: model, classifier and persistence (#827)

### DIFF
--- a/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
+++ b/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
@@ -44,7 +44,7 @@ Classification is a pure function over machinery JIM already has. Nothing new is
 3. `ConfigurationChangeClassifier` maps each changed node's key to its class and returns the highest.
 4. `ConfigurationChangeCaptureService` persists the result on `Activity.ConfigurationChangeClass`.
 
-Because the class is persisted, downstream consumers (the "Configuration changed since last full synchronisation" indicator, apply-time acknowledgement, and later the preview adapters) read one indexed column rather than re-diffing history.
+Because the class is persisted, downstream consumers (the "Configuration changed since last full synchronisation" indicator, apply-time acknowledgement, and later the preview adapters) read a single column rather than deserialising and re-diffing every stored snapshot. It also records what JIM judged at the time, which a later re-diff could not reproduce if the classification changes.
 
 Classification keys off the **snapshot node key**, not the C# property name or the REST DTO. The snapshot is the one representation shared by every write surface (portal, REST API, PowerShell), so classifying there means all three surfaces are covered by construction.
 
@@ -263,7 +263,9 @@ The Service Setting snapshot's structural nodes are Class C (see the object-type
 Classification applies to **updates**, where a diff exists between two snapshots.
 
 - **Create** has no prior snapshot, so nothing is being changed and no existing object is at risk. Creates are recorded with no class.
-- **Delete** is inherently destructive and is handled by the shared `ConsequenceConfirmationDialog` and each surface's own deletion-impact evaluation, which state the consequences directly. Deletions are recorded as Class A for consistency, but the deletion dialogs, not the classifier, are what gate them.
+- **Delete** is inherently destructive and is handled by the shared `ConsequenceConfirmationDialog` and each surface's own deletion-impact evaluation, which state the consequences directly. `CaptureDeletionAsync` records Class A so history can be filtered consistently, but the deletion dialogs, not the classifier, are what gate the action.
+
+Activities predating this feature carry `NotClassified`: their class was never computed and cannot be reconstructed reliably, so the column is left honest rather than backfilled with a guess.
 
 ## Enforcement
 

--- a/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
+++ b/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
@@ -140,6 +140,7 @@ Every scoping key is Class B: scoping determines which objects the rule applies 
 | Key | Class |
 |---|---|
 | `type`, `position` | B |
+| `childGroups` (nested groups) | B |
 | `metaverseAttributeId`, `connectedSystemAttributeId` | B |
 | `comparisonType`, `caseSensitive` | B |
 | `stringValue`, `intValue`, `longValue`, `decimalValue`, `dateTimeValue`, `boolValue`, `guidValue` | B |
@@ -153,6 +154,8 @@ Every scoping key is Class B: scoping determines which objects the rule applies 
 | `connectorDefinitionId` | B | Changes the connector driving import and export. |
 | `objectMatchingRuleMode` | B | Changes how matching rules combine, so which objects join. |
 | `unresolvedReferenceHandling` | B | Changes what happens to references that cannot be resolved. |
+| `objectMatchingRules` | B | Matching rules held on the system change which objects join. |
+| `settingValues` | B | Connector settings drive what the connector reads and writes. |
 | `maxExportParallelism` | C | Throughput only; explicitly excluded from preview scope by #827. |
 
 ### Run Profiles (`runProfiles`)
@@ -203,7 +206,7 @@ Every scoping key is Class B: scoping determines which objects the rule applies 
 | `deletionRule` | **A** | Governs when a Metaverse Object is deleted; changing it makes objects deletion-eligible immediately (#827 gap G5). |
 | `deletionGracePeriod` | **A** | Shortening the period brings forward deletions that were pending (#827 gap G5). |
 | `deletionTriggerConnectedSystemIds` | **A** | Changes which system disconnections trigger deletion (#827 gap G5). |
-| `attributes` | B | Binding or unbinding an attribute changes what can flow to objects of this type. |
+| `attributes`, `attributeId` | B | Binding or unbinding an attribute changes what can flow to objects of this type. |
 
 ## Metaverse Attribute
 
@@ -214,7 +217,7 @@ Every scoping key is Class B: scoping determines which objects the rule applies 
 | `attributePlurality` | B | Single versus multi-valued changes what flows. |
 | `builtIn` | C | System flag; not administrator-editable. |
 | `renderingHint` | C | Portal display only. |
-| `metaverseObjectTypes` | B | Changes which Object Types the attribute is available to. |
+| `metaverseObjectTypes`, `metaverseObjectTypeId` | B | Changes which Object Types the attribute is available to. |
 | `standardMappings.standard` | C | Interoperability hint; advisory metadata only. |
 | `standardMappings.counterpartName` | C | Interoperability hint; advisory metadata only. |
 | `standardMappings.notes` | C | Free text. |
@@ -267,3 +270,5 @@ Classification applies to **updates**, where a diff exists between two snapshots
 `ConfigurationChangeClassificationCompletenessTests` (JIM.Worker.Tests) reflects over every key `ConfigurationSnapshotService` can emit and asserts each has an explicit classification. It runs in every unit pass and in `build-and-test` on every PR, so adding a configuration property without classifying it fails the build with a message naming the key.
 
 This is the same enforcement pattern as `BulkInsertColumnCompletenessTests`, and it exists for the same reason: a hand-maintained map that nothing checks will drift, and the drift is invisible until it produces a wrong answer in front of a customer.
+
+The guard earned its place immediately: the first run caught four keys that a careful manual read of `ConfigurationSnapshotService` had missed (`childGroups` on nested scoping groups, `attributeId` and `metaverseObjectTypeId` on the association collections, and `objectMatchingRules` on Connected Systems). Do not classify by reading the source; let the test tell you what the snapshot actually emits.

--- a/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
+++ b/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
@@ -1,0 +1,269 @@
+# Configuration Change Classification
+
+> How JIM decides whether a configuration change is destructive, sync-affecting, or cosmetic, and what every developer must do when adding or altering a configuration property.
+
+- **Status:** Done
+- **Applies to:** every configuration property captured in a `ConfigurationSnapshot`
+- **Related:** [`plans/CONFIGURATION_CHANGE_PREVIEW.md`](plans/CONFIGURATION_CHANGE_PREVIEW.md) (the framework this feeds), issue #827
+
+## Why this exists
+
+An administrator saving a Synchronisation Rule can be renaming it or can be switching its Outbound Deprovision Action from Disconnect to Delete. The first is harmless; the second can delete thousands of accounts on the next synchronisation run. JIM must be able to tell those apart **before** it decides whether to warn, to demand confirmation, or to say nothing at all.
+
+Classification is what makes that possible. It is deliberately **property-level, not page-level**: a single edit page mixes harmless fields with dangerous ones, so classifying by page would either cry wolf on every rename or stay silent on the dangerous field sitting next to it. A warning that fires on cosmetic edits is worse than no warning, because administrators learn to dismiss it.
+
+## The model
+
+Every configuration property is assigned one of three classes.
+
+| Class | Meaning | Save-time behaviour | Examples |
+|---|---|---|---|
+| **A: Destructive** | Can cascade deletions or mass deprovisioning | Preview and a count-stating confirmation are **mandatory**; the administrator must consent to the stated consequences | Outbound Deprovision Action, Metaverse Object Type Deletion Rule, Connected System Object Type deselection |
+| **B: Sync-affecting** | Changes synchronisation outcomes without directly destroying data | Preview is **offered**; the save is never blocked | Scoping criteria, Object Matching Rules, Attribute Flow, schema selection |
+| **C: Cosmetic / operational** | No effect on synchronisation outcomes | Never prompts; the save proceeds untouched | Names, descriptions, icons, schedule timing, page sizes, UI preferences |
+
+**A change is classified by the highest class among the properties that actually changed.** A save that renames a Synchronisation Rule *and* switches its Outbound Deprovision Action is Class A. A save touching only Class C properties never produces a preview, an acknowledgement, or a confirmation.
+
+### Where the line sits between A and B
+
+The distinction is **directness**, not severity.
+
+- Class A means the change itself, once applied, causes objects to be deleted or deprovisioned. Nothing else has to go wrong.
+- Class B means the change alters what synchronisation will do, and a later run may well remove objects as a consequence, but the change on its own does not.
+
+Switching a Metaverse Object Type's Deletion Rule is Class A: deletion eligibility changes the moment it is saved. Narrowing a Synchronisation Rule's scope is Class B: objects fall out of scope, and what happens to them then depends on the Inbound Out-of-Scope Action (itself Class A).
+
+When genuinely torn, choose the higher class. Over-warning costs an administrator one dialog; under-warning costs them their data.
+
+## How classification is computed
+
+Classification is a pure function over machinery JIM already has. Nothing new is diffed or intercepted.
+
+1. `ConfigurationSnapshotService` builds a `ConfigurationSnapshot` of the object being saved, a tree of nodes each carrying a stable string `Key` (`"outboundDeprovisionAction"`, `"deletionRule"`, and so on).
+2. `ConfigurationDiffService.Diff(old, new)` returns the nodes that actually changed.
+3. `ConfigurationChangeClassifier` maps each changed node's key to its class and returns the highest.
+4. `ConfigurationChangeCaptureService` persists the result on `Activity.ConfigurationChangeClass`.
+
+Because the class is persisted, downstream consumers (the "Configuration changed since last full synchronisation" indicator, apply-time acknowledgement, and later the preview adapters) read one indexed column rather than re-diffing history.
+
+Classification keys off the **snapshot node key**, not the C# property name or the REST DTO. The snapshot is the one representation shared by every write surface (portal, REST API, PowerShell), so classifying there means all three surfaces are covered by construction.
+
+## What you must do as a developer
+
+**Adding a new configuration property, or changing an existing one, is not complete until it is classified.**
+
+1. Add the property to its `ConfigurationSnapshotService` builder as usual, giving it a stable key.
+2. Add that key to the matching table in `ConfigurationChangeClassifier`, choosing A, B or C using the model above.
+3. Add a row to the relevant table in **this document**, with the same class and a one-line reason.
+4. Run the unit tests. `ConfigurationChangeClassificationCompletenessTests` enumerates every key the snapshot service can emit and fails when one has no explicit classification, naming the key.
+
+There is **no default class.** An unclassified key fails the build rather than being silently assumed harmless or silently assumed dangerous. This is deliberate: a default would let the map rot, and a rotten map produces a framework that warns about the wrong things, which is worse than one that does not warn at all.
+
+If you are changing an existing property's *behaviour* such that its class should change (for example, making a previously advisory setting actually destructive), update the class and this document in the same change, and say why in the commit message.
+
+### Choosing a class: a short checklist
+
+Ask, in order:
+
+1. **Does saving this cause objects to be deleted, disconnected, or deprovisioned?** If yes, Class A.
+2. **Does it change which objects synchronisation touches, how they join, or what values flow?** If yes, Class B.
+3. **Would a synchronisation run produce byte-identical outcomes before and after?** If yes, Class C.
+
+Performance and recording settings (page sizes, parallelism, verbosity, history retention) are Class C: they change how synchronisation runs, not what it produces.
+
+## Classification by object type
+
+Nine of the fourteen snapshot object types do not participate in synchronisation at all. These are classified **wholly Class C** at object-type level, with the reason recorded here. Per-key tables are not kept for them, because there is no property within them that could be anything other than Class C.
+
+| Object type | Class | Reason |
+|---|---|---|
+| Schedule (and its steps) | C | Determines *when* work runs, never what it does. A schedule change cannot alter a synchronisation outcome. |
+| Trusted Certificate | C | Transport trust; affects whether a Connected System can be reached, not what synchronisation decides. |
+| API Key | C | Authentication credential for the REST API; no bearing on synchronisation. |
+| Role | C | Authorisation within JIM's own portal and API; no bearing on synchronisation. |
+| Predefined Search (and criteria) | C | A saved view over Metaverse Objects. Read-only; changes what an administrator sees, never what synchronisation does. |
+| Connector Definition (and capabilities, settings, files) | C | Package metadata describing what a connector can do. Not administrator-set configuration; changes only when a connector is upgraded. |
+| Example Data Set | C | Test data generation input; never consulted by synchronisation. |
+| Example Data Template (and object types, attributes, referenced sets) | C | As above. Its *execution* is an operational activity, not a configuration change. |
+| Service Setting (structural fields) | C | The `key`, `displayName`, `category`, `valueType`, `defaultValue` and `overridden` nodes are metadata. Only the `value` node carries meaning, and it is classified by setting key (see below). |
+
+The remaining five types are classified per key.
+
+## Synchronisation Rule
+
+| Key | Class | Reason |
+|---|---|---|
+| `name` | C | Label only. |
+| `description` | C | Label only. |
+| `direction` | B | Reverses which way attribute values flow. |
+| `enabled` | B | Stops or starts the rule contributing; downstream removal depends on the out-of-scope and deprovision actions. |
+| `provisionToConnectedSystem` | B | Governs whether new objects are created in the Connected System. |
+| `projectToMetaverse` | B | Governs whether new Metaverse Objects are created. |
+| `outboundDeprovisionAction` | **A** | Disconnect to Delete converts deprovisioning into deletion in the Connected System. |
+| `inboundOutOfScopeAction` | **A** | Remain Joined to Disconnect disconnects every object that falls out of scope. |
+| `enforceState` | B | Changes whether JIM overwrites divergent values in the Connected System. |
+| `connectedSystemId` | B | Repoints the rule at a different Connected System. |
+| `connectedSystemObjectTypeId` | B | Repoints the rule at a different Connected System Object Type. |
+| `metaverseObjectTypeId` | B | Repoints the rule at a different Metaverse Object Type. |
+
+### Attribute Flow (`attributeFlowRules`, `sources`)
+
+| Key | Class | Reason |
+|---|---|---|
+| `targetMetaverseAttributeId` | B | Changes which attribute receives flowed values. |
+| `targetConnectedSystemAttributeId` | B | Changes which attribute receives flowed values. |
+| `inboundValueProcessing` | B | Alters the value written (trimming, whitespace handling). |
+| `caseNormalisation` | B | Alters the value written. |
+| `priority` | B | Changes which contributing rule wins an attribute. |
+| `nullIsValue` | B | Decides whether a null clears the target or is ignored. |
+| `initialExportOnly` | B | Decides whether the value flows once or on every run. |
+| `order` | B | Ordering of mapping sources changes the computed value. |
+| `metaverseAttributeId` | B | Changes the source attribute. |
+| `connectedSystemAttributeId` | B | Changes the source attribute. |
+| `expression` | B | Changes the computed value. |
+
+### Object Matching Rules (`objectMatchingRules`, `sources`)
+
+| Key | Class | Reason |
+|---|---|---|
+| `order` | B | Changes which matching rule is evaluated first, so which objects join. |
+| `caseSensitive` | B | Changes which objects match. |
+| `metaverseObjectTypeId` | B | Changes what the rule matches against. |
+| `targetMetaverseAttributeId` | B | Changes the attribute matched on, so which objects join. |
+| `connectedSystemAttributeId` | B | As above, on the Connected System side. |
+| `expression` | B | Changes the computed matching value. |
+
+### Scoping (`objectScopingCriteriaGroups`, `criteria`)
+
+Every scoping key is Class B: scoping determines which objects the rule applies to, so any change moves objects in or out of scope. What then happens to the objects that left is governed by `inboundOutOfScopeAction`, which is Class A.
+
+| Key | Class |
+|---|---|
+| `type`, `position` | B |
+| `metaverseAttributeId`, `connectedSystemAttributeId` | B |
+| `comparisonType`, `caseSensitive` | B |
+| `stringValue`, `intValue`, `longValue`, `decimalValue`, `dateTimeValue`, `boolValue`, `guidValue` | B |
+
+## Connected System
+
+| Key | Class | Reason |
+|---|---|---|
+| `name` | C | Label only. |
+| `description` | C | Label only. |
+| `connectorDefinitionId` | B | Changes the connector driving import and export. |
+| `objectMatchingRuleMode` | B | Changes how matching rules combine, so which objects join. |
+| `unresolvedReferenceHandling` | B | Changes what happens to references that cannot be resolved. |
+| `maxExportParallelism` | C | Throughput only; explicitly excluded from preview scope by #827. |
+
+### Run Profiles (`runProfiles`)
+
+| Key | Class | Reason |
+|---|---|---|
+| `name` | C | Label only. |
+| `runType` | B | Changes what the profile does (full versus delta, import versus sync versus export). |
+| `pageSize` | C | Throughput only. |
+| `filePath` | B | Changes the source data a file-based import reads, so what lands in the connector space. |
+| `partitionId` | B | Changes which partition the profile operates on. |
+
+### Connected System schema (`objectTypes`, `attributes`)
+
+| Key | Class | Reason |
+|---|---|---|
+| `objectTypes.name` | C | Label only. |
+| `objectTypes.selected` | **A** | Deselecting an Object Type removes its Connected System Objects and deprovisions what they were joined to (#827 gap G4). |
+| `removeContributedAttributesOnObsoletion` | B | Decides whether contributed values are withdrawn when an object obsoletes. |
+| `attributes.name` | C | Label only. |
+| `attributes.type` | B | Changes how values are interpreted and flowed. |
+| `attributes.attributePlurality` | B | Single versus multi-valued changes what flows. |
+| `attributes.isExternalId` | B | Changes the anchor used to correlate objects, so join outcomes. |
+| `attributes.isSecondaryExternalId` | B | As above. |
+| `attributes.writability` | B | Decides whether JIM may export the attribute. |
+
+### Partitions and Containers (`partitions`, `containers`)
+
+| Key | Class | Reason |
+|---|---|---|
+| `partitions.name` | C | Label only. |
+| `partitions.externalId` | C | Identifier recorded from the Connected System, not administrator-set. |
+| `partitions.selected` | **A** | Deselecting a partition removes the Connected System Objects imported from it (#827 gap G4). |
+| `containers.name` | C | Label only. |
+| `containers.externalId` | C | Identifier recorded from the Connected System, not administrator-set. |
+| `containers.hidden` | C | Portal display only. |
+
+> **Known gap.** Container *selection* is not currently captured in the Connected System snapshot; only `hidden` is. Until selection is added to `ConfigurationSnapshotService`, the container half of #827 gap G4 cannot be classified or previewed. Capturing it is a prerequisite for the G4 adapter.
+
+## Metaverse Object Type
+
+| Key | Class | Reason |
+|---|---|---|
+| `name` | C | Label only. |
+| `pluralName` | C | Label only. |
+| `builtIn` | C | System flag; not administrator-editable. |
+| `icon` | C | Portal display only. |
+| `deletionRule` | **A** | Governs when a Metaverse Object is deleted; changing it makes objects deletion-eligible immediately (#827 gap G5). |
+| `deletionGracePeriod` | **A** | Shortening the period brings forward deletions that were pending (#827 gap G5). |
+| `deletionTriggerConnectedSystemIds` | **A** | Changes which system disconnections trigger deletion (#827 gap G5). |
+| `attributes` | B | Binding or unbinding an attribute changes what can flow to objects of this type. |
+
+## Metaverse Attribute
+
+| Key | Class | Reason |
+|---|---|---|
+| `name` | C | Label only. |
+| `type` | B | Changes how values are interpreted and flowed. |
+| `attributePlurality` | B | Single versus multi-valued changes what flows. |
+| `builtIn` | C | System flag; not administrator-editable. |
+| `renderingHint` | C | Portal display only. |
+| `metaverseObjectTypes` | B | Changes which Object Types the attribute is available to. |
+| `standardMappings.standard` | C | Interoperability hint; advisory metadata only. |
+| `standardMappings.counterpartName` | C | Interoperability hint; advisory metadata only. |
+| `standardMappings.notes` | C | Free text. |
+
+## Service Settings
+
+The Service Setting snapshot's structural nodes are Class C (see the object-type table). The `value` node is classified by the **setting key**, because a Service Setting is a key/value pair whose significance lives entirely in which setting it is.
+
+| Setting key | Class | Reason |
+|---|---|---|
+| `PartitionValidationMode` | B | Switching Error to Warning lets a Run Profile whose partition is missing proceed and import zero objects, which a full import then treats as everything having disappeared. |
+| `SyncPageSize` | C | Throughput only. |
+| `VerboseNoChangeRecording` | C | Recording verbosity; no outcome change. |
+| `MaintenanceMode` | C | Blocks operations from starting; does not change their outcome. |
+| `HistoryRetentionPeriod` | C | Retention of records, not synchronisation behaviour. |
+| `ConfigurationChangeRetentionPeriod` | C | As above. |
+| `SecurityEventRetentionPeriod` | C | As above. |
+| `HistoryCleanupBatchSize` | C | Throughput of the cleanup job. |
+| `ChangeTrackingCsoChangesEnabled` | C | Governs what history is recorded, not what synchronisation does. |
+| `ChangeTrackingMvoChangesEnabled` | C | As above. |
+| `ChangeTrackingConfigurationChangesEnabled` | C | As above. |
+| `ChangeTrackingSyncOutcomesLevel` | C | As above. |
+| `SsoAuthority` | C | Portal and API authentication. |
+| `SsoClientId` | C | As above. |
+| `SsoSecret` | C | As above. |
+| `SsoApiScope` | C | As above. |
+| `SsoClaimType` | C | As above. |
+| `SsoMvAttribute` | C | Selects the attribute used to identify the signing-in user; affects sign-in, not synchronisation. |
+| `SsoUniqueIdentifierClaimType` | C | As above. |
+| `SsoEnableLogOut` | C | As above. |
+| `CredentialEncryptionEnabled` | C | Protection of stored credentials at rest. |
+| `EncryptionKeyPath` | C | As above. |
+| `RateLimitingEnabled` | C | API throughput control. |
+| `RateLimitingAuthenticatedRequestsPerMinute` | C | As above. |
+| `RateLimitingUnauthenticatedRequestsPerMinute` | C | As above. |
+| `ProgressUpdateInterval` | C | Portal refresh cadence. |
+| `ServiceName` | C | Instance branding. |
+
+> `PartitionValidationMode` is the one Service Setting worth revisiting. It is Class B because it does not itself remove anything, but it removes a guard that exists to prevent a destructive outcome. If the preview framework later shows administrators reaching for it without understanding the consequence, promote it to Class A.
+
+## Creation and deletion
+
+Classification applies to **updates**, where a diff exists between two snapshots.
+
+- **Create** has no prior snapshot, so nothing is being changed and no existing object is at risk. Creates are recorded with no class.
+- **Delete** is inherently destructive and is handled by the shared `ConsequenceConfirmationDialog` and each surface's own deletion-impact evaluation, which state the consequences directly. Deletions are recorded as Class A for consistency, but the deletion dialogs, not the classifier, are what gate them.
+
+## Enforcement
+
+`ConfigurationChangeClassificationCompletenessTests` (JIM.Worker.Tests) reflects over every key `ConfigurationSnapshotService` can emit and asserts each has an explicit classification. It runs in every unit pass and in `build-and-test` on every PR, so adding a configuration property without classifying it fails the build with a message naming the key.
+
+This is the same enforcement pattern as `BulkInsertColumnCompletenessTests`, and it exists for the same reason: a hand-maintained map that nothing checks will drift, and the drift is invisible until it produces a wrong answer in front of a customer.

--- a/src/JIM.Application/Services/ConfigurationChangeCaptureService.cs
+++ b/src/JIM.Application/Services/ConfigurationChangeCaptureService.cs
@@ -104,6 +104,11 @@ public class ConfigurationChangeCaptureService
                 return;
 
             activity.ConfigurationChangeSnapshot = ConfigurationSnapshotService.Serialise(snapshot);
+
+            // Deleting a configuration object is inherently destructive, whatever its properties were. The deletion
+            // dialogs, not the classifier, are what gate the action; this records what happened for consumers
+            // filtering history by class.
+            activity.ConfigurationChangeClass = ConfigurationChangeClass.Destructive;
         }
         catch (Exception ex) when (ex is InvalidOperationException or NullReferenceException or FormatException or JsonException or DbException)
         {
@@ -145,10 +150,18 @@ public class ConfigurationChangeCaptureService
             // stored in a jsonb column, and PostgreSQL normalises the text (key ordering, spacing) so the string
             // read back never equals a fresh serialisation.
             var latest = ConfigurationSnapshotService.Deserialise(await getLatestSnapshotAsync());
-            if (latest != null && !Application.ConfigurationDiffs.Diff(latest, snapshot).HasChanges)
+            if (latest != null)
             {
-                Log.Debug("CaptureChangeAsync: configuration of {Target} is unchanged from its latest snapshot; no new version recorded.", targetDescription);
-                return;
+                var diff = Application.ConfigurationDiffs.Diff(latest, snapshot);
+                if (!diff.HasChanges)
+                {
+                    Log.Debug("CaptureChangeAsync: configuration of {Target} is unchanged from its latest snapshot; no new version recorded.", targetDescription);
+                    return;
+                }
+
+                // Classified from the diff that was computed anyway. A create (latest == null) has no prior state to
+                // diff, so nothing is at risk and the class stays NotClassified.
+                activity.ConfigurationChangeClass = ClassifyOrDefault(diff, snapshot.ObjectKey, targetDescription);
             }
 
             activity.ConfigurationChangeVersion = await getNextVersionAsync();
@@ -161,6 +174,25 @@ public class ConfigurationChangeCaptureService
             // the change history simply misses this snapshot. The failure is logged (never silent) so the gap is
             // diagnosable.
             Log.Warning(ex, "CaptureChangeAsync: failed to capture configuration snapshot for {Target}; the change was saved but its history snapshot was not recorded.", targetDescription);
+        }
+    }
+
+    /// <summary>
+    /// Classifies the change, degrading to <see cref="ConfigurationChangeClass.NotClassified"/> rather than losing
+    /// the snapshot when a property has no classification. The completeness tests exist to stop that reaching a
+    /// deployment, but if it ever does, an audit gap is a far worse outcome than an unclassified entry: the change
+    /// history is the record customers rely on, whilst the class only decides how loudly JIM warns.
+    /// </summary>
+    private static ConfigurationChangeClass ClassifyOrDefault(ConfigurationDiff diff, string? objectKey, string targetDescription)
+    {
+        try
+        {
+            return ConfigurationChangeClassifier.Classify(diff, objectKey);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.Warning(ex, "CaptureChangeAsync: could not classify the configuration change for {Target}; the snapshot was recorded without a classification. Classify the property named above; see engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.", targetDescription);
+            return ConfigurationChangeClass.NotClassified;
         }
     }
 

--- a/src/JIM.Application/Services/ConfigurationChangeClassifier.cs
+++ b/src/JIM.Application/Services/ConfigurationChangeClassifier.cs
@@ -262,10 +262,11 @@ public static class ConfigurationChangeClassifier
         if (!diff.HasChanges || diff.Root == null)
             return ConfigurationChangeClass.NotClassified;
 
+        // Projected rather than mapped inside the loop, and lazily, so the break below still stops the
+        // enumeration at the first Destructive key.
         var highest = ConfigurationChangeClass.NotClassified;
-        foreach (var key in CollectChangedKeys(diff.Root))
+        foreach (var nodeClass in CollectChangedKeys(diff.Root).Select(key => ClassifyKey(diff.ObjectType, key, objectKey)))
         {
-            var nodeClass = ClassifyKey(diff.ObjectType, key, objectKey);
             if (nodeClass > highest)
                 highest = nodeClass;
 

--- a/src/JIM.Application/Services/ConfigurationChangeClassifier.cs
+++ b/src/JIM.Application/Services/ConfigurationChangeClassifier.cs
@@ -1,0 +1,368 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Activities;
+using JIM.Models.Core;
+
+namespace JIM.Application.Services;
+
+/// <summary>
+/// Decides how consequential a configuration change is, so JIM knows whether to demand confirmation,
+/// offer a preview, or say nothing. Classification is a pure function over the diff that
+/// <see cref="ConfigurationDiffService"/> already computes on every configuration save; nothing extra
+/// is diffed or intercepted.
+///
+/// **The classification tables here and the tables in engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
+/// must agree.** That document is the reviewable source of truth and carries the reason for every
+/// decision; this file is its executable mirror. When you add a configuration property, classify it in
+/// both. There is deliberately no default class: an unclassified key throws, and
+/// ConfigurationChangeClassificationCompletenessTests turns that into a build failure naming the key,
+/// rather than letting the map rot into a framework that warns about the wrong things.
+///
+/// Keys are matched per object type without path qualification, because no key within a single object
+/// type currently carries two different classes. Where a key does repeat (a `name` on a Run Profile and
+/// on a Partition), both occurrences share a class, so the flat lookup is unambiguous. If a future
+/// property introduces a genuine collision, split it into a path-qualified entry rather than picking
+/// one class for both.
+/// </summary>
+public static class ConfigurationChangeClassifier
+{
+    private const ConfigurationChangeClass A = ConfigurationChangeClass.Destructive;
+    private const ConfigurationChangeClass B = ConfigurationChangeClass.SyncAffecting;
+    private const ConfigurationChangeClass C = ConfigurationChangeClass.Cosmetic;
+
+    /// <summary>
+    /// Object types that take no part in synchronisation, classified wholly Class C. The reason for
+    /// each is recorded in engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md; no property within them
+    /// could be anything other than cosmetic or operational, so they need no per-key table.
+    /// </summary>
+    private static readonly HashSet<string> WhollyCosmeticObjectTypes = new(StringComparer.Ordinal)
+    {
+        ConfigurationSnapshotService.ScheduleObjectType,
+        ConfigurationSnapshotService.TrustedCertificateObjectType,
+        ConfigurationSnapshotService.ApiKeyObjectType,
+        ConfigurationSnapshotService.RoleObjectType,
+        ConfigurationSnapshotService.PredefinedSearchObjectType,
+        ConfigurationSnapshotService.ConnectorDefinitionObjectType,
+        ConfigurationSnapshotService.ExampleDataSetObjectType,
+        ConfigurationSnapshotService.ExampleDataTemplateObjectType
+    };
+
+    private static readonly Dictionary<string, ConfigurationChangeClass> SyncRuleKeys = new(StringComparer.Ordinal)
+    {
+        // The rule itself.
+        ["synchronisationRule"] = C,
+        ["name"] = C,
+        ["description"] = C,
+        ["direction"] = B,
+        ["enabled"] = B,
+        ["provisionToConnectedSystem"] = B,
+        ["projectToMetaverse"] = B,
+        ["outboundDeprovisionAction"] = A,
+        ["inboundOutOfScopeAction"] = A,
+        ["enforceState"] = B,
+        ["connectedSystemId"] = B,
+        ["connectedSystemObjectTypeId"] = B,
+        ["metaverseObjectTypeId"] = B,
+
+        // Attribute Flow: changes what values flow.
+        ["attributeFlowRules"] = B,
+        ["attributeFlowRule"] = B,
+        ["targetMetaverseAttributeId"] = B,
+        ["targetConnectedSystemAttributeId"] = B,
+        ["inboundValueProcessing"] = B,
+        ["caseNormalisation"] = B,
+        ["priority"] = B,
+        ["nullIsValue"] = B,
+        ["initialExportOnly"] = B,
+
+        // Mapping and matching sources: change the computed value.
+        ["sources"] = B,
+        ["source"] = B,
+        ["order"] = B,
+        ["metaverseAttributeId"] = B,
+        ["connectedSystemAttributeId"] = B,
+        ["expression"] = B,
+
+        // Object Matching: changes which objects join.
+        ["objectMatchingRules"] = B,
+        ["objectMatchingRule"] = B,
+        ["caseSensitive"] = B,
+
+        // Scoping: changes which objects the rule applies to. What happens to those that leave scope
+        // is governed by inboundOutOfScopeAction, which is Class A.
+        ["objectScopingCriteriaGroups"] = B,
+        ["group"] = B,
+        ["childGroups"] = B,
+        ["type"] = B,
+        ["position"] = B,
+        ["criteria"] = B,
+        ["criterion"] = B,
+        ["comparisonType"] = B,
+        ["stringValue"] = B,
+        ["intValue"] = B,
+        ["longValue"] = B,
+        ["decimalValue"] = B,
+        ["dateTimeValue"] = B,
+        ["boolValue"] = B,
+        ["guidValue"] = B
+    };
+
+    private static readonly Dictionary<string, ConfigurationChangeClass> ConnectedSystemKeys = new(StringComparer.Ordinal)
+    {
+        // The system itself.
+        ["connectedSystem"] = C,
+        ["name"] = C,
+        ["description"] = C,
+        ["connectorDefinitionId"] = B,
+        ["objectMatchingRuleMode"] = B,
+        ["unresolvedReferenceHandling"] = B,
+        ["maxExportParallelism"] = C,
+        ["settingValues"] = B,
+
+        // Run Profiles.
+        ["runProfiles"] = C,
+        ["runProfile"] = C,
+        ["runType"] = B,
+        ["pageSize"] = C,
+        ["filePath"] = B,
+        ["partitionId"] = B,
+
+        // Connected System schema. Deselecting an Object Type removes its Connected System Objects.
+        ["objectTypes"] = B,
+        ["objectType"] = B,
+        ["selected"] = A,
+        ["removeContributedAttributesOnObsoletion"] = B,
+        ["attributes"] = B,
+        ["attribute"] = B,
+        ["type"] = B,
+        ["attributePlurality"] = B,
+        ["isExternalId"] = B,
+        ["isSecondaryExternalId"] = B,
+        ["writability"] = B,
+
+        // Partitions and containers. Deselecting a partition removes the objects imported from it;
+        // `selected` above covers both, since both carry Class A.
+        ["objectMatchingRules"] = B,
+        ["objectMatchingRule"] = B,
+        ["partitions"] = B,
+        ["partition"] = B,
+        ["externalId"] = C,
+        ["containers"] = C,
+        ["container"] = C,
+        ["hidden"] = C
+    };
+
+    private static readonly Dictionary<string, ConfigurationChangeClass> MetaverseObjectTypeKeys = new(StringComparer.Ordinal)
+    {
+        ["metaverseObjectType"] = C,
+        ["name"] = C,
+        ["pluralName"] = C,
+        ["builtIn"] = C,
+        ["icon"] = C,
+        ["deletionRule"] = A,
+        ["deletionGracePeriod"] = A,
+        ["deletionTriggerConnectedSystemIds"] = A,
+        ["attributes"] = B,
+        ["attribute"] = B,
+        ["attributeId"] = B
+    };
+
+    private static readonly Dictionary<string, ConfigurationChangeClass> MetaverseAttributeKeys = new(StringComparer.Ordinal)
+    {
+        ["metaverseAttribute"] = C,
+        ["name"] = C,
+        ["type"] = B,
+        ["attributePlurality"] = B,
+        ["builtIn"] = C,
+        ["renderingHint"] = C,
+        ["metaverseObjectTypes"] = B,
+        ["metaverseObjectType"] = B,
+        ["metaverseObjectTypeId"] = B,
+        ["standardMappings"] = C,
+        ["standardMapping"] = C,
+        ["standard"] = C,
+        ["counterpartName"] = C,
+        ["notes"] = C
+    };
+
+    /// <summary>
+    /// A Service Setting snapshot's structural nodes are metadata; only the value node carries meaning,
+    /// and its significance depends on which setting it is. Classified by setting key in
+    /// <see cref="ServiceSettingKeys"/>.
+    /// </summary>
+    private static readonly Dictionary<string, ConfigurationChangeClass> ServiceSettingNodeKeys = new(StringComparer.Ordinal)
+    {
+        ["serviceSetting"] = C,
+        ["key"] = C,
+        ["displayName"] = C,
+        ["category"] = C,
+        ["valueType"] = C,
+        ["defaultValue"] = C,
+        ["overridden"] = C
+        // "value" is deliberately absent: it is classified by setting key, not by node key.
+    };
+
+    /// <summary>
+    /// Classification of a Service Setting's value, by setting key. Nearly every setting is
+    /// operational; PartitionValidationMode is the exception, because relaxing it lets a Run Profile
+    /// whose partition is missing import zero objects, which a full import then reads as everything
+    /// having disappeared.
+    /// </summary>
+    private static readonly Dictionary<string, ConfigurationChangeClass> ServiceSettingKeys = new(StringComparer.Ordinal)
+    {
+        [Constants.SettingKeys.PartitionValidationMode] = B,
+        [Constants.SettingKeys.SyncPageSize] = C,
+        [Constants.SettingKeys.VerboseNoChangeRecording] = C,
+        [Constants.SettingKeys.MaintenanceMode] = C,
+        [Constants.SettingKeys.HistoryRetentionPeriod] = C,
+        [Constants.SettingKeys.ConfigurationChangeRetentionPeriod] = C,
+        [Constants.SettingKeys.SecurityEventRetentionPeriod] = C,
+        [Constants.SettingKeys.HistoryCleanupBatchSize] = C,
+        [Constants.SettingKeys.ChangeTrackingCsoChangesEnabled] = C,
+        [Constants.SettingKeys.ChangeTrackingMvoChangesEnabled] = C,
+        [Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled] = C,
+        [Constants.SettingKeys.ChangeTrackingSyncOutcomesLevel] = C,
+        [Constants.SettingKeys.SsoAuthority] = C,
+        [Constants.SettingKeys.SsoClientId] = C,
+        [Constants.SettingKeys.SsoSecret] = C,
+        [Constants.SettingKeys.SsoApiScope] = C,
+        [Constants.SettingKeys.SsoClaimType] = C,
+        [Constants.SettingKeys.SsoMvAttribute] = C,
+        [Constants.SettingKeys.SsoUniqueIdentifierClaimType] = C,
+        [Constants.SettingKeys.SsoEnableLogOut] = C,
+        [Constants.SettingKeys.CredentialEncryptionEnabled] = C,
+        [Constants.SettingKeys.EncryptionKeyPath] = C,
+        [Constants.SettingKeys.RateLimitingEnabled] = C,
+        [Constants.SettingKeys.RateLimitingAuthenticatedRequestsPerMinute] = C,
+        [Constants.SettingKeys.RateLimitingUnauthenticatedRequestsPerMinute] = C,
+        [Constants.SettingKeys.ProgressUpdateInterval] = C,
+        [Constants.SettingKeys.ServiceName] = C,
+
+        // Internal settings, not surfaced for administrators to edit, but classified so the
+        // completeness test covers every key Constants.SettingKeys declares.
+        [Constants.SettingKeys.ConfigurationChangeHashKey] = C,
+        [Constants.SettingKeys.StaleTaskTimeout] = C,
+        [Constants.SettingKeys.ServiceId] = C
+    };
+
+    /// <summary>
+    /// Classifies a configuration change by the highest class among the properties that actually
+    /// changed. Returns <see cref="ConfigurationChangeClass.NotClassified"/> when nothing changed.
+    /// </summary>
+    /// <param name="diff">The diff between the previous and proposed snapshots.</param>
+    /// <param name="objectKey">
+    /// The Service Setting's key, required only when classifying a Service Setting change; ignored for
+    /// every other object type.
+    /// </param>
+    public static ConfigurationChangeClass Classify(ConfigurationDiff diff, string? objectKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+
+        if (!diff.HasChanges || diff.Root == null)
+            return ConfigurationChangeClass.NotClassified;
+
+        var highest = ConfigurationChangeClass.NotClassified;
+        foreach (var key in CollectChangedKeys(diff.Root))
+        {
+            var nodeClass = ClassifyKey(diff.ObjectType, key, objectKey);
+            if (nodeClass > highest)
+                highest = nodeClass;
+
+            // Destructive is the ceiling; no later key can raise it further.
+            if (highest == ConfigurationChangeClass.Destructive)
+                break;
+        }
+
+        return highest;
+    }
+
+    /// <summary>
+    /// Classifies a single snapshot node key within an object type. Throws when the key has no explicit
+    /// classification, which is what turns an unclassified new property into a test failure rather than
+    /// a silent wrong answer.
+    /// </summary>
+    public static ConfigurationChangeClass ClassifyKey(string objectType, string nodeKey, string? objectKey = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(objectType);
+        ArgumentException.ThrowIfNullOrEmpty(nodeKey);
+
+        if (WhollyCosmeticObjectTypes.Contains(objectType))
+            return ConfigurationChangeClass.Cosmetic;
+
+        if (objectType == ConfigurationSnapshotService.ServiceSettingObjectType)
+            return ClassifyServiceSettingNode(nodeKey, objectKey);
+
+        var table = TableFor(objectType);
+        if (table.TryGetValue(nodeKey, out var result))
+            return result;
+
+        throw new InvalidOperationException(
+            $"Configuration property '{nodeKey}' on '{objectType}' has no classification. Add it to " +
+            $"{nameof(ConfigurationChangeClassifier)} and to the matching table in " +
+            "engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md. There is no default class by design.");
+    }
+
+    /// <summary>
+    /// True when the object type is classified wholly Class C, so its individual properties need no
+    /// entry. Exposed for the completeness tests.
+    /// </summary>
+    public static bool IsWhollyCosmetic(string objectType) => WhollyCosmeticObjectTypes.Contains(objectType);
+
+    private static ConfigurationChangeClass ClassifyServiceSettingNode(string nodeKey, string? objectKey)
+    {
+        if (ServiceSettingNodeKeys.TryGetValue(nodeKey, out var structural))
+            return structural;
+
+        if (nodeKey != "value")
+        {
+            throw new InvalidOperationException(
+                $"Service Setting snapshot node '{nodeKey}' has no classification. Add it to " +
+                $"{nameof(ConfigurationChangeClassifier)} and to engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.");
+        }
+
+        // The value node's significance is the setting's, not the node's.
+        if (string.IsNullOrEmpty(objectKey))
+        {
+            throw new InvalidOperationException(
+                "Classifying a Service Setting value requires the setting key; none was supplied.");
+        }
+
+        if (ServiceSettingKeys.TryGetValue(objectKey, out var settingClass))
+            return settingClass;
+
+        throw new InvalidOperationException(
+            $"Service Setting '{objectKey}' has no classification. Add it to " +
+            $"{nameof(ConfigurationChangeClassifier)} and to engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md. " +
+            "There is no default class by design.");
+    }
+
+    private static Dictionary<string, ConfigurationChangeClass> TableFor(string objectType) => objectType switch
+    {
+        var t when t == ConfigurationSnapshotService.SyncRuleObjectType => SyncRuleKeys,
+        var t when t == ConfigurationSnapshotService.ConnectedSystemObjectType => ConnectedSystemKeys,
+        var t when t == ConfigurationSnapshotService.MetaverseObjectTypeObjectType => MetaverseObjectTypeKeys,
+        var t when t == ConfigurationSnapshotService.MetaverseAttributeObjectType => MetaverseAttributeKeys,
+        _ => throw new InvalidOperationException(
+            $"Object type '{objectType}' has no classification table and is not declared wholly cosmetic. " +
+            $"Add it to {nameof(ConfigurationChangeClassifier)} and to " +
+            "engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.")
+    };
+
+    /// <summary>
+    /// Walks the diff tree yielding the key of every node that actually changed. Unchanged branches are
+    /// skipped entirely, so a save that touched one field does not drag its siblings into the
+    /// classification.
+    /// </summary>
+    private static IEnumerable<string> CollectChangedKeys(ConfigurationDiffNode node)
+    {
+        if (node.ChangeType != ConfigurationDiffChangeType.Unchanged)
+            yield return node.Key;
+
+        if (node.Children == null)
+            yield break;
+
+        foreach (var key in node.Children.SelectMany(CollectChangedKeys))
+            yield return key;
+    }
+}

--- a/src/JIM.Models/Activities/Activity.cs
+++ b/src/JIM.Models/Activities/Activity.cs
@@ -473,6 +473,17 @@ public class Activity
     public int? ConfigurationChangeVersion { get; set; }
 
     /// <summary>
+    /// How consequential this configuration change was: destructive, sync-affecting, or cosmetic. Computed from the
+    /// properties that actually changed, so consumers (the changed-since-last-synchronisation indicator, apply-time
+    /// messaging, and the preview adapters) can filter to changes that matter without re-diffing history.
+    ///
+    /// <see cref="ConfigurationChangeClass.NotClassified"/> for creates (no prior snapshot to diff), for
+    /// non-configuration activities, and where classification could not be determined. See
+    /// engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.
+    /// </summary>
+    public ConfigurationChangeClass ConfigurationChangeClass { get; set; } = ConfigurationChangeClass.NotClassified;
+
+    /// <summary>
     /// Records which integer-keyed configuration object this activity's configuration change belongs to, by setting
     /// the target type's own column (see the target-column block above). A column already set at activity-creation
     /// time (e.g. by a granular sub-entity endpoint) is preserved. This is the single forward mapping of target type

--- a/src/JIM.Models/Activities/ConfigurationChangeClass.cs
+++ b/src/JIM.Models/Activities/ConfigurationChangeClass.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Activities;
+
+/// <summary>
+/// How consequential a configuration change is, and therefore what JIM must show the administrator
+/// before it is applied. See engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md for the model, the
+/// boundary between Destructive and SyncAffecting, and the classification of every property.
+///
+/// The numeric order is the severity order: a change is classified by the highest class among the
+/// properties that actually changed, so these values must never be reordered or renumbered.
+/// </summary>
+public enum ConfigurationChangeClass
+{
+    /// <summary>
+    /// No classification applies. Used for creates, which have no prior snapshot to diff and so put
+    /// no existing object at risk.
+    /// </summary>
+    NotClassified = 0,
+
+    /// <summary>
+    /// Class C: no effect on synchronisation outcomes (names, descriptions, display hints, schedule
+    /// timing, page sizes). Never prompts; the save proceeds untouched.
+    /// </summary>
+    Cosmetic = 1,
+
+    /// <summary>
+    /// Class B: changes synchronisation outcomes without directly destroying data (scoping, Object
+    /// Matching Rules, Attribute Flow, schema selection). A preview is offered; the save is never
+    /// blocked.
+    /// </summary>
+    SyncAffecting = 2,
+
+    /// <summary>
+    /// Class A: can cascade deletions or mass deprovisioning the moment it is applied (deprovision
+    /// actions, deletion rules, Object Type and partition deselection). A preview and a count-stating
+    /// confirmation are mandatory.
+    /// </summary>
+    Destructive = 3
+}

--- a/src/JIM.PostgresData/Migrations/20260730110312_AddConfigurationChangeClassToActivity.Designer.cs
+++ b/src/JIM.PostgresData/Migrations/20260730110312_AddConfigurationChangeClassToActivity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using JIM.PostgresData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JIM.PostgresData.Migrations
 {
     [DbContext(typeof(JimDbContext))]
-    partial class JimDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730110312_AddConfigurationChangeClassToActivity")]
+    partial class AddConfigurationChangeClassToActivity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/JIM.PostgresData/Migrations/20260730110312_AddConfigurationChangeClassToActivity.cs
+++ b/src/JIM.PostgresData/Migrations/20260730110312_AddConfigurationChangeClassToActivity.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JIM.PostgresData.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfigurationChangeClassToActivity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ConfigurationChangeClass",
+                table: "Activities",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConfigurationChangeClass",
+                table: "Activities");
+        }
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/ConfigurationChangeClassificationCompletenessTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConfigurationChangeClassificationCompletenessTests.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Reflection;
+using JIM.Application;
+using JIM.Application.Services;
+using JIM.Data;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// The guard that keeps the classification map honest. It drives <see cref="ConfigurationSnapshotService"/>
+/// with fully populated objects, walks every node key the snapshot actually emits, and asserts each one
+/// has an explicit classification. Adding a configuration property without classifying it therefore fails
+/// the build naming the key, instead of silently defaulting to a class nobody chose.
+///
+/// This is the same enforcement idea as BulkInsertColumnCompletenessTests, and exists for the same reason:
+/// a hand-maintained map that nothing checks will drift, and the drift stays invisible until it produces a
+/// wrong answer in front of a customer. See engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.
+/// </summary>
+[TestFixture]
+public class ConfigurationChangeClassificationCompletenessTests
+{
+    private JimApplication _jim = null!;
+    private ConfigurationSnapshotService _service = null!;
+    private static readonly byte[] HashKey = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+        _jim = new JimApplication(new Mock<IRepository>().Object);
+        _service = _jim.ConfigurationSnapshots;
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    #region Snapshot key completeness
+
+    [Test]
+    public void Classification_SyncRuleSnapshot_ClassifiesEveryEmittedKey()
+    {
+        AssertEveryKeyClassified(_service.CreateSnapshot(BuildFullSyncRule(), HashKey));
+    }
+
+    [Test]
+    public void Classification_ConnectedSystemSnapshot_ClassifiesEveryEmittedKey()
+    {
+        AssertEveryKeyClassified(_service.CreateSnapshot(BuildFullConnectedSystem(), HashKey));
+    }
+
+    [Test]
+    public void Classification_MetaverseObjectTypeSnapshot_ClassifiesEveryEmittedKey()
+    {
+        AssertEveryKeyClassified(_service.CreateSnapshot(BuildFullMetaverseObjectType(), HashKey));
+    }
+
+    [Test]
+    public void Classification_MetaverseAttributeSnapshot_ClassifiesEveryEmittedKey()
+    {
+        AssertEveryKeyClassified(_service.CreateSnapshot(BuildFullMetaverseAttribute(), HashKey));
+    }
+
+    #endregion
+
+    #region Service Settings
+
+    [Test]
+    public void Classification_EveryDeclaredServiceSettingKey_IsClassified()
+    {
+        // Reflects over Constants.SettingKeys so a newly declared setting fails here until it is
+        // classified, rather than throwing the first time an administrator edits it.
+        var settingKeys = typeof(Constants.SettingKeys)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f is { IsLiteral: true, IsInitOnly: false } && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        Assert.That(settingKeys, Is.Not.Empty, "expected Constants.SettingKeys to declare setting keys");
+
+        var unclassified = settingKeys
+            .Where(key => !TryClassifyServiceSetting(key))
+            .ToList();
+
+        Assert.That(unclassified, Is.Empty,
+            "Service Setting(s) with no classification: " + string.Join(", ", unclassified) +
+            ". Classify them in ConfigurationChangeClassifier and in " +
+            "engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.");
+    }
+
+    #endregion
+
+    #region Object type coverage
+
+    [Test]
+    public void Classification_EverySnapshotObjectType_IsEitherWhollyCosmeticOrHasAKeyTable()
+    {
+        // Every object type the snapshot service can produce must be accounted for: either declared
+        // wholly cosmetic, or backed by a per-key table. A new snapshot type fails here.
+        var objectTypes = typeof(ConfigurationSnapshotService)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f is { IsLiteral: true, IsInitOnly: false } && f.FieldType == typeof(string)
+                        && f.Name.EndsWith("ObjectType", StringComparison.Ordinal))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        Assert.That(objectTypes, Is.Not.Empty, "expected snapshot object type discriminators to be declared");
+
+        var unaccounted = objectTypes.Where(t => !IsAccountedFor(t)).ToList();
+
+        Assert.That(unaccounted, Is.Empty,
+            "Snapshot object type(s) with no classification: " + string.Join(", ", unaccounted) +
+            ". Either declare them wholly cosmetic or give them a key table in " +
+            "ConfigurationChangeClassifier, and record the decision in " +
+            "engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static void AssertEveryKeyClassified(ConfigurationSnapshot snapshot)
+    {
+        var failures = new List<string>();
+        foreach (var key in CollectKeys(snapshot.Root).Distinct())
+        {
+            try
+            {
+                ConfigurationChangeClassifier.ClassifyKey(snapshot.ObjectType, key, snapshot.ObjectKey);
+            }
+            catch (InvalidOperationException ex)
+            {
+                failures.Add($"{key}: {ex.Message}");
+            }
+        }
+
+        Assert.That(failures, Is.Empty,
+            $"Unclassified key(s) on '{snapshot.ObjectType}':{Environment.NewLine}" +
+            string.Join(Environment.NewLine, failures));
+    }
+
+    private static bool TryClassifyServiceSetting(string settingKey)
+    {
+        try
+        {
+            ConfigurationChangeClassifier.ClassifyKey(
+                ConfigurationSnapshotService.ServiceSettingObjectType, "value", settingKey);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsAccountedFor(string objectType)
+    {
+        if (ConfigurationChangeClassifier.IsWhollyCosmetic(objectType))
+            return true;
+
+        try
+        {
+            // Service Settings are keyed differently; probe a structural node instead.
+            var probeKey = objectType == ConfigurationSnapshotService.ServiceSettingObjectType ? "key" : "name";
+            ConfigurationChangeClassifier.ClassifyKey(objectType, probeKey);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static IEnumerable<string> CollectKeys(ConfigurationSnapshotNode node)
+    {
+        yield return node.Key;
+
+        if (node.Children == null)
+            yield break;
+
+        foreach (var key in node.Children.SelectMany(CollectKeys))
+            yield return key;
+    }
+
+    #endregion
+
+    #region Fully populated objects
+
+    // These deliberately populate every collection, because an empty collection emits no child nodes and
+    // would let an unclassified nested property slip past the guard.
+
+    private static SyncRule BuildFullSyncRule()
+    {
+        var mapping = new SyncRuleMapping
+        {
+            Id = 100,
+            TargetMetaverseAttributeId = 5,
+            TargetConnectedSystemAttributeId = 6,
+            Priority = 2,
+            NullIsValue = true,
+            InitialExportOnly = true
+        };
+        mapping.Sources.Add(new SyncRuleMappingSource
+        {
+            Id = 200, Order = 0, ConnectedSystemAttributeId = 9, MetaverseAttributeId = 10, Expression = "x"
+        });
+
+        var matchingRule = new ObjectMatchingRule { Id = 300, Order = 0, TargetMetaverseAttributeId = 11 };
+        matchingRule.Sources.Add(new ObjectMatchingRuleSource
+        {
+            Id = 400, Order = 0, ConnectedSystemAttributeId = 12, Expression = "y"
+        });
+
+        var group = new SyncRuleScopingCriteriaGroup { Id = 500, Position = 0 };
+        group.Criteria.Add(new SyncRuleScopingCriteria
+        {
+            Id = 600,
+            MetaverseAttributeId = 13,
+            ConnectedSystemAttributeId = 14,
+            StringValue = "s",
+            IntValue = 1,
+            LongValue = 2L,
+            DecimalValue = 3.5m,
+            DateTimeValue = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            BoolValue = true,
+            GuidValue = Guid.Empty,
+            CaseSensitive = true
+        });
+
+        var rule = new SyncRule
+        {
+            Id = 42,
+            Name = "HR Inbound",
+            Description = "Everything populated.",
+            Direction = SyncRuleDirection.Import,
+            Enabled = true,
+            ProvisionToConnectedSystem = true,
+            ProjectToMetaverse = true,
+            EnforceState = true,
+            ConnectedSystemId = 3,
+            ConnectedSystemObjectTypeId = 7,
+            MetaverseObjectTypeId = 1
+        };
+        rule.AttributeFlowRules.Add(mapping);
+        rule.ObjectMatchingRules.Add(matchingRule);
+        rule.ObjectScopingCriteriaGroups.Add(group);
+        return rule;
+    }
+
+    private static ConnectedSystem BuildFullConnectedSystem()
+    {
+        var objectType = new ConnectedSystemObjectType { Id = 10, Name = "user", Selected = true };
+        objectType.Attributes.Add(new ConnectedSystemObjectTypeAttribute
+        {
+            Id = 20, Name = "sAMAccountName", IsExternalId = true, IsSecondaryExternalId = false
+        });
+
+        var partition = new ConnectedSystemPartition
+        {
+            Id = 30, Name = "DC=example", ExternalId = "abc", Selected = true,
+            Containers = [new ConnectedSystemContainer { Id = 40, Name = "OU=Users", ExternalId = "def", Hidden = false }]
+        };
+
+        var system = new ConnectedSystem
+        {
+            Id = 3,
+            Name = "Payroll",
+            Description = "Everything populated.",
+            ConnectorDefinitionId = 1,
+            MaxExportParallelism = 4
+        };
+        system.ObjectTypes!.Add(objectType);
+        system.Partitions = [partition];
+        system.RunProfiles!.Add(new ConnectedSystemRunProfile
+        {
+            Id = 50, Name = "Full Import", RunType = ConnectedSystemRunType.FullImport, PageSize = 100
+        });
+        return system;
+    }
+
+    private static MetaverseObjectType BuildFullMetaverseObjectType()
+    {
+        var type = new MetaverseObjectType
+        {
+            Id = 1,
+            Name = "User",
+            PluralName = "Users",
+            BuiltIn = false,
+            DeletionGracePeriod = TimeSpan.FromDays(7)
+        };
+        type.Attributes.Add(new MetaverseAttribute { Id = 2, Name = "displayName" });
+        return type;
+    }
+
+    private static MetaverseAttribute BuildFullMetaverseAttribute()
+    {
+        var attribute = new MetaverseAttribute
+        {
+            Id = 2,
+            Name = "displayName",
+            BuiltIn = false
+        };
+        attribute.MetaverseObjectTypes = [new MetaverseObjectType { Id = 1, Name = "User", PluralName = "Users" }];
+        return attribute;
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Servers/ConfigurationChangeClassifierTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConfigurationChangeClassifierTests.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Application.Services;
+using JIM.Data;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Behaviour of <see cref="ConfigurationChangeClassifier"/>: that a change takes the highest class among
+/// the properties that actually changed, that cosmetic-only edits stay silent, and that an unclassified
+/// property fails loudly rather than defaulting. See engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md.
+/// </summary>
+[TestFixture]
+public class ConfigurationChangeClassifierTests
+{
+    private JimApplication _jim = null!;
+    private ConfigurationSnapshotService _snapshots = null!;
+    private ConfigurationDiffService _diffs = null!;
+    private static readonly byte[] HashKey = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+        _jim = new JimApplication(new Mock<IRepository>().Object);
+        _snapshots = _jim.ConfigurationSnapshots;
+        _diffs = new ConfigurationDiffService();
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    #region Highest class wins
+
+    [Test]
+    public void Classify_RenameOnly_IsCosmetic()
+    {
+        // The question an administrator actually asks: renaming a rule must not raise a preview.
+        var before = SyncRule("HR Inbound");
+        var after = SyncRule("HR Inbound (EMEA)");
+
+        Assert.That(ClassifyChange(before, after), Is.EqualTo(ConfigurationChangeClass.Cosmetic));
+    }
+
+    [Test]
+    public void Classify_DescriptionOnly_IsCosmetic()
+    {
+        var before = SyncRule("HR Inbound");
+        var after = SyncRule("HR Inbound");
+        after.Description = "Now with a description.";
+
+        Assert.That(ClassifyChange(before, after), Is.EqualTo(ConfigurationChangeClass.Cosmetic));
+    }
+
+    [Test]
+    public void Classify_ScopeChange_IsSyncAffecting()
+    {
+        var before = SyncRule("HR Inbound");
+        var after = SyncRule("HR Inbound");
+        after.Enabled = false;
+
+        Assert.That(ClassifyChange(before, after), Is.EqualTo(ConfigurationChangeClass.SyncAffecting));
+    }
+
+    [Test]
+    public void Classify_DeprovisionActionChange_IsDestructive()
+    {
+        var before = SyncRule("HR Inbound");
+        var after = SyncRule("HR Inbound");
+        after.OutboundDeprovisionAction = OutboundDeprovisionAction.Delete;
+
+        Assert.That(ClassifyChange(before, after), Is.EqualTo(ConfigurationChangeClass.Destructive));
+    }
+
+    [Test]
+    public void Classify_RenameAlongsideDeprovisionActionChange_TakesTheHighestClass()
+    {
+        // A cosmetic edit must never mask a destructive one sharing the same save.
+        var before = SyncRule("HR Inbound");
+        var after = SyncRule("HR Inbound (EMEA)");
+        after.OutboundDeprovisionAction = OutboundDeprovisionAction.Delete;
+
+        Assert.That(ClassifyChange(before, after), Is.EqualTo(ConfigurationChangeClass.Destructive));
+    }
+
+    [Test]
+    public void Classify_NoChange_IsNotClassified()
+    {
+        var before = SyncRule("HR Inbound");
+        var after = SyncRule("HR Inbound");
+
+        Assert.That(ClassifyChange(before, after), Is.EqualTo(ConfigurationChangeClass.NotClassified));
+    }
+
+    #endregion
+
+    #region Object types and settings
+
+    [Test]
+    public void ClassifyKey_WhollyCosmeticObjectType_IsCosmeticWithoutAKeyTable()
+    {
+        // Schedules never affect a synchronisation outcome, so any of their properties is Class C.
+        var result = ConfigurationChangeClassifier.ClassifyKey(
+            ConfigurationSnapshotService.ScheduleObjectType, "anyPropertyAtAll");
+
+        Assert.That(result, Is.EqualTo(ConfigurationChangeClass.Cosmetic));
+    }
+
+    [Test]
+    public void ClassifyKey_ServiceSettingValue_IsClassifiedBySettingKeyNotNodeKey()
+    {
+        var partitionValidation = ConfigurationChangeClassifier.ClassifyKey(
+            ConfigurationSnapshotService.ServiceSettingObjectType, "value", Constants.SettingKeys.PartitionValidationMode);
+        var pageSize = ConfigurationChangeClassifier.ClassifyKey(
+            ConfigurationSnapshotService.ServiceSettingObjectType, "value", Constants.SettingKeys.SyncPageSize);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(partitionValidation, Is.EqualTo(ConfigurationChangeClass.SyncAffecting));
+            Assert.That(pageSize, Is.EqualTo(ConfigurationChangeClass.Cosmetic));
+        }
+    }
+
+    [Test]
+    public void ClassifyKey_ServiceSettingValueWithoutASettingKey_Throws()
+    {
+        // Silently classifying an unidentified setting would be a guess; the framework must not guess.
+        Assert.Throws<InvalidOperationException>(() => ConfigurationChangeClassifier.ClassifyKey(
+            ConfigurationSnapshotService.ServiceSettingObjectType, "value"));
+    }
+
+    #endregion
+
+    #region No default class
+
+    [Test]
+    public void ClassifyKey_UnknownProperty_ThrowsNamingTheKey()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => ConfigurationChangeClassifier.ClassifyKey(
+            ConfigurationSnapshotService.SyncRuleObjectType, "somePropertyNobodyClassified"));
+
+        Assert.That(ex!.Message, Does.Contain("somePropertyNobodyClassified"),
+            "the failure must name the offending key so the developer knows what to classify");
+    }
+
+    [Test]
+    public void ClassifyKey_UnknownObjectType_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => ConfigurationChangeClassifier.ClassifyKey(
+            "SomeNewSnapshotType", "name"));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private ConfigurationChangeClass ClassifyChange(SyncRule before, SyncRule after)
+    {
+        var diff = _diffs.Diff(_snapshots.CreateSnapshot(before, HashKey), _snapshots.CreateSnapshot(after, HashKey));
+        return ConfigurationChangeClassifier.Classify(diff);
+    }
+
+    private static SyncRule SyncRule(string name) => new()
+    {
+        Id = 42,
+        Name = name,
+        Direction = SyncRuleDirection.Import,
+        Enabled = true,
+        ConnectedSystemId = 3,
+        ConnectedSystemObjectTypeId = 7,
+        MetaverseObjectTypeId = 1
+    };
+
+    #endregion
+}


### PR DESCRIPTION
## Description

Foundation work for #827 (Configuration change preview): a persisted classification of *how consequential* each configuration change was, so downstream surfaces (the "changed since last Full Synchronisation" indicator, and later the preview itself) can tell a rename apart from a change that alters synchronisation outcomes.

Three parts:

1. **The model and the developer guide** (`engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md`). Three classes: **A Destructive**, **B Sync-affecting**, **C Cosmetic/operational**. The distinction is *directness*, not severity. A change takes the highest class among the properties that actually changed. The guide is written as a developer guide: what the model is, where the A/B line sits, and what you must do when you add or change a configuration property.
2. **The classifier** (`ConfigurationChangeClassifier`), driven by explicit per-key tables for Synchronisation Rule, Connected System, Metaverse Object Type, Metaverse Attribute and Service Settings (by setting key), plus a set of object types declared wholly cosmetic. There is deliberately **no default class**: an unclassified key throws, naming itself.
3. **Persistence.** `Activity.ConfigurationChangeClass` (new column, migration `20260730110312`), populated in `ConfigurationChangeCaptureService` from the diff it already computes for the no-change dedupe guard. Deletions record `Destructive` unconditionally.

Nothing surfaces the class yet; this PR is the hook the next chunk reads.

Part of #827.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

`dotnet build JIM.sln`: 0 errors, 0 warnings. `dotnet test JIM.sln`: 4,397 passed, 0 failed.

Two new fixtures:

- `ConfigurationChangeClassifierTests` covers the behaviour that matters to an administrator: a rename is Cosmetic, disabling a rule is Sync-affecting, changing the Outbound Deprovision Action is Destructive, and a rename sharing a save with a destructive edit still reports Destructive.
- `ConfigurationChangeClassificationCompletenessTests` is the durability mechanism, in the same spirit as `BulkInsertColumnCompletenessTests`. It drives `ConfigurationSnapshotService` with fully populated objects, walks every node key the snapshot actually emits, and asserts each one classifies. It also reflects over `Constants.SettingKeys` and over the snapshot object type discriminators. Adding a configuration property without classifying it fails the build naming the key.

That guard earned its keep immediately: it caught four keys a careful manual read of the snapshot service had missed (`childGroups`, `attributeId`, `metaverseObjectTypeId`, `objectMatchingRules`).

### Runtime verification

Unit tests prove the classifier; they do not prove the capture path persists what it computes. Verified against the running stack (database, Keycloak, JIM.Web, JIM.Worker) by driving the portal and reading the `Activities` table directly. Every case landed as designed:

| Action on a Metaverse Object Type | Version | `ConfigurationChangeClass` |
|---|---|---|
| Create | 1 | `NotClassified` (no prior state to diff) |
| Deletion grace period 0 → 7 days | 2 | `Destructive` |
| Rename to "Contractor (EMEA)" | 3 | `Cosmetic` |
| Delete | unversioned | `Destructive` |

A Connected System update performed by the Worker during startup was independently recorded as `Cosmetic`, confirming the non-portal capture paths classify too. The migration applied cleanly to an existing database, and pre-existing Activities read back as `NotClassified` as intended.

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

No `docs/` change and no changelog entry: this is internal framework plumbing with no user-visible behaviour yet. The first user-facing change lands with the surface that reads the column.

<!-- Docs: n/a - internal framework foundation; no user-visible behaviour in this PR -->

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

**Classification failure degrades rather than losing the audit record.** `ClassifyOrDefault` catches the classifier's `InvalidOperationException`, logs a warning naming the key, and records the snapshot with `NotClassified`. The completeness tests exist to stop that ever reaching a deployment, but if it does, an audit gap is far worse than an unclassified entry: the change history is what customers rely on, whilst the class only decides how loudly JIM warns.

**Pre-existing Activities carry `NotClassified`.** The column defaults to 0 and is not backfilled; guessing a class for historical changes would be inventing audit data.

**Creates are not classified.** A create has no prior state to diff, so nothing is at risk and the class stays `NotClassified`.

**Known gap recorded for the adapter work:** container selection is not captured in the Connected System snapshot (only `name`, `externalId`, `hidden` are), so the container half of #827's gap G4 cannot be classified or previewed until `ConfigurationSnapshotService` captures it.

**Follow-up:** the "Configuration changed since last Full Synchronisation" indicator, which reads this column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR