### PR TITLE
LDAPS certificate validation: make it work, honour the JIM certificate store, and show the certificate when a directory refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- 🔄 Stack traces are now hidden behind a "Show stack trace" toggle wherever JIM reports an error (Activity detail, Import Results detail, the Operations history panel and Pending Export detail), so the error message itself leads. The trace is unchanged and one click away. (#1132)
 - 🔄 The LDAP Connector's "Certificate Validation" setting has been removed. Its "Skip Validation" option could never be honoured for an individual Connected System, and validation is now always applied to LDAPS connections. Where a directory's certificate is not trusted, add it in Admin > Certificates; where the certificate name does not match the host being connected to, give the JIM containers a host entry for that name (`extra_hosts` in Docker Compose) and use the name in the Host setting, rather than weakening validation. See the [LDAP Connector documentation](https://tetronio.github.io/JIM/connectors/jim-ldap-connector/) for both. (#1132)
 
 ## [0.14.0] - 2026-07-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- 🔒 LDAPS connections to a directory now genuinely validate the certificate it presents, checking the issuer, the validity period, and that the certificate was issued for the host JIM connects to, before the service account's credentials are sent. Certificates added in Admin > Certificates are honoured for the first time: they are trusted in addition to the operating system's trust store, never in place of it, so adding one can only ever allow more connections, never fewer. An internal certificate authority or a directory's own self-signed certificate both work. Previously the validation code could not run at all in JIM's containers, so adding any certificate broke LDAPS with a connectivity error instead. (#1132)
+
+### Fixed
+
+- 🐛 A setting withdrawn from a Connector no longer lingers on Connected Systems that already held a value for it. The setting was being detached from its Connector Definition rather than deleted, leaving the row behind with the saved values still pointing at it. (#1132)
+
+### Changed
+
+- 🔄 The LDAP Connector's "Certificate Validation" setting has been removed. Its "Skip Validation" option could never be honoured for an individual Connected System, and validation is now always applied to LDAPS connections. Where a directory's certificate is not trusted, add it in Admin > Certificates; where the certificate name does not match the host being connected to, give the JIM containers a host entry for that name (`extra_hosts` in Docker Compose) and use the name in the Host setting, rather than weakening validation. See the [LDAP Connector documentation](https://tetronio.github.io/JIM/connectors/jim-ldap-connector/) for both. (#1132)
+
 ## [0.14.0] - 2026-07-25
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🔒 LDAPS connections to a directory now genuinely validate the certificate it presents, checking the issuer, the validity period, and that the certificate was issued for the host JIM connects to, before the service account's credentials are sent. Certificates added in Admin > Certificates are honoured for the first time: they are trusted in addition to the operating system's trust store, never in place of it, so adding one can only ever allow more connections, never fewer. An internal certificate authority or a directory's own self-signed certificate both work. Previously the validation code could not run at all in JIM's containers, so adding any certificate broke LDAPS with a connectivity error instead. (#1132)
 
+### Added
+
+- ✨ When an LDAPS connection to a directory fails because of the certificate it presented, JIM now shows you that certificate rather than an unhelpful "the server is unavailable": its subject, the names it was issued for, its issuer, validity dates and thumbprint, laid out as the certificate itself, alongside which check it failed and what to do about it. It appears when testing a Connected System's settings and on the failed Activity, with the same detail available to automation on the Activity's `errorDetail` field in the REST API. Nothing is trusted in order to show it, and a failure unrelated to the certificate reports exactly as before. (#1132)
+
 ### Fixed
 
 - 🐛 A setting withdrawn from a Connector no longer lingers on Connected Systems that already held a value for it. The setting was being detached from its Connector Definition rather than deleted, leaving the row behind with the saved values still pointing at it. (#1132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - 🐛 A setting withdrawn from a Connector no longer lingers on Connected Systems that already held a value for it. The setting was being detached from its Connector Definition rather than deleted, leaving the row behind with the saved values still pointing at it. (#1132)
+- 🐛 Saving an LDAPS Connected System's settings, retrieving its schema, or retrieving its hierarchy no longer hangs indefinitely in the portal when certificates are present in Admin > Certificates. Reading the certificate store blocked the page's own thread waiting for work that could only run on that same thread, so the operation never finished and the page sat on its progress spinner. (#1132)
 
 ### Changed
 

--- a/docs/configuration/certificates.md
+++ b/docs/configuration/certificates.md
@@ -6,6 +6,8 @@ title: Certificates
 
 **Certificates** store trusted CA and intermediate certificates used by [connectors](../connectors/index.md) for LDAP and HTTPS authentication. Each certificate can be enabled or disabled independently without removing it.
 
+Certificates added here are trusted **in addition to** the operating system's own trust store, never in place of it, so adding one can only ever allow more connections to succeed. A directory server's own self-signed certificate can be added directly, not just the certificate authority that issued it. Certificate validation itself cannot be switched off for an individual Connected System; see [certificate validation](../connectors/jim-ldap-connector.md#certificate-validation) in the LDAP Connector documentation for what is checked.
+
 ## Two source types
 
 Certificates can be added in one of two ways:

--- a/docs/connectors/jim-ldap-connector.md
+++ b/docs/connectors/jim-ldap-connector.md
@@ -200,8 +200,10 @@ If JIM cannot connect to the directory server:
 - Check that the port is correct (389 for LDAP, 636 for LDAPS) and not blocked by a firewall.
 - Increase the Connection Timeout if the directory server is slow to respond.
 
-!!! tip "LDAPS failures report as an unavailable server"
-    The LDAP client library reports a rejected certificate the same way it reports an unreachable server, so "The LDAP server is unavailable" on port 636 is as likely to be a certificate problem as a network one. Check the worker log for the warnings JIM writes when preparing certificates, then work through [Certificate validation](#certificate-validation): the usual causes are an issuer JIM has not been given, and a certificate whose name does not match the Host setting.
+!!! tip "LDAPS failures show you the certificate"
+    The LDAP client library reports a rejected certificate the same way it reports an unreachable server, so its own message ("The LDAP server is unavailable") tells you nothing. JIM therefore looks at the certificate itself when an LDAPS connection fails, and shows it to you: its subject, the names it was issued for, its issuer, its validity dates and its thumbprint, alongside which check it failed and what to do about it.
+
+    You will see it in two places: on the Connected System's settings when you test the connection, and on the failed Activity when a Run Profile could not connect. The same detail is available to automation on the Activity's `errorDetail` field in the REST API. If the connection failed for a reason that is nothing to do with the certificate, the original error stands unchanged.
 
 ### Authentication failures
 

--- a/docs/connectors/jim-ldap-connector.md
+++ b/docs/connectors/jim-ldap-connector.md
@@ -50,7 +50,7 @@ JIM automatically detects the directory type during schema discovery by inspecti
 ### Security and Connectivity
 
 - **LDAPS (SSL/TLS)**<br /> Encrypted communication over port 636 (or custom port).
-- **Certificate validation**<br /> Full validation against system CA store and JIM-managed certificates, with an option to skip validation for testing.
+- **Certificate validation**<br /> Always on for LDAPS: the certificate chain, its validity period, and its name are all checked. Certificates added in Admin > Certificates are trusted in addition to the operating system's own trust store.
 - **Authentication types**<br /> Simple bind or NTLM authentication.
 - **Automatic retry**<br /> Configurable retry with exponential backoff for transient failures.
 
@@ -62,8 +62,7 @@ JIM automatically detects the directory type during schema discovery by inspecti
 |---------|-------------|---------|---------|
 | Host | Hostname or IP address of the directory server. IP address is fastest. | *(required)* | `dc01.corp.local` |
 | Port | Port for the LDAP connection. Use 389 for LDAP or 636 for LDAPS. | `389` | `636` |
-| Use Secure Connection (LDAPS)? | Enable LDAPS (SSL/TLS) for encrypted communication. | `false` | `true` |
-| Certificate Validation | How to validate the server's SSL certificate. Full Validation uses the system CA store plus any certificates added in Admin > Certificates. Only shown, and required, when "Use Secure Connection (LDAPS)?" is enabled. | `Full Validation` | `Skip Validation` |
+| Use Secure Connection (LDAPS)? | Enable LDAPS (SSL/TLS) for encrypted communication. Certificate validation is always applied; see [Certificate validation](#certificate-validation). | `false` | `true` |
 | Connection Timeout | Time in seconds to wait before giving up on a connection attempt. | `10` | `30` |
 
 ### Credentials
@@ -136,10 +135,42 @@ JIM's own large-scale integration testing (up to 500,000 users, with individual 
 
 LDAP traffic is unencrypted by default. In production environments, **always enable LDAPS** (SSL/TLS) to protect credentials and identity data in transit. Set the port to 636 and enable the "Use Secure Connection (LDAPS)?" setting.
 
-If your directory server uses a certificate issued by an internal certificate authority, upload the CA certificate to JIM via **Admin > Certificates** so that certificate validation can succeed.
+### Certificate validation
 
-!!! warning "Skip Validation"
-    The "Skip Validation" certificate option is provided for testing and initial setup only. It disables certificate chain verification, which exposes the connection to man-in-the-middle attacks. Never use this setting in production.
+When LDAPS is enabled, JIM validates the certificate the directory server presents. Three things are checked, and any one of them failing stops the connection before the service account's credentials are sent:
+
+- **Chain**<br /> The certificate must chain to an issuer JIM trusts: either one in the operating system's trust store, or one added in **Admin > Certificates**.
+- **Validity period**<br /> An expired or not-yet-valid certificate is rejected, including when its issuer is one you added yourself.
+- **Name**<br /> The certificate must have been issued for the value in the Host setting. A certificate for `dc01.corp.local` is not accepted when JIM connects to `10.0.0.5`, or to `dc01`.
+
+There is no per Connected System option to relax any of this.
+
+#### Trusting an internal certificate authority, or a self-signed certificate
+
+Upload the certificate to JIM via **Admin > Certificates**. Both work:
+
+- **An internal certificate authority**<br /> Upload the CA (and any intermediates). Every directory server whose certificate it issued is then trusted.
+- **The directory server's own self-signed certificate**<br /> Upload the server certificate itself. Only that certificate is then trusted, which is the tighter option where a directory has no certificate authority behind it.
+
+Certificates added this way are trusted **in addition to** the operating system's trust store, so adding one never stops a publicly-issued or already-trusted certificate from working.
+
+#### When the certificate name does not match the host you connect to
+
+This is the common obstacle: a certificate issued for a fully-qualified name, in an environment where JIM cannot resolve that name, so the Host setting holds an IP address instead. Uploading the certificate does not help, because the name still does not match.
+
+Rather than weakening validation, give JIM's containers a way to resolve the name. In Docker Compose, add a host entry to the `jim.web` and `jim.worker` services:
+
+```yaml
+services:
+  jim.worker:
+    extra_hosts:
+      - "dc01.corp.local:10.0.0.5"
+```
+
+Set the Host setting to `dc01.corp.local`. The name now resolves inside the container, the certificate matches, and the connection is fully validated. This works when DNS is unavailable or unreliable, because the mapping is static and needs no name server. The alternative is to have the certificate reissued with the name (or IP address) you actually connect to.
+
+!!! warning "Disabling validation entirely"
+    OpenLDAP's own `LDAPTLS_REQCERT=never` environment variable is honoured by the LDAP client library JIM's containers use, and switches certificate validation off. It applies to the whole container, so it affects **every** LDAPS Connected System that container serves, and it cannot be scoped to one directory. JIM's development and integration test stacks set it for their throw-away directories. Never set it in production: it exposes the service account's credentials to anyone able to intercept the connection.
 
 ### Service Account Permissions
 
@@ -167,8 +198,10 @@ If JIM cannot connect to the directory server:
 
 - Verify the hostname or IP address is correct and reachable from the JIM container (`ping` or `nslookup` from within the container).
 - Check that the port is correct (389 for LDAP, 636 for LDAPS) and not blocked by a firewall.
-- For LDAPS, ensure the server's certificate is trusted -- either by the system CA store or by uploading it to JIM via Admin > Certificates.
 - Increase the Connection Timeout if the directory server is slow to respond.
+
+!!! tip "LDAPS failures report as an unavailable server"
+    The LDAP client library reports a rejected certificate the same way it reports an unreachable server, so "The LDAP server is unavailable" on port 636 is as likely to be a certificate problem as a network one. Check the worker log for the warnings JIM writes when preparing certificates, then work through [Certificate validation](#certificate-validation): the usual causes are an issuer JIM has not been given, and a certificate whose name does not match the Host setting.
 
 ### Authentication failures
 

--- a/src/JIM.Application/Servers/ActivityServer.cs
+++ b/src/JIM.Application/Servers/ActivityServer.cs
@@ -330,6 +330,7 @@ public class ActivityServer
     {
         var now = DateTime.UtcNow;
         activity.ErrorMessage = GetFullExceptionMessage(exception);
+        activity.ErrorDetail = ActivityErrorDetail.TryDescribe(exception);
 
         // Only persist stack traces for unexpected errors (bugs), not for operational errors
         // that have clear, user-actionable messages

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -1317,9 +1317,18 @@ public class ConnectedSystemServer
 
         // resolve the connector so its own, connector-specific validation can run too. connectors that don't
         // implement IConnectorSettings have no such validation to add; the generic results above stand alone.
+        // validation opens real connections, so the connector is disposed here rather than left to the collector:
+        // it holds the connection and any temporary files prepared for it.
         var connector = CreateConnector(connectedSystem);
-        if (connector is IConnectorSettings settingsConnector)
-            results.AddRange(settingsConnector.ValidateSettingValues(connectedSystem.SettingValues, Log.Logger));
+        try
+        {
+            if (connector is IConnectorSettings settingsConnector)
+                results.AddRange(settingsConnector.ValidateSettingValues(connectedSystem.SettingValues, Log.Logger));
+        }
+        finally
+        {
+            (connector as IDisposable)?.Dispose();
+        }
 
         return results;
     }

--- a/src/JIM.Application/Servers/SeedingServer.cs
+++ b/src/JIM.Application/Servers/SeedingServer.cs
@@ -1576,6 +1576,14 @@ internal class SeedingServer
                 ActivityInitiatorType.System, null, "System",
                 changeReason: "Connector Definition updated automatically by JIM to match the latest connector.",
                 parentActivityId: parentActivityId);
+
+            // Detaching an obsolete setting from the definition above only severs it: its foreign key is nullable, so
+            // the row survives holding no definition while every value an administrator saved against it still points
+            // at it, and the withdrawn setting keeps appearing on Connected Systems that hold one. Delete the rows so
+            // those values cascade away with them.
+            if (settingsToRemove.Count > 0)
+                await Application.Repository.ConnectedSystems.DeleteConnectorDefinitionSettingsAsync(settingsToRemove);
+
             Log.Information($"SyncConnectorDefinitionAsync: Saved changes for '{connector.Name}'");
         }
         else

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -148,22 +148,28 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     public async Task<ConnectorSchema> GetSchemaAsync(List<ConnectedSystemSettingValue> settingValues, ILogger logger)
     {
         OpenImportConnection(settingValues, logger);
-        if (_connection == null)
-            throw new Exception("No connection available to get schema with");
 
-        var includeAuxiliaryClasses = settingValues.SingleOrDefault(q => q.Setting.Name == _settingIncludeAuxiliaryClasses)?.CheckboxValue ?? false;
+        try
+        {
+            if (_connection == null)
+                throw new InvalidOperationException("No connection available to get schema with");
 
-        var rootDse = LdapConnectorUtilities.GetBasicRootDseInformation(_connection, logger);
+            var includeAuxiliaryClasses = settingValues.SingleOrDefault(q => q.Setting.Name == _settingIncludeAuxiliaryClasses)?.CheckboxValue ?? false;
 
-        // Auto-tune settings based on the detected directory type.
-        // This modifies setting values in-place; the application layer persists
-        // the Connected System after schema import, saving any changes.
-        AutoTuneExportConcurrency(settingValues, rootDse, logger);
+            var rootDse = LdapConnectorUtilities.GetBasicRootDseInformation(_connection, logger);
 
-        var ldapConnectorSchema = new LdapConnectorSchema(_connection, logger, rootDse, includeAuxiliaryClasses);
-        var schema = await ldapConnectorSchema.GetSchemaAsync();
-        CloseImportConnection();
-        return schema;
+            // Auto-tune settings based on the detected directory type.
+            // This modifies setting values in-place; the application layer persists
+            // the Connected System after schema import, saving any changes.
+            AutoTuneExportConcurrency(settingValues, rootDse, logger);
+
+            var ldapConnectorSchema = new LdapConnectorSchema(_connection, logger, rootDse, includeAuxiliaryClasses);
+            return await ldapConnectorSchema.GetSchemaAsync();
+        }
+        finally
+        {
+            CloseImportConnection();
+        }
     }
     #endregion
 
@@ -213,18 +219,24 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     public async Task<List<ConnectorPartition>> GetPartitionsAsync(List<ConnectedSystemSettingValue> settingValues, ILogger logger)
     {
         OpenImportConnection(settingValues, logger);
-        if (_connection == null)
-            throw new Exception("No connection available to get partitions with");
 
-        var skipHiddenPartitions = settingValues.SingleOrDefault(q => q.Setting.Name == _settingSkipHiddenPartitions)?.CheckboxValue ?? true;
+        try
+        {
+            if (_connection == null)
+                throw new InvalidOperationException("No connection available to get partitions with");
 
-        // Detect directory type so partition discovery can use the appropriate mechanism
-        var rootDse = LdapConnectorUtilities.GetBasicRootDseInformation(_connection, logger);
+            var skipHiddenPartitions = settingValues.SingleOrDefault(q => q.Setting.Name == _settingSkipHiddenPartitions)?.CheckboxValue ?? true;
 
-        var ldapConnectorPartitions = new LdapConnectorPartitions(_connection, logger, rootDse.DirectoryType);
-        var partitions = await ldapConnectorPartitions.GetPartitionsAsync(skipHiddenPartitions);
-        CloseImportConnection();
-        return partitions;
+            // Detect directory type so partition discovery can use the appropriate mechanism
+            var rootDse = LdapConnectorUtilities.GetBasicRootDseInformation(_connection, logger);
+
+            var ldapConnectorPartitions = new LdapConnectorPartitions(_connection, logger, rootDse.DirectoryType);
+            return await ldapConnectorPartitions.GetPartitionsAsync(skipHiddenPartitions);
+        }
+        finally
+        {
+            CloseImportConnection();
+        }
     }
     #endregion
 
@@ -284,11 +296,22 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         _connectionFactory = () => CreateConnection(identifier, credential, authTypeEnumValue,
             TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value), useSsl, logger);
 
-        // Execute connection with retry logic
-        ExecuteWithRetry(() =>
+        // Execute connection with retry logic. A failure here leaves nothing behind: the trust directory is only of
+        // use to a connection that was established, and a rejected certificate reports as a failure to connect, so
+        // without this every refused LDAPS attempt would leave one on disk.
+        try
         {
-            _connection = _connectionFactory();
-        }, maxRetries, retryDelayMs, logger);
+            ExecuteWithRetry(() =>
+            {
+                _connection = _connectionFactory();
+            }, maxRetries, retryDelayMs, logger);
+        }
+        catch
+        {
+            _trustDirectory?.Dispose();
+            _trustDirectory = null;
+            throw;
+        }
     }
 
     /// <summary>
@@ -665,8 +688,15 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     {
         try
         {
-            OpenImportConnection(settingValues, logger);
-            CloseImportConnection();
+            try
+            {
+                OpenImportConnection(settingValues, logger);
+            }
+            finally
+            {
+                CloseImportConnection();
+            }
+
             return new ConnectorSettingValueValidationResult
             {
                 IsValid = true

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -9,7 +9,6 @@ using JIM.Models.Transactional;
 using Serilog;
 using System.DirectoryServices.Protocols;
 using System.Net;
-using System.Security.Cryptography.X509Certificates;
 namespace JIM.Connectors.LDAP;
 
 public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSettings, IConnectorSchema, IConnectorPartitions, IConnectorImportUsingCalls, IConnectorExportUsingCalls, IConnectorCertificateAware, IConnectorCredentialAware, IConnectorContainerCreation, IConnectorRecommendedExportParallelism, IDisposable
@@ -20,7 +19,7 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     private bool _disposed;
     private ICertificateProvider? _certificateProvider;
     private ICredentialProtection? _credentialProtection;
-    private List<X509Certificate2>? _trustedCertificates;
+    private LdapTrustedCertificateDirectory? _trustDirectory;
     private LdapConnectorExport? _currentExport;
 
     #region IConnector members
@@ -55,7 +54,6 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     private readonly string _settingDirectoryServer = "Host";
     private readonly string _settingDirectoryServerPort = "Port";
     private readonly string _settingUseSecureConnection = "Use Secure Connection (LDAPS)?";
-    private readonly string _settingCertificateValidation = "Certificate Validation";
     private readonly string _settingConnectionTimeout = "Connection Timeout";
     private readonly string _settingUsername = "Username";
     private readonly string _settingPassword = "Password";
@@ -90,7 +88,6 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
             new() { Name = _settingDirectoryServer, Required = true, Description = "Supply a directory server/domain controller hostname or IP address. IP address is fastest.", Category = ConnectedSystemSettingCategory.Connectivity, Type = ConnectedSystemSettingType.String },
             new() { Name = _settingDirectoryServerPort, Required = true, Description = "The port to connect to the directory service on. Use 389 for LDAP or 636 for LDAPS.", DefaultIntValue = LdapConnectorConstants.DEFAULT_LDAP_PORT, Category = ConnectedSystemSettingCategory.Connectivity, Type = ConnectedSystemSettingType.Integer },
             new() { Name = _settingUseSecureConnection, Description = "Enable LDAPS (SSL/TLS) for encrypted communication. Requires appropriate port (typically 636).", DefaultCheckboxValue = false, Category = ConnectedSystemSettingCategory.Connectivity, Type = ConnectedSystemSettingType.CheckBox },
-            new() { Name = _settingCertificateValidation, Required = false, RequiredWhenSetting = _settingUseSecureConnection, RequiredWhenValue = "true", DefaultStringValue = LdapConnectorConstants.CERT_VALIDATION_FULL, Description = "How to validate the server's SSL certificate. Full validation uses system CA store plus any certificates added in Admin > Certificates.", Type = ConnectedSystemSettingType.DropDown, DropDownValues = new() { LdapConnectorConstants.CERT_VALIDATION_FULL, LdapConnectorConstants.CERT_VALIDATION_SKIP }, Category = ConnectedSystemSettingCategory.Connectivity },
             new() { Name = _settingConnectionTimeout, Required = true, Description = "How long to wait, in seconds, before giving up on trying to connect", DefaultIntValue = 10, Category = ConnectedSystemSettingCategory.Connectivity, Type = ConnectedSystemSettingType.Integer },
 
             new() { Name = "Credentials", Category = ConnectedSystemSettingCategory.Connectivity, Type = ConnectedSystemSettingType.Heading },
@@ -242,7 +239,6 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         var password = settingValues.SingleOrDefault(q => q.Setting.Name == _settingPassword);
         var authTypeSettingValue = settingValues.SingleOrDefault(q => q.Setting.Name == _settingAuthType);
         var useSecureConnection = settingValues.SingleOrDefault(q => q.Setting.Name == _settingUseSecureConnection);
-        var certificateValidation = settingValues.SingleOrDefault(q => q.Setting.Name == _settingCertificateValidation);
         var maxRetriesSetting = settingValues.SingleOrDefault(q => q.Setting.Name == _settingMaxRetries);
         var retryDelaySetting = settingValues.SingleOrDefault(q => q.Setting.Name == _settingRetryDelay);
 
@@ -255,20 +251,17 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
             throw new InvalidSettingValuesException($"Missing setting values for {_settingDirectoryServer}, {_settingDirectoryServerPort}, {_settingConnectionTimeout}, {_settingUsername},{_settingPassword}, or {_settingAuthType}.");
 
         var useSsl = useSecureConnection?.CheckboxValue ?? false;
-        var skipCertValidation = certificateValidation?.StringValue == LdapConnectorConstants.CERT_VALIDATION_SKIP;
         var maxRetries = maxRetriesSetting?.IntValue ?? LdapConnectorConstants.DEFAULT_MAX_RETRIES;
         var retryDelayMs = retryDelaySetting?.IntValue ?? LdapConnectorConstants.DEFAULT_RETRY_DELAY_MS;
 
-        logger.Debug("OpenImportConnection() Trying to connect to '{Server}' on port '{Port}' with username '{Username}' via auth type {AuthType}. SSL: {UseSsl}, SkipCertValidation: {SkipCertValidation}",
-            directoryServer.StringValue, directoryServerPort.IntValue, username.StringValue, authTypeSettingValue.StringValue, useSsl, skipCertValidation);
+        logger.Debug("OpenImportConnection() Trying to connect to '{Server}' on port '{Port}' with username '{Username}' via auth type {AuthType}. SSL: {UseSsl}",
+            directoryServer.StringValue, directoryServerPort.IntValue, username.StringValue, authTypeSettingValue.StringValue, useSsl);
 
-        // Load JIM certificates for full validation (supplements system CA store)
-        if (useSsl && !skipCertValidation && _certificateProvider != null)
-        {
-            _trustedCertificates = _certificateProvider.GetTrustedCertificatesAsync().GetAwaiter().GetResult();
-            if (_trustedCertificates.Count > 0)
-                logger.Debug("Loaded {Count} additional trusted certificates from JIM Store", _trustedCertificates.Count);
-        }
+        // Supply the certificates from the JIM certificate store as additional trust anchors for LDAPS. The platform
+        // LDAP client still performs the validation itself, so the chain, the validity period and the certificate's
+        // name are all checked against the Directory Server value above.
+        if (useSsl && _certificateProvider != null)
+            PrepareTrustedCertificateDirectory(logger);
 
         var identifier = new LdapDirectoryIdentifier(directoryServer.StringValue, directoryServerPort.IntValue.Value);
 
@@ -289,7 +282,7 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         // connections for parallel imports (one connection per container+objectType combo).
         // Captured values are immutable for the duration of the import session.
         _connectionFactory = () => CreateConnection(identifier, credential, authTypeEnumValue,
-            TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value), useSsl, skipCertValidation, logger);
+            TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value), useSsl, logger);
 
         // Execute connection with retry logic
         ExecuteWithRetry(() =>
@@ -309,7 +302,6 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         AuthType authType,
         TimeSpan timeout,
         bool useSsl,
-        bool skipCertValidation,
         ILogger logger)
     {
         var connection = new LdapConnection(identifier, credential, authType);
@@ -321,26 +313,18 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         {
             connection.SessionOptions.SecureSocketLayer = true;
 
-            if (skipCertValidation)
+            // The platform guard is a compile-time requirement, not a behavioural choice: both members below are
+            // unsupported on Windows. PrepareTrustedCertificateDirectory warns when that costs an administrator
+            // anything, so there is nothing further to say here.
+            if (_trustDirectory != null && !OperatingSystem.IsWindows())
             {
-                logger.Warning("Certificate validation is disabled. This is not recommended for production environments.");
-                // On Linux, setting VerifyServerCertificate can fail. Use LDAPTLS_REQCERT=never
-                // environment variable instead. On Windows, set the callback directly.
-                if (OperatingSystem.IsWindows())
-                {
-                    connection.SessionOptions.VerifyServerCertificate = (_, _) => true;
-                }
-                else
-                {
-                    logger.Debug("Skipping VerifyServerCertificate callback on Linux - using LDAPTLS_REQCERT environment variable");
-                }
+                // Adds the certificates from the JIM certificate store, alongside the operating system's own bundle,
+                // to what this connection will trust. A new TLS session context is mandatory: without it the platform
+                // LDAP client accepts the directory silently and carries on using the trust anchors it already had.
+                connection.SessionOptions.TrustedCertificatesDirectory = _trustDirectory.DirectoryPath;
+                connection.SessionOptions.StartNewTlsSessionContext();
+                logger.Debug("LDAPS: supplied the JIM certificate store as additional trust anchors for this connection");
             }
-            else if (_trustedCertificates != null && _trustedCertificates.Count > 0)
-            {
-                // Full validation with JIM certificates supplementing system store
-                connection.SessionOptions.VerifyServerCertificate = ValidateServerCertificate;
-            }
-            // else: use system default validation only
         }
 
         connection.Bind();
@@ -427,6 +411,11 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     public void CloseImportConnection()
     {
         _connection?.Dispose();
+
+        // The trust directory is only read while a TLS session is being established, so it is safe to remove as soon
+        // as the connection is closed. A later Open call prepares a fresh one.
+        _trustDirectory?.Dispose();
+        _trustDirectory = null;
     }
     #endregion
 
@@ -624,62 +613,51 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
 
     #region private methods
     /// <summary>
-    /// Validates a server certificate against both system CA store and JIM certificate store.
-    /// Returns true if the certificate is trusted by either store.
+    /// Materialises the certificates held in the JIM certificate store into a temporary trust directory that LDAPS
+    /// connections from this connector instance will consult, on top of the operating system's own trust anchors.
     /// </summary>
-    private bool ValidateServerCertificate(LdapConnection connection, X509Certificate certificate)
+    /// <remarks>
+    /// A failure here is deliberately not fatal: the connection still proceeds under the operating system's trust
+    /// anchors alone, which is stricter than proceeding without them, and the administrator gets a warning naming the
+    /// cause rather than a connection that silently trusts less than they configured.
+    /// </remarks>
+    private void PrepareTrustedCertificateDirectory(ILogger logger)
     {
+        if (_certificateProvider == null)
+            return;
+
+        if (OperatingSystem.IsWindows())
+        {
+            // JIM ships as Linux containers; the platform LDAP client on Windows offers no supported way to add trust
+            // anchors to a connection. Running JIM directly on Windows is a UI development loop only, so warn and
+            // leave the operating system's own trust anchors in charge rather than pretending the store was applied.
+            logger.Warning("LDAPS: certificates from the JIM certificate store cannot be applied when JIM runs directly on Windows. The connection will use the operating system trust anchors only");
+            return;
+        }
+
+        var trustedCertificates = _certificateProvider.GetTrustedCertificatesAsync().GetAwaiter().GetResult();
+
         try
         {
-            var serverCert = new X509Certificate2(certificate);
-
-            // First try standard system validation
-            using var systemChain = new X509Chain();
-            systemChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-            if (systemChain.Build(serverCert))
+            if (trustedCertificates.Count == 0)
             {
-                Log.Debug("Server certificate validated by system CA store");
-                return true;
+                logger.Debug("No certificates in the JIM certificate store; LDAPS validation will use the operating system trust anchors only");
+                return;
             }
 
-            // System validation failed - try with JIM certificates
-            if (_trustedCertificates == null || _trustedCertificates.Count == 0)
-            {
-                Log.Warning("Server certificate not trusted by system CA store and no JIM certificates available. Thumbprint: {Thumbprint}, Subject: {Subject}",
-                    serverCert.Thumbprint, serverCert.Subject);
-                return false;
-            }
-
-            // Build chain with JIM certificates as additional trust anchors
-            using var jimChain = new X509Chain();
-            jimChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-            jimChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
-
-            foreach (var trustedCert in _trustedCertificates)
-            {
-                jimChain.ChainPolicy.ExtraStore.Add(trustedCert);
-            }
-
-            jimChain.Build(serverCert);
-
-            // Check if any certificate in the chain is in JIM's trusted store
-            foreach (var chainElement in jimChain.ChainElements)
-            {
-                if (_trustedCertificates.Any(tc => tc.Thumbprint.Equals(chainElement.Certificate.Thumbprint, StringComparison.OrdinalIgnoreCase)))
-                {
-                    Log.Debug("Server certificate validated via JIM certificate store");
-                    return true;
-                }
-            }
-
-            Log.Warning("Server certificate validation failed. Not trusted by system or JIM store. Thumbprint: {Thumbprint}, Subject: {Subject}",
-                serverCert.Thumbprint, serverCert.Subject);
-            return false;
+            _trustDirectory?.Dispose();
+            _trustDirectory = LdapTrustedCertificateDirectory.Create(trustedCertificates, logger);
+            logger.Debug("Loaded {Count} trusted certificate(s) from the JIM certificate store for LDAPS validation", trustedCertificates.Count);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or System.Security.SecurityException)
         {
-            Log.Error(ex, "Error validating server certificate");
-            return false;
+            _trustDirectory = null;
+            logger.Warning(ex, "Could not prepare the trusted certificate directory for LDAPS. Certificates from the JIM certificate store will not be used for this connection");
+        }
+        finally
+        {
+            foreach (var certificate in trustedCertificates)
+                certificate.Dispose();
         }
     }
 
@@ -728,6 +706,8 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         {
             _connection?.Dispose();
             _connection = null;
+            _trustDirectory?.Dispose();
+            _trustDirectory = null;
         }
 
         _disposed = true;

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using JIM.Models.Connectors;
 using JIM.Models.Core;
 using JIM.Models.Exceptions;
 using JIM.Models.Interfaces;
 using JIM.Models.Staging;
 using JIM.Models.Transactional;
+using JIM.Utilities;
 using Serilog;
 using System.DirectoryServices.Protocols;
 using System.Net;
@@ -306,11 +308,59 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
                 _connection = _connectionFactory();
             }, maxRetries, retryDelayMs, logger);
         }
+        catch (LdapException ex)
+        {
+            _trustDirectory?.Dispose();
+            _trustDirectory = null;
+
+            // "The LDAP server is unavailable" is what a refused certificate looks like, so before reporting a
+            // connectivity failure, go and look at what the server actually presented.
+            if (useSsl)
+                ThrowIfCertificateWasRejected(directoryServer.StringValue, directoryServerPort.IntValue.Value,
+                    TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value), logger, ex);
+
+            throw;
+        }
         catch
         {
             _trustDirectory?.Dispose();
             _trustDirectory = null;
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Examines the certificate the directory server presents and, when that is what refused the connection, replaces
+    /// the platform's opaque failure with one naming the certificate and what to do about it.
+    /// </summary>
+    /// <remarks>
+    /// Only ever called after a connection has already failed. The examination cannot make a connection succeed, and
+    /// deliberately trusts nothing: it exists so an administrator is told "this certificate, this problem" instead of
+    /// "the server is unavailable".
+    /// </remarks>
+    private void ThrowIfCertificateWasRejected(string host, int port, TimeSpan timeout, ILogger logger, LdapException originalException)
+    {
+        var trustedCertificates = _certificateProvider?.GetTrustedCertificatesAsync().GetAwaiter().GetResult() ?? [];
+
+        try
+        {
+            var diagnostic = ServerCertificateProbe.Probe(host, port, trustedCertificates, timeout, logger);
+            if (diagnostic == null || diagnostic.FailureReason == ServerCertificateFailureReason.None)
+                return;
+
+            logger.Error("LDAPS connection to {Host}:{Port} was refused because of the server's certificate. Reason: {Reason}. Subject: {Subject}, Issuer: {Issuer}, Thumbprint: {Thumbprint}, Valid to: {ValidTo}",
+                LogSanitiser.Sanitise(host), port, diagnostic.FailureReason, LogSanitiser.Sanitise(diagnostic.Subject),
+                LogSanitiser.Sanitise(diagnostic.Issuer), LogSanitiser.Sanitise(diagnostic.Thumbprint), diagnostic.ValidTo);
+
+            throw new ServerCertificateRejectedException(
+                $"The directory server's certificate was rejected: {diagnostic.Remediation}",
+                diagnostic,
+                originalException);
+        }
+        finally
+        {
+            foreach (var certificate in trustedCertificates)
+                certificate.Dispose();
         }
     }
 

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -11,6 +11,7 @@ using JIM.Utilities;
 using Serilog;
 using System.DirectoryServices.Protocols;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 namespace JIM.Connectors.LDAP;
 
 public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSettings, IConnectorSchema, IConnectorPartitions, IConnectorImportUsingCalls, IConnectorExportUsingCalls, IConnectorCertificateAware, IConnectorCredentialAware, IConnectorContainerCreation, IConnectorRecommendedExportParallelism, IDisposable
@@ -340,7 +341,7 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
     /// </remarks>
     private void ThrowIfCertificateWasRejected(string host, int port, TimeSpan timeout, ILogger logger, LdapException originalException)
     {
-        var trustedCertificates = _certificateProvider?.GetTrustedCertificatesAsync().GetAwaiter().GetResult() ?? [];
+        var trustedCertificates = GetTrustedCertificates();
 
         try
         {
@@ -708,7 +709,7 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
             return;
         }
 
-        var trustedCertificates = _certificateProvider.GetTrustedCertificatesAsync().GetAwaiter().GetResult();
+        var trustedCertificates = GetTrustedCertificates();
 
         try
         {
@@ -732,6 +733,24 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
             foreach (var certificate in trustedCertificates)
                 certificate.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Reads the certificates an administrator has added to the JIM certificate store.
+    /// </summary>
+    /// <remarks>
+    /// The connector API is synchronous, so this has to block; what matters is which thread it blocks. It blocks on a
+    /// thread-pool thread, because the portal validates Connected System settings on Blazor's renderer
+    /// synchronisation context, which runs one callback at a time: awaiting the store on that context would post the
+    /// continuation behind the very call that is waiting for it, and neither would ever finish.
+    /// </remarks>
+    private List<X509Certificate2> GetTrustedCertificates()
+    {
+        if (_certificateProvider == null)
+            return [];
+
+        var provider = _certificateProvider;
+        return Task.Run(provider.GetTrustedCertificatesAsync).GetAwaiter().GetResult();
     }
 
     private ConnectorSettingValueValidationResult TestDirectoryConnectivity(List<ConnectedSystemSettingValue> settingValues, ILogger logger)

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -270,7 +270,8 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         var retryDelayMs = retryDelaySetting?.IntValue ?? LdapConnectorConstants.DEFAULT_RETRY_DELAY_MS;
 
         logger.Debug("OpenImportConnection() Trying to connect to '{Server}' on port '{Port}' with username '{Username}' via auth type {AuthType}. SSL: {UseSsl}",
-            directoryServer.StringValue, directoryServerPort.IntValue, username.StringValue, authTypeSettingValue.StringValue, useSsl);
+            LogSanitiser.Sanitise(directoryServer.StringValue), directoryServerPort.IntValue,
+            LogSanitiser.Sanitise(username.StringValue), LogSanitiser.Sanitise(authTypeSettingValue.StringValue), useSsl);
 
         // Supply the certificates from the JIM certificate store as additional trust anchors for LDAPS. The platform
         // LDAP client still performs the validation itself, so the chain, the validity period and the certificate's
@@ -293,11 +294,15 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         else if (authTypeSettingValueString == LdapConnectorConstants.SETTING_AUTH_TYPE_NTLM)
             authTypeEnumValue = AuthType.Ntlm;
 
+        // Resolved once: the setting's validation guarantees a value by the time a connection is opened, and taking
+        // it here keeps the nullable dereference out of the lambda below and the failure path further down.
+        var connectionTimeout = TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value);
+
         // Build a reusable connection factory so LdapConnectorImport can create additional
         // connections for parallel imports (one connection per container+objectType combo).
         // Captured values are immutable for the duration of the import session.
         _connectionFactory = () => CreateConnection(identifier, credential, authTypeEnumValue,
-            TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value), useSsl, logger);
+            connectionTimeout, useSsl, logger);
 
         // Execute connection with retry logic. A failure here leaves nothing behind: the trust directory is only of
         // use to a connection that was established, and a rejected certificate reports as a failure to connect, so
@@ -318,7 +323,7 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
             // connectivity failure, go and look at what the server actually presented.
             if (useSsl)
                 ThrowIfCertificateWasRejected(directoryServer.StringValue, directoryServerPort.IntValue.Value,
-                    TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value), logger, ex);
+                    connectionTimeout, logger, ex);
 
             throw;
         }

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -294,9 +294,11 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorSetti
         else if (authTypeSettingValueString == LdapConnectorConstants.SETTING_AUTH_TYPE_NTLM)
             authTypeEnumValue = AuthType.Ntlm;
 
