### PR TITLE
Configuration changed since last Full Synchronisation indicator (#827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ✨ The Synchronisation Rules list can now be filtered by Connected System, Direction, Action (Projects, Provisions or Flow Only) and Status. The filters combine with the existing search box, which narrows whatever the filters left.
 - ✨ The same filters are available to automation: `Get-JIMSyncRule` gains `-Direction`, `-ActionType` and `-Status`, and the Synchronisation Rules REST endpoint gains matching query parameters.
+- ✨ Connected Systems now show when their configuration has changed in a way that needs a Full Synchronisation to take effect: an indicator in the Connected Systems list and a notice on the Connected System page, stating how many changes are waiting and warning distinctly when one of them is destructive. Cosmetic changes such as renames never raise it, and a change to a Metaverse Attribute raises it only on the systems whose Synchronisation Rules actually reference that attribute. Systems that have never completed a Full Synchronisation, and the case where configuration change tracking is switched off, are reported as such rather than as "up to date". Available to automation as `(Get-JIMConnectedSystem -Id <id>).ConfigurationDrift` and on the REST Connected System response.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,26 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ✨ When an LDAPS connection to a directory fails because of the certificate it presented, JIM now shows you that certificate rather than an unhelpful "the server is unavailable": its subject, the names it was issued for, its issuer, validity dates and thumbprint, laid out as the certificate itself, alongside which check it failed and what to do about it. It appears when testing a Connected System's settings and on the failed Activity, with the same detail available to automation on the Activity's `errorDetail` field in the REST API. Nothing is trusted in order to show it, and a failure unrelated to the certificate reports exactly as before. (#1132)
-
-### Fixed
-
-- 🐛 A setting withdrawn from a Connector no longer lingers on Connected Systems that already held a value for it. The setting was being detached from its Connector Definition rather than deleted, leaving the row behind with the saved values still pointing at it. (#1132)
-- 🐛 Saving an LDAPS Connected System's settings, retrieving its schema, or retrieving its hierarchy no longer hangs indefinitely in the portal when certificates are present in Admin > Certificates. Reading the certificate store blocked the page's own thread waiting for work that could only run on that same thread, so the operation never finished and the page sat on its progress spinner. (#1132)
-
-### Changed
-
-- 🔄 Stack traces are now hidden behind a "Show stack trace" toggle wherever JIM reports an error (Activity detail, Import Results detail, the Operations history panel and Pending Export detail), so the error message itself leads. The trace is unchanged and one click away. (#1132)
-- 🔄 The LDAP Connector's "Certificate Validation" setting has been removed. Its "Skip Validation" option could never be honoured for an individual Connected System, and validation is now always applied to LDAPS connections. Where a directory's certificate is not trusted, add it in Admin > Certificates; where the certificate name does not match the host being connected to, give the JIM containers a host entry for that name (`extra_hosts` in Docker Compose) and use the name in the Host setting, rather than weakening validation. See the [LDAP Connector documentation](https://tetronio.github.io/JIM/connectors/jim-ldap-connector/) for both. (#1132)
-### Added
-
 - ✨ The Synchronisation Rules list can now be filtered by Connected System, Direction, Action (Projects, Provisions or Flow Only) and Status. The filters combine with the existing search box, which narrows whatever the filters left.
 - ✨ The same filters are available to automation: `Get-JIMSyncRule` gains `-Direction`, `-ActionType` and `-Status`, and the Synchronisation Rules REST endpoint gains matching query parameters.
 - ✨ Connected Systems now show when their configuration has changed in a way that needs a Full Synchronisation to take effect: an indicator in the Connected Systems list and a notice on the Connected System page, stating how many changes are waiting and warning distinctly when one of them is destructive. Cosmetic changes such as renames never raise it, and a change to a Metaverse Attribute raises it only on the systems whose Synchronisation Rules actually reference that attribute. Systems that have never completed a Full Synchronisation, and the case where configuration change tracking is switched off, are reported as such rather than as "up to date". Available to automation as `(Get-JIMConnectedSystem -Id <id>).ConfigurationDrift` and on the REST Connected System response.
 
 ### Fixed
 
+- 🐛 A setting withdrawn from a Connector no longer lingers on Connected Systems that already held a value for it. The setting was being detached from its Connector Definition rather than deleted, leaving the row behind with the saved values still pointing at it. (#1132)
+- 🐛 Saving an LDAPS Connected System's settings, retrieving its schema, or retrieving its hierarchy no longer hangs indefinitely in the portal when certificates are present in Admin > Certificates. Reading the certificate store blocked the page's own thread waiting for work that could only run on that same thread, so the operation never finished and the page sat on its progress spinner. (#1132)
 - 🐛 `Get-JIMSyncRule` now returns every Synchronisation Rule rather than only the first 25, paging through the full result set.
 - 🐛 Piping a Connected System into `Get-JIMSyncRule`, as its documentation has always shown, now works instead of failing to bind.
+
+### Changed
+
+- 🔄 Stack traces are now hidden behind a "Show stack trace" toggle wherever JIM reports an error (Activity detail, Import Results detail, the Operations history panel and Pending Export detail), so the error message itself leads. The trace is unchanged and one click away. (#1132)
+- 🔄 The LDAP Connector's "Certificate Validation" setting has been removed. Its "Skip Validation" option could never be honoured for an individual Connected System, and validation is now always applied to LDAPS connections. Where a directory's certificate is not trusted, add it in Admin > Certificates; where the certificate name does not match the host being connected to, give the JIM containers a host entry for that name (`extra_hosts` in Docker Compose) and use the name in the Host setting, rather than weakening validation. See the [LDAP Connector documentation](https://tetronio.github.io/JIM/connectors/jim-ldap-connector/) for both. (#1132)
 
 ## [0.14.0] - 2026-07-25
 

--- a/docs/configuration/connected-systems.md
+++ b/docs/configuration/connected-systems.md
@@ -89,6 +89,49 @@ Set the mode from the **Import Behaviour** panel on the Connected System's Setti
 
 Changes destined for the Connected System that have been computed by synchronisation but not yet written back. Run an export Run Profile to flush them. Inspecting Pending Exports is the right place to look when you want to know "what is JIM about to change in this system?"
 
+## Configuration changes pending a Full Synchronisation
+
+Most configuration changes do not take effect the moment you save them. Scoping criteria, Attribute Flow, Object
+Matching Rules and schema selection all describe what synchronisation *should* do; the change reaches your data only
+when synchronisation next runs over the objects it affects. Until then the portal and the configuration are ahead of
+reality.
+
+JIM tracks this for you. A Connected System whose configuration has changed in a way that affects synchronisation
+outcomes shows an indicator in the Connected Systems list, and a notice on the Connected System page saying how many
+changes are waiting and when the last Full Synchronisation ran.
+
+**Only consequential changes count.** Renaming a Connected System or editing a description changes nothing about what
+synchronisation does, so it never raises the indicator. Changes are classified as they are recorded, and only the two
+classes that alter outcomes are counted:
+
+| Class | Examples | How it shows |
+|-------|----------|--------------|
+| Sync-affecting | Scoping criteria, Attribute Flow, Object Matching Rules, schema selection | Amber, with the number of changes |
+| Destructive | Outbound Deprovision Action, deletion rules, deselecting an Object Type or partition | Red, because applying it can cascade deletions or mass deprovisioning |
+
+**Attribution is precise.** Editing a Metaverse Attribute raises the indicator only on the Connected Systems whose
+Synchronisation Rules actually reference that attribute, not on every system. Deleting a Synchronisation Rule raises
+it on the system that rule belonged to.
+
+**Two states mean "JIM cannot tell", not "up to date":**
+
+- **Never synchronised.** The Connected System has never completed a Full Synchronisation, so no configuration has
+  ever been applied in full and there is nothing to compare against.
+- **Unknown.** Configuration change tracking is switched off (see
+  [configuration change history](activities.md#configuration-change-history)), so JIM holds no record of what changed.
+
+Both are shown distinctly rather than as a clean result, because reporting a settled configuration JIM cannot vouch
+for would be worse than reporting nothing.
+
+!!! note "The reference point is when the run started"
+    A change made while a long Full Synchronisation was still running may not have been picked up by it, so it is
+    counted as still pending. You may occasionally be prompted for a re-run you did not strictly need; the alternative
+    would be hiding a change that really was missed.
+
+Read the same status from automation with `(Get-JIMConnectedSystem -Id <id>).ConfigurationDrift`, or from the
+`configurationDrift` object on the REST Connected System response. In both cases, check `IsDeterminable` before
+treating `HasPendingChanges` as `false`.
+
 ## Common workflows
 
 **Setting up a new Connected System:**

--- a/docs/powershell/connected-systems.md
+++ b/docs/powershell/connected-systems.md
@@ -40,7 +40,7 @@ Get-JIMConnectedSystem -Id <int> -DeletionPreview
 ### Output
 
 - **List**: Connected System headers with properties such as `Id`, `Name`, `Description`, `Status`, `ObjectCount`, `ConnectorName`, and `ConnectorId`.
-- **ById**: the full Connected System, including its nested `Connector` (use `$cs.Connector.Id` for the connector definition ID) and configuration state.
+- **ById**: the full Connected System, including its nested `Connector` (use `$cs.Connector.Id` for the connector definition ID), configuration state, and a nested `ConfigurationDrift` object (see below).
 - **ObjectTypes**: Object type definitions for the specified Connected System.
 - **DeletionPreview**: Deletion impact preview with counts and warnings.
 
@@ -61,6 +61,35 @@ Get-JIMConnectedSystem -Id 3
 ```powershell title="Retrieve object types for a Connected System"
 Get-JIMConnectedSystem -Id 3 -ObjectTypes
 ```
+
+```powershell title="Find Connected Systems needing a Full Synchronisation"
+Get-JIMConnectedSystem |
+    ForEach-Object { Get-JIMConnectedSystem -Id $_.Id } |
+    Where-Object { $_.ConfigurationDrift.HasPendingChanges } |
+    Select-Object Name, @{n='Changes';e={$_.ConfigurationDrift.ChangeCount}},
+                        @{n='Highest';e={$_.ConfigurationDrift.HighestChangeClass}}
+```
+
+#### ConfigurationDrift (ById only)
+
+Whether the configuration has changed in a way that needs a Full Synchronisation to take effect. Only Sync-affecting
+and Destructive changes count, so a rename never registers here.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `HasPendingChanges` | `bool` | Qualifying changes have been recorded since the last completed Full Synchronisation |
+| `IsDeterminable` | `bool` | The question has a meaningful answer; see the caution below |
+| `NeverFullySynchronised` | `bool` | No Full Synchronisation has ever completed, so there is no reference point |
+| `TrackingDisabled` | `bool` | Configuration change tracking is off, so JIM holds no record of what changed |
+| `LastFullSynchronisation` | `datetime?` | When the last completed Full Synchronisation started, or `$null` |
+| `MostRecentChange` | `datetime?` | When the most recent qualifying change was recorded, or `$null` |
+| `ChangeCount` | `int` | How many qualifying changes there are |
+| `HighestChangeClass` | `string` | `Cosmetic`, `SyncAffecting` or `Destructive`; `NotClassified` when there are no changes |
+
+!!! warning "Check `IsDeterminable` before treating `HasPendingChanges` as false"
+    `HasPendingChanges` is also `$false` when JIM cannot tell: when the Connected System has never completed a Full
+    Synchronisation, and when configuration change tracking is switched off. Scripts that gate a run on
+    `-not $_.ConfigurationDrift.HasPendingChanges` will skip those systems silently. Test `IsDeterminable` first.
 
 ```powershell title="Preview the impact of deleting a Connected System"
 Get-JIMConnectedSystem -Id 3 -DeletionPreview

--- a/src/JIM.Application/JimApplication.cs
+++ b/src/JIM.Application/JimApplication.cs
@@ -59,6 +59,7 @@ public class JimApplication : IDisposable
     public ChangeHistoryServer ChangeHistory { get; }
     public ConfigurationChangeCaptureService ConfigurationChangeCapture { get; }
     public ConfigurationDiffService ConfigurationDiffs { get; }
+    public ConfigurationDriftService ConfigurationDrift { get; }
     public ConfigurationSnapshotService ConfigurationSnapshots { get; }
     public ConnectedSystemServer ConnectedSystems { get; }
     public ExampleDataServer ExampleData { get; }
@@ -86,6 +87,7 @@ public class JimApplication : IDisposable
         ChangeHistory = new ChangeHistoryServer(this);
         ConfigurationChangeCapture = new ConfigurationChangeCaptureService(this);
         ConfigurationDiffs = new ConfigurationDiffService();
+        ConfigurationDrift = new ConfigurationDriftService(this);
         ConfigurationSnapshots = new ConfigurationSnapshotService(this);
         ConnectedSystems = new ConnectedSystemServer(this);
         ExampleData = new ExampleDataServer(this);

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -5627,7 +5627,13 @@ public class ConnectedSystemServer
             TargetName = syncRule.Name,
             TargetContext = connectedSystem?.Name,
             TargetType = ActivityTargetType.SynchronisationRule,
-            TargetOperationType = ActivityTargetOperationType.Delete
+            TargetOperationType = ActivityTargetOperationType.Delete,
+            // Deletion capture deliberately records no SyncRuleId (the rule is about to cease to exist), which would
+            // otherwise leave the deletion unattributable to any system and invisible to the "configuration changed
+            // since last Full Synchronisation" indicator: a false negative on one of the most consequential changes
+            // there is. The Connected System survives the deletion, so its id is the durable link. This does not
+            // pollute the system's own configuration history, which additionally requires a captured version.
+            ConnectedSystemId = syncRule.ConnectedSystemId
         };
         await Application.Activities.CreateActivityAsync(activity, initiatedBy);
 
@@ -5657,7 +5663,10 @@ public class ConnectedSystemServer
             TargetName = syncRule.Name,
             TargetContext = connectedSystem?.Name,
             TargetType = ActivityTargetType.SynchronisationRule,
-            TargetOperationType = ActivityTargetOperationType.Delete
+            TargetOperationType = ActivityTargetOperationType.Delete,
+            // See the MetaverseObject-initiated overload above: the Connected System id is what keeps a rule deletion
+            // attributable once the rule itself is gone.
+            ConnectedSystemId = syncRule.ConnectedSystemId
         };
         await Application.Activities.CreateActivityAsync(activity, initiatedByApiKey);
 

--- a/src/JIM.Application/Services/ConfigurationDriftService.cs
+++ b/src/JIM.Application/Services/ConfigurationDriftService.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
+using JIM.Models.Staging.DTOs;
+
+namespace JIM.Application.Services;
+
+/// <summary>
+/// Answers "has this Connected System's configuration changed in a way that needs a Full Synchronisation to take
+/// effect?" by comparing the classified configuration changes recorded against the system with the start of its last
+/// completed Full Synchronisation.
+///
+/// Attribution is precise rather than blanket: a Metaverse Attribute edit raises the indicator only on the systems
+/// whose Synchronisation Rules actually reference that attribute. Flagging every system on every Metaverse-side edit
+/// would make the indicator noise, and an indicator administrators learn to ignore is worse than none.
+/// </summary>
+public class ConfigurationDriftService
+{
+    private JimApplication Application { get; }
+
+    internal ConfigurationDriftService(JimApplication application)
+    {
+        Application = application;
+    }
+
+    /// <summary>
+    /// Determines whether one Connected System has Sync-affecting or Destructive configuration changes recorded since
+    /// its last completed Full Synchronisation.
+    /// </summary>
+    public async Task<ConfigurationDriftStatus> GetConnectedSystemDriftAsync(int connectedSystemId)
+    {
+        var results = await GetConnectedSystemDriftAsync([connectedSystemId]);
+        return results[connectedSystemId];
+    }
+
+    /// <summary>
+    /// The batch counterpart of <see cref="GetConnectedSystemDriftAsync(int)"/>, for list surfaces that need a status
+    /// per system. Issues a fixed number of queries regardless of how many systems are asked about, so a list page
+    /// does not degrade into an N+1.
+    /// </summary>
+    /// <returns>A status for every requested system id.</returns>
+    public async Task<Dictionary<int, ConfigurationDriftStatus>> GetConnectedSystemDriftAsync(IList<int> connectedSystemIds)
+    {
+        ArgumentNullException.ThrowIfNull(connectedSystemIds);
+
+        var ids = connectedSystemIds.Distinct().ToList();
+        if (ids.Count == 0)
+            return new Dictionary<int, ConfigurationDriftStatus>();
+
+        // With change tracking off nothing is recorded, so drift is unknowable. Reporting that honestly matters more
+        // than reporting a comfortable answer: "no changes pending" here would be a claim JIM cannot support.
+        if (!await Application.ServiceSettings.GetConfigurationChangeTrackingEnabledAsync())
+            return ids.ToDictionary(id => id, id => new ConfigurationDriftStatus
+            {
+                ConnectedSystemId = id,
+                TrackingDisabled = true
+            });
+
+        var lastFullSyncs = await Application.Repository.Activity.GetLastFullSynchronisationStartsAsync(ids);
+
+        var synchronisedIds = ids.Where(lastFullSyncs.ContainsKey).ToList();
+        var results = ids.Where(id => !lastFullSyncs.ContainsKey(id))
+            .ToDictionary(id => id, id => new ConfigurationDriftStatus
+            {
+                ConnectedSystemId = id,
+                NeverFullySynchronised = true
+            });
+
+        if (synchronisedIds.Count == 0)
+            return results;
+
+        // One changes query covering the earliest reference point across the batch, then per-system filtering. Each
+        // system still compares against its own reference point below.
+        var earliestReferencePoint = synchronisedIds.Min(id => lastFullSyncs[id]);
+        var impacts = await Application.Repository.Activity.GetConfigurationChangeImpactsSinceAsync(
+            earliestReferencePoint, ConfigurationChangeClass.SyncAffecting);
+
+        var scopes = (await Application.Repository.ConnectedSystems.GetConfigurationScopesAsync(synchronisedIds))
+            .ToDictionary(s => s.ConnectedSystemId);
+
+        foreach (var id in synchronisedIds)
+        {
+            var referencePoint = lastFullSyncs[id];
+
+            // A system with no scope entry is treated as having an empty scope rather than skipped: changes to the
+            // system itself still count, and silently dropping it would under-report.
+            var scope = scopes.TryGetValue(id, out var found)
+                ? found
+                : new ConnectedSystemConfigurationScope { ConnectedSystemId = id };
+
+            var qualifying = impacts
+                .Where(i => i.When >= referencePoint && Affects(i, scope))
+                .ToList();
+
+            results[id] = new ConfigurationDriftStatus
+            {
+                ConnectedSystemId = id,
+                HasPendingChanges = qualifying.Count > 0,
+                LastFullSynchronisation = referencePoint,
+                MostRecentChange = qualifying.Count > 0 ? qualifying.Max(i => i.When) : null,
+                ChangeCount = qualifying.Count,
+                HighestChangeClass = qualifying.Count > 0
+                    ? qualifying.Max(i => i.Class)
+                    : ConfigurationChangeClass.NotClassified
+            };
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Whether a recorded configuration change affects the given system's synchronisation outcomes.
+    /// </summary>
+    private static bool Affects(ConfigurationChangeImpactData impact, ConnectedSystemConfigurationScope scope)
+    {
+        // The system itself, its sub-entities, and Synchronisation Rule deletions (which carry the owning system's id
+        // because the rule they describe no longer exists to be referenced).
+        if (impact.ConnectedSystemId == scope.ConnectedSystemId)
+            return true;
+
+        if (impact.SyncRuleId is { } syncRuleId && scope.SyncRuleIds.Contains(syncRuleId))
+            return true;
+
+        if (impact.MetaverseObjectTypeId is { } objectTypeId && scope.MetaverseObjectTypeIds.Contains(objectTypeId))
+            return true;
+
+        if (impact.MetaverseAttributeId is { } attributeId && scope.MetaverseAttributeIds.Contains(attributeId))
+            return true;
+
+        // Service Settings are global, so a Sync-affecting one affects every system. The change reaching here has
+        // already been classified at or above Sync-affecting, so no further filtering by key is needed.
+        return impact.ServiceSettingKey != null;
+    }
+}

--- a/src/JIM.Application/Services/ConfigurationDriftService.cs
+++ b/src/JIM.Application/Services/ConfigurationDriftService.cs
@@ -80,10 +80,10 @@ public class ConfigurationDriftService
         var scopes = (await Application.Repository.ConnectedSystems.GetConfigurationScopesAsync(synchronisedIds))
             .ToDictionary(s => s.ConnectedSystemId);
 
-        foreach (var id in synchronisedIds)
+        // The reference point is projected alongside the id rather than looked up as the loop body's first statement,
+        // which reads as a map-only foreach to the code-quality analyser (see the Select rule in src/CLAUDE.md).
+        foreach (var (id, referencePoint) in synchronisedIds.Select(id => (id, referencePoint: lastFullSyncs[id])))
         {
-            var referencePoint = lastFullSyncs[id];
-
             // A system with no scope entry is treated as having an empty scope rather than skipped: changes to the
             // system itself still count, and silently dropping it would under-report.
             var scope = scopes.TryGetValue(id, out var found)

--- a/src/JIM.Data/Repositories/IActivityRepository.cs
+++ b/src/JIM.Data/Repositories/IActivityRepository.cs
@@ -257,4 +257,25 @@ public interface IActivityRepository
     /// <returns>True if a matching row was found and incremented; false if no row exists yet for this window bucket
     /// (the caller must then create one).</returns>
     public Task<bool> IncrementAggregatedFailedAuthenticationAsync(string apiKeyPrefix, string clientIp, string reason, DateTime windowStart, DateTime lastSeen);
+
+    /// <summary>
+    /// Returns, for each of the given Connected Systems that has one, the <see cref="Activity.Executed"/> time of its
+    /// most recent successfully completed Full Synchronisation. Systems that have never completed one are absent from
+    /// the dictionary rather than carrying a sentinel date, so callers must distinguish "never" from "long ago".
+    ///
+    /// Runs that failed, errored or were cancelled do not count: a Full Synchronisation that did not finish cleanly
+    /// cannot be relied on to have applied the configuration, so treating it as a reference point would hide real
+    /// pending changes.
+    /// </summary>
+    public Task<Dictionary<int, DateTime>> GetLastFullSynchronisationStartsAsync(IList<int> connectedSystemIds);
+
+    /// <summary>
+    /// Returns the target columns and classification of every configuration change recorded at or after
+    /// <paramref name="since"/> whose class is at least <paramref name="minimumClass"/>, for the caller to attribute
+    /// to the Connected Systems it affects.
+    ///
+    /// Unlike the per-object configuration history queries, this deliberately does not require a captured version:
+    /// deletions are recorded without one and are precisely the changes that most need surfacing.
+    /// </summary>
+    public Task<List<ConfigurationChangeImpactData>> GetConfigurationChangeImpactsSinceAsync(DateTime since, ConfigurationChangeClass minimumClass);
 }

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -1044,5 +1044,16 @@ public interface IConnectedSystemRepository
     /// <param name="afterUtc">Exclusive lower bound on the date value, or null to omit the lower bound (bootstrap / open window).</param>
     /// <param name="throughUtc">Inclusive upper bound on the date value.</param>
     Task<List<Guid>> GetConnectedSystemObjectIdsByDateAttributeRangeAsync(int attributeId, DateTime? afterUtc, DateTime throughUtc);
+
+    /// <summary>
+    /// Returns, for each of the given Connected Systems, the configuration objects whose change affects that system's
+    /// synchronisation outcomes: its Synchronisation Rules, the Metaverse Object Types those rules target, and the
+    /// Metaverse Attributes those rules reference. Backs the "configuration changed since last Full Synchronisation"
+    /// indicator, which uses these sets to attribute each recorded change to precisely the systems it affects.
+    ///
+    /// Every requested system gets an entry, including ones with no Synchronisation Rules at all (an empty scope, so
+    /// only changes to the system itself count).
+    /// </summary>
+    Task<List<ConnectedSystemConfigurationScope>> GetConfigurationScopesAsync(IList<int> connectedSystemIds);
     #endregion
 }

--- a/src/JIM.Models/Activities/DTOs/ConfigurationChangeImpactData.cs
+++ b/src/JIM.Models/Activities/DTOs/ConfigurationChangeImpactData.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Activities.DTOs;
+
+/// <summary>
+/// The minimal projection of a configuration change Activity needed to decide which Connected Systems it affects.
+/// Carries the change's classification and its target columns; the drift calculation matches those columns against
+/// each system's configuration scope rather than loading whole Activities.
+/// </summary>
+public class ConfigurationChangeImpactData
+{
+    /// <summary>
+    /// When the change was recorded.
+    /// </summary>
+    public DateTime When { get; init; }
+
+    /// <summary>
+    /// How consequential the change was.
+    /// </summary>
+    public ConfigurationChangeClass Class { get; init; }
+
+    /// <summary>
+    /// Set when the change targets a Connected System directly (including its Run Profiles, object types, partitions
+    /// and Simple Mode Object Matching Rules), and on a Synchronisation Rule deletion, where it is the only surviving
+    /// link back to the owning system.
+    /// </summary>
+    public int? ConnectedSystemId { get; init; }
+
+    /// <summary>
+    /// Set when the change targets a Synchronisation Rule that still exists.
+    /// </summary>
+    public int? SyncRuleId { get; init; }
+
+    /// <summary>
+    /// Set when the change targets a Metaverse Object Type.
+    /// </summary>
+    public int? MetaverseObjectTypeId { get; init; }
+
+    /// <summary>
+    /// Set when the change targets a Metaverse Attribute.
+    /// </summary>
+    public int? MetaverseAttributeId { get; init; }
+
+    /// <summary>
+    /// Set when the change targets a Service Setting, identified by its key.
+    /// </summary>
+    public string? ServiceSettingKey { get; init; }
+}

--- a/src/JIM.Models/Activities/DTOs/ConfigurationDriftStatus.cs
+++ b/src/JIM.Models/Activities/DTOs/ConfigurationDriftStatus.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Activities.DTOs;
+
+/// <summary>
+/// Whether a Connected System's configuration has changed in a way that affects synchronisation outcomes since its
+/// last Full Synchronisation, and therefore whether the administrator should be told that a re-run is needed for the
+/// configuration to take effect.
+///
+/// Only <see cref="ConfigurationChangeClass.SyncAffecting"/> and <see cref="ConfigurationChangeClass.Destructive"/>
+/// changes count: a rename changes nothing about what synchronisation does, so it must not raise the indicator and
+/// train administrators to ignore it.
+/// </summary>
+public class ConfigurationDriftStatus
+{
+    /// <summary>
+    /// The Connected System this status describes.
+    /// </summary>
+    public int ConnectedSystemId { get; init; }
+
+    /// <summary>
+    /// True when at least one Sync-affecting or Destructive configuration change affecting this system was recorded
+    /// after the reference point (the start of the last completed Full Synchronisation). False when the configuration
+    /// is settled, and also false whenever the answer is not knowable: check <see cref="IsDeterminable"/> before
+    /// presenting this as "no changes pending".
+    /// </summary>
+    public bool HasPendingChanges { get; init; }
+
+    /// <summary>
+    /// True when this system has never completed a Full Synchronisation, so no configuration has ever been applied in
+    /// full. Distinct from <see cref="HasPendingChanges"/>: there is no reference point to compare against, so the
+    /// surfaces word this case differently rather than claiming changes are pending.
+    /// </summary>
+    public bool NeverFullySynchronised { get; init; }
+
+    /// <summary>
+    /// True when configuration change tracking is switched off, so JIM has no record of what changed and drift cannot
+    /// be determined. Reported honestly rather than as "no changes pending": a silent false negative here would tell
+    /// an administrator their configuration is live when it is not.
+    /// </summary>
+    public bool TrackingDisabled { get; init; }
+
+    /// <summary>
+    /// True when the drift question has a meaningful answer, i.e. tracking is on and there is a Full Synchronisation
+    /// to compare against.
+    /// </summary>
+    public bool IsDeterminable => !TrackingDisabled && !NeverFullySynchronised;
+
+    /// <summary>
+    /// When the last completed Full Synchronisation for this system started. This is deliberately the run's start and
+    /// not its completion: a change made while a long run was in flight may not have been picked up by it, so counting
+    /// it as pending errs towards prompting an unnecessary re-run rather than hiding a real one.
+    /// Null when <see cref="NeverFullySynchronised"/>.
+    /// </summary>
+    public DateTime? LastFullSynchronisation { get; init; }
+
+    /// <summary>
+    /// When the most recent qualifying change was recorded. Null when there are none.
+    /// </summary>
+    public DateTime? MostRecentChange { get; init; }
+
+    /// <summary>
+    /// How many qualifying changes were recorded since the reference point.
+    /// </summary>
+    public int ChangeCount { get; init; }
+
+    /// <summary>
+    /// The highest class among the qualifying changes, so a surface can distinguish "configuration needs applying"
+    /// from "a destructive change is waiting to be applied". <see cref="ConfigurationChangeClass.NotClassified"/>
+    /// when there are none.
+    /// </summary>
+    public ConfigurationChangeClass HighestChangeClass { get; init; }
+}

--- a/src/JIM.Models/Staging/DTOs/ConnectedSystemConfigurationScope.cs
+++ b/src/JIM.Models/Staging/DTOs/ConnectedSystemConfigurationScope.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Staging.DTOs;
+
+/// <summary>
+/// The set of configuration objects whose change affects one Connected System's synchronisation outcomes. Used to
+/// decide, precisely, whether a given configuration change is relevant to this system: a Metaverse Attribute edit
+/// matters only to systems whose Synchronisation Rules actually reference that attribute, so unrelated systems are
+/// not made to display a re-run prompt they do not need.
+/// </summary>
+public class ConnectedSystemConfigurationScope
+{
+    /// <summary>
+    /// The Connected System this scope belongs to.
+    /// </summary>
+    public int ConnectedSystemId { get; init; }
+
+    /// <summary>
+    /// The ids of this system's Synchronisation Rules. Deleted rules are necessarily absent, which is why a rule
+    /// deletion attributes to its system through the Activity's Connected System id instead.
+    /// </summary>
+    public HashSet<int> SyncRuleIds { get; init; } = [];
+
+    /// <summary>
+    /// The ids of the Metaverse Object Types this system's Synchronisation Rules target.
+    /// </summary>
+    public HashSet<int> MetaverseObjectTypeIds { get; init; } = [];
+
+    /// <summary>
+    /// The ids of the Metaverse Attributes this system's Synchronisation Rules reference, whether as an Attribute
+    /// Flow target, an Attribute Flow source, a scoping criterion, or an Object Matching Rule target.
+    /// </summary>
+    public HashSet<int> MetaverseAttributeIds { get; init; } = [];
+}

--- a/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
@@ -1607,7 +1607,7 @@ public class ActivityRepository : IActivityRepository
         // do not count, so a system whose Full Synchronisation failed keeps reporting its changes as pending.
         return await Repository.Database.Activities
             .Where(a => a.ConnectedSystemId != null
-                        && connectedSystemIds.Contains(a.ConnectedSystemId.Value)
+                        && connectedSystemIds.Contains(a.ConnectedSystemId!.Value)
                         && a.TargetType == ActivityTargetType.ConnectedSystemRunProfile
                         && a.TargetOperationType == ActivityTargetOperationType.Execute
                         && a.ConnectedSystemRunType == ConnectedSystemRunType.FullSynchronisation

--- a/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
@@ -1592,6 +1592,49 @@ public class ActivityRepository : IActivityRepository
     }
     #endregion
 
+    #region configuration drift
+    public async Task<Dictionary<int, DateTime>> GetLastFullSynchronisationStartsAsync(IList<int> connectedSystemIds)
+    {
+        if (connectedSystemIds.Count == 0)
+            return new Dictionary<int, DateTime>();
+
+        // TargetOperationType must be Execute: Run Profile CRUD activities carry ConnectedSystemRunType too (so the
+        // run type survives the profile's deletion), and without this filter deleting a Full Synchronisation Run
+        // Profile would be mistaken for having run one.
+        //
+        // CompleteWithWarning counts: a warning is a non-fatal operational note (e.g. a delta falling back to a full
+        // import), not a reason to distrust that the run applied the configuration. Errors, failures and cancellations
+        // do not count, so a system whose Full Synchronisation failed keeps reporting its changes as pending.
+        return await Repository.Database.Activities
+            .Where(a => a.ConnectedSystemId != null
+                        && connectedSystemIds.Contains(a.ConnectedSystemId.Value)
+                        && a.TargetType == ActivityTargetType.ConnectedSystemRunProfile
+                        && a.TargetOperationType == ActivityTargetOperationType.Execute
+                        && a.ConnectedSystemRunType == ConnectedSystemRunType.FullSynchronisation
+                        && (a.Status == ActivityStatus.Complete || a.Status == ActivityStatus.CompleteWithWarning))
+            .GroupBy(a => a.ConnectedSystemId!.Value)
+            .Select(g => new { ConnectedSystemId = g.Key, LastStart = g.Max(a => a.Executed) })
+            .ToDictionaryAsync(x => x.ConnectedSystemId, x => x.LastStart);
+    }
+
+    public async Task<List<ConfigurationChangeImpactData>> GetConfigurationChangeImpactsSinceAsync(DateTime since, ConfigurationChangeClass minimumClass)
+    {
+        return await Repository.Database.Activities
+            .Where(a => a.Created >= since && a.ConfigurationChangeClass >= minimumClass)
+            .Select(a => new ConfigurationChangeImpactData
+            {
+                When = a.Created,
+                Class = a.ConfigurationChangeClass,
+                ConnectedSystemId = a.ConnectedSystemId,
+                SyncRuleId = a.SyncRuleId,
+                MetaverseObjectTypeId = a.MetaverseObjectTypeId,
+                MetaverseAttributeId = a.MetaverseAttributeId,
+                ServiceSettingKey = a.ServiceSettingKey
+            })
+            .ToListAsync();
+    }
+    #endregion
+
     // Bulk RPEI operations (BulkInsertRpeisAsync, BulkUpdateRpeiOutcomesAsync,
     // PersistRpeiCsoChangesAsync, DetachRpeisFromChangeTracker, UpdateActivityProgressOutOfBandAsync)
     // have been moved to PostgresData.SyncRepository.RpeiOperations.cs — they are Worker-only

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -5551,5 +5551,58 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
             .ToListAsync();
     }
 
+    public async Task<List<ConnectedSystemConfigurationScope>> GetConfigurationScopesAsync(IList<int> connectedSystemIds)
+    {
+        if (connectedSystemIds.Count == 0)
+            return [];
+
+        // Projected in one pass over the rules rather than four separate queries, then grouped in memory. The result
+        // set is bounded by configuration size (rules and their mappings), not by object counts, so it stays small.
+        var references = await Repository.Database.SyncRules
+            .Where(sr => connectedSystemIds.Contains(sr.ConnectedSystemId))
+            .Select(sr => new
+            {
+                sr.ConnectedSystemId,
+                SyncRuleId = sr.Id,
+                sr.MetaverseObjectTypeId,
+                FlowTargetAttributeIds = sr.AttributeFlowRules
+                    .Where(m => m.TargetMetaverseAttributeId != null)
+                    .Select(m => m.TargetMetaverseAttributeId!.Value),
+                FlowSourceAttributeIds = sr.AttributeFlowRules
+                    .SelectMany(m => m.Sources)
+                    .Where(s => s.MetaverseAttributeId != null)
+                    .Select(s => s.MetaverseAttributeId!.Value),
+                ScopingAttributeIds = sr.ObjectScopingCriteriaGroups
+                    .SelectMany(g => g.Criteria)
+                    .Where(c => c.MetaverseAttributeId != null)
+                    .Select(c => c.MetaverseAttributeId!.Value),
+                MatchingAttributeIds = sr.ObjectMatchingRules
+                    .Where(o => o.TargetMetaverseAttributeId != null)
+                    .Select(o => o.TargetMetaverseAttributeId!.Value)
+            })
+            .ToListAsync();
+
+        var bySystem = references.GroupBy(r => r.ConnectedSystemId)
+            .ToDictionary(g => g.Key, g => new ConnectedSystemConfigurationScope
+            {
+                ConnectedSystemId = g.Key,
+                SyncRuleIds = g.Select(r => r.SyncRuleId).ToHashSet(),
+                MetaverseObjectTypeIds = g.Select(r => r.MetaverseObjectTypeId).ToHashSet(),
+                MetaverseAttributeIds = g.SelectMany(r => r.FlowTargetAttributeIds
+                        .Concat(r.FlowSourceAttributeIds)
+                        .Concat(r.ScopingAttributeIds)
+                        .Concat(r.MatchingAttributeIds))
+                    .ToHashSet()
+            });
+
+        // Every requested system gets an entry, so a system with no Synchronisation Rules reports an empty scope
+        // rather than being silently absent (which a caller could mistake for "not evaluated").
+        return connectedSystemIds
+            .Select(id => bySystem.TryGetValue(id, out var scope)
+                ? scope
+                : new ConnectedSystemConfigurationScope { ConnectedSystemId = id })
+            .ToList();
+    }
+
     #endregion
 }

--- a/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystem.ps1
+++ b/src/JIM.PowerShell/Public/ConnectedSystems/Get-JIMConnectedSystem.ps1
@@ -29,6 +29,12 @@ function Get-JIMConnectedSystem {
     .OUTPUTS
         PSCustomObject representing Connected System(s), object types, or deletion preview.
 
+        The -Id form includes a ConfigurationDrift object describing whether the configuration has changed in a way
+        that needs a Full Synchronisation to take effect: HasPendingChanges, IsDeterminable, NeverFullySynchronised,
+        TrackingDisabled, LastFullSynchronisation, MostRecentChange, ChangeCount and HighestChangeClass. Note that
+        HasPendingChanges is also false when JIM cannot tell (never synchronised, or change tracking switched off),
+        so test IsDeterminable before treating false as "up to date".
+
     .EXAMPLE
         Get-JIMConnectedSystem
 
@@ -48,6 +54,11 @@ function Get-JIMConnectedSystem {
         Get-JIMConnectedSystem -Id 1 -ObjectTypes
 
         Gets the object types defined in the Connected System's schema.
+
+    .EXAMPLE
+        (Get-JIMConnectedSystem -Id 1).ConfigurationDrift
+
+        Gets whether the Connected System's configuration has changed since its last Full Synchronisation.
 
     .EXAMPLE
         Get-JIMConnectedSystem -Id 1 -DeletionPreview

--- a/src/JIM.PowerShell/Tests/Get-JIMConnectedSystem.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/Get-JIMConnectedSystem.Tests.ps1
@@ -112,6 +112,17 @@ Describe 'Get-JIMConnectedSystem' {
         It 'Should have related links' {
             $help.RelatedLinks | Should -Not -BeNullOrEmpty
         }
+
+        It 'Should document the ConfigurationDrift output shape' {
+            # The -Id form carries drift status; callers script against these property names.
+            ($help.returnValues | Out-String) | Should -Match 'ConfigurationDrift'
+        }
+
+        It 'Should warn that HasPendingChanges is false when drift cannot be determined' {
+            # A caller gating a Full Synchronisation on this flag would otherwise silently skip systems that have
+            # never been synchronised, or where change tracking is off.
+            ($help.returnValues | Out-String) | Should -Match 'IsDeterminable'
+        }
     }
 }
 

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -96,8 +96,9 @@ public class SynchronisationController(
         // matching how the Blazor UI does it.
         var pendingExportCount = await _application.ConnectedSystems.GetPendingExportsCountAsync(connectedSystemId);
         var objectCount = await _application.ConnectedSystems.GetConnectedSystemObjectCountAsync(connectedSystemId);
+        var configurationDrift = await _application.ConfigurationDrift.GetConnectedSystemDriftAsync(connectedSystemId);
 
-        return Ok(ConnectedSystemDetailDto.FromEntity(system, pendingExportCount, objectCount));
+        return Ok(ConnectedSystemDetailDto.FromEntity(system, pendingExportCount, objectCount, configurationDrift));
     }
 
     /// <summary>

--- a/src/JIM.Web/Models/Api/ConfigurationDriftDto.cs
+++ b/src/JIM.Web/Models/Api/ConfigurationDriftDto.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
+
+namespace JIM.Web.Models.Api;
+
+/// <summary>
+/// API representation of whether a Connected System's configuration has changed in a way that needs a Full
+/// Synchronisation to take effect. Only Sync-affecting and Destructive changes are counted, so a rename never
+/// registers here.
+/// </summary>
+public class ConfigurationDriftDto
+{
+    /// <summary>
+    /// True when Sync-affecting or Destructive configuration changes have been recorded since the last completed Full
+    /// Synchronisation. Always false when <see cref="IsDeterminable"/> is false, so never read this on its own as
+    /// "the configuration is settled".
+    /// </summary>
+    public bool HasPendingChanges { get; set; }
+
+    /// <summary>
+    /// True when the drift question has a meaningful answer: change tracking is on, and there is a completed Full
+    /// Synchronisation to compare against.
+    /// </summary>
+    public bool IsDeterminable { get; set; }
+
+    /// <summary>
+    /// True when this Connected System has never completed a Full Synchronisation, so no configuration has ever been
+    /// applied in full and there is no reference point to compare against.
+    /// </summary>
+    public bool NeverFullySynchronised { get; set; }
+
+    /// <summary>
+    /// True when configuration change tracking is switched off, so JIM holds no record of what changed and drift
+    /// cannot be determined.
+    /// </summary>
+    public bool TrackingDisabled { get; set; }
+
+    /// <summary>
+    /// When the last completed Full Synchronisation started, or null if there has never been one. This is the run's
+    /// start rather than its completion, so a change made while a long run was in flight still counts as pending.
+    /// </summary>
+    public DateTime? LastFullSynchronisation { get; set; }
+
+    /// <summary>
+    /// When the most recent qualifying change was recorded, or null if there are none.
+    /// </summary>
+    public DateTime? MostRecentChange { get; set; }
+
+    /// <summary>
+    /// How many qualifying changes have been recorded since the last Full Synchronisation.
+    /// </summary>
+    public int ChangeCount { get; set; }
+
+    /// <summary>
+    /// The highest class among those changes, so a caller can tell a change that alters synchronisation outcomes from
+    /// one that can cascade deletions the moment it is applied.
+    /// </summary>
+    public ConfigurationChangeClass HighestChangeClass { get; set; }
+
+    /// <summary>
+    /// Creates a DTO from the application-layer status.
+    /// </summary>
+    public static ConfigurationDriftDto FromStatus(ConfigurationDriftStatus status)
+    {
+        return new ConfigurationDriftDto
+        {
+            HasPendingChanges = status.HasPendingChanges,
+            IsDeterminable = status.IsDeterminable,
+            NeverFullySynchronised = status.NeverFullySynchronised,
+            TrackingDisabled = status.TrackingDisabled,
+            LastFullSynchronisation = status.LastFullSynchronisation,
+            MostRecentChange = status.MostRecentChange,
+            ChangeCount = status.ChangeCount,
+            HighestChangeClass = status.HighestChangeClass
+        };
+    }
+}

--- a/src/JIM.Web/Models/Api/ConnectedSystemDto.cs
+++ b/src/JIM.Web/Models/Api/ConnectedSystemDto.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using JIM.Models.Activities.DTOs;
 using JIM.Models.Staging;
 using JIM.Models.Staging.DTOs;
 
@@ -32,6 +33,12 @@ public class ConnectedSystemDetailDto
     public UnresolvedReferenceHandling UnresolvedReferenceHandling { get; set; }
 
     /// <summary>
+    /// Whether the configuration has changed in a way that needs a Full Synchronisation to take effect. Null on the
+    /// create and update responses, which describe the write that just happened rather than the system's readiness.
+    /// </summary>
+    public ConfigurationDriftDto? ConfigurationDrift { get; set; }
+
+    /// <summary>
     /// Creates a detailed DTO from a ConnectedSystem entity.
     /// </summary>
     /// <param name="entity">The Connected System entity.</param>
@@ -43,10 +50,15 @@ public class ConnectedSystemDetailDto
     /// Pre-computed Connected System Object count. Required because GetConnectedSystemAsync
     /// does not load the Objects navigation property (it can be very large).
     /// </param>
-    public static ConnectedSystemDetailDto FromEntity(ConnectedSystem entity, int pendingExportCount = 0, int objectCount = 0)
+    /// <param name="configurationDrift">
+    /// Pre-computed configuration drift status, or null to omit it (create and update responses do not carry it).
+    /// </param>
+    public static ConnectedSystemDetailDto FromEntity(ConnectedSystem entity, int pendingExportCount = 0, int objectCount = 0,
+        ConfigurationDriftStatus? configurationDrift = null)
     {
         return new ConnectedSystemDetailDto
         {
+            ConfigurationDrift = configurationDrift == null ? null : ConfigurationDriftDto.FromStatus(configurationDrift),
             Id = entity.Id,
             Name = entity.Name,
             Description = entity.Description,

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemDetail.razor
@@ -27,29 +27,25 @@
 @* ─── Configuration drift notice ─── *@
 @if (_drift is { HasPendingChanges: true })
 {
+    @* Composed in C# rather than assembled from markup fragments, so the punctuation sits tight against the
+       timestamp and the singular and plural readings are both correct. *@
     var driftClass = _drift.HighestChangeClass;
     var driftCount = _drift.ChangeCount;
+    var lastSync = _drift.LastFullSynchronisation;
+    var driftWhen = lastSync.HasValue ? $" ({lastSync.Value.ToLocalTime().ToFriendlyDate()})" : string.Empty;
+    var driftLead = driftCount == 1
+        ? $"1 configuration change has been made since the last Full Synchronisation{driftWhen}."
+        : $"{driftCount:N0} configuration changes have been made since the last Full Synchronisation{driftWhen}.";
+    var driftGuidance = driftClass == ConfigurationChangeClass.Destructive
+        ? driftCount == 1
+            ? "It is destructive and can cascade deletions or mass deprovisioning the moment it is applied. Review it before running a Full Synchronisation."
+            : "At least one of them is destructive and can cascade deletions or mass deprovisioning the moment it is applied. Review them before running a Full Synchronisation."
+        : driftCount == 1
+            ? "Run a Full Synchronisation for it to take effect."
+            : "Run a Full Synchronisation for them to take effect.";
     <MudAlert Severity="@(driftClass == ConfigurationChangeClass.Destructive ? Severity.Error : Severity.Warning)"
               Variant="Variant.Outlined" Class="mt-2">
-        @(driftCount == 1 ? "1 configuration change has" : $"{driftCount:N0} configuration changes have")
-        been made since the last Full Synchronisation
-        @if (_drift.LastFullSynchronisation.HasValue)
-        {
-            var lastSync = _drift.LastFullSynchronisation.Value;
-            <text>(@lastSync.ToLocalTime().ToFriendlyDate())</text>
-        }
-        .
-        @if (driftClass == ConfigurationChangeClass.Destructive)
-        {
-            <text>
-                At least one of them is destructive and can cascade deletions or mass deprovisioning the moment it is
-                applied. Review the change history before running a Full Synchronisation.
-            </text>
-        }
-        else
-        {
-            <text>Run a Full Synchronisation for them to take effect.</text>
-        }
+        @driftLead @driftGuidance
     </MudAlert>
 }
 else if (_drift is { NeverFullySynchronised: true })
@@ -57,6 +53,13 @@ else if (_drift is { NeverFullySynchronised: true })
     <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-2">
         This Connected System has never completed a Full Synchronisation, so its configuration has never been applied
         in full.
+    </MudAlert>
+}
+else if (_drift is { TrackingDisabled: true })
+{
+    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-2">
+        Configuration change tracking is switched off, so JIM cannot tell whether this Connected System has
+        configuration changes waiting for a Full Synchronisation.
     </MudAlert>
 }
 

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemDetail.razor
@@ -1,6 +1,7 @@
 ﻿@page "/admin/connected-systems/{Id:int}"
 @attribute [Authorize(Roles = "Administrator")]
 @using JIM.Models.Activities
+@using JIM.Models.Activities.DTOs
 @using JIM.Models.Core
 @using JIM.Models.Logic
 @using JIM.Models.Staging
@@ -22,6 +23,42 @@
         <AuditInfo Entity="@_connectedSystem" />
     }
 </div>
+
+@* ─── Configuration drift notice ─── *@
+@if (_drift is { HasPendingChanges: true })
+{
+    var driftClass = _drift.HighestChangeClass;
+    var driftCount = _drift.ChangeCount;
+    <MudAlert Severity="@(driftClass == ConfigurationChangeClass.Destructive ? Severity.Error : Severity.Warning)"
+              Variant="Variant.Outlined" Class="mt-2">
+        @(driftCount == 1 ? "1 configuration change has" : $"{driftCount:N0} configuration changes have")
+        been made since the last Full Synchronisation
+        @if (_drift.LastFullSynchronisation.HasValue)
+        {
+            var lastSync = _drift.LastFullSynchronisation.Value;
+            <text>(@lastSync.ToLocalTime().ToFriendlyDate())</text>
+        }
+        .
+        @if (driftClass == ConfigurationChangeClass.Destructive)
+        {
+            <text>
+                At least one of them is destructive and can cascade deletions or mass deprovisioning the moment it is
+                applied. Review the change history before running a Full Synchronisation.
+            </text>
+        }
+        else
+        {
+            <text>Run a Full Synchronisation for them to take effect.</text>
+        }
+    </MudAlert>
+}
+else if (_drift is { NeverFullySynchronised: true })
+{
+    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-2">
+        This Connected System has never completed a Full Synchronisation, so its configuration has never been applied
+        in full.
+    </MudAlert>
+}
 
 @if (_connectedSystem != null)
 {
@@ -84,6 +121,7 @@
     private string? _partitionAndHierarchyText;
     private int _pendingExportCount;
     private int _changeCount;
+    private ConfigurationDriftStatus? _drift;
     private List<BreadcrumbItem> _breadcrumbs = null!;
 
     private IList<MetaverseAttribute>? _metaverseAttributes;
@@ -131,6 +169,7 @@
         }
 
         _pendingExportCount = await jim.ConnectedSystems.GetPendingExportsCountAsync(Id);
+        _drift = await jim.ConfigurationDrift.GetConnectedSystemDriftAsync(Id);
         _changeCount = (await jim.ChangeHistory.GetConfigurationChangeHistoryAsync(ActivityTargetType.ConnectedSystem, Id, 1, 1)).TotalResults;
         _metaverseAttributes ??= await jim.Metaverse.GetMetaverseAttributesAsync();
     }

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
@@ -1,9 +1,11 @@
 ﻿@page "/admin/connected-systems"
 @attribute [Authorize(Roles = "Administrator")]
+@using JIM.Models.Activities.DTOs
 @using JIM.Models.Staging.DTOs
 @using JIM.Utilities;
 @using JIM.Web.Services
 @using System;
+@using System.Linq;
 @inject IJimApplicationFactory JimFactory
 @inject IUserPreferenceService PreferenceService
 
@@ -82,6 +84,7 @@
                         </MudChip>
                     </MudTooltip>
                 }
+                <ConfigurationDriftIndicator Status="@GetDrift(context.Id)" ConnectedSystemName="@context.Name" />
             </MudStack>
         </MudTd>
         <MudTd DataLabel="Connector">@context.ConnectorName</MudTd>
@@ -105,6 +108,7 @@
 
 @code {
     private IList<ConnectedSystemHeader>? _connectedSystemHeaders;
+    private Dictionary<int, ConfigurationDriftStatus>? _drift;
     private string _searchString = "";
     private bool _dense;
 
@@ -119,7 +123,15 @@
     {
         using var jim = JimFactory.Create();
         _connectedSystemHeaders = await jim.ConnectedSystems.GetConnectedSystemHeadersAsync();
+
+        // One batched call for the whole page; the drift service issues a fixed number of queries regardless of how
+        // many systems are listed, so this does not become an N+1.
+        if (_connectedSystemHeaders.Count > 0)
+            _drift = await jim.ConfigurationDrift.GetConnectedSystemDriftAsync(_connectedSystemHeaders.Select(cs => cs.Id).ToList());
     }
+
+    private ConfigurationDriftStatus? GetDrift(int connectedSystemId) =>
+        _drift != null && _drift.TryGetValue(connectedSystemId, out var status) ? status : null;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
+++ b/src/JIM.Web/Pages/Admin/ConnectedSystemList.razor
@@ -32,6 +32,15 @@
     <MudButton StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled" Href="/admin/connected-systems/new" Color="Color.Primary" DropShadow="false">Create Connected System</MudButton>
 </div>
 
+@* Tracking off is a global condition, so it is stated once here rather than repeated on every row. *@
+@if (_drift != null && _drift.Values.Any(d => d.TrackingDisabled))
+{
+    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-5">
+        Configuration change tracking is switched off, so JIM cannot tell which Connected Systems have configuration
+        changes waiting for a Full Synchronisation.
+    </MudAlert>
+}
+
 <MudTable Items="@_connectedSystemHeaders" Hover="true" Dense="@_dense" Breakpoint="Breakpoint.Sm" Class="@(_dense ? "mt-5 mb-5 dense-body-only" : "mt-5 mb-5")" SortLabel="Sort By" Filter="new Func<ConnectedSystemHeader,bool>(FilterFunc1)" Outlined="true" Elevation="0">
     <ToolBarContent>
         <TableDensityToggle @bind-Dense="_dense" />

--- a/src/JIM.Web/Shared/ConfigurationDriftIndicator.razor
+++ b/src/JIM.Web/Shared/ConfigurationDriftIndicator.razor
@@ -4,8 +4,10 @@
 @* Copyright (c) Tetron Limited. All rights reserved. *@
 @* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
 
-@* Renders nothing at all when the configuration is settled: silence is the reward for a system that needs no action. *@
-@if (Status != null && (Status.HasPendingChanges || !Status.IsDeterminable))
+@* Renders nothing at all when the configuration is settled: silence is the reward for a system that needs no action.
+   Tracking being switched off is deliberately not rendered here either. It is a single global condition, so repeating
+   it on every row of a list states the same fact many times over; the hosting page says it once instead. *@
+@if (Status != null && (Status.HasPendingChanges || Status.NeverFullySynchronised))
 {
     <MudTooltip Text="@TooltipText" Arrow="true" Placement="Placement.Top">
         <MudChip T="string" Color="@ChipColour" Variant="Variant.Text" Icon="@ChipIcon" Class="jim-stat-chip">
@@ -30,16 +32,14 @@
 
     private Color ChipColour => Status switch
     {
-        null => Color.Default,
-        { TrackingDisabled: true } or { NeverFullySynchronised: true } => Color.Default,
+        null or { NeverFullySynchronised: true } => Color.Default,
         { HighestChangeClass: ConfigurationChangeClass.Destructive } => Color.Error,
         _ => Color.Warning
     };
 
     private string ChipIcon => Status switch
     {
-        null => Icons.Material.Filled.HelpOutline,
-        { TrackingDisabled: true } or { NeverFullySynchronised: true } => Icons.Material.Filled.HelpOutline,
+        null or { NeverFullySynchronised: true } => Icons.Material.Filled.HelpOutline,
         { HighestChangeClass: ConfigurationChangeClass.Destructive } => Icons.Material.Filled.Warning,
         _ => Icons.Material.Filled.Sync
     };
@@ -47,7 +47,6 @@
     private string ChipLabel => Status switch
     {
         null => string.Empty,
-        { TrackingDisabled: true } => "Unknown",
         { NeverFullySynchronised: true } => "Never synchronised",
         _ => Status.ChangeCount.ToString("N0")
     };
@@ -60,10 +59,6 @@
                 return string.Empty;
 
             var subject = string.IsNullOrWhiteSpace(ConnectedSystemName) ? "This Connected System" : ConnectedSystemName;
-
-            if (Status.TrackingDisabled)
-                return "Configuration change tracking is switched off, so JIM cannot tell whether the configuration " +
-                       "has changed since the last Full Synchronisation.";
 
             if (Status.NeverFullySynchronised)
                 return $"{subject} has never completed a Full Synchronisation, so its configuration has never been " +
@@ -79,9 +74,11 @@
                 ? $" since the last Full Synchronisation ({lastFullSync.Value.ToLocalTime().ToFriendlyDate()})"
                 : " since the last Full Synchronisation";
 
+            var apply = Status.ChangeCount == 1 ? "apply it" : "apply them";
+
             return Status.HighestChangeClass == ConfigurationChangeClass.Destructive
                 ? $"{changes}{since}, including a destructive change. Review before running a Full Synchronisation."
-                : $"{changes}{since}. Run a Full Synchronisation to apply them.";
+                : $"{changes}{since}. Run a Full Synchronisation to {apply}.";
         }
     }
 }

--- a/src/JIM.Web/Shared/ConfigurationDriftIndicator.razor
+++ b/src/JIM.Web/Shared/ConfigurationDriftIndicator.razor
@@ -1,0 +1,87 @@
+@using JIM.Models.Activities
+@using JIM.Models.Activities.DTOs
+
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+@* Renders nothing at all when the configuration is settled: silence is the reward for a system that needs no action. *@
+@if (Status != null && (Status.HasPendingChanges || !Status.IsDeterminable))
+{
+    <MudTooltip Text="@TooltipText" Arrow="true" Placement="Placement.Top">
+        <MudChip T="string" Color="@ChipColour" Variant="Variant.Text" Icon="@ChipIcon" Class="jim-stat-chip">
+            @ChipLabel
+        </MudChip>
+    </MudTooltip>
+}
+
+@code {
+    /// <summary>
+    /// The drift status to render. Null (not yet loaded) renders nothing, so a list does not flash an indicator
+    /// before the answer is known.
+    /// </summary>
+    [Parameter]
+    public ConfigurationDriftStatus? Status { get; set; }
+
+    /// <summary>
+    /// The name of the Connected System, woven into the tooltip where it reads better than "this Connected System".
+    /// </summary>
+    [Parameter]
+    public string? ConnectedSystemName { get; set; }
+
+    private Color ChipColour => Status switch
+    {
+        null => Color.Default,
+        { TrackingDisabled: true } or { NeverFullySynchronised: true } => Color.Default,
+        { HighestChangeClass: ConfigurationChangeClass.Destructive } => Color.Error,
+        _ => Color.Warning
+    };
+
+    private string ChipIcon => Status switch
+    {
+        null => Icons.Material.Filled.HelpOutline,
+        { TrackingDisabled: true } or { NeverFullySynchronised: true } => Icons.Material.Filled.HelpOutline,
+        { HighestChangeClass: ConfigurationChangeClass.Destructive } => Icons.Material.Filled.Warning,
+        _ => Icons.Material.Filled.Sync
+    };
+
+    private string ChipLabel => Status switch
+    {
+        null => string.Empty,
+        { TrackingDisabled: true } => "Unknown",
+        { NeverFullySynchronised: true } => "Never synchronised",
+        _ => Status.ChangeCount.ToString("N0")
+    };
+
+    private string TooltipText
+    {
+        get
+        {
+            if (Status == null)
+                return string.Empty;
+
+            var subject = string.IsNullOrWhiteSpace(ConnectedSystemName) ? "This Connected System" : ConnectedSystemName;
+
+            if (Status.TrackingDisabled)
+                return "Configuration change tracking is switched off, so JIM cannot tell whether the configuration " +
+                       "has changed since the last Full Synchronisation.";
+
+            if (Status.NeverFullySynchronised)
+                return $"{subject} has never completed a Full Synchronisation, so its configuration has never been " +
+                       "applied in full.";
+
+            var changes = Status.ChangeCount == 1 ? "1 configuration change" : $"{Status.ChangeCount:N0} configuration changes";
+
+            // The value is hoisted out of the conditional rather than dereferenced inside it: nullable flow analysis
+            // is not something CodeQL follows reliably through a guard here (see the Razor and lambda rules in
+            // src/CLAUDE.md), and the local costs nothing.
+            var lastFullSync = Status.LastFullSynchronisation;
+            var since = lastFullSync.HasValue
+                ? $" since the last Full Synchronisation ({lastFullSync.Value.ToLocalTime().ToFriendlyDate()})"
+                : " since the last Full Synchronisation";
+
+            return Status.HighestChangeClass == ConfigurationChangeClass.Destructive
+                ? $"{changes}{since}, including a destructive change. Review before running a Full Synchronisation."
+                : $"{changes}{since}. Run a Full Synchronisation to apply them.";
+        }
+    }
+}

--- a/test/JIM.Web.Api.Tests/ConnectedSystemConfigurationDriftDtoTests.cs
+++ b/test/JIM.Web.Api.Tests/ConnectedSystemConfigurationDriftDtoTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+using JIM.Web.Models.Api;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// Tests for the configuration drift status carried on the Connected System detail response: whether the
+/// configuration has changed in a way that needs a Full Synchronisation to take effect.
+///
+/// The behaviour that matters to an API consumer is that a false <c>HasPendingChanges</c> is not by itself a claim
+/// that the configuration is settled: it is also false when JIM cannot tell. Those cases must reach the wire
+/// distinguishable, or a caller gating a run on the flag will silently skip the systems that most need attention.
+/// </summary>
+[TestFixture]
+public class ConnectedSystemConfigurationDriftDtoTests
+{
+    [Test]
+    public void FromEntity_NoDriftSupplied_OmitsConfigurationDrift()
+    {
+        // Create and update responses describe the write that just happened, not the system's readiness.
+        var dto = ConnectedSystemDetailDto.FromEntity(CreateConnectedSystemEntity());
+
+        Assert.That(dto.ConfigurationDrift, Is.Null);
+    }
+
+    [Test]
+    public void FromEntity_PendingSyncAffectingChanges_MapsCountAndClass()
+    {
+        var lastSync = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc);
+        var mostRecent = lastSync.AddHours(4);
+        var status = new ConfigurationDriftStatus
+        {
+            ConnectedSystemId = 1,
+            HasPendingChanges = true,
+            LastFullSynchronisation = lastSync,
+            MostRecentChange = mostRecent,
+            ChangeCount = 3,
+            HighestChangeClass = ConfigurationChangeClass.SyncAffecting
+        };
+
+        var dto = ConnectedSystemDetailDto.FromEntity(CreateConnectedSystemEntity(), configurationDrift: status);
+
+        Assert.That(dto.ConfigurationDrift, Is.Not.Null);
+        var drift = dto.ConfigurationDrift!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(drift.HasPendingChanges, Is.True);
+            Assert.That(drift.IsDeterminable, Is.True);
+            Assert.That(drift.ChangeCount, Is.EqualTo(3));
+            Assert.That(drift.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.SyncAffecting));
+            Assert.That(drift.LastFullSynchronisation, Is.EqualTo(lastSync));
+            Assert.That(drift.MostRecentChange, Is.EqualTo(mostRecent));
+        });
+    }
+
+    [Test]
+    public void FromEntity_DestructiveChangePending_SurfacesDestructiveAsHighestClass()
+    {
+        // The class is what tells a caller apart a scoping tweak from a change that can cascade deletions.
+        var status = new ConfigurationDriftStatus
+        {
+            ConnectedSystemId = 1,
+            HasPendingChanges = true,
+            LastFullSynchronisation = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc),
+            ChangeCount = 7,
+            HighestChangeClass = ConfigurationChangeClass.Destructive
+        };
+
+        var dto = ConnectedSystemDetailDto.FromEntity(CreateConnectedSystemEntity(), configurationDrift: status);
+
+        Assert.That(dto.ConfigurationDrift!.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.Destructive));
+    }
+
+    [Test]
+    public void FromEntity_NeverFullySynchronised_IsNotDeterminableDespiteNoPendingChanges()
+    {
+        var status = new ConfigurationDriftStatus { ConnectedSystemId = 1, NeverFullySynchronised = true };
+
+        var dto = ConnectedSystemDetailDto.FromEntity(CreateConnectedSystemEntity(), configurationDrift: status);
+
+        var drift = dto.ConfigurationDrift!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(drift.NeverFullySynchronised, Is.True);
+            Assert.That(drift.HasPendingChanges, Is.False);
+            Assert.That(drift.IsDeterminable, Is.False, "a caller must be able to tell this apart from a settled configuration");
+            Assert.That(drift.LastFullSynchronisation, Is.Null);
+        });
+    }
+
+    [Test]
+    public void FromEntity_TrackingDisabled_IsNotDeterminableDespiteNoPendingChanges()
+    {
+        var status = new ConfigurationDriftStatus { ConnectedSystemId = 1, TrackingDisabled = true };
+
+        var dto = ConnectedSystemDetailDto.FromEntity(CreateConnectedSystemEntity(), configurationDrift: status);
+
+        var drift = dto.ConfigurationDrift!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(drift.TrackingDisabled, Is.True);
+            Assert.That(drift.HasPendingChanges, Is.False);
+            Assert.That(drift.IsDeterminable, Is.False, "a caller must be able to tell this apart from a settled configuration");
+        });
+    }
+
+    [Test]
+    public void FromEntity_SettledConfiguration_IsDeterminableWithNoPendingChanges()
+    {
+        var status = new ConfigurationDriftStatus
+        {
+            ConnectedSystemId = 1,
+            LastFullSynchronisation = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var dto = ConnectedSystemDetailDto.FromEntity(CreateConnectedSystemEntity(), configurationDrift: status);
+
+        var drift = dto.ConfigurationDrift!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(drift.HasPendingChanges, Is.False);
+            Assert.That(drift.IsDeterminable, Is.True);
+            Assert.That(drift.ChangeCount, Is.EqualTo(0));
+            Assert.That(drift.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.NotClassified));
+        });
+    }
+
+    private static ConnectedSystem CreateConnectedSystemEntity()
+    {
+        return new ConnectedSystem
+        {
+            Id = 1,
+            Name = "Test System",
+            Description = "Test Description",
+            ConnectorDefinition = new ConnectorDefinition
+            {
+                Id = 1,
+                Name = "Test Connector"
+            },
+            ObjectTypes = new List<ConnectedSystemObjectType>(),
+            Objects = new List<ConnectedSystemObject>(),
+            PendingExports = new List<PendingExport>(),
+            SettingValues = new List<ConnectedSystemSettingValue>()
+        };
+    }
+}

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerGetConnectedSystemTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerGetConnectedSystemTests.cs
@@ -33,6 +33,8 @@ public class SynchronisationControllerGetConnectedSystemTests
     private Mock<IRepository> _mockRepository = null!;
     private Mock<IConnectedSystemRepository> _mockConnectedSystemRepo = null!;
     private Mock<IApiKeyRepository> _mockApiKeyRepo = null!;
+    private Mock<IServiceSettingsRepository> _mockServiceSettingsRepo = null!;
+    private Mock<IActivityRepository> _mockActivityRepo = null!;
     private Mock<ILogger<SynchronisationController>> _mockLogger = null!;
     private Mock<ICredentialProtectionService> _mockCredentialProtection = null!;
     private IExpressionEvaluator _expressionEvaluator = null!;
@@ -47,6 +49,15 @@ public class SynchronisationControllerGetConnectedSystemTests
         _mockApiKeyRepo = new Mock<IApiKeyRepository>();
         _mockRepository.Setup(r => r.ConnectedSystems).Returns(_mockConnectedSystemRepo.Object);
         _mockRepository.Setup(r => r.ApiKeys).Returns(_mockApiKeyRepo.Object);
+
+        // The endpoint annotates its response with configuration drift, which reads the change-tracking setting and
+        // the Connected System's Full Synchronisation history.
+        _mockServiceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _mockActivityRepo = new Mock<IActivityRepository>();
+        _mockRepository.Setup(r => r.ServiceSettings).Returns(_mockServiceSettingsRepo.Object);
+        _mockRepository.Setup(r => r.Activity).Returns(_mockActivityRepo.Object);
+        _mockActivityRepo.Setup(r => r.GetLastFullSynchronisationStartsAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime>());
         _mockLogger = new Mock<ILogger<SynchronisationController>>();
         _mockCredentialProtection = new Mock<ICredentialProtectionService>();
         _expressionEvaluator = new DynamicExpressoEvaluator();

--- a/test/JIM.Worker.Tests/Servers/ConfigurationChangeCaptureTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConfigurationChangeCaptureTests.cs
@@ -109,6 +109,22 @@ public class ConfigurationChangeCaptureTests
     }
 
     [Test]
+    public async Task DeleteSyncRuleAsync_RecordsOwningConnectedSystemIdAsync()
+    {
+        // The rule id is deliberately not recorded (the rule is about to cease to exist), so without the Connected
+        // System id the deletion would be attributable to nothing, and invisible to the "configuration changed since
+        // last Full Synchronisation" indicator: a false negative on one of the most consequential changes there is.
+        SetupTrackingSetting(enabled: true);
+        SetupHashKeySetting();
+        _csRepo.Setup(r => r.DeleteSyncRuleAsync(It.IsAny<SyncRule>())).Returns(Task.CompletedTask);
+
+        await _jim.ConnectedSystems.DeleteSyncRuleAsync(BuildExportRule(), NewApiKey());
+
+        Assert.That(_completedActivity, Is.Not.Null);
+        Assert.That(_completedActivity!.ConnectedSystemId, Is.EqualTo(3), "the surviving Connected System is the deletion's durable link");
+    }
+
+    [Test]
     public async Task GetNextConfigurationChangeVersionAsync_ReturnsExistingMaximumPlusOneAsync()
     {
         _activityRepo.Setup(r => r.GetMaxConfigurationChangeVersionAsync(ActivityTargetType.ConnectedSystem, 9)).ReturnsAsync(3);

--- a/test/JIM.Worker.Tests/Servers/ConfigurationDriftServiceTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConfigurationDriftServiceTests.cs
@@ -1,0 +1,360 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Activities.DTOs;
+using JIM.Models.Core;
+using JIM.Models.Staging.DTOs;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Tests for <see cref="JIM.Application.Services.ConfigurationDriftService"/>: whether a Connected System's
+/// configuration has changed in a way that needs a Full Synchronisation to take effect.
+///
+/// The behaviour that matters to an administrator is that the indicator is trustworthy in both directions. It must
+/// stay silent for changes that cannot alter synchronisation outcomes (or it becomes noise they learn to ignore), and
+/// it must never claim a settled configuration when JIM cannot actually tell.
+/// </summary>
+[TestFixture]
+public class ConfigurationDriftServiceTests
+{
+    private Mock<IRepository> _repo = null!;
+    private Mock<IActivityRepository> _activityRepo = null!;
+    private Mock<IConnectedSystemRepository> _connectedSystemRepo = null!;
+    private Mock<IServiceSettingsRepository> _serviceSettingsRepo = null!;
+    private JimApplication _jim = null!;
+
+    private const int SystemId = 7;
+    private const int OtherSystemId = 8;
+    private static readonly DateTime LastFullSync = new(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime AfterSync = LastFullSync.AddHours(3);
+    private static readonly DateTime BeforeSync = LastFullSync.AddHours(-3);
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+        _repo = new Mock<IRepository>();
+        _activityRepo = new Mock<IActivityRepository>();
+        _connectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _serviceSettingsRepo = new Mock<IServiceSettingsRepository>();
+        _repo.Setup(r => r.Activity).Returns(_activityRepo.Object);
+        _repo.Setup(r => r.ConnectedSystems).Returns(_connectedSystemRepo.Object);
+        _repo.Setup(r => r.ServiceSettings).Returns(_serviceSettingsRepo.Object);
+
+        // Change tracking on by default; the disabled case sets this explicitly.
+        SetChangeTrackingEnabled(true);
+
+        // Sensible defaults: the system was fully synchronised, has one rule, and nothing has changed since.
+        _activityRepo.Setup(r => r.GetLastFullSynchronisationStartsAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime> { [SystemId] = LastFullSync });
+        _activityRepo.Setup(r => r.GetConfigurationChangeImpactsSinceAsync(It.IsAny<DateTime>(), It.IsAny<ConfigurationChangeClass>()))
+            .ReturnsAsync([]);
+        _connectedSystemRepo.Setup(r => r.GetConfigurationScopesAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync([Scope(SystemId, syncRuleIds: [100], objectTypeIds: [20], attributeIds: [30])]);
+
+        _jim = new JimApplication(_repo.Object);
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_NoChangesSinceLastFullSynchronisation_ReportsNoPendingChangesAsync()
+    {
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.HasPendingChanges, Is.False);
+            Assert.That(result.IsDeterminable, Is.True);
+            Assert.That(result.ChangeCount, Is.EqualTo(0));
+            Assert.That(result.LastFullSynchronisation, Is.EqualTo(LastFullSync));
+            Assert.That(result.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.NotClassified));
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_SyncAffectingChangeToTheSystem_ReportsPendingChangesAsync()
+    {
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, connectedSystemId: SystemId));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.HasPendingChanges, Is.True);
+            Assert.That(result.ChangeCount, Is.EqualTo(1));
+            Assert.That(result.MostRecentChange, Is.EqualTo(AfterSync));
+            Assert.That(result.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.SyncAffecting));
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_ChangeRecordedBeforeTheLastFullSynchronisation_IsNotPendingAsync()
+    {
+        // The reference point is what makes the indicator meaningful: a change the last run already applied must not
+        // keep prompting for another.
+        SetImpacts(Impact(BeforeSync, ConfigurationChangeClass.Destructive, connectedSystemId: SystemId));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.False);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_DestructiveChange_ReportsHighestClassAsDestructiveAsync()
+    {
+        // The highest class drives how loudly the surface warns, so a destructive change alongside a sync-affecting
+        // one must not be softened into the lesser of the two.
+        SetImpacts(
+            Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, connectedSystemId: SystemId),
+            Impact(AfterSync.AddMinutes(10), ConfigurationChangeClass.Destructive, connectedSystemId: SystemId));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ChangeCount, Is.EqualTo(2));
+            Assert.That(result.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.Destructive));
+            Assert.That(result.MostRecentChange, Is.EqualTo(AfterSync.AddMinutes(10)));
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_ChangeToOneOfItsSynchronisationRules_ReportsPendingChangesAsync()
+    {
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, syncRuleId: 100));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.True);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_ChangeToAnotherSystemsSynchronisationRule_IsNotPendingAsync()
+    {
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.Destructive, syncRuleId: 999));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.False);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_MetaverseAttributeReferencedByItsRules_ReportsPendingChangesAsync()
+    {
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, metaverseAttributeId: 30));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.True);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_MetaverseAttributeItsRulesDoNotReference_IsNotPendingAsync()
+    {
+        // The point of precise attribution: editing an attribute no rule of this system touches must leave it alone.
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, metaverseAttributeId: 31));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.False);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_MetaverseObjectTypeTargetedByItsRules_ReportsPendingChangesAsync()
+    {
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.Destructive, metaverseObjectTypeId: 20));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.True);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_MetaverseObjectTypeItsRulesDoNotTarget_IsNotPendingAsync()
+    {
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.Destructive, metaverseObjectTypeId: 21));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.False);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_SyncAffectingServiceSetting_AffectsEverySystemAsync()
+    {
+        // Service Settings are global, so there is no scope to match against; every system must pick them up.
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.SyncAffecting,
+            serviceSettingKey: Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.True);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_DeletedSynchronisationRule_ReportsPendingChangesOnItsSystemAsync()
+    {
+        // A rule deletion records no SyncRuleId (the rule is gone), so the Connected System id is the only link back.
+        // Without it this change would be invisible: a false negative on one of the most consequential edits there is.
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.Destructive, connectedSystemId: SystemId));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.HasPendingChanges, Is.True);
+            Assert.That(result.HighestChangeClass, Is.EqualTo(ConfigurationChangeClass.Destructive));
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_NeverFullySynchronised_ReportsNeverRatherThanPendingAsync()
+    {
+        _activityRepo.Setup(r => r.GetLastFullSynchronisationStartsAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime>());
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.NeverFullySynchronised, Is.True);
+            Assert.That(result.HasPendingChanges, Is.False);
+            Assert.That(result.IsDeterminable, Is.False);
+            Assert.That(result.LastFullSynchronisation, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_ChangeTrackingDisabled_ReportsUndeterminableRatherThanCleanAsync()
+    {
+        SetChangeTrackingEnabled(false);
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.TrackingDisabled, Is.True);
+            Assert.That(result.HasPendingChanges, Is.False);
+            Assert.That(result.IsDeterminable, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_BatchOfSystems_EvaluatesEachAgainstItsOwnReferencePointAsync()
+    {
+        // The two systems were last fully synchronised at different times, and the change falls between them: pending
+        // for the one that synchronised earlier, already applied for the one that synchronised later.
+        var laterSync = AfterSync.AddHours(1);
+        _activityRepo.Setup(r => r.GetLastFullSynchronisationStartsAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime> { [SystemId] = LastFullSync, [OtherSystemId] = laterSync });
+        _connectedSystemRepo.Setup(r => r.GetConfigurationScopesAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync([Scope(SystemId), Scope(OtherSystemId)]);
+        SetImpacts(
+            Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, connectedSystemId: SystemId),
+            Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, connectedSystemId: OtherSystemId));
+
+        var results = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync([SystemId, OtherSystemId]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results[SystemId].HasPendingChanges, Is.True);
+            Assert.That(results[OtherSystemId].HasPendingChanges, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_BatchOfSystems_QueriesChangesOnceRegardlessOfSystemCountAsync()
+    {
+        // Guards the list surface against an N+1: the query count must not scale with the number of systems.
+        _activityRepo.Setup(r => r.GetLastFullSynchronisationStartsAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime> { [SystemId] = LastFullSync, [OtherSystemId] = LastFullSync });
+        _connectedSystemRepo.Setup(r => r.GetConfigurationScopesAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync([Scope(SystemId), Scope(OtherSystemId)]);
+
+        await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync([SystemId, OtherSystemId]);
+
+        _activityRepo.Verify(r => r.GetConfigurationChangeImpactsSinceAsync(It.IsAny<DateTime>(), It.IsAny<ConfigurationChangeClass>()), Times.Once);
+        _connectedSystemRepo.Verify(r => r.GetConfigurationScopesAsync(It.IsAny<IList<int>>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_OnlyRequestsSyncAffectingAndAboveAsync()
+    {
+        // Cosmetic changes are excluded at the query, so a rename can never raise the indicator.
+        await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        _activityRepo.Verify(r => r.GetConfigurationChangeImpactsSinceAsync(
+            It.IsAny<DateTime>(), ConfigurationChangeClass.SyncAffecting), Times.Once);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_SystemWithNoSynchronisationRules_StillReportsChangesToItselfAsync()
+    {
+        _connectedSystemRepo.Setup(r => r.GetConfigurationScopesAsync(It.IsAny<IList<int>>()))
+            .ReturnsAsync([Scope(SystemId)]);
+        SetImpacts(Impact(AfterSync, ConfigurationChangeClass.SyncAffecting, connectedSystemId: SystemId));
+
+        var result = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync(SystemId);
+
+        Assert.That(result.HasPendingChanges, Is.True);
+    }
+
+    [Test]
+    public async Task GetConnectedSystemDriftAsync_NoSystemIds_ReturnsEmptyWithoutQueryingAsync()
+    {
+        var results = await _jim.ConfigurationDrift.GetConnectedSystemDriftAsync([]);
+
+        Assert.That(results, Is.Empty);
+        _activityRepo.Verify(r => r.GetLastFullSynchronisationStartsAsync(It.IsAny<IList<int>>()), Times.Never);
+    }
+
+    #region helpers
+    private void SetChangeTrackingEnabled(bool enabled)
+    {
+        _serviceSettingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled,
+                ValueType = ServiceSettingValueType.Boolean,
+                Value = enabled ? "true" : "false"
+            });
+    }
+
+    private void SetImpacts(params ConfigurationChangeImpactData[] impacts)
+    {
+        _activityRepo.Setup(r => r.GetConfigurationChangeImpactsSinceAsync(It.IsAny<DateTime>(), It.IsAny<ConfigurationChangeClass>()))
+            .ReturnsAsync(impacts.ToList());
+    }
+
+    private static ConfigurationChangeImpactData Impact(DateTime when, ConfigurationChangeClass changeClass,
+        int? connectedSystemId = null, int? syncRuleId = null, int? metaverseObjectTypeId = null,
+        int? metaverseAttributeId = null, string? serviceSettingKey = null) => new()
+    {
+        When = when,
+        Class = changeClass,
+        ConnectedSystemId = connectedSystemId,
+        SyncRuleId = syncRuleId,
+        MetaverseObjectTypeId = metaverseObjectTypeId,
+        MetaverseAttributeId = metaverseAttributeId,
+        ServiceSettingKey = serviceSettingKey
+    };
+
+    private static ConnectedSystemConfigurationScope Scope(int connectedSystemId, int[]? syncRuleIds = null,
+        int[]? objectTypeIds = null, int[]? attributeIds = null) => new()
+    {
+        ConnectedSystemId = connectedSystemId,
+        SyncRuleIds = [.. syncRuleIds ?? []],
+        MetaverseObjectTypeIds = [.. objectTypeIds ?? []],
+        MetaverseAttributeIds = [.. attributeIds ?? []]
+    };
+    #endregion
+}


### PR DESCRIPTION
## Description

Tells administrators when a Connected System's configuration has changed in a way that needs a Full Synchronisation to take effect. Builds on the classification persisted by #1140, which recorded *how consequential* each configuration change was but surfaced nothing.

Three parts:

1. **The determination logic** (`ConfigurationDriftService`). Compares the classified changes recorded against a system with the start of its last completed Full Synchronisation. Only Sync-affecting and Destructive changes count, so a rename never registers.
2. **The surfaces**, across all three: a chip in the Connected Systems list, a notice on the Connected System page, a `configurationDrift` object on the REST Connected System response, and `(Get-JIMConnectedSystem -Id <n>).ConfigurationDrift` in PowerShell.
3. **An attribution fix** that would otherwise have made the indicator lie (see Additional context).

**Attribution is precise, not blanket.** A Metaverse Attribute edit raises the indicator only on the systems whose Synchronisation Rules actually reference that attribute, matched against a per-system configuration scope: the system's rules, the Metaverse Object Types they target, and the attributes they reference via Attribute Flow targets and sources, scoping criteria and Object Matching Rules. Flagging every system on every Metaverse-side edit would make the indicator noise, and an indicator administrators learn to ignore is worse than none. Sync-affecting Service Settings are global and so affect every system.

**Two states are reported honestly rather than as "up to date":** a system that has never completed a Full Synchronisation, and configuration change tracking being switched off. In both cases JIM cannot answer the question, and claiming a settled configuration would be a claim it cannot support. `HasPendingChanges` is `false` in both, so the API carries an `IsDeterminable` flag and both the docs and the cmdlet help lead with the trap: a script gating a run on `HasPendingChanges` alone would silently skip the systems that most need attention.

Part of #827.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

`dotnet build JIM.sln`: 0 errors, 0 warnings. `dotnet test JIM.sln`: 4,459 passed, 0 failed. Pester: 26 passed.

**Unit tests.** `ConfigurationDriftServiceTests` (19 tests) covers what matters to an administrator: a Cosmetic change never raises the indicator, a Sync-affecting one does, a Destructive one reports as such, a change recorded before the last run does not count, an attribute the system's rules do not reference does not count, each system in a batch is evaluated against its own reference point, and the batch path issues one changes query regardless of system count. `ConnectedSystemConfigurationDriftDtoTests` (6 tests) covers the wire shape, focusing on the two undeterminable states staying distinguishable from a settled configuration.

The tests were checked against mutations rather than assumed sound: broadening the fan-out, sharing one reference point across systems, treating tracking-disabled as clean, and including Cosmetic changes each failed exactly the tests that should catch them. The attribution fix was likewise confirmed red before the fix.

### Runtime verification

Unit tests mock away the part most likely to be wrong here: the reference-point semantics and the EF translation of the two new queries. Verified against the full stack (database, Keycloak, JIM.Web, JIM.Worker) by seeding Full Synchronisation runs and classified changes, then driving the portal and the REST API.

| Connected System | Fixture | Result |
|---|---|---|
| HR System | 3 Sync-affecting changes since its run | Amber chip, count 3 |
| Corporate Directory | 1 Destructive change since its run, 1 Destructive *before* it | Red chip, count 1 (the earlier change correctly excluded) |
| Service Desk | Only a Cosmetic change since its run | Nothing shown |
| Payroll | No Full Synchronisation ever | "Never synchronised" |
| All | Change tracking switched off | Single page-level notice |

The REST payload matched the portal in every case, including `isDeterminable` correctly `false` for the last two.

That pass earned its keep: it caught three defects the unit tests could not. The detail notice had a stray space before its full stop (the sentence was assembled from markup fragments), read "at least one of **them** is destructive" when there was exactly one change, and rendered an "Unknown" chip on *every* row when tracking was off, stating one global fact once per system. All three are fixed in 41ab812.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `docs/configuration/connected-systems.md`, `docs/powershell/connected-systems.md`

## Screenshots / output (if applicable)

Connected Systems list, showing a Destructive pending change, three Sync-affecting changes, a never-synchronised system, and a settled system rendering nothing:

```
Corporate Directory   [!] 1                  JIM LDAP Connector
HR System             [~] 3                  JIM File Connector
Payroll               [?] Never synchronised JIM File Connector
Service Desk                                 JIM File Connector
```

Connected System page, Destructive case:

> 1 configuration change has been made since the last Full Synchronisation (25 Jul 2026 17:07:37). It is destructive and can cascade deletions or mass deprovisioning the moment it is applied. Review it before running a Full Synchronisation.

REST response for the same system:

```json
"configurationDrift": {
  "hasPendingChanges": true, "isDeterminable": true,
  "neverFullySynchronised": false, "trackingDisabled": false,
  "lastFullSynchronisation": "2026-07-25T17:07:37.006276+00:00",
  "mostRecentChange": "2026-07-28T17:07:37.013764+00:00",
  "changeCount": 1, "highestChangeClass": "Destructive"
}
```

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

**The attribution fix.** Deletion capture deliberately records no target id, because the object is about to cease to exist. A Synchronisation Rule deletion therefore carried only the Connected System's *name*, in `TargetContext`, and could never be attributed to a system: a false negative on one of the most consequential changes there is, and matching on a mutable name string is not an acceptable substitute. The delete Activity now records the owning system's id, which survives the rule's deletion. This does not pollute the Connected System's own configuration history, which additionally requires a captured version that deletions never carry.

**The reference point is the run's start, not its completion.** A change made while a long Full Synchronisation was in flight may not have been picked up by it, so it counts as still pending. That errs towards prompting a re-run that was not strictly needed, rather than hiding one that was. Runs that failed, errored or were cancelled do not count as a reference point at all.

**Batch query shape.** The list surface uses a batch overload issuing a fixed number of queries regardless of how many systems are shown, so the page does not degrade into an N+1. A test asserts the query count does not scale with system count.

**Parity note, agreed with the maintainer.** The drift status is on the single-system GET, not the list endpoint, which returns `ConnectedSystemHeader` directly; adding it there would either change that response shape or push drift work onto every header fetch. Automation resolves ids from the list and reads drift per system. Deliberately deferred rather than overlooked.

**Known gap inherited from #1140.** Container selection is not captured in the Connected System snapshot, so container changes cannot be classified and therefore cannot raise this indicator until `ConfigurationSnapshotService` captures them.

**Follow-up:** the change preview itself, which reads the same classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR

---
_Generated by [Claude Code](https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR)_