### PR TITLE
Remove render races from the confirmation dialog tests

### DIFF
--- a/test/JIM.Web.Components.Tests/ConsequenceConfirmationDialogTests.cs
+++ b/test/JIM.Web.Components.Tests/ConsequenceConfirmationDialogTests.cs
@@ -27,12 +27,20 @@ public class ConsequenceConfirmationDialogTests : JimComponentTestContext
     /// <summary>
     /// Shows the dialog through MudBlazor's dialog service (the way callers open it) and returns the
     /// rendered provider so tests can assert on the dialog's markup.
+    ///
+    /// Showing a dialog is dispatched onto the renderer rather than performed inline, so the dialog's
+    /// first render is not guaranteed to have landed when the call returns. Every test here goes on to
+    /// query the dialog's markup immediately, which on a loaded machine can run before that render
+    /// completes and fail with an element that is merely not there yet. Waiting for the confirm button
+    /// (rendered unconditionally, whatever the dialog's state) makes the handover deterministic for
+    /// every test in the fixture rather than leaving each one to race.
     /// </summary>
     private IRenderedComponent<MudDialogProvider> ShowDialog(DialogParameters<ConsequenceConfirmationDialog> parameters)
     {
         var provider = Render<MudDialogProvider>();
         var dialogService = Services.GetRequiredService<IDialogService>();
         provider.InvokeAsync(() => dialogService.ShowAsync<ConsequenceConfirmationDialog>("Confirm", parameters));
+        provider.WaitForElement($"[data-testid='{ConfirmButtonMarker}']");
 
         return provider;
     }
@@ -269,14 +277,14 @@ public class ConsequenceConfirmationDialogTests : JimComponentTestContext
         });
 
         ConfirmButton(provider).Click();
-        var disabledWhilstRunning = ConfirmIsDisabled(provider);
+
+        // The confirmation is still in flight, so the disabled state holds until the task is released
+        // below: waiting for the re-render rather than sampling it once removes the race between the
+        // click's render batch and this assertion, without weakening what is being asserted.
+        provider.WaitForAssertion(() => Assert.That(ConfirmIsDisabled(provider), Is.True));
         release.SetResult(true);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(disabledWhilstRunning, Is.True);
-            Assert.That(callCount, Is.EqualTo(1));
-        }
+        Assert.That(callCount, Is.EqualTo(1));
     }
 
     [Test]
@@ -291,10 +299,10 @@ public class ConsequenceConfirmationDialogTests : JimComponentTestContext
         });
 
         ConfirmButton(provider).Click();
-        var markupWhilstRunning = provider.Markup;
-        release.SetResult(true);
 
-        Assert.That(markupWhilstRunning, Does.Contain("Deleting..."));
+        // As above: the busy text stays on screen until the confirmation task is released.
+        provider.WaitForAssertion(() => Assert.That(provider.Markup, Does.Contain("Deleting...")));
+        release.SetResult(true);
     }
 
     #endregion


### PR DESCRIPTION
## Description

PR #1143's `build-and-test` failed with **one** failure in `JIM.Web.Components.Tests` (54 tests, 53 passed). The test's name never reached the log: VSTest reported `MSB4181` ("the `VSTestTask` task returned false but did not log an error") and the parallel console output dropped whole result blocks, including 29 of that project's 54 results. A re-run went green and #1143 merged.

This removes the only unsynchronised patterns in that fixture.

**`ShowDialog` dispatched without waiting.** It called `provider.InvokeAsync(() => dialogService.ShowAsync<...>(...))` and returned without awaiting the result, then every test queried the dialog's markup immediately. Nothing guaranteed the dialog's first render had landed, and a query that runs too early fails on an element that is merely not there yet. It now waits for the confirm button, which renders unconditionally whatever the dialog's state, so the handover is deterministic for all 29 tests rather than each one racing.

**Two tests sampled state mid-flight.** `WhileConfirming_DisablesConfirmToPreventDoubleSubmit` and `WhileConfirming_ShowsBusyText` read the rendered markup in the window between clicking confirm and releasing the `TaskCompletionSource` it awaits:

```csharp
ConfirmButton(provider).Click();
var disabledWhilstRunning = ConfirmIsDisabled(provider);   // races the click's render batch
release.SetResult(true);
```

Whether the click's render batch had been processed by that read was a race. They now wait for the state rather than sampling it once. The confirmation is still in flight at that point, so what is being asserted is unchanged.

## Type of change

- [x] Other (test-only change; no production code touched)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes

0 errors, 0 warnings; 4,459 passed.

**This is not a reproduction-led fix, and I want that on the record.** The fixture passed **12 consecutive runs unmodified** with eight cores deliberately saturated, so the failure could not be reproduced locally and this change cannot be shown to address the specific failure CI saw. It removes the only races present in the fixture, which is the most that can be claimed for it. The fixed version also passed 12/12 under the same load.

The sibling `ServerCertificateCardTests` were checked as an alternative culprit and ruled out: they use fixed dates throughout, with no `DateTime.Now`/`UtcNow`, so they are not time-dependent.

**Waiting does not weaken the assertions.** Verified by mutation: with `ConsequenceConfirmationDialog.CanConfirm` changed so the busy state no longer disables the button, `DisablesConfirmToPreventDoubleSubmit` still fails, now because the wait times out rather than because an immediate read saw the wrong value. A `WaitForAssertion` that could never fail would have been worse than the race it replaced.

## Documentation

- [x] No documentation needed

Test-only change with no user-facing behaviour; no changelog entry either, per the changelog rules.

## Additional context

The diagnosis cost #1143 a red CI run and a re-run. Whether or not this is the specific cause, the unawaited dispatch is a real defect in the fixture: it is one scheduling decision away from failing any of the 29 tests that call it, and it would present exactly as this did, as a single unnamed failure in a random test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR

---
_Generated by [Claude Code](https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR)_