-        // Resolved once: the setting's validation guarantees a value by the time a connection is opened, and taking
-        // it here keeps the nullable dereference out of the lambda below and the failure path further down.
-        var connectionTimeout = TimeSpan.FromSeconds(timeoutSeconds.IntValue.Value);
+        // Resolved once, and reused by the connection factory below and the failure path further down. The guard
+        // above has already thrown if this setting has no value; the null-forgiving operator says so to the
+        // analyser, which does not carry null-state out of a pattern guard. A second check here would be a
+        // redundant condition, which is its own code-quality finding.
+        var connectionTimeout = TimeSpan.FromSeconds(timeoutSeconds.IntValue!.Value);
 
         // Build a reusable connection factory so LdapConnectorImport can create additional
         // connections for parallel imports (one connection per container+objectType combo).

--- a/src/JIM.Connectors/LDAP/LdapConnectorConstants.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorConstants.cs
@@ -49,10 +49,6 @@ internal static class LdapConnectorConstants
     internal const int DEFAULT_LDAPS_PORT = 636;
     internal const int DEFAULT_LDAP_PORT = 389;
 
-    // Certificate validation options
-    internal const string CERT_VALIDATION_FULL = "Full Validation";
-    internal const string CERT_VALIDATION_SKIP = "Skip Validation (Not Recommended)";
-
     // Retry settings
     internal const int DEFAULT_MAX_RETRIES = 3;
     internal const int DEFAULT_RETRY_DELAY_MS = 1000;

--- a/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
+++ b/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
@@ -103,7 +103,14 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
             var writtenThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var certificate in trustedCertificates.Where(certificate => writtenThumbprints.Add(certificate.Thumbprint)))
             {
-                var certificatePath = Path.Combine(directoryPath, $"{certificate.Thumbprint}.crt");
+                // The thumbprint becomes a file name. It is a hex string, so it cannot traverse anywhere today;
+                // asserted rather than assumed because the value reaches a file write and is derived from a
+                // certificate JIM did not issue.
+                var certificateFileName = $"{certificate.Thumbprint}.crt";
+                if (!string.Equals(certificateFileName, Path.GetFileName(certificateFileName), StringComparison.Ordinal))
+                    throw new ArgumentException("A certificate in the JIM certificate store has a thumbprint that cannot be used as a file name.", nameof(trustedCertificates));
+
+                var certificatePath = Path.Combine(directoryPath, certificateFileName);
                 System.IO.File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
                 if (!OperatingSystem.IsWindows())
                     System.IO.File.SetUnixFileMode(certificatePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);

--- a/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
+++ b/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
@@ -45,6 +45,17 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
         "/etc/ssl/ca-bundle.pem"
     ];
 
+    /// <summary>
+    /// Prefix every trust directory carries, so abandoned ones can be recognised and swept.
+    /// </summary>
+    private const string DirectoryNamePrefix = "jim-ldap-trust-";
+
+    /// <summary>
+    /// How old an abandoned trust directory must be before the sweep removes it. Comfortably longer than any single
+    /// import can run, so a directory still in use by a long-running run is never taken out from under it.
+    /// </summary>
+    private static readonly TimeSpan AbandonedDirectoryAge = TimeSpan.FromDays(7);
+
     private bool _disposed;
 
     /// <summary>
@@ -74,7 +85,9 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
         if (trustedCertificates.Count == 0)
             throw new ArgumentException("At least one certificate is required; without one there is nothing to add to the platform's trust configuration.", nameof(trustedCertificates));
 
-        var directoryPath = Path.Combine(Path.GetTempPath(), $"jim-ldap-trust-{Guid.NewGuid():N}");
+        RemoveAbandonedDirectories(logger);
+
+        var directoryPath = Path.Combine(Path.GetTempPath(), $"{DirectoryNamePrefix}{Guid.NewGuid():N}");
         var trustDirectory = new LdapTrustedCertificateDirectory(directoryPath);
 
         try
