### PR TITLE
Name the right phase for Connector-reported import errors in the portal

### DIFF
--- a/src/JIM.Web/Helpers.cs
+++ b/src/JIM.Web/Helpers.cs
@@ -185,6 +185,64 @@ public static class Helpers
         return $"{Math.Round(timeSpan.TotalMilliseconds)} ms";
     }
 
+    /// <summary>
+    /// The heading shown above a Run Profile Execution Item's error, naming the phase the error belongs to.
+    /// Every <see cref="ActivityRunProfileExecutionItemErrorType"/> must appear here; a missing entry reads
+    /// as a confident statement about the wrong phase rather than as an obvious omission, so
+    /// ErrorPhaseTitleTests asserts the coverage.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<ActivityRunProfileExecutionItemErrorType, string> ErrorPhaseTitles =
+        new Dictionary<ActivityRunProfileExecutionItemErrorType, string>
+        {
+            // No error at all.
+            [ActivityRunProfileExecutionItemErrorType.NotSet] = "No Error",
+
+            // Import-phase errors: the object was rejected before its Connected System Object was created.
+            [ActivityRunProfileExecutionItemErrorType.DuplicateObject] = "Import Rejected",
+            [ActivityRunProfileExecutionItemErrorType.MissingExternalIdAttributeValue] = "Import Rejected",
+            [ActivityRunProfileExecutionItemErrorType.DuplicateImportedAttributes] = "Import Rejected",
+            [ActivityRunProfileExecutionItemErrorType.UnsupportedExternalIdAttributeType] = "Import Rejected",
+            [ActivityRunProfileExecutionItemErrorType.CsoCreationFailed] = "Import Rejected",
+            [ActivityRunProfileExecutionItemErrorType.ConnectorConfigurationError] = "Import Rejected",
+
+            // The object imported; a single attribute value did not. Neither "Rejected" nor "Failed" is
+            // true here, and saying either sends an administrator hunting for a problem that does not exist.
+            [ActivityRunProfileExecutionItemErrorType.ImportAttributeValueError] = "Attribute Not Imported",
+
+            // Import-phase diagnostics: the object imported and its changes were applied.
+            [ActivityRunProfileExecutionItemErrorType.ImportHashVerificationFailed] = "Import Verification",
+            [ActivityRunProfileExecutionItemErrorType.DeltaImportFallbackToFullImport] = "Import Fell Back",
+
+            // Synchronisation-phase errors: the Connected System Object exists but synchronisation failed.
+            [ActivityRunProfileExecutionItemErrorType.AmbiguousMatch] = "Synchronisation Failed",
+            [ActivityRunProfileExecutionItemErrorType.CouldNotMatchObjectType] = "Synchronisation Failed",
+            [ActivityRunProfileExecutionItemErrorType.CouldNotJoinDueToExistingJoin] = "Synchronisation Failed",
+            [ActivityRunProfileExecutionItemErrorType.UnexpectedAttribute] = "Synchronisation Failed",
+            [ActivityRunProfileExecutionItemErrorType.UnresolvedReference] = "Synchronisation Failed",
+            [ActivityRunProfileExecutionItemErrorType.MultiValuedToSingleValued] = "Synchronisation Failed",
+            [ActivityRunProfileExecutionItemErrorType.ExpressionEvaluationError] = "Synchronisation Failed",
+
+            // Export-phase errors.
+            [ActivityRunProfileExecutionItemErrorType.ExportNotConfirmed] = "Export Pending",
+            [ActivityRunProfileExecutionItemErrorType.ExportConfirmationFailed] = "Export Failed",
+            [ActivityRunProfileExecutionItemErrorType.InvalidGeneratedExternalId] = "Export Failed",
+
+            // Generic.
+            [ActivityRunProfileExecutionItemErrorType.UnhandledError] = "Operation Failed"
+        };
+
+    /// <summary>
+    /// Returns the heading for a Run Profile Execution Item's error, naming the phase it belongs to.
+    /// </summary>
+    public static string GetErrorPhaseTitle(ActivityRunProfileExecutionItemErrorType? errorType)
+    {
+        if (errorType.HasValue && ErrorPhaseTitles.TryGetValue(errorType.Value, out var title))
+            return title;
+
+        // Unreachable while ErrorPhaseTitleTests passes; a neutral fallback beats an empty heading.
+        return "Operation Failed";
+    }
+
     #region mudblazor related
     public static Color GetActivityMudBlazorColorForStatus(ActivityStatus status)
     {

--- a/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
+++ b/src/JIM.Web/Pages/ActivityRunProfileExecutionItemDetail.razor
@@ -1436,34 +1436,11 @@ else if (_activityRunProfileExecutionItem.ObjectChangeType == ObjectChangeType.N
 
     /// <summary>
     /// Returns an appropriate error title based on the error type (import vs sync vs export phase).
+    /// The mapping itself lives in Helpers so that a test can prove every error type is covered.
     /// </summary>
     private string GetErrorPhaseTitle()
     {
-        return _activityRunProfileExecutionItem?.ErrorType switch
-        {
-            // Import-phase errors - object rejected before CSO creation
-            ActivityRunProfileExecutionItemErrorType.DuplicateObject => "Import Rejected",
-            ActivityRunProfileExecutionItemErrorType.MissingExternalIdAttributeValue => "Import Rejected",
-            ActivityRunProfileExecutionItemErrorType.DuplicateImportedAttributes => "Import Rejected",
-            ActivityRunProfileExecutionItemErrorType.UnsupportedExternalIdAttributeType => "Import Rejected",
-            ActivityRunProfileExecutionItemErrorType.CsoCreationFailed => "Import Rejected",
-
-            // Sync-phase errors - CSO exists but sync failed
-            ActivityRunProfileExecutionItemErrorType.AmbiguousMatch => "Synchronisation Failed",
-            ActivityRunProfileExecutionItemErrorType.CouldNotMatchObjectType => "Synchronisation Failed",
-            ActivityRunProfileExecutionItemErrorType.CouldNotJoinDueToExistingJoin => "Synchronisation Failed",
-            ActivityRunProfileExecutionItemErrorType.UnexpectedAttribute => "Synchronisation Failed",
-            ActivityRunProfileExecutionItemErrorType.UnresolvedReference => "Synchronisation Failed",
-            ActivityRunProfileExecutionItemErrorType.MultiValuedToSingleValued => "Synchronisation Failed",
-
-            // Export-phase errors
-            ActivityRunProfileExecutionItemErrorType.ExportNotConfirmed => "Export Pending",
-            ActivityRunProfileExecutionItemErrorType.ExportConfirmationFailed => "Export Failed",
-
-            // Generic/unhandled
-            ActivityRunProfileExecutionItemErrorType.UnhandledError => "Operation Failed",
-            _ => "Synchronisation Failed"
-        };
+        return Helpers.GetErrorPhaseTitle(_activityRunProfileExecutionItem?.ErrorType);
     }
 
     /// <summary>

--- a/test/JIM.Web.Api.Tests/ErrorPhaseTitleTests.cs
+++ b/test/JIM.Web.Api.Tests/ErrorPhaseTitleTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Linq;
+using JIM.Models.Activities;
+using NUnit.Framework;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// The heading above a Run Profile Execution Item's error tells an administrator which phase went wrong.
+/// A missing mapping breaks nothing visibly, it just names the wrong phase, which is why it needs a test
+/// rather than a code review to catch: the two error types added for Connector-reported import problems
+/// (#637) silently inherited a "Synchronisation Failed" heading, one of them on an object that imported.
+/// </summary>
+[TestFixture]
+public class ErrorPhaseTitleTests
+{
+    [Test]
+    public void ErrorPhaseTitles_CoverEveryErrorType()
+    {
+        var unmapped = Enum.GetValues<ActivityRunProfileExecutionItemErrorType>()
+            .Where(errorType => !JIM.Web.Helpers.ErrorPhaseTitles.ContainsKey(errorType))
+            .ToList();
+
+        Assert.That(unmapped, Is.Empty,
+            "Every error type needs an explicit heading naming the phase it belongs to. Unmapped: " +
+            string.Join(", ", unmapped));
+    }
+
+    [Test]
+    public void GetErrorPhaseTitle_ForAnImportRejection_SaysTheImportWasRejected()
+    {
+        Assert.That(JIM.Web.Helpers.GetErrorPhaseTitle(ActivityRunProfileExecutionItemErrorType.ConnectorConfigurationError),
+            Is.EqualTo("Import Rejected"));
+    }
+
+    [Test]
+    public void GetErrorPhaseTitle_ForAnAttributeValueError_DoesNotClaimTheObjectFailed()
+    {
+        // The object imported; only the failing attribute was omitted. Saying "Synchronisation Failed" or
+        // "Import Rejected" here would send an administrator looking for a problem that does not exist.
+        var title = JIM.Web.Helpers.GetErrorPhaseTitle(ActivityRunProfileExecutionItemErrorType.ImportAttributeValueError);
+
+        Assert.That(title, Is.EqualTo("Attribute Not Imported"));
+    }
+
+    [Test]
+    public void GetErrorPhaseTitle_ForNoErrorType_FallsBackWithoutThrowing()
+    {
+        Assert.That(JIM.Web.Helpers.GetErrorPhaseTitle(null), Is.Not.Empty);
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #1148, found while runtime-validating it against a live stack. No separate issue was raised; this fixes a defect introduced there.

The two error types added in #1148 (`ImportAttributeValueError`, `ConnectorConfigurationError`) had no case in the Run Profile Execution Item detail page's phase-title switch, so both fell through its catch-all and were headed **"Synchronisation Failed"**. On an `ImportAttributeValueError` item that is wrong twice over: the problem happened during import, and nothing failed to synchronise, because the object imported with the values that did parse. An administrator reading that heading goes looking for a synchronisation problem that does not exist.

The mapping moves out of the page into `Helpers` as a dictionary keyed by error type, so a test can assert every error type is covered. The switch's catch-all was the root cause: it made a missing case indistinguishable from a deliberate one, which is exactly how these two slipped through in the first place. The test fails by name instead, and I verified it fails when a mapping is removed rather than trusting that it would.

Four other values were relying on the same catch-all and being described as synchronisation failures: `ExpressionEvaluationError` (correct as-is), `InvalidGeneratedExternalId` (an export failure), `ImportHashVerificationFailed` and `DeltaImportFallbackToFullImport` (both import-phase, both applied their changes normally). Those are now explicit too.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

`ErrorPhaseTitleTests` covers the mapping: one test asserts every `ActivityRunProfileExecutionItemErrorType` has an entry (naming any that do not), and one per new type asserts the specific heading. Proven non-vacuous by removing a mapping and watching it fail with `Unmapped: ImportAttributeValueError`.

The underlying behaviour was validated on the sandbox stack against real PostgreSQL before this PR: a File Connected System importing a CSV with one unparseable value and one row of an unknown object type produced 4 Run Profile Execution Items (2 clean, 1 `ImportAttributeValueError` with the object still imported, 1 `CouldNotMatchObjectType` with it skipped), 3 Connected System Objects from 4 rows, and Activity status `CompleteWithWarning`. This PR only corrects what the portal calls those items.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

Docs: n/a - corrects a UI heading for error types introduced in the same unreleased cycle as #1148; no behaviour change and no public surface change.

No changelog entry: the error types themselves have not shipped in a release yet, so this corrects an unreleased heading rather than changing behaviour an administrator has seen.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

The new heading for `ImportAttributeValueError` is **"Attribute Not Imported"**. Every existing label implies total failure of the object (`Import Rejected`, `Synchronisation Failed`, `Export Failed`), and none of them is true when the object imported and one value did not, so this needed a new string rather than a reuse.

`Helpers.GetErrorPhaseTitle` keeps a neutral `"Operation Failed"` fallback for an unmapped value. It is unreachable while the coverage test passes; it exists so a future enum value renders something sane rather than an empty heading in the window before the test is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5BQcqQd6U9vpbPwLNedhp