@@ -106,6 +119,36 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
         {
             trustDirectory.Dispose();
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Removes trust directories left behind by a process that was killed before it could clean up its own.
+    /// </summary>
+    /// <remarks>
+    /// Each directory is removed when its connection closes, but a killed process never reaches that, and a container
+    /// that is restarted rather than replaced keeps its temporary files. Sweeping here means no deployment ever needs
+    /// manual clean-up. Failures are logged and ignored: this is housekeeping, and must never stop a connection being
+    /// established.
+    /// </remarks>
+    private static void RemoveAbandonedDirectories(ILogger logger)
+    {
+        try
+        {
+            var cutoff = DateTime.UtcNow - AbandonedDirectoryAge;
+            var abandoned = Directory.EnumerateDirectories(Path.GetTempPath(), $"{DirectoryNamePrefix}*")
+                .Where(d => Directory.GetLastWriteTimeUtc(d) < cutoff)
+                .ToList();
+
+            foreach (var directory in abandoned)
+                Directory.Delete(directory, true);
+
+            if (abandoned.Count > 0)
+                logger.Debug("LdapTrustedCertificateDirectory: removed {Count} abandoned trust director(ies) left by an earlier process", abandoned.Count);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or NotSupportedException or System.Security.SecurityException)
+        {
+            logger.Debug(ex, "LdapTrustedCertificateDirectory: could not sweep abandoned trust directories");
         }
     }
 

--- a/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
+++ b/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using Serilog;
+using System.Security.Cryptography.X509Certificates;
+namespace JIM.Connectors.LDAP;
+
+/// <summary>
+/// A short-lived on-disk directory of trust anchors handed to the platform LDAP client for LDAPS connections,
+/// holding the certificates an administrator added to the JIM certificate store plus the operating system's own
+/// certificate bundle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// JIM does not make the trust decision itself. The platform LDAP client validates the chain, the validity period
+/// and the certificate's name against the Directory Server value being connected to; JIM only supplies additional
+/// issuers for it to consider. That is why there is no managed validation callback here:
+/// <c>LdapSessionOptions.VerifyServerCertificate</c> is unsupported on Linux, which is the only platform JIM's
+/// containers run on, and installing it throws.
+/// </para>
+/// <para>
+/// The system bundle is copied in deliberately. Pointing the client at a trust directory <em>replaces</em> its
+/// configured trust anchors rather than adding to them, so a directory holding only JIM's certificates would stop
+/// every publicly-issued or otherwise system-trusted directory certificate validating. Copying the bundle in keeps
+/// trust strictly additive: adding certificates to the JIM store can only ever allow more connections, never fewer.
+/// </para>
+/// </remarks>
+internal sealed class LdapTrustedCertificateDirectory : IDisposable
+{
+    /// <summary>
+    /// File name used for the operating system's certificate bundle inside the trust directory. The numeric prefix
+    /// keeps it visibly distinct from the thumbprint-named JIM certificates.
+    /// </summary>
+    internal const string SystemBundleFileName = "00-system-ca-bundle.crt";
+
+    /// <summary>
+    /// Where the operating system's certificate bundle is expected to live, in probe order. The first entry is the
+    /// path used by the Debian and Ubuntu images JIM ships on, and is the same file the platform LDAP client is
+    /// configured with by default (<c>TLS_CACERT</c> in <c>/etc/ldap/ldap.conf</c>).
+    /// </summary>
+    private static readonly string[] DefaultSystemBundlePaths =
+    [
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/pki/tls/certs/ca-bundle.crt",
+        "/etc/ssl/ca-bundle.pem"
+    ];
+
+    private bool _disposed;
+
+    /// <summary>
+    /// Absolute path of the directory. Pass this to <c>LdapSessionOptions.TrustedCertificatesDirectory</c>.
+    /// </summary>
+    internal string DirectoryPath { get; }
+
+    private LdapTrustedCertificateDirectory(string directoryPath)
+    {
+        DirectoryPath = directoryPath;
+    }
+
+    /// <summary>
+    /// Materialises the supplied certificates, and the operating system's certificate bundle, into a new directory.
+    /// </summary>
+    /// <param name="trustedCertificates">Certificates from the JIM certificate store. Must not be empty; callers that hold no certificates should leave the platform's own trust configuration alone rather than handing it an emptier one.</param>
+    /// <param name="logger">Logger for the calling operation.</param>
+    /// <param name="systemBundleCandidatePaths">Overrides the default operating system bundle locations. Intended for tests.</param>
+    /// <exception cref="ArgumentException">No certificates were supplied.</exception>
+    internal static LdapTrustedCertificateDirectory Create(
+        IReadOnlyCollection<X509Certificate2> trustedCertificates,
+        ILogger logger,
+        IReadOnlyList<string>? systemBundleCandidatePaths = null)
+    {
+        ArgumentNullException.ThrowIfNull(trustedCertificates);
+
+        if (trustedCertificates.Count == 0)
+            throw new ArgumentException("At least one certificate is required; without one there is nothing to add to the platform's trust configuration.", nameof(trustedCertificates));
+
+        var directoryPath = Path.Combine(Path.GetTempPath(), $"jim-ldap-trust-{Guid.NewGuid():N}");
+        var trustDirectory = new LdapTrustedCertificateDirectory(directoryPath);
+
+        try
+        {
+            // The directory holds trust anchors, so restrict it to the account JIM runs as: anything able to write
+            // here could make JIM trust an issuer of its choosing.
+            Directory.CreateDirectory(directoryPath);
+            if (!OperatingSystem.IsWindows())
+                System.IO.File.SetUnixFileMode(directoryPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            var writtenThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var certificate in trustedCertificates)
+            {
+                if (!writtenThumbprints.Add(certificate.Thumbprint))
+                    continue;
+
+                var certificatePath = Path.Combine(directoryPath, $"{certificate.Thumbprint}.crt");
+                System.IO.File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
+                if (!OperatingSystem.IsWindows())
+                    System.IO.File.SetUnixFileMode(certificatePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+
+            CopySystemBundle(directoryPath, systemBundleCandidatePaths ?? DefaultSystemBundlePaths, logger);
+
+            logger.Debug("LdapTrustedCertificateDirectory: prepared {Count} trusted certificate(s) from the JIM certificate store for LDAPS validation", writtenThumbprints.Count);
+            return trustDirectory;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or ArgumentException or NotSupportedException or System.Security.SecurityException)
+        {
+            trustDirectory.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Copies the operating system's certificate bundle into the trust directory so that system-trusted issuers keep
+    /// validating. A missing bundle is not fatal, but it does narrow what will validate, so it is logged as a warning.
+    /// </summary>
+    private static void CopySystemBundle(string directoryPath, IReadOnlyList<string> candidatePaths, ILogger logger)
+    {
+        var bundlePath = candidatePaths.FirstOrDefault(System.IO.File.Exists);
+        if (bundlePath == null)
+        {
+            logger.Warning("LdapTrustedCertificateDirectory: no operating system certificate bundle found in any of {CandidateCount} expected locations. Only certificates from the JIM certificate store will be trusted for LDAPS connections from this Connected System", candidatePaths.Count);
+            return;
+        }
+
+        var destinationPath = Path.Combine(directoryPath, SystemBundleFileName);
+        System.IO.File.Copy(bundlePath, destinationPath, true);
+        if (!OperatingSystem.IsWindows())
+            System.IO.File.SetUnixFileMode(destinationPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        logger.Debug("LdapTrustedCertificateDirectory: copied the operating system certificate bundle from {BundlePath} so system-trusted issuers continue to validate", bundlePath);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        try
+        {
+            if (Directory.Exists(DirectoryPath))
+                Directory.Delete(DirectoryPath, true);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or NotSupportedException or System.Security.SecurityException)
+        {
+            // Nothing here is secret (public certificates only) and the containers JIM runs in have ephemeral
+            // filesystems, so a failed clean-up must not take a synchronisation run down with it.
+            Log.Warning(ex, "LdapTrustedCertificateDirectory: could not remove the temporary trust directory. It holds public certificates only and will go when the container is replaced");
+        }
+    }
+}

--- a/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
+++ b/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
@@ -98,12 +98,11 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
             if (!OperatingSystem.IsWindows())
                 System.IO.File.SetUnixFileMode(directoryPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
+            // Filtering in the sequence rather than the body: the same certificate can legitimately appear twice in
+            // the store, and writing it twice would be harmless but pointless. Add returns false once seen.
             var writtenThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var certificate in trustedCertificates)
+            foreach (var certificate in trustedCertificates.Where(certificate => writtenThumbprints.Add(certificate.Thumbprint)))
             {
-                if (!writtenThumbprints.Add(certificate.Thumbprint))
-                    continue;
-
                 var certificatePath = Path.Combine(directoryPath, $"{certificate.Thumbprint}.crt");
                 System.IO.File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
                 if (!OperatingSystem.IsWindows())

--- a/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
+++ b/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
@@ -166,7 +166,10 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
     private static string ResolveWithin(string directoryPath, string fileName)
     {
         var directoryFullPath = Path.GetFullPath(directoryPath);
-        var candidate = Path.GetFullPath(Path.Combine(directoryFullPath, fileName));
+
+        // Resolved against the directory in one step. A rooted file name resolves to itself rather than being
+        // joined, which the containment check below then rejects, so there is no separate case to test for.
+        var candidate = Path.GetFullPath(fileName, directoryFullPath);
         var prefix = directoryFullPath.EndsWith(Path.DirectorySeparatorChar)
             ? directoryFullPath
             : directoryFullPath + Path.DirectorySeparatorChar;

--- a/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
+++ b/src/JIM.Connectors/LDAP/LdapTrustedCertificateDirectory.cs
@@ -103,14 +103,7 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
             var writtenThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var certificate in trustedCertificates.Where(certificate => writtenThumbprints.Add(certificate.Thumbprint)))
             {
-                // The thumbprint becomes a file name. It is a hex string, so it cannot traverse anywhere today;
-                // asserted rather than assumed because the value reaches a file write and is derived from a
-                // certificate JIM did not issue.
-                var certificateFileName = $"{certificate.Thumbprint}.crt";
-                if (!string.Equals(certificateFileName, Path.GetFileName(certificateFileName), StringComparison.Ordinal))
-                    throw new ArgumentException("A certificate in the JIM certificate store has a thumbprint that cannot be used as a file name.", nameof(trustedCertificates));
-
-                var certificatePath = Path.Combine(directoryPath, certificateFileName);
+                var certificatePath = ResolveWithin(directoryPath, $"{certificate.Thumbprint}.crt");
                 System.IO.File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
                 if (!OperatingSystem.IsWindows())
                     System.IO.File.SetUnixFileMode(certificatePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
@@ -162,6 +155,28 @@ internal sealed class LdapTrustedCertificateDirectory : IDisposable
     /// Copies the operating system's certificate bundle into the trust directory so that system-trusted issuers keep
     /// validating. A missing bundle is not fatal, but it does narrow what will validate, so it is logged as a warning.
     /// </summary>
+    /// <summary>
+    /// Joins a file name onto the trust directory and proves the result is still inside it.
+    /// </summary>
+    /// <remarks>
+    /// A certificate's thumbprint is a hex string, so today it cannot traverse anywhere. This is checked rather
+    /// than assumed because the name is derived from a certificate JIM did not issue and it decides where a file
+    /// is written; the trust directory's whole purpose is to hold anchors nothing else can tamper with.
+    /// </remarks>
+    private static string ResolveWithin(string directoryPath, string fileName)
+    {
+        var directoryFullPath = Path.GetFullPath(directoryPath);
+        var candidate = Path.GetFullPath(Path.Combine(directoryFullPath, fileName));
+        var prefix = directoryFullPath.EndsWith(Path.DirectorySeparatorChar)
+            ? directoryFullPath
+            : directoryFullPath + Path.DirectorySeparatorChar;
+
+        if (!candidate.StartsWith(prefix, StringComparison.Ordinal))
+            throw new ArgumentException($"'{fileName}' does not resolve to a file inside the trust directory.", nameof(fileName));
+
+        return candidate;
+    }
+
     private static void CopySystemBundle(string directoryPath, IReadOnlyList<string> candidatePaths, ILogger logger)
     {
         var bundlePath = candidatePaths.FirstOrDefault(System.IO.File.Exists);

--- a/src/JIM.Connectors/ServerCertificateProbe.cs
+++ b/src/JIM.Connectors/ServerCertificateProbe.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Connectors;
+using Serilog;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+namespace JIM.Connectors;
+
+/// <summary>
+/// Connects to a server over TLS purely to look at the certificate it presents, so a refused connection can be
+/// reported as the certificate problem it is.
+/// </summary>
+/// <remarks>
+/// This exists because the platform LDAP client tells JIM nothing when it refuses a certificate: the failure arrives
+/// as "the server is unavailable", indistinguishable from an unreachable host. .NET's own TLS stack hands the
+/// presented certificate to a callback, so JIM can look at a certificate it does not trust without ever trusting it:
+/// the probe always refuses the connection, and is only ever used to explain a failure that already happened.
+/// </remarks>
+public static class ServerCertificateProbe
+{
+    /// <summary>
+    /// Fetches the certificate a server presents and works out why it would be refused.
+    /// </summary>
+    /// <param name="host">Host being connected to, as configured on the Connected System. The certificate's names are checked against this.</param>
+    /// <param name="port">Port being connected to.</param>
+    /// <param name="trustedCertificates">Certificates from the JIM certificate store, treated as additional trust anchors when judging the issuer.</param>
+    /// <param name="timeout">How long to wait for the connection and handshake.</param>
+    /// <param name="logger">Logger for the calling operation.</param>
+    /// <returns>What the server presented and why it fails, or null when the server could not be reached at all, which is a different problem.</returns>
+    public static ServerCertificateDiagnostic? Probe(
+        string host,
+        int port,
+        IReadOnlyCollection<X509Certificate2> trustedCertificates,
+        TimeSpan timeout,
+        ILogger logger)
+    {
+        X509Certificate2? presented = null;
+
+        try
+        {
+            using var client = new TcpClient();
+            if (!client.ConnectAsync(host, port).Wait(timeout))
+            {
+                logger.Debug("ServerCertificateProbe: no response from {Host}:{Port} within the timeout, so this is a connectivity problem rather than a certificate one", host, port);
+                return null;
+            }
+
+            using var sslStream = new SslStream(client.GetStream(), false, (_, certificate, _, _) =>
+            {
+                if (certificate != null)
+                    presented = X509CertificateLoader.LoadCertificate(certificate.GetRawCertData());
+
+                // Always refuse. Nothing is being connected to here; the handshake exists only to see the certificate.
+                return false;
+            });
+
+            try
+            {
+                sslStream.AuthenticateAsClient(host);
+            }
+            catch (AuthenticationException)
+            {
+                // Expected: the callback above refuses every certificate, by design.
+            }
+        }
+        catch (Exception ex) when (ex is SocketException or IOException or AggregateException or ObjectDisposedException)
+        {
+            logger.Debug(ex, "ServerCertificateProbe: could not reach {Host}:{Port} to examine its certificate", host, port);
+            return null;
+        }
+
+        if (presented == null)
+        {
+            return new ServerCertificateDiagnostic
+            {
+                Host = host,
+                Port = port,
+                FailureReason = ServerCertificateFailureReason.NoCertificatePresented,
+                Remediation = "The directory server offered no certificate. Check that it is configured for LDAPS on this port."
+            };
+        }
+
+        using (presented)
+            return Describe(presented, host, port, trustedCertificates);
+    }
+
+    /// <summary>
+    /// Works out which check the certificate fails, in the order an administrator would act on them: a name mismatch
+    /// is reported ahead of an untrusted issuer, because adding the certificate to the JIM certificate store fixes
+    /// the second and not the first.
+    /// </summary>
+    private static ServerCertificateDiagnostic Describe(
+        X509Certificate2 certificate,
+        string host,
+        int port,
+        IReadOnlyCollection<X509Certificate2> trustedCertificates)
+    {
+        var diagnostic = new ServerCertificateDiagnostic
+        {
+            Host = host,
+            Port = port,
+            Subject = certificate.Subject,
+            Issuer = certificate.Issuer,
+            SubjectAlternativeNames = GetSubjectAlternativeNames(certificate),
+            ValidFrom = certificate.NotBefore.ToUniversalTime(),
+            ValidTo = certificate.NotAfter.ToUniversalTime(),
+            Thumbprint = certificate.Thumbprint,
+            SignatureAlgorithm = certificate.SignatureAlgorithm.FriendlyName,
+            IsSelfSigned = string.Equals(certificate.Subject, certificate.Issuer, StringComparison.Ordinal)
+        };
+
+        var now = DateTime.UtcNow;
+        if (diagnostic.ValidTo.HasValue && diagnostic.ValidTo.Value < now)
+        {
+            diagnostic.FailureReason = ServerCertificateFailureReason.Expired;
+            diagnostic.Remediation = "The certificate expired. Renew it on the directory server; trusting its issuer does not waive the expiry date.";
+            return diagnostic;
+        }
+
+        if (diagnostic.ValidFrom.HasValue && diagnostic.ValidFrom.Value > now)
+        {
+            diagnostic.FailureReason = ServerCertificateFailureReason.NotYetValid;
+            diagnostic.Remediation = "The certificate is not valid yet, which usually means the clocks on JIM and the directory server disagree.";
+            return diagnostic;
+        }
+
+        if (!certificate.MatchesHostname(host, false, false))
+        {
+            diagnostic.FailureReason = ServerCertificateFailureReason.NameMismatch;
+            diagnostic.Remediation = $"The certificate was not issued for '{host}'. Adding it to the JIM certificate store will not help; connect using a name the certificate carries, giving the JIM containers a host entry for it if that name cannot be resolved.";
+            return diagnostic;
+        }
+
+        if (!ChainsToATrustedIssuer(certificate, trustedCertificates))
+        {
+            diagnostic.FailureReason = ServerCertificateFailureReason.UntrustedIssuer;
+            diagnostic.Remediation = diagnostic.IsSelfSigned
+                ? "The certificate is self-signed and not trusted. Add this certificate to the JIM certificate store (Admin > Certificates) to trust this directory server."
+                : "The issuing certificate authority is not trusted. Add it, and any intermediates, to the JIM certificate store (Admin > Certificates).";
+            return diagnostic;
+        }
+
+        // Deliberately not judged on .NET's own policy errors: those are reported against the operating system's
+        // trust anchors alone, so a certificate that JIM's certificate store legitimately vouches for still arrives
+        // with a chain error. Everything JIM validates has now been checked, with those anchors taken into account.
+        diagnostic.FailureReason = ServerCertificateFailureReason.None;
+        return diagnostic;
+    }
+
+    /// <summary>
+    /// Builds the certificate's chain with the JIM certificate store supplied as additional trust anchors, mirroring
+    /// what the platform LDAP client is given.
+    /// </summary>
+    private static bool ChainsToATrustedIssuer(X509Certificate2 certificate, IReadOnlyCollection<X509Certificate2> trustedCertificates)
+    {
+        using var chain = new X509Chain();
+
+        // Air-gapped deployments cannot reach a revocation list or responder, matching the LDAP connection itself.
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreNotTimeValid;
+
+        foreach (var trustedCertificate in trustedCertificates)
+        {
+            chain.ChainPolicy.CustomTrustStore.Add(trustedCertificate);
+            chain.ChainPolicy.ExtraStore.Add(trustedCertificate);
+        }
+
+        if (chain.Build(certificate))
+            return true;
+
+        // Nothing in the JIM certificate store vouched for it; fall back to the operating system's own anchors.
+        using var systemChain = new X509Chain();
+        systemChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        systemChain.ChainPolicy.VerificationFlags = X509VerificationFlags.IgnoreNotTimeValid;
+        return systemChain.Build(certificate);
+    }
+
+    /// <summary>
+    /// Reads the names the certificate was issued for out of its subject alternative name extension.
+    /// </summary>
+    private static List<string> GetSubjectAlternativeNames(X509Certificate2 certificate)
+    {
+        var names = new List<string>();
+
+        foreach (var extension in certificate.Extensions.OfType<X509SubjectAlternativeNameExtension>())
+        {
+            names.AddRange(extension.EnumerateDnsNames());
+            names.AddRange(extension.EnumerateIPAddresses().Select(ip => ip.ToString()));
+        }
+
+        return names;
+    }
+}

--- a/src/JIM.Connectors/ServerCertificateProbe.cs
+++ b/src/JIM.Connectors/ServerCertificateProbe.cs
@@ -2,6 +2,7 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Models.Connectors;
+using JIM.Utilities;
 using Serilog;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -44,7 +45,7 @@ public static class ServerCertificateProbe
             using var client = new TcpClient();
             if (!client.ConnectAsync(host, port).Wait(timeout))
             {
-                logger.Debug("ServerCertificateProbe: no response from {Host}:{Port} within the timeout, so this is a connectivity problem rather than a certificate one", host, port);
+                logger.Debug("ServerCertificateProbe: no response from {Host}:{Port} within the timeout, so this is a connectivity problem rather than a certificate one", LogSanitiser.Sanitise(host), port);
                 return null;
             }
 
@@ -68,7 +69,7 @@ public static class ServerCertificateProbe
         }
         catch (Exception ex) when (ex is SocketException or IOException or AggregateException or ObjectDisposedException)
         {
-            logger.Debug(ex, "ServerCertificateProbe: could not reach {Host}:{Port} to examine its certificate", host, port);
+            logger.Debug(ex, "ServerCertificateProbe: could not reach {Host}:{Port} to examine its certificate", LogSanitiser.Sanitise(host), port);
             return null;
         }
 

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -909,6 +909,17 @@ public interface IConnectedSystemRepository
     public Task DeleteConnectedSystemPartitionAsync(ConnectedSystemPartition connectedSystemPartition);
     public Task DeleteConnectedSystemRunProfileAsync(ConnectedSystemRunProfile runProfile);
     public Task DeleteConnectorDefinitionAsync(ConnectorDefinition connectorDefinition);
+
+    /// <summary>
+    /// Deletes settings a Connector no longer declares, along with any values administrators saved against them.
+    /// </summary>
+    /// <remarks>
+    /// Detaching the setting from its Connector Definition is not sufficient: the relationship's foreign key is
+    /// nullable, so the row survives with no definition while still being referenced by saved values, and the
+    /// withdrawn setting keeps appearing on Connected Systems that hold one.
+    /// </remarks>
+    public Task DeleteConnectorDefinitionSettingsAsync(IList<ConnectorDefinitionSetting> connectorDefinitionSettings);
+
     public Task DeleteConnectorDefinitionFileAsync(ConnectorDefinitionFile connectorDefinitionFile);
     public Task DeleteSyncRuleAsync(SyncRule syncRule);
 

--- a/src/JIM.Models/Activities/Activity.cs
+++ b/src/JIM.Models/Activities/Activity.cs
@@ -68,6 +68,17 @@ public class Activity
     public string? ErrorStackTrace { get; set; }
 
     /// <summary>
+    /// Structured detail about the failure, as JSON, for failures where there is something specific worth showing an
+    /// administrator beyond the message. Populated today by LDAPS certificate rejections, which record the certificate
+    /// the directory server presented so the portal can show it and name what to do about it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately open-ended: the shape is owned by whatever produced the failure, and the portal renders what it
+    /// recognises. Never holds secrets; a certificate is public by definition.
+    /// </remarks>
+    public string? ErrorDetail { get; set; }
+
+    /// <summary>
     /// Connector-level warning message describing a non-fatal operational note about the activity.
     /// For example, when a delta import falls back to a full import because the watermark was unavailable.
     /// This is displayed on the activity detail page and causes the activity to complete with warning status.

--- a/src/JIM.Models/Activities/ActivityErrorDetail.cs
+++ b/src/JIM.Models/Activities/ActivityErrorDetail.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Connectors;
+using JIM.Models.Exceptions;
+using System.Text.Json;
+
+namespace JIM.Models.Activities;
+
+/// <summary>
+/// Turns a failure into the structured detail stored on <see cref="Activity.ErrorDetail"/>, and back again for the
+/// portal to render.
+/// </summary>
+/// <remarks>
+/// An error message is a sentence; some failures also have facts worth showing. A rejected LDAPS certificate is the
+/// first: an administrator needs to see which certificate was presented, and by whom, to know whether to trust it,
+/// renew it, or reach the directory by a different name.
+/// </remarks>
+public static class ActivityErrorDetail
+{
+    /// <summary>
+    /// Identifies the payload's shape, so a reader can tell whether it recognises the content before parsing it.
+    /// </summary>
+    public const string ServerCertificateKind = "server-certificate";
+
+    private static readonly JsonSerializerOptions SerialiserOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Produces structured detail for the failures that have any, walking inner exceptions so a wrapped failure is
+    /// still described. Returns null when there is nothing to add beyond the message.
+    /// </summary>
+    public static string? TryDescribe(Exception exception)
+    {
+        var certificateRejection = FindCertificateRejection(exception);
+        if (certificateRejection == null)
+            return null;
+
+        return JsonSerializer.Serialize(new ActivityErrorDetailEnvelope
+        {
+            Kind = ServerCertificateKind,
+            ServerCertificate = certificateRejection.Diagnostic
+        }, SerialiserOptions);
+    }
+
+    /// <summary>
+    /// Reads back detail written by <see cref="TryDescribe"/>. Returns null when the value is absent, unrecognised, or
+    /// no longer parses, so a rendering caller can fall back to the plain message rather than failing.
+    /// </summary>
+    public static ServerCertificateDiagnostic? TryReadServerCertificate(string? errorDetail)
+    {
+        if (string.IsNullOrWhiteSpace(errorDetail))
+            return null;
+
+        try
+        {
+            var envelope = JsonSerializer.Deserialize<ActivityErrorDetailEnvelope>(errorDetail, SerialiserOptions);
+            return envelope?.Kind == ServerCertificateKind ? envelope.ServerCertificate : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static ServerCertificateRejectedException? FindCertificateRejection(Exception? exception)
+    {
+        while (exception != null)
+        {
+            if (exception is ServerCertificateRejectedException certificateRejection)
+                return certificateRejection;
+
+            exception = exception.InnerException;
+        }
+
+        return null;
+    }
+}

--- a/src/JIM.Models/Activities/ActivityErrorDetailEnvelope.cs
+++ b/src/JIM.Models/Activities/ActivityErrorDetailEnvelope.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Connectors;
+
+namespace JIM.Models.Activities;
+
+/// <summary>
+/// The serialised shape of <see cref="Activity.ErrorDetail"/>. <see cref="Kind"/> names the payload so a reader can
+/// recognise what it is looking at before parsing further, leaving room for other kinds of structured failure detail.
+/// </summary>
+public class ActivityErrorDetailEnvelope
+{
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Present when <see cref="Kind"/> is <see cref="ActivityErrorDetail.ServerCertificateKind"/>.
+    /// </summary>
+    public ServerCertificateDiagnostic? ServerCertificate { get; set; }
+}

--- a/src/JIM.Models/Connectors/ServerCertificateDiagnostic.cs
+++ b/src/JIM.Models/Connectors/ServerCertificateDiagnostic.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Connectors;
+
+/// <summary>
+/// What a server presented when an encrypted connection to it was refused, and why it was refused.
+/// </summary>
+/// <remarks>
+/// The platform LDAP client reports a rejected certificate the same way it reports an unreachable server, and hands
+/// back nothing about the certificate itself. Everything here is gathered by connecting again over plain TLS purely
+/// to look, so an administrator is told which certificate was presented and which check it failed, rather than being
+/// left with "the server is unavailable" and no way to tell a certificate problem from a network one.
+/// </remarks>
+public class ServerCertificateDiagnostic
+{
+    /// <summary>
+    /// The host the connection was made to, as configured on the Connected System. Compared against the certificate's
+    /// subject and subject alternative names to decide <see cref="ServerCertificateFailureReason.NameMismatch"/>.
+    /// </summary>
+    public string Host { get; set; } = string.Empty;
+
+    public int Port { get; set; }
+
+    /// <summary>
+    /// Why the certificate was refused. Drives what an administrator is told to do about it.
+    /// </summary>
+    public ServerCertificateFailureReason FailureReason { get; set; }
+
+    public string? Subject { get; set; }
+
+    public string? Issuer { get; set; }
+
+    /// <summary>
+    /// The names the certificate was issued for, from its subject alternative name extension. The name check uses
+    /// these, so showing them is what makes a mismatch self-explanatory.
+    /// </summary>
+    public List<string> SubjectAlternativeNames { get; set; } = [];
+
+    public DateTime? ValidFrom { get; set; }
+
+    public DateTime? ValidTo { get; set; }
+
+    /// <summary>
+    /// SHA-1 thumbprint, the identifier an administrator uses to confirm this is the same certificate they hold, and
+    /// the one to search for in the JIM certificate store.
+    /// </summary>
+    public string? Thumbprint { get; set; }
+
+    public string? SignatureAlgorithm { get; set; }
+
+    /// <summary>
+    /// Whether the certificate is self-signed, which tells an administrator whether to add the certificate itself to
+    /// the JIM certificate store or the certificate authority that issued it.
+    /// </summary>
+    public bool IsSelfSigned { get; set; }
+
+    /// <summary>
+    /// A sentence naming what to do about it, shown alongside the certificate.
+    /// </summary>
+    public string? Remediation { get; set; }
+
+    public bool IsExpired => ValidTo.HasValue && ValidTo.Value < DateTime.UtcNow;
+
+    public bool IsNotYetValid => ValidFrom.HasValue && ValidFrom.Value > DateTime.UtcNow;
+}

--- a/src/JIM.Models/Connectors/ServerCertificateFailureReason.cs
+++ b/src/JIM.Models/Connectors/ServerCertificateFailureReason.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Connectors;
+
+/// <summary>
+/// Why a server's certificate was refused. Each value maps to a different thing an administrator has to do, which is
+/// the point of distinguishing them.
+/// </summary>
+public enum ServerCertificateFailureReason
+{
+    /// <summary>
+    /// Nothing is wrong with the certificate; the connection failed for another reason.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The issuer is trusted by neither the operating system nor the JIM certificate store. Resolved by adding the
+    /// issuing certificate authority, or the certificate itself when self-signed, to the JIM certificate store.
+    /// </summary>
+    UntrustedIssuer = 1,
+
+    /// <summary>
+    /// The certificate was issued for a different name than the one being connected to. Adding it to the JIM
+    /// certificate store does not help; the host has to be reached by a name the certificate carries.
+    /// </summary>
+    NameMismatch = 2,
+
+    /// <summary>
+    /// The certificate's validity period has passed. Trusting its issuer does not waive this.
+    /// </summary>
+    Expired = 3,
+
+    /// <summary>
+    /// The certificate's validity period has not started yet, which usually means clock skew between JIM and the
+    /// directory server.
+    /// </summary>
+    NotYetValid = 4,
+
+    /// <summary>
+    /// The server offered no certificate at all, so the connection could not be encrypted.
+    /// </summary>
+    NoCertificatePresented = 5,
+
+    /// <summary>
+    /// A certificate was presented and refused, but for a reason JIM could not narrow down.
+    /// </summary>
+    Unknown = 6
+}

--- a/src/JIM.Models/Exceptions/ServerCertificateRejectedException.cs
+++ b/src/JIM.Models/Exceptions/ServerCertificateRejectedException.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Connectors;
+
+namespace JIM.Models.Exceptions;
+
+/// <summary>
+/// Thrown when a connection is refused because of the certificate the server presented, carrying what that
+/// certificate was so the failure can be reported with something an administrator can act on.
+/// </summary>
+public class ServerCertificateRejectedException : Exception
+{
+    public ServerCertificateDiagnostic Diagnostic { get; }
+
+    public ServerCertificateRejectedException(string message, ServerCertificateDiagnostic diagnostic, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Diagnostic = diagnostic;
+    }
+}

--- a/src/JIM.PostgresData/Migrations/20260730075647_ActivityErrorDetail.Designer.cs
+++ b/src/JIM.PostgresData/Migrations/20260730075647_ActivityErrorDetail.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using JIM.PostgresData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JIM.PostgresData.Migrations
 {
     [DbContext(typeof(JimDbContext))]
-    partial class JimDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260730075647_ActivityErrorDetail")]
+    partial class ActivityErrorDetail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/JIM.PostgresData/Migrations/20260730075647_ActivityErrorDetail.cs
+++ b/src/JIM.PostgresData/Migrations/20260730075647_ActivityErrorDetail.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JIM.PostgresData.Migrations
+{
+    /// <inheritdoc />
+    public partial class ActivityErrorDetail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ErrorDetail",
+                table: "Activities",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ErrorDetail",
+                table: "Activities");
+        }
+    }
+}

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -104,6 +104,12 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         await Repository.Database.SaveChangesAsync();
     }
 
+    public async Task DeleteConnectorDefinitionSettingsAsync(IList<ConnectorDefinitionSetting> connectorDefinitionSettings)
+    {
+        Repository.Database.ConnectorDefinitionSettings.RemoveRange(connectorDefinitionSettings);
+        await Repository.Database.SaveChangesAsync();
+    }
+
     public async Task CreateConnectorDefinitionFileAsync(ConnectorDefinitionFile connectorDefinitionFile)
     {
         Repository.Database.ConnectorDefinitionFiles.Add(connectorDefinitionFile);

--- a/src/JIM.Web/CLAUDE.md
+++ b/src/JIM.Web/CLAUDE.md
@@ -85,6 +85,7 @@ For a table cell (or inline value) that is null/empty, render `<EmptyValue />` (
 ## Alerts
 - ALWAYS use `Variant="Variant.Outlined"` on all `<MudAlert>` components
 - This ensures a consistent outlined style across the entire UI
+- **A button placed inside an alert should carry `Color="Color.Inherit"`** unless it genuinely needs a colour of its own. `site.css` then paints it, and its icon, in the alert's severity colour, so the action reads as part of the message rather than as something dropped into it. This works for every severity and both themes; do not hand-pick a colour per call site. A button that names its own `Color` (the filled Primary/Warning/Info actions in the Schema, Partitions and Example Data alerts) is left exactly as specified.
 
 ## Errors and stack traces
 - The **error message is the thing to read**; the stack trace is for the occasions it is not enough. Never render a stack trace unconditionally beside its message: it buries the sentence that actually answers the question, and stack traces routinely run to thousands of characters.

--- a/src/JIM.Web/CLAUDE.md
+++ b/src/JIM.Web/CLAUDE.md
@@ -19,6 +19,7 @@ These components exist so a convention has a single source of truth. Prefer the 
 | `<WhitespaceValue Value="@x" />` | A value that is present but consists only of whitespace (the `<EmptyValue />` sibling) | "Empty values" below |
 | `<TextValueDisplay Value="@x" />` | Any text attribute-value display: dispatches to `<EmptyValue />` / `<WhitespaceValue />` / the value | "Empty values" below |
 | `<PrefilledFormValidator />` | Inside any `MudForm` prefilled with an existing entity, so validity-gated buttons enable on load | "Form action gating" below |
+| `<CollapsibleStackTrace StackTrace="@x" />` | Any place an error's stack trace is offered alongside its message | "Errors and stack traces" below |
 
 ## Form action gating and input immediacy
 
@@ -84,6 +85,10 @@ For a table cell (or inline value) that is null/empty, render `<EmptyValue />` (
 ## Alerts
 - ALWAYS use `Variant="Variant.Outlined"` on all `<MudAlert>` components
 - This ensures a consistent outlined style across the entire UI
+
+## Errors and stack traces
+- The **error message is the thing to read**; the stack trace is for the occasions it is not enough. Never render a stack trace unconditionally beside its message: it buries the sentence that actually answers the question, and stack traces routinely run to thousands of characters.
+- Use `<CollapsibleStackTrace StackTrace="@x" />` wherever a trace is available. It renders nothing when there is no trace, shows a "Show stack trace" toggle when there is, and only puts the trace in the DOM once it has been asked for. Do not hand-roll the toggle, and do not wrap it in an expansion panel of its own; that is what it already is.
 
 ## Date and time display
 - **Relative** ("2 hours ago"): `dateTime.ToRelativeTime()`, e.g. as the primary text under a tooltip

--- a/src/JIM.Web/Models/Api/ActivityDtos.cs
+++ b/src/JIM.Web/Models/Api/ActivityDtos.cs
@@ -369,6 +369,14 @@ public class ActivityDetailDto
     public string? ErrorStackTrace { get; set; }
 
     /// <summary>
+    /// Structured detail about the failure, as JSON, where there is something specific worth acting on beyond the
+    /// message. An LDAPS connection refused because of the directory server's certificate records that certificate
+    /// here: its subject, issuer, the names it was issued for, its validity dates, its thumbprint, and which check
+    /// it failed. Null for failures with no structured detail.
+    /// </summary>
+    public string? ErrorDetail { get; set; }
+
+    /// <summary>
     /// The run type if this is a sync activity.
     /// </summary>
     public ConnectedSystemRunType? ConnectedSystemRunType { get; set; }
@@ -445,6 +453,7 @@ public class ActivityDetailDto
             WarningMessage = activity.WarningMessage,
             ErrorMessage = activity.ErrorMessage,
             ErrorStackTrace = activity.ErrorStackTrace,
+            ErrorDetail = activity.ErrorDetail,
             ConnectedSystemRunType = activity.ConnectedSystemRunType,
             ConnectedSystemId = activity.ConnectedSystemId,
             ConnectedSystemRunProfileId = activity.ConnectedSystemRunProfileId,

--- a/src/JIM.Web/Pages/ActivityDetail.razor
+++ b/src/JIM.Web/Pages/ActivityDetail.razor
@@ -254,11 +254,7 @@
                 <MudText Typo="Typo.body1" Style="font-weight: 500;">@_activity.ErrorMessage</MudText>
             }
 
-            @if (!string.IsNullOrEmpty(_activity.ErrorStackTrace))
-            {
-                <MudText Typo="Typo.button" Class="mt-3">Stack Trace:</MudText>
-                <pre>@_activity.ErrorStackTrace</pre>
-            }
+            <CollapsibleStackTrace StackTrace="@_activity.ErrorStackTrace" />
         </MudAlert>
 
         @* Some failures carry facts worth showing, not just a sentence. A rejected directory certificate is one:

--- a/src/JIM.Web/Pages/ActivityDetail.razor
+++ b/src/JIM.Web/Pages/ActivityDetail.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize(Roles = "User")]
 @using JIM.Models.Activities;
 @using JIM.Models.Activities.DTOs;
+@using JIM.Models.Connectors;
 @using JIM.Models.Core.DTOs;
 @using JIM.Models.Enums;
 @using JIM.Models.Staging
@@ -259,6 +260,14 @@
                 <pre>@_activity.ErrorStackTrace</pre>
             }
         </MudAlert>
+
+        @* Some failures carry facts worth showing, not just a sentence. A rejected directory certificate is one:
+           what was presented, and by whom, is what tells an administrator whether to trust it, renew it, or reach
+           the directory by a different name. *@
+        @if (_serverCertificate != null)
+        {
+            <ServerCertificateCard Diagnostic="_serverCertificate" />
+        }
     }
 
     @if (_configChangeDetail != null)
@@ -918,6 +927,11 @@
     private Guid _loadedId;
     private MudTable<ActivityRunProfileExecutionItemHeader>? _table;
     private Activity? _activity;
+
+    /// <summary>
+    /// Structured detail for a failure caused by a directory server's certificate, when the Activity carries it.
+    /// </summary>
+    private ServerCertificateDiagnostic? _serverCertificate;
     private Activity? _parentActivity;
     private ConfigurationChangeDetail? _configChangeDetail;
     private bool _isAdministrator;
@@ -1004,6 +1018,8 @@
             NavManager.NavigateTo("../");
             return;
         }
+
+        _serverCertificate = ActivityErrorDetail.TryReadServerCertificate(_activity.ErrorDetail);
 
         // Seed the ETA sample window so the estimate appears as soon as a second sample lands.
         UpdateEtaEstimate(_activity);

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -866,15 +866,7 @@ else if (_activityRunProfileExecutionItem.ObjectChangeType == ObjectChangeType.N
                                     }
                                 </MudAlert>
 
-                                @if (!string.IsNullOrEmpty(_activityRunProfileExecutionItem.ErrorStackTrace))
-                                {
-                                    <MudExpansionPanels Elevation="0" Class="mb-5 jim-expansion-panel">
-                                        <MudExpansionPanel Text="Stack Trace" MaxHeight="400">
-                                            <pre class="jim-text-code"
-                                                 style="white-space: pre-wrap; word-wrap: break-word; overflow-x: auto; font-size: 0.8rem; margin: 0;">@_activityRunProfileExecutionItem.ErrorStackTrace</pre>
-                                        </MudExpansionPanel>
-                                    </MudExpansionPanels>
-                                }
+                                <CollapsibleStackTrace StackTrace="@_activityRunProfileExecutionItem.ErrorStackTrace" />
                             }
 
                             @* Pending Export Details - shown for PendingExport items and export-related errors *@

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSettingsTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemSettingsTab.razor
@@ -1,4 +1,6 @@
+@using JIM.Models.Connectors
 @using JIM.Models.Core
+@using JIM.Models.Exceptions
 @using JIM.Models.Staging
 @inject IJimApplicationFactory JimFactory
 @inject IDialogService DialogService
@@ -164,6 +166,13 @@
                 }
             </ul>
         </MudAlert>
+
+        @* When the directory refused the connection because of its certificate, show the certificate itself: which
+           one was presented, and what to do about it, is the whole answer here. *@
+        @if (_serverCertificate != null)
+        {
+            <ServerCertificateCard Diagnostic="_serverCertificate" Compact="true" />
+        }
     }
 </MudForm>
 <MudButton Variant="Variant.Filled" Color="@(IsSettingsFormValid || !_settingsBeingSaved ? Color.Primary : Color.Default)" Disabled="@(!IsSettingsFormValid || !AreSettingGroupsSatisfied() || _settingsBeingSaved)" Class="mt-5" DropShadow="false" OnClick="HandleValidSettingsSubmitAsync">
@@ -194,6 +203,11 @@
     private bool IsSettingsFormValid { get; set; }
     private string[] SettingsFormErrors { get; set; } = [];
     private Dictionary<string, string> SettingsFormCustomErrors { get; } = new();
+
+    /// <summary>
+    /// The certificate a directory server presented when it refused the connection, when that is why validation failed.
+    /// </summary>
+    private ServerCertificateDiagnostic? _serverCertificate;
     private bool _settingsBeingSaved;
     private MudForm? _settingsForm;
 
@@ -212,6 +226,7 @@
         using var jim = JimFactory.Create();
         _settingsBeingSaved = true;
         SettingsFormCustomErrors.Clear();
+        _serverCertificate = null;
 
         StateHasChanged();
         await Task.Delay(1);
@@ -222,6 +237,9 @@
             var result = results[i];
             if (result.IsValid)
                 continue;
+
+            // a refused certificate is worth more than a sentence, so keep the detail for the card below
+            _serverCertificate ??= FindServerCertificateDiagnostic(result.Exception);
 
             // indexer assignment (not .Add) so two results targeting the same setting cannot throw a duplicate-key exception
             switch (result.SettingValue)
@@ -284,5 +302,21 @@
         {
             await _settingsForm.ValidateAsync();
         }
+    }
+
+    /// <summary>
+    /// Walks a validation failure's exception chain for a refused certificate, so the detail survives being wrapped.
+    /// </summary>
+    private static ServerCertificateDiagnostic? FindServerCertificateDiagnostic(Exception? exception)
+    {
+        while (exception != null)
+        {
+            if (exception is ServerCertificateRejectedException certificateRejection)
+                return certificateRejection.Diagnostic;
+
+            exception = exception.InnerException;
+        }
+
+        return null;
     }
 }

--- a/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/OperationsHistoryTab.razor
@@ -771,11 +771,7 @@
                             <MudText Typo="Typo.body2" Style="white-space: pre-wrap; word-break: break-word;">
                                 @_selectedActivity.ErrorMessage
                             </MudText>
-                            @if (!string.IsNullOrEmpty(_selectedActivity.ErrorStackTrace))
-                            {
-                                <MudDivider Class="my-2" />
-                                <pre class="jim-text-code" style="white-space: pre-wrap; word-break: break-word; font-size: 0.75rem; margin: 0; padding: 12px; background: var(--mud-palette-background); border-radius: 4px; overflow-x: auto;">@_selectedActivity.ErrorStackTrace</pre>
-                            }
+                            <CollapsibleStackTrace StackTrace="@_selectedActivity.ErrorStackTrace" />
                         </ChildContent>
                     </MudExpansionPanel>
                 </MudExpansionPanels>

--- a/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
+++ b/src/JIM.Web/Pages/Admin/PendingExportDetail.razor
@@ -204,7 +204,7 @@
                                 <tr>
                                     <td><strong>Stack Trace</strong></td>
                                     <td>
-                                        <pre style="white-space: pre-wrap; word-wrap: break-word; margin: 0; font-size: 0.85em;">@_pendingExport.LastErrorStackTrace</pre>
+                                        <CollapsibleStackTrace StackTrace="@_pendingExport.LastErrorStackTrace" />
                                     </td>
                                 </tr>
                             }

--- a/src/JIM.Web/Shared/CollapsibleStackTrace.razor
+++ b/src/JIM.Web/Shared/CollapsibleStackTrace.razor
@@ -1,0 +1,37 @@
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+@*
+    A stack trace, kept out of the way until it is asked for. The error message answers the question most of the
+    time; the trace is for the occasions it does not, and printing it unasked buries the message that matters.
+    The trace is not rendered at all while hidden, so a long one costs the page nothing.
+*@
+
+@if (!string.IsNullOrWhiteSpace(StackTrace))
+{
+    <div class="jim-stack-trace">
+        <MudButton Variant="Variant.Text"
+                   Size="Size.Small"
+                   Color="Color.Inherit"
+                   DropShadow="false"
+                   StartIcon="@(_shown ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                   OnClick="@(() => _shown = !_shown)">
+            @(_shown ? "Hide stack trace" : "Show stack trace")
+        </MudButton>
+
+        @if (_shown)
+        {
+            <pre class="jim-stack-trace-text">@StackTrace</pre>
+        }
+    </div>
+}
+
+@code {
+    /// <summary>
+    /// The stack trace to offer. Nothing is rendered when there is none.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public string? StackTrace { get; set; }
+
+    private bool _shown;
+}

--- a/src/JIM.Web/Shared/ServerCertificateCard.razor
+++ b/src/JIM.Web/Shared/ServerCertificateCard.razor
@@ -17,73 +17,75 @@
                 <MudIcon Icon="@SealIcon" Size="Size.Medium" />
             </div>
 
-            <div class="jim-certificate-eyebrow">Certificate presented by @Diagnostic.Host:@Diagnostic.Port</div>
+            @* The frame stretches with the page; the content does not. It stays a centred column of a readable
+               width, which is what keeps a wide card reading as a certificate rather than a banner. *@
+            <div class="jim-certificate-content">
+                <div class="jim-certificate-eyebrow">Certificate presented by @Diagnostic.Host:@Diagnostic.Port</div>
 
-            <div class="jim-certificate-subject">@FormatDistinguishedName(Diagnostic.Subject)</div>
+                <div class="jim-certificate-subject">@FormatDistinguishedName(Diagnostic.Subject)</div>
 
-            <div class="jim-certificate-issuer">
-                @if (Diagnostic.IsSelfSigned)
-                {
-                    <span>Self-signed</span>
-                }
-                else
-                {
-                    <span>Issued by @FormatDistinguishedName(Diagnostic.Issuer)</span>
-                }
-            </div>
-
-            <div class="jim-certificate-rule"></div>
-
-            <div class="jim-certificate-fields">
-                <div class="jim-certificate-field">
-                    <span class="jim-certificate-label">Issued for</span>
-                    @if (Diagnostic.SubjectAlternativeNames.Count > 0)
+                <div class="jim-certificate-issuer">
+                    @if (Diagnostic.IsSelfSigned)
                     {
-                        <span class="jim-certificate-names">
-                            @foreach (var name in Diagnostic.SubjectAlternativeNames)
-                            {
-                                <span class="jim-certificate-name @(NameMatchesHost(name) ? "jim-certificate-name-match" : "")">@name</span>
-                            }
-                        </span>
+                        <span>Self-signed</span>
                     }
                     else
                     {
-                        <EmptyValue />
+                        <span>Issued by @FormatDistinguishedName(Diagnostic.Issuer)</span>
                     }
                 </div>
 
-                <div class="jim-certificate-field">
-                    <span class="jim-certificate-label">Valid</span>
-                    <span class="jim-certificate-value @(Diagnostic.IsExpired || Diagnostic.IsNotYetValid ? "jim-certificate-value-problem" : "")">
-                        @FormatDate(Diagnostic.ValidFrom) to @FormatDate(Diagnostic.ValidTo)
-                    </span>
-                </div>
+                <div class="jim-certificate-rule"></div>
 
-                @if (!string.IsNullOrEmpty(Diagnostic.SignatureAlgorithm))
-                {
+                <div class="jim-certificate-fields">
                     <div class="jim-certificate-field">
-                        <span class="jim-certificate-label">Signature</span>
-                        <span class="jim-certificate-value">@Diagnostic.SignatureAlgorithm</span>
+                        <span class="jim-certificate-label">Issued for</span>
+                        @if (Diagnostic.SubjectAlternativeNames.Count > 0)
+                        {
+                            <span class="jim-certificate-names">
+                                @foreach (var name in Diagnostic.SubjectAlternativeNames)
+                                {
+                                    <span class="jim-certificate-name @(NameMatchesHost(name) ? "jim-certificate-name-match" : "")">@name</span>
+                                }
+                            </span>
+                        }
+                        else
+                        {
+                            <EmptyValue />
+                        }
                     </div>
-                }
 
-                @* Last, and given a row to itself once the card is wide enough to have columns, so the thumbprint
-                   never breaks across lines. *@
-                <div class="jim-certificate-field jim-certificate-field-wide">
-                    <span class="jim-certificate-label">Thumbprint</span>
-                    <span class="jim-certificate-value jim-certificate-thumbprint">@FormatThumbprint(Diagnostic.Thumbprint)</span>
+                    <div class="jim-certificate-field">
+                        <span class="jim-certificate-label">Valid</span>
+                        <span class="jim-certificate-value @(Diagnostic.IsExpired || Diagnostic.IsNotYetValid ? "jim-certificate-value-problem" : "")">
+                            @FormatDate(Diagnostic.ValidFrom) to @FormatDate(Diagnostic.ValidTo)
+                        </span>
+                    </div>
+
+                    <div class="jim-certificate-field">
+                        <span class="jim-certificate-label">Thumbprint</span>
+                        <span class="jim-certificate-value jim-certificate-thumbprint">@FormatThumbprint(Diagnostic.Thumbprint)</span>
+                    </div>
+
+                    @if (!string.IsNullOrEmpty(Diagnostic.SignatureAlgorithm))
+                    {
+                        <div class="jim-certificate-field">
+                            <span class="jim-certificate-label">Signature</span>
+                            <span class="jim-certificate-value">@Diagnostic.SignatureAlgorithm</span>
+                        </div>
+                    }
                 </div>
-            </div>
 
-            <div class="jim-certificate-verdict">
-                <MudIcon Icon="@Icons.Material.Filled.Block" Size="Size.Small" Class="mr-2" />
-                <span class="jim-certificate-verdict-reason">@DescribeReason(Diagnostic.FailureReason)</span>
-            </div>
+                <div class="jim-certificate-verdict">
+                    <MudIcon Icon="@Icons.Material.Filled.Block" Size="Size.Small" Class="mr-2" />
+                    <span class="jim-certificate-verdict-reason">@DescribeReason(Diagnostic.FailureReason)</span>
+                </div>
 
-            @if (!string.IsNullOrEmpty(Diagnostic.Remediation))
-            {
-                <div class="jim-certificate-remediation">@Diagnostic.Remediation</div>
-            }
+                @if (!string.IsNullOrEmpty(Diagnostic.Remediation))
+                {
+                    <div class="jim-certificate-remediation">@Diagnostic.Remediation</div>
+                }
+            </div>
         </div>
     </div>
 }

--- a/src/JIM.Web/Shared/ServerCertificateCard.razor
+++ b/src/JIM.Web/Shared/ServerCertificateCard.razor
@@ -1,0 +1,166 @@
+@using JIM.Models.Connectors
+
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+@*
+    Presents the certificate a directory server offered when a connection to it was refused, laid out like the
+    certificate itself so it reads as the document being talked about rather than another block of error text.
+    Everything here is public certificate material; no private key or credential is ever involved.
+*@
+
+@if (Diagnostic != null)
+{
+    <div class="jim-certificate @(Compact ? "jim-certificate-compact" : "")">
+        <div class="jim-certificate-inner">
+            <div class="jim-certificate-seal">
+                <MudIcon Icon="@SealIcon" Size="Size.Medium" />
+            </div>
+
+            <div class="jim-certificate-eyebrow">Certificate presented by @Diagnostic.Host:@Diagnostic.Port</div>
+
+            <div class="jim-certificate-subject">@FormatDistinguishedName(Diagnostic.Subject)</div>
+
+            <div class="jim-certificate-issuer">
+                @if (Diagnostic.IsSelfSigned)
+                {
+                    <span>Self-signed</span>
+                }
+                else
+                {
+                    <span>Issued by @FormatDistinguishedName(Diagnostic.Issuer)</span>
+                }
+            </div>
+
+            <div class="jim-certificate-rule"></div>
+
+            <div class="jim-certificate-fields">
+                <div class="jim-certificate-field">
+                    <span class="jim-certificate-label">Issued for</span>
+                    @if (Diagnostic.SubjectAlternativeNames.Count > 0)
+                    {
+                        <span class="jim-certificate-names">
+                            @foreach (var name in Diagnostic.SubjectAlternativeNames)
+                            {
+                                <span class="jim-certificate-name @(NameMatchesHost(name) ? "jim-certificate-name-match" : "")">@name</span>
+                            }
+                        </span>
+                    }
+                    else
+                    {
+                        <EmptyValue />
+                    }
+                </div>
+
+                <div class="jim-certificate-field">
+                    <span class="jim-certificate-label">Valid</span>
+                    <span class="jim-certificate-value @(Diagnostic.IsExpired || Diagnostic.IsNotYetValid ? "jim-certificate-value-problem" : "")">
+                        @FormatDate(Diagnostic.ValidFrom) to @FormatDate(Diagnostic.ValidTo)
+                    </span>
+                </div>
+
+                <div class="jim-certificate-field">
+                    <span class="jim-certificate-label">Thumbprint</span>
+                    <span class="jim-certificate-value jim-certificate-thumbprint">@FormatThumbprint(Diagnostic.Thumbprint)</span>
+                </div>
+
+                @if (!string.IsNullOrEmpty(Diagnostic.SignatureAlgorithm))
+                {
+                    <div class="jim-certificate-field">
+                        <span class="jim-certificate-label">Signature</span>
+                        <span class="jim-certificate-value">@Diagnostic.SignatureAlgorithm</span>
+                    </div>
+                }
+            </div>
+
+            <div class="jim-certificate-verdict">
+                <MudIcon Icon="@Icons.Material.Filled.Block" Size="Size.Small" Class="mr-2" />
+                <span class="jim-certificate-verdict-reason">@DescribeReason(Diagnostic.FailureReason)</span>
+            </div>
+
+            @if (!string.IsNullOrEmpty(Diagnostic.Remediation))
+            {
+                <div class="jim-certificate-remediation">@Diagnostic.Remediation</div>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    /// <summary>
+    /// The certificate and the reason it was refused.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public ServerCertificateDiagnostic? Diagnostic { get; set; }
+
+    /// <summary>
+    /// Tightens the layout for use inside a settings form, where the card sits alongside other validation output.
+    /// </summary>
+    [Parameter]
+    public bool Compact { get; set; }
+
+    private string SealIcon => Diagnostic?.FailureReason switch
+    {
+        ServerCertificateFailureReason.Expired => Icons.Material.Filled.HistoryToggleOff,
+        ServerCertificateFailureReason.NotYetValid => Icons.Material.Filled.HistoryToggleOff,
+        ServerCertificateFailureReason.NameMismatch => Icons.Material.Filled.WrongLocation,
+        ServerCertificateFailureReason.UntrustedIssuer => Icons.Material.Filled.GppMaybe,
+        ServerCertificateFailureReason.NoCertificatePresented => Icons.Material.Filled.NoEncryption,
+        _ => Icons.Material.Filled.WorkspacePremium
+    };
+
+    private static string DescribeReason(ServerCertificateFailureReason reason) => reason switch
+    {
+        ServerCertificateFailureReason.UntrustedIssuer => "Not trusted: JIM has not been given this certificate's issuer",
+        ServerCertificateFailureReason.NameMismatch => "Wrong name: this certificate was not issued for the host JIM connected to",
+        ServerCertificateFailureReason.Expired => "Expired",
+        ServerCertificateFailureReason.NotYetValid => "Not valid yet",
+        ServerCertificateFailureReason.NoCertificatePresented => "No certificate was offered",
+        ServerCertificateFailureReason.None => "No problem found with this certificate",
+        _ => "Refused for an unrecognised reason"
+    };
+
+    /// <summary>
+    /// Highlights the name that would have satisfied the check, so a mismatch is visible at a glance rather than
+    /// needing the reader to compare strings themselves.
+    /// </summary>
+    private bool NameMatchesHost(string name)
+    {
+        if (Diagnostic == null || string.IsNullOrEmpty(Diagnostic.Host))
+            return false;
+
+        return string.Equals(name, Diagnostic.Host, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Distinguished names read as "CN=dc01.corp.local, O=Corp"; the common name alone is what an administrator
+    /// recognises, so lead with it and drop the rest.
+    /// </summary>
+    private static string FormatDistinguishedName(string? distinguishedName)
+    {
+        if (string.IsNullOrWhiteSpace(distinguishedName))
+            return "Unknown";
+
+        var commonName = distinguishedName
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(part => part.StartsWith("CN=", StringComparison.OrdinalIgnoreCase));
+
+        return commonName != null ? commonName[3..] : distinguishedName;
+    }
+
+    private static string FormatDate(DateTime? value) => value.HasValue ? value.Value.ToString("dd MMM yyyy") : "unknown";
+
+    /// <summary>
+    /// Grouped into pairs, the way certificate viewers present a thumbprint, so it can be compared by eye against
+    /// the one shown in Admin &gt; Certificates.
+    /// </summary>
+    private static string FormatThumbprint(string? thumbprint)
+    {
+        if (string.IsNullOrWhiteSpace(thumbprint))
+            return "unknown";
+
+        return string.Join(' ', Enumerable
+            .Range(0, thumbprint.Length / 2)
+            .Select(i => thumbprint.Substring(i * 2, 2)));
+    }
+}

--- a/src/JIM.Web/Shared/ServerCertificateCard.razor
+++ b/src/JIM.Web/Shared/ServerCertificateCard.razor
@@ -59,11 +59,6 @@
                     </span>
                 </div>
 
-                <div class="jim-certificate-field">
-                    <span class="jim-certificate-label">Thumbprint</span>
-                    <span class="jim-certificate-value jim-certificate-thumbprint">@FormatThumbprint(Diagnostic.Thumbprint)</span>
-                </div>
-
                 @if (!string.IsNullOrEmpty(Diagnostic.SignatureAlgorithm))
                 {
                     <div class="jim-certificate-field">
@@ -71,6 +66,13 @@
                         <span class="jim-certificate-value">@Diagnostic.SignatureAlgorithm</span>
                     </div>
                 }
+
+                @* Last, and given a row to itself once the card is wide enough to have columns, so the thumbprint
+                   never breaks across lines. *@
+                <div class="jim-certificate-field jim-certificate-field-wide">
+                    <span class="jim-certificate-label">Thumbprint</span>
+                    <span class="jim-certificate-value jim-certificate-thumbprint">@FormatThumbprint(Diagnostic.Thumbprint)</span>
+                </div>
             </div>
 
             <div class="jim-certificate-verdict">

--- a/src/JIM.Web/Shared/ServerCertificateCard.razor
+++ b/src/JIM.Web/Shared/ServerCertificateCard.razor
@@ -152,7 +152,7 @@
         return commonName != null ? commonName[3..] : distinguishedName;
     }
 
-    private static string FormatDate(DateTime? value) => value.HasValue ? value.Value.ToString("dd MMM yyyy") : "unknown";
+    private static string FormatDate(DateTime? value) => value?.ToString("dd MMM yyyy") ?? "unknown";
 
     /// <summary>
     /// Grouped into pairs, the way certificate viewers present a thumbprint, so it can be compared by eye against

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -2061,16 +2061,21 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
    Built entirely from MudBlazor palette variables so it follows the theme into
    dark mode rather than carrying its own colours.
    --------------------------------------------------------------------------- */
-/* Fluid, like every other block on JIM's pages: the card fills the width it is given rather than stopping short
-   of it. What changes with that width is the layout inside, via the container queries below, so a wide card gains
-   columns instead of gaining empty space. */
+/* Fluid, like every other block on JIM's pages: the frame fills the width it is given rather than stopping short
+   of it. The content inside stays a centred column (see .jim-certificate-content), so widening the page widens
+   the frame without stretching the certificate. */
 .jim-certificate {
     border: 1px solid var(--mud-palette-lines-default);
     border-radius: var(--mud-default-borderradius);
     background-color: var(--mud-palette-surface);
     padding: 6px;
     margin-top: 16px;
-    container-type: inline-size;
+}
+
+/* Sized so the thumbprint, grouped into pairs, fits on one line. */
+.jim-certificate-content {
+    max-width: 580px;
+    margin-inline: auto;
 }
 
 /* The inner rule is what reads as "certificate": a second, tighter frame
@@ -2206,44 +2211,11 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
     text-align: left;
 }
 
-/* Capped to a readable measure and centred under the verdict, so a wide card does not stretch the advice into a
-   single very long line. */
 .jim-certificate-remediation {
-    margin: 8px auto 0;
-    max-width: 72ch;
+    margin-top: 8px;
     color: var(--mud-palette-text-secondary);
     font-size: 0.875rem;
-    text-align: center;
-}
-
-/* Given room, the fields become columns rather than a tall list with a wide empty margin beside it. Tracks that
-   end up with nothing in them collapse, so the fields always share the full width evenly however many there are. */
-@container (min-width: 560px) {
-    .jim-certificate-fields {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        column-gap: 32px;
-        row-gap: 16px;
-        align-items: start;
-    }
-
-    /* The label sits above its value here: a fixed label gutter would squeeze the values once the row is shared. */
-    .jim-certificate-field {
-        grid-template-columns: minmax(0, 1fr);
-        gap: 2px;
-    }
-
-    /* Spans the whole row, because a thumbprint broken across lines is materially harder to compare by eye
-       against the one shown in Admin > Certificates. */
-    .jim-certificate-field-wide {
-        grid-column: 1 / -1;
-    }
-
-    /* With a row to itself there is no longer any need to squeeze it, so it can be read at a normal size. */
-    .jim-certificate-thumbprint {
-        font-size: 0.85rem;
-        letter-spacing: normal;
-    }
+    text-align: left;
 }
 
 /* ─── Collapsible stack trace ─── */

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -2235,3 +2235,41 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
     overflow-y: auto;
     margin: 4px 0 0;
 }
+
+/* ─── Buttons inside alerts ─── */
+
+/* A button offered inside an alert belongs to that alert's message. Left to itself it renders in the page's
+   default text colour while its icon picks up MudBlazor's accent, so the label and the icon read as two unrelated
+   things sitting inside a third. Both now take the alert's severity colour from the palette, which is the
+   text-grade shade rather than the brighter one the alert's border and icon use, so the label keeps its contrast
+   against the alert's tinted background (measured 4.6:1 light, 7.5:1 dark: WCAG AA).
+
+   Scoped to buttons that asked to inherit their colour. A button that names its own Color has made a deliberate
+   choice and keeps it, which is what the filled Primary/Warning/Info buttons already sitting inside alerts rely
+   on. Filled alerts need no rule: an inheriting button already takes their text colour. The alert's own severity
+   icon is left alone.
+
+   Written against the alert rather than any one component, so every button placed in one from here on picks the
+   behaviour up without anybody having to remember it. */
+:is(.mud-alert-text-error, .mud-alert-outlined-error, .jim-alert-error) :is(.mud-button-text-inherit, .mud-button-outlined-inherit) {
+    color: var(--mud-palette-error) !important;
+}
+
+:is(.mud-alert-text-error, .mud-alert-outlined-error, .jim-alert-error) :is(.mud-button-text-inherit, .mud-button-outlined-inherit) .mud-icon-root {
+    color: var(--mud-palette-error) !important;
+}
+
+:is(.mud-alert-text-warning, .mud-alert-outlined-warning) :is(.mud-button-text-inherit, .mud-button-outlined-inherit),
+:is(.mud-alert-text-warning, .mud-alert-outlined-warning) :is(.mud-button-text-inherit, .mud-button-outlined-inherit) .mud-icon-root {
+    color: var(--mud-palette-warning) !important;
+}
+
+:is(.mud-alert-text-info, .mud-alert-outlined-info) :is(.mud-button-text-inherit, .mud-button-outlined-inherit),
+:is(.mud-alert-text-info, .mud-alert-outlined-info) :is(.mud-button-text-inherit, .mud-button-outlined-inherit) .mud-icon-root {
+    color: var(--mud-palette-info) !important;
+}
+
+:is(.mud-alert-text-success, .mud-alert-outlined-success) :is(.mud-button-text-inherit, .mud-button-outlined-inherit),
+:is(.mud-alert-text-success, .mud-alert-outlined-success) :is(.mud-button-text-inherit, .mud-button-outlined-inherit) .mud-icon-root {
+    color: var(--mud-palette-success) !important;
+}

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -2050,3 +2050,162 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
 .jim-flow-option .jim-standard-hint {
     flex: 0 0 auto;
 }
+
+/* ---------------------------------------------------------------------------
+   Server certificate card (<ServerCertificateCard />)
+
+   Presents the certificate a directory server offered when a connection was
+   refused. Styled as the document itself: a ruled border, a seal, and the
+   fields laid out the way a certificate viewer presents them, so an
+   administrator recognises what they are looking at before reading a word.
+   Built entirely from MudBlazor palette variables so it follows the theme into
+   dark mode rather than carrying its own colours.
+   --------------------------------------------------------------------------- */
+.jim-certificate {
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background-color: var(--mud-palette-surface);
+    padding: 6px;
+    margin-top: 16px;
+    max-width: 640px;
+}
+
+/* The inner rule is what reads as "certificate": a second, tighter frame
+   inside the outer border, as engraved documents have. */
+.jim-certificate-inner {
+    position: relative;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: calc(var(--mud-default-borderradius) - 1px);
+    padding: 28px 28px 20px;
+    text-align: center;
+}
+
+.jim-certificate-compact .jim-certificate-inner {
+    padding: 20px 20px 16px;
+}
+
+/* The seal sits over the top rule, the way a wax seal or foil disc overlaps a
+   certificate's border. */
+.jim-certificate-seal {
+    position: absolute;
+    top: -18px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background-color: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--mud-palette-text-secondary);
+}
+
+.jim-certificate-eyebrow {
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--mud-palette-text-secondary);
+    margin-top: 6px;
+}
+
+.jim-certificate-subject {
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-top: 10px;
+    word-break: break-word;
+}
+
+.jim-certificate-issuer {
+    color: var(--mud-palette-text-secondary);
+    font-size: 0.875rem;
+    margin-top: 4px;
+}
+
+.jim-certificate-rule {
+    height: 1px;
+    background: linear-gradient(to right, transparent, var(--mud-palette-lines-default), transparent);
+    margin: 18px auto;
+    width: 70%;
+}
+
+.jim-certificate-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    text-align: left;
+}
+
+.jim-certificate-field {
+    display: grid;
+    grid-template-columns: 7.5rem minmax(0, 1fr);
+    gap: 12px;
+    align-items: baseline;
+}
+
+.jim-certificate-label {
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--mud-palette-text-secondary);
+}
+
+.jim-certificate-value {
+    word-break: break-word;
+}
+
+.jim-certificate-value-problem {
+    color: var(--mud-palette-error);
+    font-weight: 500;
+}
+
+/* Sized so a full 40-character SHA-1 thumbprint, grouped into pairs, stays on one line at the card's width:
+   a thumbprint split across lines is materially harder to compare against the one in Admin > Certificates. */
+.jim-certificate-thumbprint {
+    font-family: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    letter-spacing: -0.01em;
+}
+
+.jim-certificate-names {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.jim-certificate-name {
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    padding: 1px 8px;
+    font-size: 0.8rem;
+}
+
+/* The name that satisfies the check, when there is one, so a mismatch does not
+   have to be spotted by comparing strings. */
+.jim-certificate-name-match {
+    border-color: var(--mud-palette-success);
+    color: var(--mud-palette-success);
+}
+
+.jim-certificate-verdict {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 20px;
+    padding-top: 14px;
+    border-top: 1px solid var(--mud-palette-lines-default);
+    color: var(--mud-palette-error);
+    font-weight: 500;
+}
+
+.jim-certificate-verdict-reason {
+    text-align: left;
+}
+
+.jim-certificate-remediation {
+    margin-top: 8px;
+    color: var(--mud-palette-text-secondary);
+    font-size: 0.875rem;
+    text-align: left;
+}

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -2061,13 +2061,16 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
    Built entirely from MudBlazor palette variables so it follows the theme into
    dark mode rather than carrying its own colours.
    --------------------------------------------------------------------------- */
+/* Fluid, like every other block on JIM's pages: the card fills the width it is given rather than stopping short
+   of it. What changes with that width is the layout inside, via the container queries below, so a wide card gains
+   columns instead of gaining empty space. */
 .jim-certificate {
     border: 1px solid var(--mud-palette-lines-default);
     border-radius: var(--mud-default-borderradius);
     background-color: var(--mud-palette-surface);
     padding: 6px;
     margin-top: 16px;
-    max-width: 640px;
+    container-type: inline-size;
 }
 
 /* The inner rule is what reads as "certificate": a second, tighter frame
@@ -2203,9 +2206,60 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
     text-align: left;
 }
 
+/* Capped to a readable measure and centred under the verdict, so a wide card does not stretch the advice into a
+   single very long line. */
 .jim-certificate-remediation {
-    margin-top: 8px;
+    margin: 8px auto 0;
+    max-width: 72ch;
     color: var(--mud-palette-text-secondary);
     font-size: 0.875rem;
-    text-align: left;
+    text-align: center;
+}
+
+/* Given room, the fields become columns rather than a tall list with a wide empty margin beside it. Tracks that
+   end up with nothing in them collapse, so the fields always share the full width evenly however many there are. */
+@container (min-width: 560px) {
+    .jim-certificate-fields {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        column-gap: 32px;
+        row-gap: 16px;
+        align-items: start;
+    }
+
+    /* The label sits above its value here: a fixed label gutter would squeeze the values once the row is shared. */
+    .jim-certificate-field {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 2px;
+    }
+
+    /* Spans the whole row, because a thumbprint broken across lines is materially harder to compare by eye
+       against the one shown in Admin > Certificates. */
+    .jim-certificate-field-wide {
+        grid-column: 1 / -1;
+    }
+
+    /* With a row to itself there is no longer any need to squeeze it, so it can be read at a normal size. */
+    .jim-certificate-thumbprint {
+        font-size: 0.85rem;
+        letter-spacing: normal;
+    }
+}
+
+/* ─── Collapsible stack trace ─── */
+
+.jim-stack-trace {
+    margin-top: 8px;
+}
+
+/* Scrolls within itself rather than stretching the page: a stack trace is long in both directions. */
+.jim-stack-trace-text {
+    font-family: "IBM Plex Mono", "Lucida Console", "Courier New", monospace;
+    font-size: 0.78rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+    max-height: 420px;
+    overflow-y: auto;
+    margin: 4px 0 0;
 }

--- a/src/JIM.Web/wwwroot/css/site.css
+++ b/src/JIM.Web/wwwroot/css/site.css
@@ -2273,3 +2273,16 @@ html[lang] .mud-paper .mud-table.attribute-change-table .mud-table-empty-row {
 :is(.mud-alert-text-success, .mud-alert-outlined-success) :is(.mud-button-text-inherit, .mud-button-outlined-inherit) .mud-icon-root {
     color: var(--mud-palette-success) !important;
 }
+
+/* The hover and focus wash, and the click ripple, follow the button's own colour rather than MudBlazor's
+   defaults, which are a blue tint and a near-black ripple: both read as foreign inside a coloured alert. Written
+   against currentColor so one rule serves every severity and both themes; on a normal-severity alert it resolves
+   to the ordinary text colour, which is the right answer there too. */
+.mud-alert :is(.mud-button-text-inherit, .mud-button-outlined-inherit):hover,
+.mud-alert :is(.mud-button-text-inherit, .mud-button-outlined-inherit):focus-visible {
+    background-color: color-mix(in srgb, currentColor 12%, transparent) !important;
+}
+
+.mud-alert :is(.mud-button-text-inherit, .mud-button-outlined-inherit) .mud-ripple-effect {
+    background-color: currentColor !important;
+}

--- a/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncImportTaskProcessor.cs
@@ -245,118 +245,128 @@ public class SyncImportTaskProcessor
                     callBasedImportConnector.OpenImportConnection(_connectedSystem.SettingValues, Log.Logger);
                 }
 
-                var initialPage = true;
-                var paginationTokens = new List<ConnectedSystemPaginationToken>();
-                var pageNumber = 0;
-
-                // Keep track of the original persisted data at the START of the import.
-                // This is critical for delta imports where subsequent pages must use the SAME
-                // watermark (USN) as the first page to query for changes.
-                // The connector will return a NEW watermark on the first page that we'll save
-                // AFTER all pages are processed.
-                var originalPersistedData = _connectedSystem.PersistedConnectorData;
-                string? newPersistedData = null;
-                string? connectorWarningMessage = null;
-
-                while (initialPage || paginationTokens.Count > 0)
+                try
                 {
-                    if (_cancellationTokenSource.IsCancellationRequested)
+                    var initialPage = true;
+                    var paginationTokens = new List<ConnectedSystemPaginationToken>();
+                    var pageNumber = 0;
+
+                    // Keep track of the original persisted data at the START of the import.
+                    // This is critical for delta imports where subsequent pages must use the SAME
+                    // watermark (USN) as the first page to query for changes.
+                    // The connector will return a NEW watermark on the first page that we'll save
+                    // AFTER all pages are processed.
+                    var originalPersistedData = _connectedSystem.PersistedConnectorData;
+                    string? newPersistedData = null;
+                    string? connectorWarningMessage = null;
+
+                    while (initialPage || paginationTokens.Count > 0)
                     {
-                        Log.Information("PerformImportAsync: Cancellation requested. Stopping before next import page.");
-                        break;
+                        if (_cancellationTokenSource.IsCancellationRequested)
+                        {
+                            Log.Information("PerformImportAsync: Cancellation requested. Stopping before next import page.");
+                            break;
+                        }
+
+                        // perform the import for this page
+                        // IMPORTANT: Always pass the ORIGINAL persisted data to ensure consistent
+                        // watermark queries across all pages of a delta import.
+                        ConnectedSystemImportResult result;
+                        var fetchMessage = pageNumber > 0
+                            ? $"Importing objects from Connected System (page {pageNumber + 1})"
+                            : "Importing objects from Connected System";
+                        await _syncRepo.UpdateActivityMessageAsync(_activity, fetchMessage);
+                        using (Diagnostics.Connector.StartSpan("ImportPage")
+                            .SetTag("connectedSystemId", _connectedSystem.Id)
+                            .SetTag("pageNumber", pageNumber)
+                            .SetTag("cumulativeObjectCount", totalObjectsImported)
+                            .SetTag("wallClockOffsetMs", importPhaseSw.Elapsed.TotalMilliseconds))
+                        {
+                            result = await callBasedImportConnector.ImportAsync(_connectedSystem, _connectedSystemRunProfile, paginationTokens, originalPersistedData, Log.Logger, _cancellationTokenSource.Token);
+                        }
+                        pageNumber++;
+                        totalObjectsImported += result.ImportObjects.Count;
+
+                        Log.Information("MetricsCheckpoint: Import processed={ObjectsProcessed} elapsed={ElapsedMs}ms cs={ConnectedSystemName}",
+                            totalObjectsImported, (long)importPhaseSw.Elapsed.TotalMilliseconds, _connectedSystem.Name);
+
+                        // Update progress - for paginated imports we don't know the total, but we track objects imported so far
+                        _activity.ObjectsProcessed = totalObjectsImported;
+                        var pageInfo = pageNumber > 1 || result.PaginationTokens.Count > 0
+                            ? $" (page {pageNumber})"
+                            : "";
+                        var progressMessage = $"Imported {totalObjectsImported:N0} objects{pageInfo}" +
+                            throughput.FormatThroughput(totalObjectsImported);
+                        await _syncRepo.UpdateActivityMessageAsync(_activity, progressMessage);
+
+                        // add the external ids from this page worth of results to our external-id collection for later deletion calculation
+                        AddExternalIdsToCollection(result, externalIdsImported);
+
+                        // make sure we pass the pagination tokens back in on the next page (if there is one)
+                        paginationTokens = result.PaginationTokens;
+
+                        // Capture the new persisted connector data from the first page only.
+                        // Subsequent pages return null (indicating "no change"), so we only capture once.
+                        // We'll save this AFTER all pages are processed to avoid affecting watermark
+                        // queries on subsequent pages.
+                        if (result.PersistedConnectorData != null && newPersistedData == null)
+                        {
+                            Log.Debug($"ExecuteAsync: captured new persisted connector data from page {pageNumber}. old value: '{LogSanitiser.Sanitise(originalPersistedData)}', new value: '{LogSanitiser.Sanitise(result.PersistedConnectorData)}'");
+                            newPersistedData = result.PersistedConnectorData;
+                        }
+
+                        // Capture connector warning from the first page that reports one
+                        if (result.WarningMessage != null && connectorWarningMessage == null)
+                        {
+                            connectorWarningMessage = result.WarningMessage;
+                        }
+
+                        // process the results from this page
+                        using (Diagnostics.Sync.StartSpan("ProcessImportObjects").SetTag("objectCount", result.ImportObjects.Count))
+                        {
+                            await ProcessImportObjectsAsync(result, connectedSystemObjectsToBeCreated, connectedSystemObjectsToBeUpdated, crossPageSeenExternalIds);
+                        }
+
+                        if (initialPage)
+                            initialPage = false;
+
+                        if (_cancellationTokenSource.IsCancellationRequested)
+                        {
+                            Log.Information("PerformImportAsync: Cancellation requested after processing page {Page}. Stopping.", pageNumber);
+                            break;
+                        }
                     }
 
-                    // perform the import for this page
-                    // IMPORTANT: Always pass the ORIGINAL persisted data to ensure consistent
-                    // watermark queries across all pages of a delta import.
-                    ConnectedSystemImportResult result;
-                    var fetchMessage = pageNumber > 0
-                        ? $"Importing objects from Connected System (page {pageNumber + 1})"
-                        : "Importing objects from Connected System";
-                    await _syncRepo.UpdateActivityMessageAsync(_activity, fetchMessage);
-                    using (Diagnostics.Connector.StartSpan("ImportPage")
-                        .SetTag("connectedSystemId", _connectedSystem.Id)
-                        .SetTag("pageNumber", pageNumber)
-                        .SetTag("cumulativeObjectCount", totalObjectsImported)
-                        .SetTag("wallClockOffsetMs", importPhaseSw.Elapsed.TotalMilliseconds))
+                    // Now that all pages are processed, update the persisted connector data
+                    // with the new watermark captured from the first page.
+                    if (newPersistedData != null && newPersistedData != originalPersistedData)
                     {
-                        result = await callBasedImportConnector.ImportAsync(_connectedSystem, _connectedSystemRunProfile, paginationTokens, originalPersistedData, Log.Logger, _cancellationTokenSource.Token);
-                    }
-                    pageNumber++;
-                    totalObjectsImported += result.ImportObjects.Count;
-
-                    Log.Information("MetricsCheckpoint: Import processed={ObjectsProcessed} elapsed={ElapsedMs}ms cs={ConnectedSystemName}",
-                        totalObjectsImported, (long)importPhaseSw.Elapsed.TotalMilliseconds, _connectedSystem.Name);
-
-                    // Update progress - for paginated imports we don't know the total, but we track objects imported so far
-                    _activity.ObjectsProcessed = totalObjectsImported;
-                    var pageInfo = pageNumber > 1 || result.PaginationTokens.Count > 0
-                        ? $" (page {pageNumber})"
-                        : "";
-                    var progressMessage = $"Imported {totalObjectsImported:N0} objects{pageInfo}" +
-                        throughput.FormatThroughput(totalObjectsImported);
-                    await _syncRepo.UpdateActivityMessageAsync(_activity, progressMessage);
-
-                    // add the external ids from this page worth of results to our external-id collection for later deletion calculation
-                    AddExternalIdsToCollection(result, externalIdsImported);
-
-                    // make sure we pass the pagination tokens back in on the next page (if there is one)
-                    paginationTokens = result.PaginationTokens;
-
-                    // Capture the new persisted connector data from the first page only.
-                    // Subsequent pages return null (indicating "no change"), so we only capture once.
-                    // We'll save this AFTER all pages are processed to avoid affecting watermark
-                    // queries on subsequent pages.
-                    if (result.PersistedConnectorData != null && newPersistedData == null)
-                    {
-                        Log.Debug($"ExecuteAsync: captured new persisted connector data from page {pageNumber}. old value: '{LogSanitiser.Sanitise(originalPersistedData)}', new value: '{LogSanitiser.Sanitise(result.PersistedConnectorData)}'");
-                        newPersistedData = result.PersistedConnectorData;
+                        Log.Debug($"ExecuteAsync: updating persisted connector data after all pages. old value: '{LogSanitiser.Sanitise(originalPersistedData)}', new value: '{LogSanitiser.Sanitise(newPersistedData)}'");
+                        await _syncServer.UpdateConnectedSystemPersistedConnectorDataAsync(_connectedSystem, newPersistedData);
                     }
 
-                    // Capture connector warning from the first page that reports one
-                    if (result.WarningMessage != null && connectorWarningMessage == null)
+                    // Record connector-level warnings on the Activity itself (not as phantom RPEIs).
+                    // Connector warnings (e.g., DeltaImportFallbackToFullImport) are operational notes about
+                    // HOW the import was performed, not errors with specific objects. Creating a phantom RPEI
+                    // with no CSO association inflates error counts and pollutes the RPEI list.
+                    if (connectorWarningMessage != null)
                     {
-                        connectorWarningMessage = result.WarningMessage;
+                        _activity.WarningMessage = connectorWarningMessage;
+                        Log.Warning("PerformImportAsync: Connector reported warning: {WarningMessage}", LogSanitiser.Sanitise(connectorWarningMessage));
                     }
 
-                    // process the results from this page
-                    using (Diagnostics.Sync.StartSpan("ProcessImportObjects").SetTag("objectCount", result.ImportObjects.Count))
+                }
+                finally
+                {
+                    using (Diagnostics.Connector.StartSpan("CloseImportConnection"))
                     {
-                        await ProcessImportObjectsAsync(result, connectedSystemObjectsToBeCreated, connectedSystemObjectsToBeUpdated, crossPageSeenExternalIds);
-                    }
-
-                    if (initialPage)
-                        initialPage = false;
-
-                    if (_cancellationTokenSource.IsCancellationRequested)
-                    {
-                        Log.Information("PerformImportAsync: Cancellation requested after processing page {Page}. Stopping.", pageNumber);
-                        break;
+                        // In a finally so an import that fails part-way still releases the connection and the
+                        // temporary trust directory prepared for it, rather than leaving both to the connector
+                        // instance being garbage collected.
+                        callBasedImportConnector.CloseImportConnection();
                     }
                 }
 
-                // Now that all pages are processed, update the persisted connector data
-                // with the new watermark captured from the first page.
-                if (newPersistedData != null && newPersistedData != originalPersistedData)
-                {
-                    Log.Debug($"ExecuteAsync: updating persisted connector data after all pages. old value: '{LogSanitiser.Sanitise(originalPersistedData)}', new value: '{LogSanitiser.Sanitise(newPersistedData)}'");
-                    await _syncServer.UpdateConnectedSystemPersistedConnectorDataAsync(_connectedSystem, newPersistedData);
-                }
-
-                // Record connector-level warnings on the Activity itself (not as phantom RPEIs).
-                // Connector warnings (e.g., DeltaImportFallbackToFullImport) are operational notes about
-                // HOW the import was performed, not errors with specific objects. Creating a phantom RPEI
-                // with no CSO association inflates error counts and pollutes the RPEI list.
-                if (connectorWarningMessage != null)
-                {
-                    _activity.WarningMessage = connectorWarningMessage;
-                    Log.Warning("PerformImportAsync: Connector reported warning: {WarningMessage}", LogSanitiser.Sanitise(connectorWarningMessage));
-                }
-
-                using (Diagnostics.Connector.StartSpan("CloseImportConnection"))
-                {
-                    callBasedImportConnector.CloseImportConnection();
-                }
                 break;
             }
             case IConnectorImportUsingFiles fileBasedImportConnector:

--- a/test/JIM.Web.Components.Tests/CollapsibleStackTraceTests.cs
+++ b/test/JIM.Web.Components.Tests/CollapsibleStackTraceTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using Bunit;
+using JIM.Web.Shared;
+using NUnit.Framework;
+
+namespace JIM.Web.Components.Tests;
+
+/// <summary>
+/// Covers the stack trace's disclosure behaviour: the error message is what an administrator reads, and the trace
+/// stays out of the way until it is asked for.
+/// </summary>
+[TestFixture]
+public class CollapsibleStackTraceTests : JimComponentTestContext
+{
+    private const string Trace = "at JIM.Connectors.LDAP.LdapConnector.OpenImportConnection(List`1 settingValues)";
+
+    [Test]
+    public void CollapsibleStackTrace_WithNoStackTrace_RendersNothing()
+    {
+        var cut = Render<CollapsibleStackTrace>(p => p.Add(c => c.StackTrace, null));
+
+        Assert.That(cut.Markup.Trim(), Is.Empty);
+    }
+
+    [Test]
+    public void CollapsibleStackTrace_WithWhitespaceStackTrace_RendersNothing()
+    {
+        var cut = Render<CollapsibleStackTrace>(p => p.Add(c => c.StackTrace, "   "));
+
+        Assert.That(cut.Markup.Trim(), Is.Empty);
+    }
+
+    [Test]
+    public void CollapsibleStackTrace_ByDefault_KeepsTheStackTraceOutOfTheMarkup()
+    {
+        var cut = Render<CollapsibleStackTrace>(p => p.Add(c => c.StackTrace, Trace));
+
+        Assert.Multiple(() =>
+        {
+            // Not merely hidden: a stack trace can run to thousands of characters, and there is no reason to send
+            // them to the browser before anybody has asked to read them.
+            Assert.That(cut.Markup, Does.Not.Contain("OpenImportConnection"));
+            Assert.That(cut.Markup, Does.Contain("Show stack trace"));
+        });
+    }
+
+    [Test]
+    public void CollapsibleStackTrace_WhenShown_RendersTheStackTrace()
+    {
+        var cut = Render<CollapsibleStackTrace>(p => p.Add(c => c.StackTrace, Trace));
+
+        cut.Find("button").Click();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cut.Markup, Does.Contain("OpenImportConnection"));
+            Assert.That(cut.Markup, Does.Contain("Hide stack trace"));
+        });
+    }
+
+    [Test]
+    public void CollapsibleStackTrace_WhenHiddenAgain_DropsTheStackTrace()
+    {
+        var cut = Render<CollapsibleStackTrace>(p => p.Add(c => c.StackTrace, Trace));
+
+        cut.Find("button").Click();
+        cut.Find("button").Click();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cut.Markup, Does.Not.Contain("OpenImportConnection"));
+            Assert.That(cut.Markup, Does.Contain("Show stack trace"));
+        });
+    }
+}

--- a/test/JIM.Web.Components.Tests/CollapsibleStackTraceTests.cs
+++ b/test/JIM.Web.Components.Tests/CollapsibleStackTraceTests.cs
@@ -37,13 +37,13 @@ public class CollapsibleStackTraceTests : JimComponentTestContext
     {
         var cut = Render<CollapsibleStackTrace>(p => p.Add(c => c.StackTrace, Trace));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Not merely hidden: a stack trace can run to thousands of characters, and there is no reason to send
             // them to the browser before anybody has asked to read them.
             Assert.That(cut.Markup, Does.Not.Contain("OpenImportConnection"));
             Assert.That(cut.Markup, Does.Contain("Show stack trace"));
-        });
+        }
     }
 
     [Test]
@@ -53,11 +53,11 @@ public class CollapsibleStackTraceTests : JimComponentTestContext
 
         cut.Find("button").Click();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cut.Markup, Does.Contain("OpenImportConnection"));
             Assert.That(cut.Markup, Does.Contain("Hide stack trace"));
-        });
+        }
     }
 
     [Test]
@@ -68,10 +68,10 @@ public class CollapsibleStackTraceTests : JimComponentTestContext
         cut.Find("button").Click();
         cut.Find("button").Click();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cut.Markup, Does.Not.Contain("OpenImportConnection"));
             Assert.That(cut.Markup, Does.Contain("Show stack trace"));
-        });
+        }
     }
 }

--- a/test/JIM.Web.Components.Tests/ServerCertificateCardTests.cs
+++ b/test/JIM.Web.Components.Tests/ServerCertificateCardTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using Bunit;
+using JIM.Models.Connectors;
+using JIM.Web.Shared;
+using NUnit.Framework;
+
+namespace JIM.Web.Components.Tests;
+
+/// <summary>
+/// Covers the certificate card's own logic: what it shows about a refused certificate, and the formatting that makes
+/// it comparable by eye against the JIM certificate store (#1132).
+/// </summary>
+[TestFixture]
+public class ServerCertificateCardTests : JimComponentTestContext
+{
+    private static ServerCertificateDiagnostic Diagnostic(
+        ServerCertificateFailureReason reason = ServerCertificateFailureReason.NameMismatch,
+        string host = "10.0.0.5",
+        bool selfSigned = false)
+    {
+        return new ServerCertificateDiagnostic
+        {
+            Host = host,
+            Port = 636,
+            FailureReason = reason,
+            Subject = "CN=dc01.corp.local, O=Corp, C=GB",
+            Issuer = selfSigned ? "CN=dc01.corp.local, O=Corp, C=GB" : "CN=Corp Issuing CA, O=Corp",
+            SubjectAlternativeNames = ["dc01.corp.local", "dc01"],
+            ValidFrom = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            ValidTo = new DateTime(2027, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            Thumbprint = "ABCDEF0123",
+            SignatureAlgorithm = "sha256RSA",
+            IsSelfSigned = selfSigned,
+            Remediation = "Connect using a name the certificate carries."
+        };
+    }
+
+    [Test]
+    public void ServerCertificateCard_ShowsTheCommonNameRatherThanTheWholeDistinguishedName()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic()));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cut.Markup, Does.Contain("dc01.corp.local"));
+            Assert.That(cut.Markup, Does.Not.Contain("CN=dc01.corp.local, O=Corp, C=GB"));
+        });
+    }
+
+    [Test]
+    public void ServerCertificateCard_ShowsWhichHostWasConnectedTo()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic()));
+
+        Assert.That(cut.Markup, Does.Contain("10.0.0.5:636"));
+    }
+
+    /// <summary>
+    /// A thumbprint is compared by eye against the one in Admin &gt; Certificates, which is why it is grouped.
+    /// </summary>
+    [Test]
+    public void ServerCertificateCard_GroupsTheThumbprintIntoPairs()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic()));
+
+        Assert.That(cut.Markup, Does.Contain("AB CD EF 01 23"));
+    }
+
+    [Test]
+    public void ServerCertificateCard_MarksTheNameThatWouldHaveSatisfiedTheCheck()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic(host: "dc01.corp.local")));
+
+        Assert.That(cut.Markup, Does.Contain("jim-certificate-name-match"));
+    }
+
+    [Test]
+    public void ServerCertificateCard_WhenNoNameMatches_MarksNone()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic(host: "10.0.0.5")));
+
+        Assert.That(cut.Markup, Does.Not.Contain("jim-certificate-name-match"));
+    }
+
+    [Test]
+    public void ServerCertificateCard_WithASelfSignedCertificate_SaysSoRatherThanNamingItsOwnSubjectAsTheIssuer()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic(selfSigned: true)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cut.Markup, Does.Contain("Self-signed"));
+            Assert.That(cut.Markup, Does.Not.Contain("Issued by"));
+        });
+    }
+
+    [Test]
+    public void ServerCertificateCard_NamesTheReasonTheCertificateWasRefused()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic(ServerCertificateFailureReason.Expired)));
+
+        Assert.That(cut.Markup, Does.Contain("Expired"));
+    }
+
+    [Test]
+    public void ServerCertificateCard_ShowsTheRemediation()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic()));
+
+        Assert.That(cut.Markup, Does.Contain("Connect using a name the certificate carries."));
+    }
+
+    /// <summary>
+    /// An expired certificate's dates are what the reader needs drawn to, so they carry the problem styling.
+    /// </summary>
+    [Test]
+    public void ServerCertificateCard_WithAnExpiredCertificate_HighlightsTheValidityDates()
+    {
+        var expired = Diagnostic(ServerCertificateFailureReason.Expired);
+        expired.ValidTo = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, expired));
+
+        Assert.That(cut.Markup, Does.Contain("jim-certificate-value-problem"));
+    }
+
+    [Test]
+    public void ServerCertificateCard_WithNoDiagnostic_RendersNothing()
+    {
+        var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, (ServerCertificateDiagnostic?)null));
+
+        Assert.That(cut.Markup.Trim(), Is.Empty);
+    }
+}

--- a/test/JIM.Web.Components.Tests/ServerCertificateCardTests.cs
+++ b/test/JIM.Web.Components.Tests/ServerCertificateCardTests.cs
@@ -42,11 +42,11 @@ public class ServerCertificateCardTests : JimComponentTestContext
     {
         var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic()));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cut.Markup, Does.Contain("dc01.corp.local"));
             Assert.That(cut.Markup, Does.Not.Contain("CN=dc01.corp.local, O=Corp, C=GB"));
-        });
+        }
     }
 
     [Test]
@@ -89,11 +89,11 @@ public class ServerCertificateCardTests : JimComponentTestContext
     {
         var cut = Render<ServerCertificateCard>(p => p.Add(c => c.Diagnostic, Diagnostic(selfSigned: true)));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cut.Markup, Does.Contain("Self-signed"));
             Assert.That(cut.Markup, Does.Not.Contain("Issued by"));
-        });
+        }
     }
 
     [Test]

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorSynchronisationContextTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorSynchronisationContextTests.cs
@@ -41,7 +41,7 @@ public class LdapConnectorSynchronisationContextTests
     [Test]
     public void OpenImportConnection_OnASingleThreadedSynchronisationContext_DoesNotDeadlock()
     {
-        var completed = new ManualResetEventSlim(false);
+        using var completed = new ManualResetEventSlim(false);
 
         RunOnSingleThreadedContext(() =>
         {

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorSynchronisationContextTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorSynchronisationContextTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors.LDAP;
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+using Serilog;
+using System.Collections.Concurrent;
+using System.Security.Cryptography.X509Certificates;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// The connector API is synchronous, but reading the JIM certificate store is not, so opening an LDAPS connection has
+/// to block on an asynchronous call. These tests pin down that it blocks safely: the portal validates Connected System
+/// settings on Blazor's renderer synchronisation context, which runs one callback at a time, and an asynchronous call
+/// whose continuation is posted back to that context can never finish while the call that is waiting for it holds it.
+/// </summary>
+/// <remarks>
+/// Nothing here needs a directory server. The connection is aimed at a port with nothing listening, because the
+/// failure being guarded against happens before the connection is attempted; what matters is that the call returns
+/// at all.
+/// </remarks>
+[TestFixture]
+public class LdapConnectorSynchronisationContextTests
+{
+    private Serilog.Core.Logger _logger = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = new LoggerConfiguration().CreateLogger();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _logger.Dispose();
+    }
+
+    [Test]
+    public void OpenImportConnection_OnASingleThreadedSynchronisationContext_DoesNotDeadlock()
+    {
+        var completed = new ManualResetEventSlim(false);
+
+        RunOnSingleThreadedContext(() =>
+        {
+            using var connector = new LdapConnector();
+            connector.SetCertificateProvider(new YieldingCertificateProvider());
+
+            try
+            {
+                // Expected to fail: nothing is listening. The assertion is about returning, not about succeeding.
+                connector.OpenImportConnection(BuildSettingValues(), _logger);
+            }
+            catch (Exception)
+            {
+                // Any connection failure is fine here.
+            }
+            finally
+            {
+                completed.Set();
+            }
+        });
+
+        Assert.That(completed.Wait(TimeSpan.FromSeconds(30)), Is.True,
+            "Opening an LDAPS connection never returned on a single-threaded synchronisation context. Reading the " +
+            "JIM certificate store must not be awaited on the caller's context, or the portal deadlocks when an " +
+            "administrator saves Connected System settings.");
+    }
+
+    /// <summary>
+    /// Runs the supplied work on a dedicated thread whose synchronisation context posts continuations back to that
+    /// same thread, one at a time, the way Blazor's renderer does.
+    /// </summary>
+    private static void RunOnSingleThreadedContext(Action work)
+    {
+        var context = new SingleThreadedSynchronisationContext();
+
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            context.Post(_ =>
+            {
+                try
+                {
+                    work();
+                }
+                finally
+                {
+                    context.Complete();
+                }
+            }, null);
+            context.Run();
+        })
+        {
+            IsBackground = true,
+            Name = "single-threaded-synchronisation-context"
+        };
+
+        thread.Start();
+    }
+
+    private static List<ConnectedSystemSettingValue> BuildSettingValues()
+    {
+        return
+        [
+            // Port 1 on the loopback interface: refused immediately rather than waiting out a timeout.
+            NewSetting("Host", stringValue: "127.0.0.1"),
+            NewSetting("Port", intValue: 1),
+            NewSetting("Use Secure Connection (LDAPS)?", checkboxValue: true),
+            NewSetting("Connection Timeout", intValue: 2),
+            NewSetting("Username", stringValue: "cn=admin,dc=example,dc=org"),
+            NewSetting("Password", encryptedValue: "adminpassword"),
+            NewSetting("Authentication Type", stringValue: "Simple"),
+            NewSetting("Maximum Retries", intValue: 0)
+        ];
+    }
+
+    private static ConnectedSystemSettingValue NewSetting(string name, string? stringValue = null, string? encryptedValue = null, int? intValue = null, bool checkboxValue = false)
+    {
+        return new ConnectedSystemSettingValue
+        {
+            Setting = new ConnectorDefinitionSetting { Name = name },
+            StringValue = stringValue,
+            StringEncryptedValue = encryptedValue,
+            IntValue = intValue,
+            CheckboxValue = checkboxValue
+        };
+    }
+
+    /// <summary>
+    /// Stands in for the JIM certificate store, completing asynchronously the way a database query does. A provider
+    /// that completes synchronously cannot reproduce the deadlock, because there is no continuation to post.
+    /// </summary>
+    private sealed class YieldingCertificateProvider : ICertificateProvider
+    {
+        public async Task<List<X509Certificate2>> GetTrustedCertificatesAsync()
+        {
+            await Task.Yield();
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// A synchronisation context that runs every posted callback on one thread, in order, like Blazor's renderer.
+    /// </summary>
+    private sealed class SingleThreadedSynchronisationContext : SynchronizationContext
+    {
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = new();
+
+        public override void Post(SendOrPostCallback d, object? state) => _queue.Add((d, state));
+
+        public override void Send(SendOrPostCallback d, object? state) => d(state);
+
+        internal void Run()
+        {
+            foreach (var (callback, state) in _queue.GetConsumingEnumerable())
+                callback(state);
+        }
+
+        internal void Complete() => _queue.CompleteAdding();
+    }
+}

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorTests.cs
@@ -111,16 +111,14 @@ public class LdapConnectorTests
     }
 
     [Test]
-    public void GetSettings_CertificateValidation_IsRequiredWhenSecureConnectionEnabled()
+    public void GetSettings_DoesNotOfferACertificateValidationChoice()
     {
-        // Certificate Validation is only relevant when LDAPS is enabled (#828)
+        // LDAPS certificate validation is not configurable per Connected System (#1132). The platform LDAP client
+        // validates the certificate and offers no supported way to relax that for one connection, so offering the
+        // choice could only ever mislead. Certificates an administrator trusts go in the JIM certificate store.
         var settings = _connector.GetSettings();
-        var certificateValidation = settings.Single(s => s.Name == "Certificate Validation");
 
-        Assert.That(certificateValidation.RequiredWhenSetting, Is.EqualTo("Use Secure Connection (LDAPS)?"));
-        Assert.That(certificateValidation.RequiredWhenValue, Is.EqualTo("true"));
-        // a sensible default so the conditional requirement is pre-satisfied when LDAPS is switched on
-        Assert.That(certificateValidation.DefaultStringValue, Is.EqualTo("Full Validation"));
+        Assert.That(settings.Any(s => s.Name == "Certificate Validation"), Is.False);
     }
 
     [Test]
@@ -275,20 +273,6 @@ public class LdapConnectorTests
         Assert.That(secureConnectionSetting!.Type, Is.EqualTo(ConnectedSystemSettingType.CheckBox));
         Assert.That(secureConnectionSetting.DefaultCheckboxValue, Is.False);
         Assert.That(secureConnectionSetting.Category, Is.EqualTo(ConnectedSystemSettingCategory.Connectivity));
-    }
-
-    [Test]
-    public void GetSettings_ContainsCertificateValidationSetting()
-    {
-        var settings = _connector.GetSettings();
-        var certValidationSetting = settings.FirstOrDefault(s => s.Name == "Certificate Validation");
-
-        Assert.That(certValidationSetting, Is.Not.Null);
-        Assert.That(certValidationSetting!.Type, Is.EqualTo(ConnectedSystemSettingType.DropDown));
-        Assert.That(certValidationSetting.DropDownValues, Does.Contain("Full Validation"));
-        Assert.That(certValidationSetting.DropDownValues, Does.Contain("Skip Validation (Not Recommended)"));
-        Assert.That(certValidationSetting.DropDownValues!.Count, Is.EqualTo(2));
-        Assert.That(certValidationSetting.Category, Is.EqualTo(ConnectedSystemSettingCategory.Connectivity));
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Connectors/LdapTrustedCertificateDirectoryTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapTrustedCertificateDirectoryTests.cs
@@ -221,6 +221,50 @@ public class LdapTrustedCertificateDirectoryTests
         }
     }
 
+    /// <summary>
+    /// Every directory is removed when its connection closes, but a process killed mid-run never gets to do that, and
+    /// a container that is restarted rather than replaced keeps its temporary files. Without a sweep, debris from
+    /// those kills accumulates until someone deletes it by hand.
+    /// </summary>
+    [Test]
+    public void Create_RemovesAbandonedTrustDirectoriesLeftByAKilledProcess()
+    {
+        var abandoned = Path.Combine(Path.GetTempPath(), $"jim-ldap-trust-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(abandoned);
+        File.WriteAllText(Path.Combine(abandoned, "debris.crt"), "-- left behind --");
+        Directory.SetLastWriteTimeUtc(abandoned, DateTime.UtcNow.AddDays(-8));
+
+        var certificate = CreateCertificate("sweep.example.test");
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+
+        Assert.That(Directory.Exists(abandoned), Is.False);
+    }
+
+    /// <summary>
+    /// A long-running import can hold its trust directory open for hours, so the sweep must only take directories old
+    /// enough that no run could still be using them.
+    /// </summary>
+    [Test]
+    public void Create_LeavesRecentTrustDirectoriesAlone()
+    {
+        var inUse = Path.Combine(Path.GetTempPath(), $"jim-ldap-trust-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(inUse);
+        Directory.SetLastWriteTimeUtc(inUse, DateTime.UtcNow.AddHours(-6));
+
+        try
+        {
+            var certificate = CreateCertificate("recent.example.test");
+            using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+
+            Assert.That(Directory.Exists(inUse), Is.True);
+        }
+        finally
+        {
+            if (Directory.Exists(inUse))
+                Directory.Delete(inUse, true);
+        }
+    }
+
     [Test]
     public void Create_ProducesADistinctDirectoryPerInstance()
     {

--- a/test/JIM.Worker.Tests/Connectors/LdapTrustedCertificateDirectoryTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapTrustedCertificateDirectoryTests.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors.LDAP;
+using Serilog;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// Covers the on-disk trust directory the LDAP Connector hands to the platform LDAP client so that
+/// certificates held in the JIM certificate store are honoured for LDAPS connections.
+/// </summary>
+[TestFixture]
+public class LdapTrustedCertificateDirectoryTests
+{
+    private Serilog.Core.Logger _logger = null!;
+    private List<X509Certificate2> _certificates = null!;
+    private string _scratchDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = new LoggerConfiguration().CreateLogger();
+        _certificates = new List<X509Certificate2>();
+        _scratchDirectory = Path.Combine(Path.GetTempPath(), $"jim-trust-dir-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_scratchDirectory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var certificate in _certificates)
+            certificate.Dispose();
+
+        if (Directory.Exists(_scratchDirectory))
+            Directory.Delete(_scratchDirectory, true);
+
+        _logger.Dispose();
+    }
+
+    /// <summary>
+    /// Builds a throw-away self-signed certificate. Only the encoding matters here; these are never presented to a server.
+    /// </summary>
+    private X509Certificate2 CreateCertificate(string commonName)
+    {
+        using var key = RSA.Create(2048);
+        var request = new CertificateRequest($"CN={commonName}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+        _certificates.Add(certificate);
+        return certificate;
+    }
+
+    private string CreateFakeSystemBundle(string content = "-- fake system bundle --")
+    {
+        var path = Path.Combine(_scratchDirectory, "ca-certificates.crt");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Test]
+    public void Create_WritesOneFilePerCertificate()
+    {
+        var first = CreateCertificate("first.example.test");
+        var second = CreateCertificate("second.example.test");
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { first, second }, _logger, new[] { CreateFakeSystemBundle() });
+
+        var certificateFiles = Directory.GetFiles(trustDirectory.DirectoryPath, "*.crt")
+            .Where(f => Path.GetFileName(f) != LdapTrustedCertificateDirectory.SystemBundleFileName)
+            .ToList();
+
+        Assert.That(certificateFiles, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Create_WritesCertificatesInPemFormatThatRoundTrips()
+    {
+        var certificate = CreateCertificate("roundtrip.example.test");
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+
+        var certificateFile = Directory.GetFiles(trustDirectory.DirectoryPath, "*.crt")
+            .Single(f => Path.GetFileName(f) != LdapTrustedCertificateDirectory.SystemBundleFileName);
+        using var readBack = X509CertificateLoader.LoadCertificateFromFile(certificateFile);
+
+        Assert.That(readBack.Thumbprint, Is.EqualTo(certificate.Thumbprint));
+    }
+
+    [Test]
+    public void Create_NamesCertificateFilesByThumbprint()
+    {
+        var certificate = CreateCertificate("named.example.test");
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+
+        var expectedPath = Path.Combine(trustDirectory.DirectoryPath, $"{certificate.Thumbprint}.crt");
+        Assert.That(File.Exists(expectedPath), Is.True);
+    }
+
+    [Test]
+    public void Create_DeduplicatesCertificatesWithTheSameThumbprint()
+    {
+        var certificate = CreateCertificate("duplicate.example.test");
+        var duplicate = X509CertificateLoader.LoadCertificate(certificate.RawData);
+        _certificates.Add(duplicate);
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate, duplicate }, _logger, new[] { CreateFakeSystemBundle() });
+
+        var certificateFiles = Directory.GetFiles(trustDirectory.DirectoryPath, "*.crt")
+            .Where(f => Path.GetFileName(f) != LdapTrustedCertificateDirectory.SystemBundleFileName)
+            .ToList();
+
+        Assert.That(certificateFiles, Has.Count.EqualTo(1));
+    }
+
+    /// <summary>
+    /// The platform LDAP client replaces its configured trust anchors when handed a trust directory, rather than
+    /// supplementing them, so the system bundle has to be copied in alongside the JIM certificates. Without this,
+    /// adding a certificate to the JIM store would stop every publicly-issued directory certificate validating.
+    /// </summary>
+    [Test]
+    public void Create_CopiesTheSystemCertificateBundleAlongsideJimCertificates()
+    {
+        const string bundleContent = "-- system bundle marker --";
+        var certificate = CreateCertificate("additive.example.test");
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle(bundleContent) });
+
+        var bundlePath = Path.Combine(trustDirectory.DirectoryPath, LdapTrustedCertificateDirectory.SystemBundleFileName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(bundlePath), Is.True);
+            Assert.That(File.ReadAllText(bundlePath), Is.EqualTo(bundleContent));
+        });
+    }
+
+    [Test]
+    public void Create_UsesTheFirstSystemBundleThatExists()
+    {
+        const string bundleContent = "-- second candidate --";
+        var bundlePath = CreateFakeSystemBundle(bundleContent);
+        var certificate = CreateCertificate("candidates.example.test");
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(
+            new[] { certificate },
+            _logger,
+            new[] { Path.Combine(_scratchDirectory, "does-not-exist.crt"), bundlePath });
+
+        var copiedBundle = Path.Combine(trustDirectory.DirectoryPath, LdapTrustedCertificateDirectory.SystemBundleFileName);
+        Assert.That(File.ReadAllText(copiedBundle), Is.EqualTo(bundleContent));
+    }
+
+    [Test]
+    public void Create_WithNoSystemBundleAvailable_StillTrustsJimCertificates()
+    {
+        var certificate = CreateCertificate("nobundle.example.test");
+
+        using var trustDirectory = LdapTrustedCertificateDirectory.Create(
+            new[] { certificate },
+            _logger,
+            new[] { Path.Combine(_scratchDirectory, "does-not-exist.crt") });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(Path.Combine(trustDirectory.DirectoryPath, $"{certificate.Thumbprint}.crt")), Is.True);
+            Assert.That(File.Exists(Path.Combine(trustDirectory.DirectoryPath, LdapTrustedCertificateDirectory.SystemBundleFileName)), Is.False);
+        });
+    }
+
+    [Test]
+    public void Create_WithNoCertificates_Throws()
+    {
+        Assert.That(
+            () => LdapTrustedCertificateDirectory.Create(Array.Empty<X509Certificate2>(), _logger),
+            Throws.TypeOf<ArgumentException>());
+    }
+
+    [Test]
+    public void Dispose_DeletesTheDirectory()
+    {
+        var certificate = CreateCertificate("disposed.example.test");
+        var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+        var path = trustDirectory.DirectoryPath;
+
+        trustDirectory.Dispose();
+
+        Assert.That(Directory.Exists(path), Is.False);
+    }
+
+    [Test]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        var certificate = CreateCertificate("twice.example.test");
+        var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+
+        trustDirectory.Dispose();
+
+        Assert.That(() => trustDirectory.Dispose(), Throws.Nothing);
+    }
+
+    /// <summary>
+    /// The directory holds trust anchors, so anything able to write to it could make JIM trust an attacker's issuer.
+    /// </summary>
+    [Test]
+    public void Create_RestrictsDirectoryPermissionsToTheOwningUser()
+    {
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            var certificate = CreateCertificate("permissions.example.test");
+
+            using var trustDirectory = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { CreateFakeSystemBundle() });
+
+            var mode = File.GetUnixFileMode(trustDirectory.DirectoryPath);
+            Assert.That(mode, Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute));
+        }
+        else
+        {
+            Assert.Ignore("Unix file mode is only meaningful on Unix-like platforms.");
+        }
+    }
+
+    [Test]
+    public void Create_ProducesADistinctDirectoryPerInstance()
+    {
+        var certificate = CreateCertificate("distinct.example.test");
+        var bundle = CreateFakeSystemBundle();
+
+        using var first = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { bundle });
+        using var second = LdapTrustedCertificateDirectory.Create(new[] { certificate }, _logger, new[] { bundle });
+
+        Assert.That(first.DirectoryPath, Is.Not.EqualTo(second.DirectoryPath));
+    }
+}

--- a/test/JIM.Worker.Tests/Connectors/LdapsCertificateValidationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapsCertificateValidationTests.cs
@@ -170,6 +170,38 @@ public class LdapsCertificateValidationTests
     }
 
     /// <summary>
+    /// A rejected certificate is reported as a failure to connect, so the trust directory prepared for that
+    /// connection has to be cleaned up on the failure path too, or every refused attempt leaves one on disk.
+    /// </summary>
+    [Test]
+    public void OpenImportConnection_WhenTheConnectionIsRejected_LeavesNoTrustDirectoryBehind()
+    {
+        var trustDirectoriesBefore = CountTrustDirectories();
+
+        // Deliberately neither closed nor disposed, mirroring a caller that abandons the connector once the
+        // connection attempt throws. The failure path itself has to clean up, not the caller.
+        var connector = new LdapConnector();
+        connector.SetCertificateProvider(new FakeCertificateProvider([_caCertificatePath]));
+
+        Assert.That(
+            () => connector.OpenImportConnection(BuildSettingValues(_mismatchedHostOrHost, _port), _logger),
+            Throws.TypeOf<LdapException>());
+
+        Assert.That(CountTrustDirectories(), Is.EqualTo(trustDirectoriesBefore));
+    }
+
+    /// <summary>
+    /// A host the certificate was not issued for, so the connection is refused after the trust directory has been
+    /// prepared. Falls back to the valid host, which still fails when the certificate is not trusted.
+    /// </summary>
+    private string _mismatchedHostOrHost => Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_MISMATCH_HOST") ?? _host;
+
+    private static int CountTrustDirectories()
+    {
+        return Directory.GetDirectories(Path.GetTempPath(), "jim-ldap-trust-*").Length;
+    }
+
+    /// <summary>
     /// Supplies certificates from PEM files in place of the JIM certificate store.
     /// </summary>
     private sealed class FakeCertificateProvider : ICertificateProvider

--- a/test/JIM.Worker.Tests/Connectors/LdapsCertificateValidationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapsCertificateValidationTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Connectors.LDAP;
+using JIM.Models.Connectors;
+using JIM.Models.Exceptions;
 using JIM.Models.Interfaces;
 using JIM.Models.Staging;
 using Serilog;
@@ -122,8 +124,13 @@ public class LdapsCertificateValidationTests
     public void OpenImportConnection_WithAnEmptyJimStore_IsRejected()
     {
         // The issuing CA is trusted by neither the operating system nor JIM, so this must not connect. If it does,
-        // validation is not happening at all.
-        Assert.That(() => OpenConnection(_host, _port), Throws.TypeOf<LdapException>());
+        // validation is not happening at all. The failure names the certificate rather than blaming the network.
+        Assert.That(
+            () => OpenConnection(_host, _port),
+            Throws.TypeOf<ServerCertificateRejectedException>()
+                .With.Property(nameof(ServerCertificateRejectedException.Diagnostic))
+                .Property(nameof(ServerCertificateDiagnostic.FailureReason))
+                .EqualTo(ServerCertificateFailureReason.UntrustedIssuer));
     }
 
     [Test]
@@ -135,7 +142,12 @@ public class LdapsCertificateValidationTests
 
         // Same server, same trusted issuer, reached by a name the certificate was not issued for. Trusting the issuer
         // must not amount to trusting any name it ever signs.
-        Assert.That(() => OpenConnection(mismatchedHost!, _port, _caCertificatePath), Throws.TypeOf<LdapException>());
+        Assert.That(
+            () => OpenConnection(mismatchedHost!, _port, _caCertificatePath),
+            Throws.TypeOf<ServerCertificateRejectedException>()
+                .With.Property(nameof(ServerCertificateRejectedException.Diagnostic))
+                .Property(nameof(ServerCertificateDiagnostic.FailureReason))
+                .EqualTo(ServerCertificateFailureReason.NameMismatch));
     }
 
     [Test]
@@ -148,7 +160,12 @@ public class LdapsCertificateValidationTests
 
         // The issuer is in the JIM certificate store, which vouches for who signed the certificate, not for how long
         // ago it stopped being valid.
-        Assert.That(() => OpenConnection(expiredHost!, int.Parse(expiredPort!), _caCertificatePath), Throws.TypeOf<LdapException>());
+        Assert.That(
+            () => OpenConnection(expiredHost!, int.Parse(expiredPort!), _caCertificatePath),
+            Throws.TypeOf<ServerCertificateRejectedException>()
+                .With.Property(nameof(ServerCertificateRejectedException.Diagnostic))
+                .Property(nameof(ServerCertificateDiagnostic.FailureReason))
+                .EqualTo(ServerCertificateFailureReason.Expired));
     }
 
     /// <summary>
@@ -185,7 +202,7 @@ public class LdapsCertificateValidationTests
 
         Assert.That(
             () => connector.OpenImportConnection(BuildSettingValues(_mismatchedHostOrHost, _port), _logger),
-            Throws.TypeOf<LdapException>());
+            Throws.TypeOf<ServerCertificateRejectedException>());
 
         Assert.That(CountTrustDirectories(), Is.EqualTo(trustDirectoriesBefore));
     }

--- a/test/JIM.Worker.Tests/Connectors/LdapsCertificateValidationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapsCertificateValidationTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors.LDAP;
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+using Serilog;
+using System.DirectoryServices.Protocols;
+using System.Security.Cryptography.X509Certificates;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// Verifies LDAPS certificate validation against real directory servers presenting real certificates (#1132).
+/// </summary>
+/// <remarks>
+/// <para>
+/// None of this is unit-testable. JIM deliberately no longer makes the trust decision itself: the platform LDAP
+/// client validates the chain, the validity period and the certificate's name, and JIM only supplies additional
+/// trust anchors. What that client does with those anchors can only be observed by connecting to a directory
+/// server over TLS, so these tests are opt-in and need servers standing by.
+/// </para>
+/// <para>
+/// Stand the servers up with <c>scripts/Start-LdapsCertificateTestServers.ps1</c>, which prints the environment
+/// variables to set. The fixture is ignored when <c>JIM_TEST_LDAPS_HOST</c> is absent.
+/// </para>
+/// </remarks>
+[TestFixture]
+[Category("RequiresLdaps")]
+public class LdapsCertificateValidationTests
+{
+    private string _host = null!;
+    private int _port;
+    private string _username = null!;
+    private string _password = null!;
+    private string _caCertificatePath = null!;
+    private Serilog.Core.Logger _logger = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _host = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_HOST") ?? string.Empty;
+        if (string.IsNullOrEmpty(_host))
+            Assert.Ignore("JIM_TEST_LDAPS_HOST not set; skipping LDAPS certificate validation tests. See scripts/Start-LdapsCertificateTestServers.ps1.");
+
+        _port = int.Parse(Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_PORT") ?? "636");
+        _username = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_USERNAME") ?? "cn=admin,dc=example,dc=org";
+        _password = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_PASSWORD") ?? "adminpassword";
+        _caCertificatePath = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_CA_PATH") ?? string.Empty;
+
+        if (string.IsNullOrEmpty(_caCertificatePath) || !File.Exists(_caCertificatePath))
+            Assert.Ignore("JIM_TEST_LDAPS_CA_PATH is not set or does not exist; skipping LDAPS certificate validation tests.");
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = new LoggerConfiguration().CreateLogger();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _logger.Dispose();
+    }
+
+    /// <summary>
+    /// Opens an import connection the way the synchronisation engine does, with the supplied certificates standing in
+    /// for the JIM certificate store.
+    /// </summary>
+    private void OpenConnection(string host, int port, params string[] trustedCertificatePaths)
+    {
+        using var connector = new LdapConnector();
+        connector.SetCertificateProvider(new FakeCertificateProvider(trustedCertificatePaths));
+
+        try
+        {
+            connector.OpenImportConnection(BuildSettingValues(host, port), _logger);
+        }
+        finally
+        {
+            connector.CloseImportConnection();
+        }
+    }
+
+    private List<ConnectedSystemSettingValue> BuildSettingValues(string host, int port)
+    {
+        return
+        [
+            NewSetting("Host", stringValue: host),
+            NewSetting("Port", intValue: port),
+            NewSetting("Use Secure Connection (LDAPS)?", checkboxValue: true),
+            NewSetting("Connection Timeout", intValue: 10),
+            NewSetting("Username", stringValue: _username),
+            NewSetting("Password", encryptedValue: _password),
+            NewSetting("Authentication Type", stringValue: "Simple"),
+            // One attempt only: a rejected certificate reports as a down server, which the connector treats as
+            // transient, and retrying it just multiplies the wait before the test can assert.
+            NewSetting("Maximum Retries", intValue: 0)
+        ];
+    }
+
+    private static ConnectedSystemSettingValue NewSetting(string name, string? stringValue = null, string? encryptedValue = null, int? intValue = null, bool checkboxValue = false)
+    {
+        return new ConnectedSystemSettingValue
+        {
+            Setting = new ConnectorDefinitionSetting { Name = name },
+            StringValue = stringValue,
+            StringEncryptedValue = encryptedValue,
+            IntValue = intValue,
+            CheckboxValue = checkboxValue
+        };
+    }
+
+    [Test]
+    public void OpenImportConnection_WithIssuingCertificateInTheJimStore_Connects()
+    {
+        Assert.That(() => OpenConnection(_host, _port, _caCertificatePath), Throws.Nothing);
+    }
+
+    [Test]
+    public void OpenImportConnection_WithAnEmptyJimStore_IsRejected()
+    {
+        // The issuing CA is trusted by neither the operating system nor JIM, so this must not connect. If it does,
+        // validation is not happening at all.
+        Assert.That(() => OpenConnection(_host, _port), Throws.TypeOf<LdapException>());
+    }
+
+    [Test]
+    public void OpenImportConnection_WhenTheCertificateNameDoesNotMatchTheDirectoryServer_IsRejected()
+    {
+        var mismatchedHost = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_MISMATCH_HOST");
+        if (string.IsNullOrEmpty(mismatchedHost))
+            Assert.Ignore("JIM_TEST_LDAPS_MISMATCH_HOST not set; skipping the certificate name mismatch test.");
+
+        // Same server, same trusted issuer, reached by a name the certificate was not issued for. Trusting the issuer
+        // must not amount to trusting any name it ever signs.
+        Assert.That(() => OpenConnection(mismatchedHost!, _port, _caCertificatePath), Throws.TypeOf<LdapException>());
+    }
+
+    [Test]
+    public void OpenImportConnection_WhenTheCertificateHasExpired_IsRejected()
+    {
+        var expiredHost = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_EXPIRED_HOST");
+        var expiredPort = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_EXPIRED_PORT");
+        if (string.IsNullOrEmpty(expiredHost) || string.IsNullOrEmpty(expiredPort))
+            Assert.Ignore("JIM_TEST_LDAPS_EXPIRED_HOST/PORT not set; skipping the expired certificate test.");
+
+        // The issuer is in the JIM certificate store, which vouches for who signed the certificate, not for how long
+        // ago it stopped being valid.
+        Assert.That(() => OpenConnection(expiredHost!, int.Parse(expiredPort!), _caCertificatePath), Throws.TypeOf<LdapException>());
+    }
+
+    /// <summary>
+    /// The acceptance criterion that populating JIM's certificate store never weakens validation. Supplying trust
+    /// anchors to the platform LDAP client replaces the ones it was configured with, so a directory whose certificate
+    /// the host already trusts has to keep connecting after an unrelated certificate is added to the JIM store.
+    /// </summary>
+    [Test]
+    public void OpenImportConnection_WithAnUnrelatedCertificateInTheJimStore_StillTrustsTheOperatingSystemAnchors()
+    {
+        var systemTrustedHost = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_SYSTEM_TRUSTED_HOST");
+        var systemTrustedPort = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_SYSTEM_TRUSTED_PORT");
+        if (string.IsNullOrEmpty(systemTrustedHost) || string.IsNullOrEmpty(systemTrustedPort))
+            Assert.Ignore("JIM_TEST_LDAPS_SYSTEM_TRUSTED_HOST/PORT not set; skipping the additive trust test.");
+
+        Assert.That(
+            () => OpenConnection(systemTrustedHost!, int.Parse(systemTrustedPort!), _caCertificatePath),
+            Throws.Nothing);
+    }
+
+    /// <summary>
+    /// Supplies certificates from PEM files in place of the JIM certificate store.
+    /// </summary>
+    private sealed class FakeCertificateProvider : ICertificateProvider
+    {
+        private readonly string[] _certificatePaths;
+
+        internal FakeCertificateProvider(string[] certificatePaths)
+        {
+            _certificatePaths = certificatePaths;
+        }
+
+        public Task<List<X509Certificate2>> GetTrustedCertificatesAsync()
+        {
+            return Task.FromResult(_certificatePaths
+                .Select(X509CertificateLoader.LoadCertificateFromFile)
+                .ToList());
+        }
+    }
+}

--- a/test/JIM.Worker.Tests/Connectors/ServerCertificateProbeTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/ServerCertificateProbeTests.cs
@@ -89,12 +89,12 @@ public class ServerCertificateProbeTests
         Assert.Multiple(() =>
         {
             Assert.That(diagnostic!.Subject, Does.Contain(_host));
-            Assert.That(diagnostic.Issuer, Is.Not.Null.And.Not.Empty);
-            Assert.That(diagnostic.Thumbprint, Is.Not.Null.And.Not.Empty);
-            Assert.That(diagnostic.SubjectAlternativeNames, Does.Contain(_host));
-            Assert.That(diagnostic.ValidFrom, Is.Not.Null);
-            Assert.That(diagnostic.ValidTo, Is.Not.Null);
-            Assert.That(diagnostic.Remediation, Is.Not.Null.And.Not.Empty);
+            Assert.That(diagnostic!.Issuer, Is.Not.Null.And.Not.Empty);
+            Assert.That(diagnostic!.Thumbprint, Is.Not.Null.And.Not.Empty);
+            Assert.That(diagnostic!.SubjectAlternativeNames, Does.Contain(_host));
+            Assert.That(diagnostic!.ValidFrom, Is.Not.Null);
+            Assert.That(diagnostic!.ValidTo, Is.Not.Null);
+            Assert.That(diagnostic!.Remediation, Is.Not.Null.And.Not.Empty);
         });
     }
 
@@ -112,7 +112,7 @@ public class ServerCertificateProbeTests
         {
             // Reported ahead of the issuer, because trusting the issuer is not what fixes this.
             Assert.That(diagnostic!.FailureReason, Is.EqualTo(ServerCertificateFailureReason.NameMismatch));
-            Assert.That(diagnostic.Remediation, Does.Contain(mismatchedHost!));
+            Assert.That(diagnostic!.Remediation, Does.Contain(mismatchedHost!));
         });
     }
 
@@ -130,7 +130,7 @@ public class ServerCertificateProbeTests
         Assert.Multiple(() =>
         {
             Assert.That(diagnostic!.FailureReason, Is.EqualTo(ServerCertificateFailureReason.Expired));
-            Assert.That(diagnostic.IsExpired, Is.True);
+            Assert.That(diagnostic!.IsExpired, Is.True);
         });
     }
 

--- a/test/JIM.Worker.Tests/Connectors/ServerCertificateProbeTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/ServerCertificateProbeTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors;
+using JIM.Models.Connectors;
+using Serilog;
+using System.Security.Cryptography.X509Certificates;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// Verifies that the certificate a directory server presents is reported accurately when a connection to it is
+/// refused (#1132), against real servers presenting real certificates.
+/// </summary>
+/// <remarks>
+/// Opt-in, like <see cref="LdapsCertificateValidationTests"/>; stand the servers up with
+/// <c>test/scripts/Start-LdapsCertificateTestServers.ps1</c>. Ignored when <c>JIM_TEST_LDAPS_HOST</c> is absent.
+/// </remarks>
+[TestFixture]
+[Category("RequiresLdaps")]
+public class ServerCertificateProbeTests
+{
+    private string _host = null!;
+    private int _port;
+    private string _caCertificatePath = null!;
+    private Serilog.Core.Logger _logger = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _host = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_HOST") ?? string.Empty;
+        if (string.IsNullOrEmpty(_host))
+            Assert.Ignore("JIM_TEST_LDAPS_HOST not set; skipping certificate probe tests. See test/scripts/Start-LdapsCertificateTestServers.ps1.");
+
+        _port = int.Parse(Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_PORT") ?? "636");
+        _caCertificatePath = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_CA_PATH") ?? string.Empty;
+
+        if (string.IsNullOrEmpty(_caCertificatePath) || !File.Exists(_caCertificatePath))
+            Assert.Ignore("JIM_TEST_LDAPS_CA_PATH is not set or does not exist; skipping certificate probe tests.");
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = new LoggerConfiguration().CreateLogger();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _logger.Dispose();
+    }
+
+    private List<X509Certificate2> TrustedCertificates()
+    {
+        return [X509CertificateLoader.LoadCertificateFromFile(_caCertificatePath)];
+    }
+
+    private ServerCertificateDiagnostic? Probe(string host, int port, IReadOnlyCollection<X509Certificate2>? trusted = null)
+    {
+        var certificates = trusted ?? [];
+
+        try
+        {
+            return ServerCertificateProbe.Probe(host, port, certificates, TimeSpan.FromSeconds(10), _logger);
+        }
+        finally
+        {
+            foreach (var certificate in certificates)
+                certificate.Dispose();
+        }
+    }
+
+    [Test]
+    public void Probe_WithAnIssuerNobodyTrusts_ReportsAnUntrustedIssuer()
+    {
+        var diagnostic = Probe(_host, _port);
+
+        Assert.That(diagnostic, Is.Not.Null);
+        Assert.That(diagnostic!.FailureReason, Is.EqualTo(ServerCertificateFailureReason.UntrustedIssuer));
+    }
+
+    [Test]
+    public void Probe_ReturnsTheCertificateDetailsAnAdministratorNeedsToIdentifyIt()
+    {
+        var diagnostic = Probe(_host, _port);
+
+        Assert.That(diagnostic, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostic!.Subject, Does.Contain(_host));
+            Assert.That(diagnostic.Issuer, Is.Not.Null.And.Not.Empty);
+            Assert.That(diagnostic.Thumbprint, Is.Not.Null.And.Not.Empty);
+            Assert.That(diagnostic.SubjectAlternativeNames, Does.Contain(_host));
+            Assert.That(diagnostic.ValidFrom, Is.Not.Null);
+            Assert.That(diagnostic.ValidTo, Is.Not.Null);
+            Assert.That(diagnostic.Remediation, Is.Not.Null.And.Not.Empty);
+        });
+    }
+
+    [Test]
+    public void Probe_WhenTheCertificateWasIssuedForAnotherName_ReportsANameMismatch()
+    {
+        var mismatchedHost = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_MISMATCH_HOST");
+        if (string.IsNullOrEmpty(mismatchedHost))
+            Assert.Ignore("JIM_TEST_LDAPS_MISMATCH_HOST not set; skipping the name mismatch test.");
+
+        var diagnostic = Probe(mismatchedHost!, _port, TrustedCertificates());
+
+        Assert.That(diagnostic, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            // Reported ahead of the issuer, because trusting the issuer is not what fixes this.
+            Assert.That(diagnostic!.FailureReason, Is.EqualTo(ServerCertificateFailureReason.NameMismatch));
+            Assert.That(diagnostic.Remediation, Does.Contain(mismatchedHost!));
+        });
+    }
+
+    [Test]
+    public void Probe_WhenTheCertificateHasExpired_ReportsItAsExpired()
+    {
+        var expiredHost = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_EXPIRED_HOST");
+        var expiredPort = Environment.GetEnvironmentVariable("JIM_TEST_LDAPS_EXPIRED_PORT");
+        if (string.IsNullOrEmpty(expiredHost) || string.IsNullOrEmpty(expiredPort))
+            Assert.Ignore("JIM_TEST_LDAPS_EXPIRED_HOST/PORT not set; skipping the expired certificate test.");
+
+        var diagnostic = Probe(expiredHost!, int.Parse(expiredPort!), TrustedCertificates());
+
+        Assert.That(diagnostic, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostic!.FailureReason, Is.EqualTo(ServerCertificateFailureReason.Expired));
+            Assert.That(diagnostic.IsExpired, Is.True);
+        });
+    }
+
+    [Test]
+    public void Probe_WithTheJimCertificateStoreSupplied_FindsNothingWrong()
+    {
+        var diagnostic = Probe(_host, _port, TrustedCertificates());
+
+        Assert.That(diagnostic, Is.Not.Null);
+        Assert.That(diagnostic!.FailureReason, Is.EqualTo(ServerCertificateFailureReason.None));
+    }
+
+    [Test]
+    public void Probe_WhenTheServerCannotBeReached_ReturnsNothingRatherThanBlamingTheCertificate()
+    {
+        // Nothing listening: a connectivity problem, which must not be reported as a certificate one.
+        var diagnostic = Probe(_host, 65014, TrustedCertificates());
+
+        Assert.That(diagnostic, Is.Null);
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/ActivityErrorDetailTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ActivityErrorDetailTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Activities;
+using JIM.Models.Connectors;
+using JIM.Models.Exceptions;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Covers the structured failure detail recorded on an Activity, which is what lets the portal show the certificate a
+/// directory server presented rather than just the sentence describing the failure (#1132).
+/// </summary>
+[TestFixture]
+public class ActivityErrorDetailTests
+{
+    private static ServerCertificateDiagnostic SampleDiagnostic()
+    {
+        return new ServerCertificateDiagnostic
+        {
+            Host = "dc01.corp.local",
+            Port = 636,
+            FailureReason = ServerCertificateFailureReason.NameMismatch,
+            Subject = "CN=dc02.corp.local",
+            Issuer = "CN=Corp Issuing CA",
+            SubjectAlternativeNames = ["dc02.corp.local", "10.0.0.5"],
+            ValidFrom = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ValidTo = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Thumbprint = "ABCDEF0123456789",
+            SignatureAlgorithm = "sha256RSA",
+            IsSelfSigned = false,
+            Remediation = "Connect using a name the certificate carries."
+        };
+    }
+
+    [Test]
+    public void TryDescribe_WithARefusedCertificate_RoundTripsEveryFieldTheCardShows()
+    {
+        var expected = SampleDiagnostic();
+
+        var detail = ActivityErrorDetail.TryDescribe(new ServerCertificateRejectedException("refused", expected));
+        var actual = ActivityErrorDetail.TryReadServerCertificate(detail);
+
+        Assert.That(actual, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual!.Host, Is.EqualTo(expected.Host));
+            Assert.That(actual.Port, Is.EqualTo(expected.Port));
+            Assert.That(actual.FailureReason, Is.EqualTo(expected.FailureReason));
+            Assert.That(actual.Subject, Is.EqualTo(expected.Subject));
+            Assert.That(actual.Issuer, Is.EqualTo(expected.Issuer));
+            Assert.That(actual.SubjectAlternativeNames, Is.EqualTo(expected.SubjectAlternativeNames));
+            Assert.That(actual.ValidFrom, Is.EqualTo(expected.ValidFrom));
+            Assert.That(actual.ValidTo, Is.EqualTo(expected.ValidTo));
+            Assert.That(actual.Thumbprint, Is.EqualTo(expected.Thumbprint));
+            Assert.That(actual.SignatureAlgorithm, Is.EqualTo(expected.SignatureAlgorithm));
+            Assert.That(actual.IsSelfSigned, Is.EqualTo(expected.IsSelfSigned));
+            Assert.That(actual.Remediation, Is.EqualTo(expected.Remediation));
+        });
+    }
+
+    /// <summary>
+    /// The worker wraps connector failures before the Activity is failed, so the detail has to survive being buried.
+    /// </summary>
+    [Test]
+    public void TryDescribe_WithARefusedCertificateInsideAnotherException_StillDescribesIt()
+    {
+        var rejection = new ServerCertificateRejectedException("refused", SampleDiagnostic());
+        var wrapped = new InvalidOperationException("Import failed", new ApplicationException("connecting", rejection));
+
+        var detail = ActivityErrorDetail.TryDescribe(wrapped);
+
+        Assert.That(ActivityErrorDetail.TryReadServerCertificate(detail), Is.Not.Null);
+    }
+
+    [Test]
+    public void TryDescribe_WithAnOrdinaryFailure_RecordsNothing()
+    {
+        Assert.That(ActivityErrorDetail.TryDescribe(new InvalidOperationException("something else")), Is.Null);
+    }
+
+    [Test]
+    public void TryReadServerCertificate_WithNothingRecorded_ReturnsNull()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ActivityErrorDetail.TryReadServerCertificate(null), Is.Null);
+            Assert.That(ActivityErrorDetail.TryReadServerCertificate(string.Empty), Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// The column is deliberately open-ended, so a reader has to cope with content it does not recognise, or content
+    /// written by a future version, without failing the page it is rendering.
+    /// </summary>
+    [Test]
+    public void TryReadServerCertificate_WithUnrecognisedOrMalformedContent_ReturnsNullRatherThanThrowing()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ActivityErrorDetail.TryReadServerCertificate("{\"kind\":\"something-else\",\"payload\":42}"), Is.Null);
+            Assert.That(ActivityErrorDetail.TryReadServerCertificate("not json at all"), Is.Null);
+        });
+    }
+}

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemSettingsValidationTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemSettingsValidationTests.cs
@@ -6,6 +6,7 @@ using JIM.Connectors;
 using JIM.Connectors.File;
 using JIM.Connectors.LDAP;
 using JIM.Data;
+using JIM.Models.Interfaces;
 using JIM.Models.Staging;
 using Moq;
 using NUnit.Framework;
@@ -105,17 +106,20 @@ public class ConnectedSystemSettingsValidationTests
     [Test]
     public void CopyConnectorSettingsToConnectorDefinition_CopiesRequiredWhen()
     {
-        // Arrange
-        var connectorDefinition = new ConnectorDefinition { Name = ConnectorConstants.LdapConnectorName };
+        // Arrange: no shipped connector currently declares a conditionally-required setting, so this uses a stand-in
+        // connector rather than coupling the test to whichever connector happens to have one.
+        var connectorDefinition = new ConnectorDefinition { Name = "Conditionally Required Settings Test Connector" };
 
         // Act
-        using var ldapConnector = new LdapConnector();
-        _jim.ConnectedSystems.CopyConnectorSettingsToConnectorDefinition(ldapConnector, connectorDefinition);
+        _jim.ConnectedSystems.CopyConnectorSettingsToConnectorDefinition(new ConditionallyRequiredSettingConnector(), connectorDefinition);
 
         // Assert
-        var certificateValidation = connectorDefinition.Settings.Single(s => s.Name == "Certificate Validation");
-        Assert.That(certificateValidation.RequiredWhenSetting, Is.EqualTo("Use Secure Connection (LDAPS)?"));
-        Assert.That(certificateValidation.RequiredWhenValue, Is.EqualTo("true"));
+        var conditionalSetting = connectorDefinition.Settings.Single(s => s.Name == "Certificate Path");
+        Assert.Multiple(() =>
+        {
+            Assert.That(conditionalSetting.RequiredWhenSetting, Is.EqualTo("Use Secure Connection?"));
+            Assert.That(conditionalSetting.RequiredWhenValue, Is.EqualTo("true"));
+        });
     }
 
     [Test]
@@ -169,5 +173,26 @@ public class ConnectedSystemSettingsValidationTests
 
         connectedSystem.SettingValues.Single(sv => sv.Setting.Name == "File Path").StringValue = _tempCsvPath;
         return connectedSystem;
+    }
+}
+
+/// <summary>
+/// Stand-in connector that declares a conditionally-required setting, so the RequiredWhen copy behaviour can be
+/// covered without depending on a shipped connector happening to have one.
+/// </summary>
+internal class ConditionallyRequiredSettingConnector : IConnectorSettings
+{
+    public List<ConnectorSetting> GetSettings()
+    {
+        return
+        [
+            new() { Name = "Use Secure Connection?", Type = ConnectedSystemSettingType.CheckBox, DefaultCheckboxValue = false, Category = ConnectedSystemSettingCategory.Connectivity },
+            new() { Name = "Certificate Path", Type = ConnectedSystemSettingType.String, Required = false, RequiredWhenSetting = "Use Secure Connection?", RequiredWhenValue = "true", Category = ConnectedSystemSettingCategory.Connectivity }
+        ];
+    }
+
+    public List<ConnectorSettingValueValidationResult> ValidateSettingValues(List<ConnectedSystemSettingValue> settings, Serilog.ILogger logger)
+    {
+        return [];
     }
 }

--- a/test/JIM.Worker.Tests/Servers/ConnectorDefinitionSettingRemovalTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectorDefinitionSettingRemovalTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Connectors;
+using JIM.Data.Repositories;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Covers what happens to a Connected System setting that a Connector no longer declares, as happened when the LDAP
+/// Connector's Certificate Validation setting was withdrawn (#1132).
+/// </summary>
+/// <remarks>
+/// Detaching the setting from its Connector Definition is not enough. The relationship's foreign key is nullable, so
+/// removing the setting from the definition's collection severs it and leaves the row behind, holding no definition
+/// but still referenced by every value an administrator had saved against it, which surfaces as a setting that has
+/// been withdrawn yet still appears on existing Connected Systems. The setting has to be deleted outright so those
+/// values cascade away with it.
+/// </remarks>
+[TestFixture]
+public class ConnectorDefinitionSettingRemovalTests
+{
+    private Mock<IRepository> _mockRepository = null!;
+    private Mock<IConnectedSystemRepository> _mockConnectedSystemRepository = null!;
+    private Mock<IActivityRepository> _mockActivityRepository = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepository = null!;
+    private JimApplication _application = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _mockRepository = new Mock<IRepository>();
+        _mockConnectedSystemRepository = new Mock<IConnectedSystemRepository>();
+        _mockActivityRepository = new Mock<IActivityRepository>();
+        _mockServiceSettingsRepository = new Mock<IServiceSettingsRepository>();
+        _mockRepository.Setup(r => r.ConnectedSystems).Returns(_mockConnectedSystemRepository.Object);
+        _mockRepository.Setup(r => r.Activity).Returns(_mockActivityRepository.Object);
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepository.Object);
+
+        // The drift-sync audits itself, so the Activity and configuration-change plumbing has to answer.
+        _mockActivityRepository.Setup(r => r.CreateActivityAsync(It.IsAny<JIM.Models.Activities.Activity>()))
+            .Returns(Task.CompletedTask);
+        _mockActivityRepository.Setup(r => r.UpdateActivityAsync(It.IsAny<JIM.Models.Activities.Activity>()))
+            .Returns(Task.CompletedTask);
+        _mockActivityRepository.Setup(r => r.GetMaxConfigurationChangeVersionAsync(It.IsAny<JIM.Models.Activities.ActivityTargetType>(), It.IsAny<int>()))
+            .ReturnsAsync(0);
+
+        _application = new JimApplication(_mockRepository.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _application?.Dispose();
+    }
+
+    [Test]
+    public async Task SyncBuiltInConnectorDefinitions_WithASettingTheConnectorNoLongerDeclares_DeletesItAsync()
+    {
+        var obsoleteSetting = new ConnectorDefinitionSetting
+        {
+            Id = 42,
+            Name = "Certificate Validation",
+            Type = ConnectedSystemSettingType.DropDown,
+            Category = ConnectedSystemSettingCategory.Connectivity
+        };
+
+        var definition = new ConnectorDefinition
+        {
+            Id = 1,
+            Name = ConnectorConstants.LdapConnectorName,
+            BuiltIn = true,
+            Settings = [obsoleteSetting]
+        };
+
+        _mockConnectedSystemRepository
+            .Setup(r => r.GetConnectorDefinitionAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((string name, bool _) => name == ConnectorConstants.LdapConnectorName ? definition : null);
+
+        List<ConnectorDefinitionSetting>? deleted = null;
+        _mockConnectedSystemRepository
+            .Setup(r => r.DeleteConnectorDefinitionSettingsAsync(It.IsAny<IList<ConnectorDefinitionSetting>>()))
+            .Callback<IList<ConnectorDefinitionSetting>>(settings => deleted = settings.ToList())
+            .Returns(Task.CompletedTask);
+
+        await _application.Seeding.SyncBuiltInConnectorDefinitionsAsync();
+
+        Assert.That(deleted, Is.Not.Null, "the withdrawn setting should have been deleted, not just detached from its Connector Definition");
+        Assert.That(deleted!.Select(s => s.Name), Does.Contain("Certificate Validation"));
+    }
+
+    [Test]
+    public async Task SyncBuiltInConnectorDefinitions_WithNoObsoleteSettings_DeletesNothingAsync()
+    {
+        using var connector = new JIM.Connectors.LDAP.LdapConnector();
+        var definition = new ConnectorDefinition
+        {
+            Id = 1,
+            Name = ConnectorConstants.LdapConnectorName,
+            BuiltIn = true,
+            Settings = connector.GetSettings().Select(s => new ConnectorDefinitionSetting
+            {
+                Name = s.Name,
+                Type = s.Type,
+                Category = s.Category,
+                Description = s.Description,
+                Required = s.Required,
+                RequiredGroup = s.RequiredGroup,
+                RequiredGroupCardinality = s.RequiredGroupCardinality,
+                RequiredWhenSetting = s.RequiredWhenSetting,
+                RequiredWhenValue = s.RequiredWhenValue,
+                DefaultCheckboxValue = s.DefaultCheckboxValue,
+                DefaultStringValue = s.DefaultStringValue,
+                DefaultIntValue = s.DefaultIntValue,
+                DropDownValues = s.DropDownValues
+            }).ToList()
+        };
+
+        _mockConnectedSystemRepository
+            .Setup(r => r.GetConnectorDefinitionAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((string name, bool _) => name == ConnectorConstants.LdapConnectorName ? definition : null);
+
+        await _application.Seeding.SyncBuiltInConnectorDefinitionsAsync();
+
+        _mockConnectedSystemRepository.Verify(
+            r => r.DeleteConnectorDefinitionSettingsAsync(It.IsAny<IList<ConnectorDefinitionSetting>>()),
+            Times.Never);
+    }
+}

--- a/test/integration/Setup-Scenario1.ps1
+++ b/test/integration/Setup-Scenario1.ps1
@@ -254,7 +254,6 @@ try {
     $usernameSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Username" }
     $passwordSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Password" }
     $useSSLSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Use Secure Connection (LDAPS)?" }
-    $certValidationSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Certificate Validation" }
     $connectionTimeoutSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Connection Timeout" }
     $authTypeSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Authentication Type" }
     $createContainersSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Create containers as needed?" }
@@ -274,9 +273,6 @@ try {
     }
     if ($useSSLSetting) {
         $ldapSettings[$useSSLSetting.id] = @{ checkboxValue = $DirectoryConfig.UseSSL }
-    }
-    if ($certValidationSetting -and $DirectoryConfig.CertValidation) {
-        $ldapSettings[$certValidationSetting.id] = @{ stringValue = $DirectoryConfig.CertValidation }
     }
     if ($connectionTimeoutSetting) {
         $ldapSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 }

--- a/test/integration/Setup-Scenario10.ps1
+++ b/test/integration/Setup-Scenario10.ps1
@@ -163,7 +163,6 @@ $portSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Port" }
 $usernameSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Username" }
 $passwordSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Password" }
 $useSSLSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Use Secure Connection (LDAPS)?" }
-$certValidationSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Certificate Validation" }
 $connectionTimeoutSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Connection Timeout" }
 $authTypeSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Authentication Type" }
 $createContainersSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Create containers as needed?" }
@@ -174,7 +173,6 @@ if ($portSetting) { $ldapSettings[$portSetting.id] = @{ intValue = $DirectoryCon
 if ($usernameSetting) { $ldapSettings[$usernameSetting.id] = @{ stringValue = $DirectoryConfig.BindDN } }
 if ($passwordSetting) { $ldapSettings[$passwordSetting.id] = @{ stringValue = $DirectoryConfig.BindPassword } }
 if ($useSSLSetting) { $ldapSettings[$useSSLSetting.id] = @{ checkboxValue = $DirectoryConfig.UseSSL } }
-if ($certValidationSetting -and $DirectoryConfig.CertValidation) { $ldapSettings[$certValidationSetting.id] = @{ stringValue = $DirectoryConfig.CertValidation } }
 if ($connectionTimeoutSetting) { $ldapSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 } }
 if ($authTypeSetting) { $ldapSettings[$authTypeSetting.id] = @{ stringValue = $DirectoryConfig.AuthType } }
 if ($createContainersSetting) { $ldapSettings[$createContainersSetting.id] = @{ checkboxValue = $true } }

--- a/test/integration/Setup-Scenario2.ps1
+++ b/test/integration/Setup-Scenario2.ps1
@@ -162,7 +162,6 @@ try {
     $usernameSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Username" }
     $passwordSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Password" }
     $useSSLSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Use Secure Connection (LDAPS)?" }
-    $certValidationSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Certificate Validation" }
     $connectionTimeoutSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Connection Timeout" }
     $authTypeSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Authentication Type" }
 
@@ -172,9 +171,6 @@ try {
     if ($usernameSetting) { $sourceSettings[$usernameSetting.id] = @{ stringValue = $SourceConfig.BindDN } }
     if ($passwordSetting) { $sourceSettings[$passwordSetting.id] = @{ stringValue = $SourceConfig.BindPassword } }
     if ($useSSLSetting) { $sourceSettings[$useSSLSetting.id] = @{ checkboxValue = $SourceConfig.UseSSL } }
-    if ($certValidationSetting -and $SourceConfig.CertValidation) {
-        $sourceSettings[$certValidationSetting.id] = @{ stringValue = $SourceConfig.CertValidation }
-    }
     if ($connectionTimeoutSetting) { $sourceSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 } }
     if ($authTypeSetting) { $sourceSettings[$authTypeSetting.id] = @{ stringValue = $SourceConfig.AuthType } }
 
@@ -215,9 +211,6 @@ try {
     if ($usernameSetting) { $targetSettings[$usernameSetting.id] = @{ stringValue = $TargetConfig.BindDN } }
     if ($passwordSetting) { $targetSettings[$passwordSetting.id] = @{ stringValue = $TargetConfig.BindPassword } }
     if ($useSSLSetting) { $targetSettings[$useSSLSetting.id] = @{ checkboxValue = $TargetConfig.UseSSL } }
-    if ($certValidationSetting -and $TargetConfig.CertValidation) {
-        $targetSettings[$certValidationSetting.id] = @{ stringValue = $TargetConfig.CertValidation }
-    }
     if ($connectionTimeoutSetting) { $targetSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 } }
     if ($authTypeSetting) { $targetSettings[$authTypeSetting.id] = @{ stringValue = $TargetConfig.AuthType } }
 

--- a/test/integration/Setup-Scenario8.ps1
+++ b/test/integration/Setup-Scenario8.ps1
@@ -332,7 +332,6 @@ $portSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Port" }
 $usernameSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Username" }
 $passwordSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Password" }
 $useSSLSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Use Secure Connection (LDAPS)?" }
-$certValidationSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Certificate Validation" }
 $connectionTimeoutSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Connection Timeout" }
 $authTypeSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Authentication Type" }
 
@@ -363,7 +362,6 @@ if ($portSetting) { $sourceSettings[$portSetting.id] = @{ intValue = $sourcePort
 if ($usernameSetting) { $sourceSettings[$usernameSetting.id] = @{ stringValue = $sourceBindDN } }
 if ($passwordSetting) { $sourceSettings[$passwordSetting.id] = @{ stringValue = $sourcePassword } }
 if ($useSSLSetting) { $sourceSettings[$useSSLSetting.id] = @{ checkboxValue = $sourceUseSSL } }
-if ($sourceUseSSL -and $certValidationSetting) { $sourceSettings[$certValidationSetting.id] = @{ stringValue = "Skip Validation (Not Recommended)" } }
 if ($connectionTimeoutSetting) { $sourceSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 } }
 if ($authTypeSetting) { $sourceSettings[$authTypeSetting.id] = @{ stringValue = "Simple" } }
 
@@ -398,7 +396,6 @@ if ($portSetting) { $targetSettings[$portSetting.id] = @{ intValue = $targetPort
 if ($usernameSetting) { $targetSettings[$usernameSetting.id] = @{ stringValue = $targetBindDN } }
 if ($passwordSetting) { $targetSettings[$passwordSetting.id] = @{ stringValue = $targetPassword } }
 if ($useSSLSetting) { $targetSettings[$useSSLSetting.id] = @{ checkboxValue = $targetUseSSL } }
-if ($targetUseSSL -and $certValidationSetting) { $targetSettings[$certValidationSetting.id] = @{ stringValue = "Skip Validation (Not Recommended)" } }
 if ($connectionTimeoutSetting) { $targetSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 } }
 if ($authTypeSetting) { $targetSettings[$authTypeSetting.id] = @{ stringValue = "Simple" } }
 

--- a/test/integration/Setup-Scenario9.ps1
+++ b/test/integration/Setup-Scenario9.ps1
@@ -144,7 +144,6 @@ try {
     $usernameSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Username" }
     $passwordSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Password" }
     $useSSLSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Use Secure Connection (LDAPS)?" }
-    $certValidationSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Certificate Validation" }
     $connectionTimeoutSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Connection Timeout" }
     $authTypeSetting = $ldapConnectorFull.settings | Where-Object { $_.name -eq "Authentication Type" }
 
@@ -154,9 +153,6 @@ try {
     if ($usernameSetting) { $ldapSettings[$usernameSetting.id] = @{ stringValue = $DirectoryConfig.BindDN } }
     if ($passwordSetting) { $ldapSettings[$passwordSetting.id] = @{ stringValue = $DirectoryConfig.BindPassword } }
     if ($useSSLSetting) { $ldapSettings[$useSSLSetting.id] = @{ checkboxValue = $DirectoryConfig.UseSSL } }
-    if ($certValidationSetting -and $DirectoryConfig.CertValidation) {
-        $ldapSettings[$certValidationSetting.id] = @{ stringValue = $DirectoryConfig.CertValidation }
-    }
     if ($connectionTimeoutSetting) { $ldapSettings[$connectionTimeoutSetting.id] = @{ intValue = 30 } }
     if ($authTypeSetting) { $ldapSettings[$authTypeSetting.id] = @{ stringValue = $DirectoryConfig.AuthType } }
 

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -321,7 +321,6 @@ function Get-DirectoryConfig {
                     Host             = "samba-ad-primary"
                     Port             = 636
                     UseSSL           = $true
-                    CertValidation   = "Skip Validation (Not Recommended)"
                     BindDN           = "CN=Administrator,CN=Users,DC=panoply,DC=local"
                     BindPassword     = "Test@123!"
                     AuthType         = "Simple"
@@ -350,7 +349,6 @@ function Get-DirectoryConfig {
                     Host             = "samba-ad-source"
                     Port             = 636
                     UseSSL           = $true
-                    CertValidation   = "Skip Validation (Not Recommended)"
                     BindDN           = "CN=Administrator,CN=Users,DC=resurgam,DC=local"
                     BindPassword     = "Test@123!"
                     AuthType         = "Simple"
@@ -379,7 +377,6 @@ function Get-DirectoryConfig {
                     Host             = "samba-ad-target"
                     Port             = 636
                     UseSSL           = $true
-                    CertValidation   = "Skip Validation (Not Recommended)"
                     BindDN           = "CN=Administrator,CN=Users,DC=gentian,DC=local"
                     BindPassword     = "Test@123!"
                     AuthType         = "Simple"
@@ -418,7 +415,6 @@ function Get-DirectoryConfig {
                     Host             = "openldap-primary"
                     Port             = 1389
                     UseSSL           = $false
-                    CertValidation   = $null
                     BindDN           = "cn=admin,dc=yellowstone,dc=local"
                     BindPassword     = "Test@123!"
                     AuthType         = "Simple"
@@ -452,7 +448,6 @@ function Get-DirectoryConfig {
                     Host             = "openldap-primary"
                     Port             = 1389
                     UseSSL           = $false
-                    CertValidation   = $null
                     BindDN           = "cn=admin,dc=yellowstone,dc=local"
                     BindPassword     = "Test@123!"
                     AuthType         = "Simple"
@@ -481,7 +476,6 @@ function Get-DirectoryConfig {
                     Host             = "openldap-primary"
                     Port             = 1389
                     UseSSL           = $false
-                    CertValidation   = $null
                     BindDN           = "cn=admin,dc=glitterband,dc=local"
                     BindPassword     = "Test@123!"
                     AuthType         = "Simple"

--- a/test/scripts/Start-LdapsCertificateTestServers.ps1
+++ b/test/scripts/Start-LdapsCertificateTestServers.ps1
@@ -1,0 +1,244 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Stands up the LDAPS directory servers needed by the RequiresLdaps test category.
+
+.DESCRIPTION
+    LDAPS certificate validation is performed by the platform LDAP client, not by JIM, so it can only be verified
+    against a real directory server presenting a real certificate. This script creates the certificates and starts
+    three OpenLDAP containers with TLS enabled:
+
+      * A server whose issuing CA is added to this machine's trust store, so it validates without JIM's help. Used to
+        prove that adding certificates to the JIM certificate store never weakens what already worked.
+      * A server whose issuing CA is trusted by nobody, standing in for a customer's internal PKI. Used to prove the
+        JIM certificate store is honoured, and that an unknown issuer is rejected without it.
+      * A server presenting an expired certificate issued by that same CA. Used to prove trusting an issuer does not
+        amount to waiving the validity period.
+
+    It then prints the environment variables that LdapsCertificateValidationTests reads.
+
+    Requires Docker, OpenSSL, and root (it writes hosts entries and adds a CA to the machine trust store).
+
+.PARAMETER Stop
+    Removes the containers, hosts entries and trusted CA, and deletes the working directory.
+
+.PARAMETER WorkingDirectory
+    Where certificates are generated. Defaults to a jim-ldaps-test directory under the system temporary path.
+
+.EXAMPLE
+    sudo pwsh ./test/scripts/Start-LdapsCertificateTestServers.ps1
+
+.EXAMPLE
+    sudo pwsh ./test/scripts/Start-LdapsCertificateTestServers.ps1 -Stop
+#>
+[CmdletBinding()]
+param(
+    [switch]$Stop,
+    [string]$WorkingDirectory = (Join-Path ([System.IO.Path]::GetTempPath()) 'jim-ldaps-test')
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Matches the image used by the integration test OpenLDAP container (test/integration/docker/openldap).
+$image = 'bitnamilegacy/openldap:latest'
+
+$servers = @(
+    @{ Name = 'jim-ldaps-system-trusted'; Port = 3636; Hostname = 'ldap-sys.local'; Ca = 'caA' }
+    @{ Name = 'jim-ldaps-jim-store';      Port = 4636; Hostname = 'ldap-jim.local'; Ca = 'caB' }
+    @{ Name = 'jim-ldaps-expired';        Port = 5636; Hostname = 'ldap-old.local'; Ca = 'caB' }
+)
+
+$systemTrustPath = '/usr/local/share/ca-certificates/jim-ldaps-test-ca-a.crt'
+$hostsFile = '/etc/hosts'
+$bindDn = 'cn=admin,dc=example,dc=org'
+$bindPassword = 'adminpassword'
+
+function Assert-Prerequisites {
+    foreach ($tool in @('docker', 'openssl')) {
+        if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+            throw "$tool is required but was not found on PATH."
+        }
+    }
+
+    if ($IsWindows) {
+        throw 'These servers exercise the Linux platform LDAP client that JIM containers use; run this on Linux.'
+    }
+}
+
+function Remove-TestServers {
+    foreach ($server in $servers) {
+        docker rm -f $server.Name 2>$null | Out-Null
+    }
+
+    if (Test-Path $systemTrustPath) {
+        Remove-Item $systemTrustPath -Force
+        & update-ca-certificates --fresh 2>$null | Out-Null
+        Write-Host 'Removed the test CA from the machine trust store.'
+    }
+
+    $hostnames = $servers.Hostname
+    $retainedLines = Get-Content $hostsFile | Where-Object {
+        $line = $_
+        -not ($hostnames | Where-Object { $line -match [regex]::Escape($_) })
+    }
+    Set-Content -Path $hostsFile -Value $retainedLines
+
+    if (Test-Path $WorkingDirectory) {
+        Remove-Item $WorkingDirectory -Recurse -Force
+    }
+
+    Write-Host 'LDAPS test servers stopped and cleaned up.'
+}
+
+function Invoke-OpenSsl {
+    param([string[]]$Arguments)
+
+    $output = & openssl @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "openssl $($Arguments -join ' ') failed: $output"
+    }
+}
+
+function New-Certificates {
+    New-Item -ItemType Directory -Path $WorkingDirectory -Force | Out-Null
+    Push-Location $WorkingDirectory
+    try {
+        foreach ($ca in @('caA', 'caB')) {
+            Invoke-OpenSsl @('req', '-x509', '-newkey', 'rsa:2048', '-keyout', "$ca.key", '-out', "$ca.crt", '-days', '5', '-nodes', '-subj', "/CN=JIM LDAPS Test CA $($ca.Substring(2))")
+        }
+
+        # Valid certificates, one per issuing CA.
+        foreach ($pair in @(@{ Name = 'sys'; Ca = 'caA'; Hostname = 'ldap-sys.local' }, @{ Name = 'jim'; Ca = 'caB'; Hostname = 'ldap-jim.local' })) {
+            Set-Content -Path "$($pair.Name).ext" -Value @(
+                "subjectAltName=DNS:$($pair.Hostname)"
+                'extendedKeyUsage=serverAuth'
+            )
+            Invoke-OpenSsl @('req', '-newkey', 'rsa:2048', '-keyout', "$($pair.Name).key", '-out', "$($pair.Name).csr", '-nodes', '-subj', "/CN=$($pair.Hostname)")
+            Invoke-OpenSsl @('x509', '-req', '-in', "$($pair.Name).csr", '-CA', "$($pair.Ca).crt", '-CAkey', "$($pair.Ca).key", '-CAcreateserial', '-out', "$($pair.Name).crt", '-days', '5', '-extfile', "$($pair.Name).ext")
+        }
+
+        # An expired certificate needs explicit dates, which only the openssl ca command accepts.
+        New-Item -ItemType Directory -Path (Join-Path $WorkingDirectory 'ca/newcerts') -Force | Out-Null
+        # The index must be genuinely empty; a file holding just a newline fails to parse ("Problem with index file").
+        [System.IO.File]::WriteAllText((Join-Path $WorkingDirectory 'ca/index.txt'), '')
+        Set-Content -Path 'ca/serial' -Value '1000'
+        Set-Content -Path 'expired-ca.cnf' -Value @(
+            '[ ca ]'
+            'default_ca = CA_default'
+            '[ CA_default ]'
+            'dir = ./ca'
+            'database = $dir/index.txt'
+            'new_certs_dir = $dir/newcerts'
+            'serial = $dir/serial'
+            'certificate = ./caB.crt'
+            'private_key = ./caB.key'
+            'default_md = sha256'
+            'policy = policy_any'
+            'copy_extensions = copy'
+            'unique_subject = no'
+            '[ policy_any ]'
+            'commonName = supplied'
+            '[ v3_srv ]'
+            'subjectAltName = DNS:ldap-old.local'
+            'extendedKeyUsage = serverAuth'
+        )
+        Invoke-OpenSsl @('req', '-newkey', 'rsa:2048', '-keyout', 'old.key', '-out', 'old.csr', '-nodes', '-subj', '/CN=ldap-old.local')
+        Invoke-OpenSsl @('ca', '-config', 'expired-ca.cnf', '-batch', '-in', 'old.csr', '-out', 'old.crt', '-startdate', '20250101000000Z', '-enddate', '20250201000000Z', '-extensions', 'v3_srv', '-notext')
+
+        # The containers read these as a non-root user.
+        Get-ChildItem -Path $WorkingDirectory -Filter '*.crt' | ForEach-Object { & chmod 644 $_.FullName }
+        Get-ChildItem -Path $WorkingDirectory -Filter '*.key' | ForEach-Object { & chmod 644 $_.FullName }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Start-TestServers {
+    $certificateNames = @{
+        'jim-ldaps-system-trusted' = 'sys'
+        'jim-ldaps-jim-store'      = 'jim'
+        'jim-ldaps-expired'        = 'old'
+    }
+
+    foreach ($server in $servers) {
+        $certificateName = $certificateNames[$server.Name]
+        $serverDirectory = Join-Path $WorkingDirectory $server.Name
+        New-Item -ItemType Directory -Path $serverDirectory -Force | Out-Null
+        foreach ($file in @("$certificateName.crt", "$certificateName.key", "$($server.Ca).crt")) {
+            Copy-Item (Join-Path $WorkingDirectory $file) $serverDirectory -Force
+        }
+
+        docker rm -f $server.Name 2>$null | Out-Null
+        docker run -d --name $server.Name `
+            -p "$($server.Port):1636" `
+            -e LDAP_ADMIN_USERNAME=admin `
+            -e LDAP_ADMIN_PASSWORD=$bindPassword `
+            -e LDAP_ROOT=dc=example,dc=org `
+            -e LDAP_ENABLE_TLS=yes `
+            -e LDAP_TLS_CERT_FILE=/certs/$certificateName.crt `
+            -e LDAP_TLS_KEY_FILE=/certs/$certificateName.key `
+            -e LDAP_TLS_CA_FILE=/certs/$($server.Ca).crt `
+            -v "${serverDirectory}:/certs:ro" `
+            $image | Out-Null
+
+        Write-Host "Started $($server.Name) on port $($server.Port) as $($server.Hostname)."
+    }
+}
+
+function Set-HostEntries {
+    $hosts = Get-Content $hostsFile
+    foreach ($server in $servers) {
+        if (-not ($hosts | Where-Object { $_ -match [regex]::Escape($server.Hostname) })) {
+            Add-Content -Path $hostsFile -Value "127.0.0.1 $($server.Hostname)"
+        }
+    }
+}
+
+function Add-CaToMachineTrustStore {
+    Copy-Item (Join-Path $WorkingDirectory 'caA.crt') $systemTrustPath -Force
+    & update-ca-certificates 2>$null | Out-Null
+    Write-Host 'Added the first test CA to the machine trust store so one server validates without JIM.'
+}
+
+Assert-Prerequisites
+
+if ($Stop) {
+    Remove-TestServers
+    return
+}
+
+if (Test-Path $WorkingDirectory) {
+    Remove-Item $WorkingDirectory -Recurse -Force
+}
+
+New-Certificates
+Start-TestServers
+Set-HostEntries
+Add-CaToMachineTrustStore
+
+Write-Host ''
+Write-Host 'Waiting for the directory servers to accept connections...'
+Start-Sleep -Seconds 16
+
+Write-Host ''
+Write-Host 'Set these, then run: dotnet test test/JIM.Worker.Tests/ --filter "Category=RequiresLdaps"'
+Write-Host ''
+$environmentVariables = [ordered]@{
+    JIM_TEST_LDAPS_HOST                 = 'ldap-jim.local'
+    JIM_TEST_LDAPS_PORT                 = '4636'
+    JIM_TEST_LDAPS_USERNAME             = $bindDn
+    JIM_TEST_LDAPS_PASSWORD             = $bindPassword
+    JIM_TEST_LDAPS_CA_PATH              = (Join-Path $WorkingDirectory 'caB.crt')
+    JIM_TEST_LDAPS_MISMATCH_HOST        = '127.0.0.1'
+    JIM_TEST_LDAPS_EXPIRED_HOST         = 'ldap-old.local'
+    JIM_TEST_LDAPS_EXPIRED_PORT         = '5636'
+    JIM_TEST_LDAPS_SYSTEM_TRUSTED_HOST  = 'ldap-sys.local'
+    JIM_TEST_LDAPS_SYSTEM_TRUSTED_PORT  = '3636'
+}
+
+foreach ($variable in $environmentVariables.GetEnumerator()) {
+    Write-Host "export $($variable.Key)=$($variable.Value)"
+}


### PR DESCRIPTION
## Description

Closes #1132

The issue reported a security exposure: the LDAP Connector's "Certificate Validation" setting offered a "Skip Validation" option. Investigating it overturned that premise. The validation code could never run in JIM's containers at all, so the setting had nothing to skip, and the real defect was the opposite of the one reported: **adding a certificate in Admin > Certificates broke LDAPS entirely**, with a connectivity error that named neither the certificate nor the reason.

Three things follow from that.

**Validation now happens, and the JIM certificate store is honoured.** Certificates added in Admin > Certificates are supplied to the connection as additional trust anchors alongside the operating system's own, never in place of them, so adding one can only ever allow more connections, never fewer. That last point is the subtle one: supplying trust anchors to the platform LDAP client *replaces* the anchors it was configured with, so the operating system's bundle is copied in deliberately. Removing that copy fails exactly one test, which is how it is guarded.

**A refused certificate now says so.** The platform LDAP client reports a rejected certificate as "the server is unavailable", indistinguishable from an unreachable host, which is what made the original defect hard to see. When an LDAPS connection fails, JIM now opens its own TLS connection purely to look at what the directory presented and works out which check it fails: expired, not yet valid, issued for a different name, or an issuer nobody trusts. Nothing is trusted in order to do it (the probe refuses every certificate it is shown), and a failure unrelated to the certificate reports exactly as before.

**The "Certificate Validation" setting is gone.** Its "Skip Validation" option could never have been honoured per Connected System: the only mechanisms available are process-wide, and the Worker opens connections for several Connected Systems concurrently, so one system's "skip" would have silently disabled validation for the others mid-run. Where a certificate is not trusted, add it in Admin > Certificates. Where the certificate's name does not match the host, give the containers a host entry for the right name (`extra_hosts`) and connect by that name, rather than weakening validation.

Three further defects were found by running the stack rather than by reading it, and are fixed here:

- **The portal hung indefinitely** when saving LDAPS settings, retrieving a schema or retrieving a hierarchy with any certificate in the store. Reading the store blocked Blazor's renderer thread waiting for a continuation that could only run on that same thread. This predates the branch: the connection setup this work replaces had the same shape.
- **Trust directories leaked** on three failure paths, and nothing swept up after a killed process.
- **Settings withdrawn from a Connector lingered** on Connected Systems that already held a value for them; they were detached from their Connector Definition rather than deleted.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

Breaking in the pre-1.0 sense: the "Certificate Validation" setting is removed, and LDAPS connections that only worked because validation never ran will now be refused until the directory's certificate is added in Admin > Certificates.

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

4,433 unit and component tests pass; the build is warning-free with `-warnaserror`.

**Against real directory servers.** Certificate validation is performed by the platform LDAP client, not by JIM, so it can only be verified against a real server presenting a real certificate. `test/scripts/Start-LdapsCertificateTestServers.ps1` stands up three TLS directory servers (one trusted by the operating system, one trusted only via the JIM certificate store, one presenting an expired certificate) and the `RequiresLdaps` tests assert against them:

- an issuer nobody trusts is refused, and reported as an untrusted issuer;
- a certificate not issued for the host connected to is refused, and reported as a name mismatch ahead of any issuer problem, because trusting the issuer is not what fixes it;
- an expired certificate is refused even when its issuer is in the JIM certificate store;
- a directory the operating system already trusted keeps working after an unrelated certificate is added to the JIM store;
- a refused connection leaves no trust directory behind.

The same suite was run against a **Samba AD Domain Controller** using its own self-signed certificate authority: 9 of the 12 pass, 3 skip (they need the expired and system-trusted servers, which were only built for the OpenLDAP set).

**End to end in the portal**, against both directory types: added the certificate authority in Admin > Certificates, connected over LDAPS, retrieved the schema, selected object types and attributes, created a Run Profile, removed the certificate, and ran a Full Import. The run failed and the Activity carried the certificate detail, written by the Worker. Against Samba AD the retrieved schema is Active Directory's (`Computer`, `Contact`, `Group`, `User`, `MSMQ-Custom-Recipient`), confirming the Active Directory code path rather than the generic one.

**Surface parity checked at runtime**, not just in code: `GET /api/v1/activities/{id}` returns the new `errorDetail`, and `Get-JIMActivity` surfaces and parses it.

**Integration:** Scenario 1 (Joiner, Nano) run against OpenLDAP, exercising the setup script this PR edits. Green end to end: HR CSV import, synchronisation, export, user provisioned in the directory, cross-domain export, confirming import, delta synchronisation.

**Migrations:** this branch and #1140 both added a migration against `Activities` in parallel. The merged model snapshot carries both columns and both migrations apply in order to a fresh database, verified against real PostgreSQL.

**Not covered, deliberately stated:** the container images. The sandbox's egress proxy prevents `dotnet restore` inside a Docker build stage, so everything above ran natively. `/tmp` is a tmpfs and the containers already write there as UID 1654 for their healthcheck, so the trust directory should be fine, but it is unproven; worth one run in a devcontainer before merging.

While verifying, I found that no integration scenario exercises certificate validation at all: the OpenLDAP scenarios connect unencrypted, and the Samba AD ones set `LDAPTLS_REQCERT=never`, which disables validation for the whole container. Filed as #1141.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `docs/connectors/jim-ldap-connector.md`, `docs/configuration/certificates.md`
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [ ] No documentation needed

Also documents what to do about a name mismatch (`extra_hosts` rather than weakening validation) and warns that `LDAPTLS_REQCERT` is honoured by the platform LDAP client, applies to the whole container, and must not be set in production.

## Screenshots / output (if applicable)

The certificate is laid out as the document itself rather than as another block of error text, so it can be compared by eye against Admin > Certificates. It appears on the Connected System's settings when validation fails, and on the failed Activity.

Stack traces across the Activity, Import Results, Operations history and Pending Export pages now sit behind a "Show stack trace" toggle so the error message leads; the trace is unchanged and one click away.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

**Two pre-existing defects found while verifying, not fixed here**, both independent of this work:

1. The portal's "Retrieve Hierarchy" always fails with a duplicate-key error on `ConnectorDefinitions`. It passes the page's detached Connected System into a new scope; the REST endpoint's own comment records that the instance must be change-tracked. It was previously masked by the deadlock fixed here, so it becomes visible now. Worth an issue.
2. `ImportConnectedSystemSchemaAsync` calls `GetSchemaAsync` outside its `try`, so a failure leaves the Activity in flight forever and records nothing against it.

**Follow-up already filed:** #1139 (offer to trust a certificate at discovery time, so an administrator can act on the card rather than going to fetch the file), and #1141 (integration coverage for connection encryption across every supported directory server type).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQ5WQciMBksFqe3UjEa4Am)_