### PR TITLE
docs: add stacked-PR workflow skill and integrate into CLAUDE.md

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -34,9 +34,31 @@ If `$ARGUMENTS` is non-empty, treat it as the proposed PR title (still under 70 
 
 3. **Check whether a PR already exists for this branch:**
    ```
-   gh pr list --head "$(git branch --show-current)" --state open --json number,title,mergeStateStatus,autoMergeRequest
+   gh pr list --head "$(git branch --show-current)" --state open --json number,title,baseRefName,mergeStateStatus,autoMergeRequest
    ```
    - If a PR already exists, skip the "Create PR" step below and resume from "Queue auto-merge" / "Resolve code-quality issues" depending on its state. Note the existing number.
+
+4. **Check for a stack (see "Stacked PRs" below):**
+   ```
+   gh pr list --state open --json number,headRefName,baseRefName
+   ```
+   - If this branch's PR has `baseRefName` other than `main`, it is the **upper PR of a stack**: its prerequisite PR must land first. Drive the prerequisite through this skill bottom-up, then return here.
+   - If another open PR has `baseRefName` equal to this branch, this branch is a **stack base**: land it normally, then run the post-land steps in "Stacked PRs" for the upper branch.
+
+## Stacked PRs
+
+Per CLAUDE.md ("Stacked PRs for discovered blockers"), a feature PR may be based on a prerequisite branch (`feature/<feature>-prereq-<desc>`) whose own PR targets `main`. Rules for landing:
+
+- **Always land bottom-up.** Never try to merge an upper PR while its base PR is open; GitHub would merge the feature into the prerequisite branch, not into `main`.
+- **While the prerequisite PR is open**, the upper PR's "up to date" target is the prerequisite branch, not `origin/main`: `git merge <prereq-branch>` on the feature branch. Skip the "up to date with origin/main" section for the upper PR until its base has landed.
+- **After the prerequisite squash-merges** (with `--delete-branch`), GitHub auto-retargets the upper PR to `main`. Verify with `gh pr view <n> --json baseRefName`; if it still points at the deleted branch, `gh pr edit <n> --base main`. Then, on the feature branch:
+  ```
+  git fetch origin --prune
+  git merge origin/main
+  git push
+  ```
+  The squash commit supersedes the prerequisite's commits; conflicts, if any, are content-identical and trivial. Eyeball `CHANGELOG.md` `[Unreleased]` for a doubled bullet (union driver duplication) and tidy. The upper PR's diff returns to feature-only work; from here it is an ordinary PR and the rest of this skill applies unchanged.
+- **Cleanup:** the prerequisite's local branch also needs `git branch -D <prereq-branch>` in the final cleanup step.
 
 ## Get the branch up to date with origin/main (CRITICAL)
 

--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -42,23 +42,17 @@ If `$ARGUMENTS` is non-empty, treat it as the proposed PR title (still under 70 
    ```
    gh pr list --state open --json number,headRefName,baseRefName
    ```
-   - If this branch's PR has `baseRefName` other than `main`, it is the **upper PR of a stack**: its prerequisite PR must land first. Drive the prerequisite through this skill bottom-up, then return here.
-   - If another open PR has `baseRefName` equal to this branch, this branch is a **stack base**: land it normally, then run the post-land steps in "Stacked PRs" for the upper branch.
+   - If this branch's PR has `baseRefName` other than `main`, or another open PR has `baseRefName` equal to this branch, the branch is a **layer in a stack**. Follow "Stacked PRs" below instead of the ordinary flow: stacks rebase rather than merge to stay current, and auto-merge is unsupported.
 
 ## Stacked PRs
 
-Per CLAUDE.md ("Stacked PRs for discovered blockers"), a feature PR may be based on a prerequisite branch (`feature/<feature>-prereq-<desc>`) whose own PR targets `main`. Rules for landing:
+Per CLAUDE.md ("Stacked PRs for discovered work"), a branch may be a layer in a GitHub native stack: a sequential chain where each PR targets the branch of the PR below it and the bottom PR targets `main`. Landing a stack differs from the ordinary flow in four ways:
 
-- **Always land bottom-up.** Never try to merge an upper PR while its base PR is open; GitHub would merge the feature into the prerequisite branch, not into `main`.
-- **While the prerequisite PR is open**, the upper PR's "up to date" target is the prerequisite branch, not `origin/main`: `git merge <prereq-branch>` on the feature branch. Skip the "up to date with origin/main" section for the upper PR until its base has landed.
-- **After the prerequisite squash-merges** (with `--delete-branch`), GitHub auto-retargets the upper PR to `main`. Verify with `gh pr view <n> --json baseRefName`; if it still points at the deleted branch, `gh pr edit <n> --base main`. Then, on the feature branch:
-  ```
-  git fetch origin --prune
-  git merge origin/main
-  git push
-  ```
-  The squash commit supersedes the prerequisite's commits; conflicts, if any, are content-identical and trivial. Eyeball `CHANGELOG.md` `[Unreleased]` for a doubled bullet (union driver duplication) and tidy. The upper PR's diff returns to feature-only work; from here it is an ordinary PR and the rest of this skill applies unchanged.
-- **Cleanup:** the prerequisite's local branch also needs `git branch -D <prereq-branch>` in the final cleanup step.
+- **Rebase, not merge, to stay current.** Stacks require fully linear history. If the merge box shows the stack is non-linear (a lower layer changed, or `main` advanced), restack with the web "Rebase stack" button, or locally with `gh stack rebase` followed by `gh stack push` (cascading rebase + force-push of the layers). Skip this skill's "up to date with origin/main" merge section entirely for stack layers.
+- **No auto-merge.** `--auto` is unsupported for stacked PRs. Instead, wait for green with a background waiter on the checks, then merge. Every PR in the stack is evaluated against `main`'s branch protections (all seven required checks), regardless of its direct base.
+- **Land bottom-up, atomically from wherever you merge.** Merging any PR in the stack also merges all unmerged PRs below it in a single operation, ordered bottom-up, each recorded individually. A mid-stack PR cannot merge in isolation. The normal move when the objective is complete is to merge from the **top** of the stack; merge a lower layer earlier only when it is ready and independently valuable. After a partial merge, GitHub automatically rebases the next unmerged PR to target `main`.
+- **Merge mechanics:** try `gh pr merge <n> --squash --delete-branch` once everything below is green. If the CLI refuses because the PR is stacked, merge from the PR's merge box on the web (it shows the stack map) - the stack merge API is distinct from the ordinary merge endpoint.
+- **Cleanup:** delete every landed layer's local branch with `git branch -D` in the final cleanup step.
 
 ## Get the branch up to date with origin/main (CRITICAL)
 

--- a/.claude/skills/stack-pr/SKILL.md
+++ b/.claude/skills/stack-pr/SKILL.md
@@ -1,101 +1,87 @@
 ---
 name: stack-pr
-description: Interrupt feature work to fix a discovered blocker in its own stacked PR; branch the prerequisite off origin/main, implement it to full standard, PR and auto-merge it, fold it back into the feature branch, and retarget the feature PR.
-argument-hint: "[one-line description of the discovered blocker]"
+description: Isolate work discovered mid-feature into the next layer of a GitHub stacked PR; branch off the current feature branch, implement to full standard, open the layer's PR against the branch below, link the stack, and carry on.
+argument-hint: "[one-line description of the discovered work]"
 ---
 
-# Stack a prerequisite PR under the current feature branch
+# Stack a new PR layer on the current feature branch
 
-This skill implements the policy in CLAUDE.md ("Stacked PRs for discovered blockers"): something has been found mid-feature that must be solved to deliver the feature but is not semantically part of it. It gets fixed now, in its own PR, stacked under the feature; never folded into the feature branch, never deferred to an issue.
+This skill implements the policy in CLAUDE.md ("Stacked PRs for discovered work"): something has been found mid-feature that must be solved to deliver the objective but is not semantically part of the current branch's work. It gets its own layer in a GitHub native stacked PR (public preview), never folded into the feature branch, never deferred to an issue.
 
-If `$ARGUMENTS` is non-empty, treat it as the blocker description; otherwise derive one from the conversation context. Announce the blocker to the user in one line and proceed; do not ask whether to stack (the policy pre-authorises it). If the prerequisite itself is architecturally significant with multiple sensible approaches, the CLAUDE.md "Ask before significant changes" rule applies to the approach, not to the decision to stack.
+A stack is a **sequential chain**: each layer branches off the branch below it, each PR targets the branch below it, and only the bottom PR targets `main`. Merging is bottom-up; merging an upper PR atomically merges everything below it, each PR recorded individually.
 
-## 1. Park the feature work
+If `$ARGUMENTS` is non-empty, treat it as the description of the discovered work; otherwise derive one from the conversation context. Announce it to the user in one line and proceed; do not ask whether to stack (the policy pre-authorises it). If the work itself is architecturally significant with multiple sensible approaches, the CLAUDE.md "Ask before significant changes" rule applies to the approach, not to the decision to stack.
+
+## 0. One-time setup
+
+The `gh stack` CLI is an extension (requires gh 2.90+):
+
+```
+gh extension list | grep -q gh-stack || gh extension install github/gh-stack
+```
+
+## 1. Park the current work
 
 ```
 git status
 git branch --show-current
 ```
 
-- You MUST be on a feature branch. If on `main`, stop; there is nothing to stack under.
-- Record the feature branch name; call it `<feature>` below.
-- If the tree is dirty, commit the WIP to the feature branch: `git add -A && git commit -m "wip: park feature work before stacked prerequisite"`. Prefer a `wip:` commit over stashing; squash-merge collapses it on landing, and a stash is invisible to other sessions.
+- You MUST be on a feature branch. If on `main`, stop; there is nothing to stack on.
+- If the tree is dirty, commit the WIP to the current branch: `git add -A && git commit -m "wip: park work before stacking next layer"`. Prefer a `wip:` commit over stashing; squash-merge collapses it on landing, and a stash is invisible to other sessions.
+- Push the current branch so the chain's lower layer exists on the remote: `git push` (or `git push -u origin <branch>` if never pushed).
 
-## 2. Create the prerequisite branch off origin/main
+## 2. Create the layer off the current branch
 
 ```
-git fetch origin --prune
-git checkout -b feature/<feature-suffix>-prereq-<desc> origin/main
+git checkout -b feature/<feature-suffix>-stack-<desc>
 ```
 
-- `<feature-suffix>` is the feature branch name without its `feature/` prefix; `<desc>` is a short kebab-case description of the blocker. Example: feature `feature/csv-connector` with an encoding bug prerequisite becomes `feature/csv-connector-prereq-fix-encoding`.
-- Branching off `origin/main` (not the feature branch) is what makes the stack work: the prerequisite PR must contain no feature commits.
+- Branch **from the current feature branch**, never from `main`; the layer must sit on top of the work below it.
+- `<feature-suffix>` is the feature branch name without its `feature/` prefix; `<desc>` is a short kebab-case description. Example: on `feature/csv-connector`, an encoding bug becomes `feature/csv-connector-stack-fix-encoding`.
+- Alternatively `gh stack add feature/<feature-suffix>-stack-<desc>` creates and tracks the branch in one step if the stack is already initialised.
 
-## 3. Implement the prerequisite to full standard
+## 3. Implement the layer to full standard
 
 Being unplanned lowers no bars. All CLAUDE.md rules apply:
 
 - TDD (failing test first; for a bug the test must reproduce it before the fix).
 - Build/test gates: targeted during the loop, `dotnet build JIM.sln` and `dotnet test JIM.sln` clean before the PR (or the documented non-code exceptions).
 - Changelog entry under `[Unreleased]` plus public docs if the change is user-facing.
-- Commit with a clear message and push: `git push -u origin feature/<feature-suffix>-prereq-<desc>`.
+- Commit with a clear message and push: `git push -u origin feature/<feature-suffix>-stack-<desc>`.
 
-## 4. Open the prerequisite PR and queue auto-merge
+## 4. Open the layer's PR and link the stack
 
-Follow `/pr-merge` conventions (title under 70 chars, JIM body template):
-
-```
-gh pr create --base main --title "fix: <desc>" --body "..."
-gh pr merge <n> --squash --delete-branch --auto
-```
-
-- The immediate `gh pr merge` failure right after create is expected; `--auto` queues it.
-- Resolve `github-code-quality` feedback per the `/pr-merge` loop. Do not wait for the merge to land before moving on; that is the point of stacking.
-
-## 5. Fold the prerequisite into the feature branch and resume
+Follow `/pr-merge` conventions (title under 70 chars, JIM body template), with the base set to the branch below, NOT `main`:
 
 ```
-git checkout feature/<feature>
-git merge feature/<feature-suffix>-prereq-<desc>
-git push
+gh pr create --base feature/<feature> --title "fix: <desc>" --body "..."
 ```
 
-The feature branch now contains the fix and work can continue immediately.
+- GitHub recognises aligned chains (each PR's base is the head of the PR below) and shows a banner offering to link them into a stack; accept it. With the `gh stack` CLI, `gh stack submit` pushes the layers and creates linked PRs in one step.
+- Reviewers see only this layer's diff. CI and all of `main`'s branch protections run for every PR in the stack.
+- Do NOT queue `--auto`: auto-merge is unsupported for stacked PRs. Landing is handled by `/pr-merge` when the objective is complete.
 
-## 6. Retarget the feature PR (if one exists)
+## 5. Continue work in the right layer
 
-```
-gh pr list --head feature/<feature> --state open --json number
-gh pr edit <feature-pr> --base feature/<feature-suffix>-prereq-<desc>
-```
+Code may only depend on its own layer or a lower one:
 
-- This keeps the feature PR's diff limited to feature work while the prerequisite is open.
-- If no feature PR exists yet, nothing to do now; if one is created while the prerequisite PR is still open, pass `--base feature/<feature-suffix>-prereq-<desc>` at creation.
+- **Remaining feature work needs this layer's code** → continue in a new layer on top: `gh stack add` (or branch off this layer), and repeat this pattern.
+- **Remaining feature work is independent of this layer** → `git checkout feature/<feature>` and continue below. Any change to a lower layer breaks the stack's linearity; restack before merging with the web "Rebase stack" button, or locally:
+  ```
+  gh stack rebase
+  gh stack push
+  ```
 
-## 7. Arm the landing notification, then resume the feature
+## 6. Landing
 
-Watch for the prerequisite landing with a background waiter (per CLAUDE.md "Closing the loop after `--auto`"):
+Use `/pr-merge`; its "Stacked PRs" section covers the differences (rebase to stay current, no auto-merge, bottom-up atomic merge, merging from the top when the objective is done, cleanup of layer branches).
 
-```
-until [ "$(gh pr view <n> --json state -q .state)" = "MERGED" ]; do sleep 30; done
-```
+## Notes and edge cases
 
-Run with `run_in_background: true` and carry on with feature work. When it fires:
+- Stacks require all branches in the same repository and fully linear history between layers; within a stack, rebase (cascading) replaces the usual merge-don't-rebase rule.
+- Keep layers shallow and single-concern; a discovery inside a layer gets its own layer the same way.
+- Layer branches belong to the same session and objective as the feature branch; the `-stack-` naming keeps the lineage visible across parallel sessions.
+- **The discovery is NOT needed to deliver the objective** → this skill does not apply. File an issue with native blocked-by/sub-issue links per CLAUDE.md and stay on the feature.
 
-1. GitHub auto-retargets the feature PR to `main` (the prerequisite branch was deleted). Verify with `gh pr view <feature-pr> --json baseRefName`; if needed, `gh pr edit <feature-pr> --base main`.
-2. On the feature branch:
-   ```
-   git fetch origin --prune
-   git merge origin/main
-   git push
-   ```
-   The squash commit supersedes the prerequisite commits; conflicts, if any, are content-identical and trivial. Eyeball `CHANGELOG.md` `[Unreleased]` for a doubled bullet (union driver duplication) and tidy.
-3. Delete the local prerequisite branch: `git branch -D feature/<feature-suffix>-prereq-<desc>`.
-
-## Nesting and edge cases
-
-- **A blocker inside the prerequisite:** apply this skill again with the prerequisite as the parent; stacks nest with the same pattern. Keep stacks shallow and always land the bottom first.
-- **Prerequisite CI goes red while you are back on feature work:** the drive-to-green duty from the PR-handling rules applies; fix the prerequisite before adding more feature work on top of it.
-- **The blocker is NOT needed to deliver the feature:** this skill does not apply. File an issue with native blocked-by/sub-issue links per CLAUDE.md and stay on the feature.
-
-End the skill (step 6) on a one-line status: prerequisite PR number, feature PR retarget state, and confirmation that feature work has resumed. Step 7's completion is reported when the waiter fires.
+End the skill on a one-line status: layer branch name, its PR number and base, and which layer work is continuing in.

--- a/.claude/skills/stack-pr/SKILL.md
+++ b/.claude/skills/stack-pr/SKILL.md
@@ -14,7 +14,7 @@ If `$ARGUMENTS` is non-empty, treat it as the description of the discovered work
 
 ## 0. One-time setup
 
-The `gh stack` CLI is an extension (requires gh 2.90+):
+The `gh stack` CLI is an extension (requires gh 2.90+). The devcontainer installs it automatically (`.devcontainer/setup.sh`); if it is missing (e.g. the install was skipped because gh was not yet authenticated):
 
 ```
 gh extension list | grep -q gh-stack || gh extension install github/gh-stack

--- a/.claude/skills/stack-pr/SKILL.md
+++ b/.claude/skills/stack-pr/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: stack-pr
+description: Interrupt feature work to fix a discovered blocker in its own stacked PR; branch the prerequisite off origin/main, implement it to full standard, PR and auto-merge it, fold it back into the feature branch, and retarget the feature PR.
+argument-hint: "[one-line description of the discovered blocker]"
+---
+
+# Stack a prerequisite PR under the current feature branch
+
+This skill implements the policy in CLAUDE.md ("Stacked PRs for discovered blockers"): something has been found mid-feature that must be solved to deliver the feature but is not semantically part of it. It gets fixed now, in its own PR, stacked under the feature; never folded into the feature branch, never deferred to an issue.
+
+If `$ARGUMENTS` is non-empty, treat it as the blocker description; otherwise derive one from the conversation context. Announce the blocker to the user in one line and proceed; do not ask whether to stack (the policy pre-authorises it). If the prerequisite itself is architecturally significant with multiple sensible approaches, the CLAUDE.md "Ask before significant changes" rule applies to the approach, not to the decision to stack.
+
+## 1. Park the feature work
+
+```
+git status
+git branch --show-current
+```
+
+- You MUST be on a feature branch. If on `main`, stop; there is nothing to stack under.
+- Record the feature branch name; call it `<feature>` below.
+- If the tree is dirty, commit the WIP to the feature branch: `git add -A && git commit -m "wip: park feature work before stacked prerequisite"`. Prefer a `wip:` commit over stashing; squash-merge collapses it on landing, and a stash is invisible to other sessions.
+
+## 2. Create the prerequisite branch off origin/main
+
+```
+git fetch origin --prune
+git checkout -b feature/<feature-suffix>-prereq-<desc> origin/main
+```
+
+- `<feature-suffix>` is the feature branch name without its `feature/` prefix; `<desc>` is a short kebab-case description of the blocker. Example: feature `feature/csv-connector` with an encoding bug prerequisite becomes `feature/csv-connector-prereq-fix-encoding`.
+- Branching off `origin/main` (not the feature branch) is what makes the stack work: the prerequisite PR must contain no feature commits.
+
+## 3. Implement the prerequisite to full standard
+
+Being unplanned lowers no bars. All CLAUDE.md rules apply:
+
+- TDD (failing test first; for a bug the test must reproduce it before the fix).
+- Build/test gates: targeted during the loop, `dotnet build JIM.sln` and `dotnet test JIM.sln` clean before the PR (or the documented non-code exceptions).
+- Changelog entry under `[Unreleased]` plus public docs if the change is user-facing.
+- Commit with a clear message and push: `git push -u origin feature/<feature-suffix>-prereq-<desc>`.
+
+## 4. Open the prerequisite PR and queue auto-merge
+
+Follow `/pr-merge` conventions (title under 70 chars, JIM body template):
+
+```
+gh pr create --base main --title "fix: <desc>" --body "..."
+gh pr merge <n> --squash --delete-branch --auto
+```
+
+- The immediate `gh pr merge` failure right after create is expected; `--auto` queues it.
+- Resolve `github-code-quality` feedback per the `/pr-merge` loop. Do not wait for the merge to land before moving on; that is the point of stacking.
+
+## 5. Fold the prerequisite into the feature branch and resume
+
+```
+git checkout feature/<feature>
+git merge feature/<feature-suffix>-prereq-<desc>
+git push
+```
+
+The feature branch now contains the fix and work can continue immediately.
+
+## 6. Retarget the feature PR (if one exists)
+
+```
+gh pr list --head feature/<feature> --state open --json number
+gh pr edit <feature-pr> --base feature/<feature-suffix>-prereq-<desc>
+```
+
+- This keeps the feature PR's diff limited to feature work while the prerequisite is open.
+- If no feature PR exists yet, nothing to do now; if one is created while the prerequisite PR is still open, pass `--base feature/<feature-suffix>-prereq-<desc>` at creation.
+
+## 7. Arm the landing notification, then resume the feature
+
+Watch for the prerequisite landing with a background waiter (per CLAUDE.md "Closing the loop after `--auto`"):
+
+```
+until [ "$(gh pr view <n> --json state -q .state)" = "MERGED" ]; do sleep 30; done
+```
+
+Run with `run_in_background: true` and carry on with feature work. When it fires:
+
+1. GitHub auto-retargets the feature PR to `main` (the prerequisite branch was deleted). Verify with `gh pr view <feature-pr> --json baseRefName`; if needed, `gh pr edit <feature-pr> --base main`.
+2. On the feature branch:
+   ```
+   git fetch origin --prune
+   git merge origin/main
+   git push
+   ```
+   The squash commit supersedes the prerequisite commits; conflicts, if any, are content-identical and trivial. Eyeball `CHANGELOG.md` `[Unreleased]` for a doubled bullet (union driver duplication) and tidy.
+3. Delete the local prerequisite branch: `git branch -D feature/<feature-suffix>-prereq-<desc>`.
+
+## Nesting and edge cases
+
+- **A blocker inside the prerequisite:** apply this skill again with the prerequisite as the parent; stacks nest with the same pattern. Keep stacks shallow and always land the bottom first.
+- **Prerequisite CI goes red while you are back on feature work:** the drive-to-green duty from the PR-handling rules applies; fix the prerequisite before adding more feature work on top of it.
+- **The blocker is NOT needed to deliver the feature:** this skill does not apply. File an issue with native blocked-by/sub-issue links per CLAUDE.md and stay on the feature.
+
+End the skill (step 6) on a one-line status: prerequisite PR number, feature PR retarget state, and confirmation that feature work has resumed. Step 7's completion is reported when the waiter fires.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -52,7 +52,7 @@ If you open the devcontainer without doing this first, `setup.sh` detects the de
 - **.NET 10.0 SDK** - Latest .NET framework
 - **dotnet-ef** - Entity Framework Core CLI tools
 - **Docker-in-Docker** - Run docker-compose inside the container
-- **GitHub CLI (gh)** - GitHub operations from terminal
+- **GitHub CLI (gh)** - GitHub operations from terminal (plus the `gh-stack` extension for stacked PRs, installed by `setup.sh`)
 - **Zsh + Oh My Zsh** - Enhanced shell with useful features
 
 ### VS Code Extensions
@@ -79,7 +79,8 @@ When the container is created, `setup.sh` automatically:
 6. ✅ Applies Entity Framework migrations
 7. ✅ Builds the JIM solution
 8. ✅ Installs the Playwright MCP browser (Chromium) for in-IDE UI validation
-9. ✅ Creates helpful shell aliases
+9. ✅ Installs the `gh-stack` CLI extension for the stacked-PR workflow
+10. ✅ Creates helpful shell aliases
 
 ### UI Validation (Playwright MCP)
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -340,6 +340,31 @@ else
 "
 fi
 
+# 11b. Install the gh-stack extension (stacked PRs)
+# The stacked-PR workflow (root CLAUDE.md "Stacked PRs for discovered work",
+# /stack-pr, /pr-merge) uses GitHub's native stacked pull requests (public
+# preview), driven locally by the github/gh-stack CLI extension. Requires
+# gh 2.90+; the github-cli Feature tracks latest, so any recent rebuild
+# qualifies. Extensions install into the user's home, not the image, so a
+# rebuild loses them - reinstall here. gh commands need auth, so on a local
+# devcontainer where login is still pending this records a follow-up action
+# instead of failing the setup.
+print_step "Installing gh-stack extension (stacked PRs)..."
+if ! command -v gh >/dev/null 2>&1; then
+    print_warning "gh CLI not found - skipping gh-stack extension install"
+elif gh extension list 2>/dev/null | grep -q 'github/gh-stack'; then
+    print_success "gh-stack extension already installed"
+elif gh extension install github/gh-stack >/dev/null 2>&1; then
+    print_success "gh-stack extension installed (run: gh stack)"
+else
+    print_warning "gh-stack extension install failed (usually: gh not yet authenticated)"
+    PENDING_ACTIONS+="  ▶ gh-stack extension not installed. After gh auth login, run:
+      gh extension install github/gh-stack
+      (Needed for the stacked-PR workflow: gh stack add/rebase/push - see /stack-pr.)
+
+"
+fi
+
 # 12. Mirror host SSH directory into the container's writable ~/.ssh
 # The host's ~/.ssh is bind-mounted read-only at /host-ssh (see devcontainer.json
 # "mounts"). We can't ssh straight from there because:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,8 @@ PRDs and plans share the same three-state lifecycle: created at the top level of
 
 - Always work on a feature branch; never commit directly to `main`
 - Branch naming: `feature/description`
-- **Reuse the existing feature branch; never create a new one because the current branch's name "doesn't fit" the task.** If you start work and find yourself already checked out on a feature branch (i.e. not `main`), commit your changes there. Do not create `feature/<something-else>` for an unrelated task. The user runs multiple chat sessions in parallel and tracks work by branch; spawning new branches makes commits invisible across sessions. If the scope has genuinely broadened, surface it: "this commit is unrelated to the current branch name; want me to rename the branch or stay on it?" and let the user decide. Only branch off `main` when the user explicitly asks, when you have just merged/finished the previous branch and are starting fresh from a clean `main`, or when creating a prerequisite branch for a stacked PR (see "Stacked PRs for discovered blockers" below; that is the one sanctioned mid-task branch creation).
-- Never automatically create a PR or merge to `main` - the user must explicitly instruct. One standing exception: prerequisite PRs in the stacked-PR flow below are pre-authorised; opening and auto-merging them is part of delivering the feature.
+- **Reuse the existing feature branch; never create a new one because the current branch's name "doesn't fit" the task.** If you start work and find yourself already checked out on a feature branch (i.e. not `main`), commit your changes there. Do not create `feature/<something-else>` for an unrelated task. The user runs multiple chat sessions in parallel and tracks work by branch; spawning new branches makes commits invisible across sessions. If the scope has genuinely broadened, surface it: "this commit is unrelated to the current branch name; want me to rename the branch or stay on it?" and let the user decide. Only branch off `main` when the user explicitly asks, when you have just merged/finished the previous branch and are starting fresh from a clean `main`, or when creating a new stack layer off the current feature branch (see "Stacked PRs for discovered work" below; that is the one sanctioned mid-task branch creation).
+- Never automatically create a PR or merge to `main` - the user must explicitly instruct. One standing exception: stack-layer PRs in the stacked-PR flow below are pre-authorised; opening them (base = the branch below) is part of delivering the feature.
 - Build and test pass before commit (per Critical Rules); push and PR only when the user asks
 - Before filing a new GitHub issue, ALWAYS search existing open and closed issues for duplicates: `gh issue list --state all --search "<keywords>"`. Surface any close matches to the user before creating a new one.
 - **Record issue relationships with GitHub's native features, never as comments or body-text markers.** The plain `gh issue` commands have no flags for these; use the API directly:
@@ -195,20 +195,20 @@ PRDs and plans share the same three-state lifecycle: created at the top level of
   - Pick blocked-by for ordering and parent/sub-issue for hierarchy; they are not interchangeable. Issue bodies may state the *rationale* for a relationship, but the relationship itself must exist as the native link (it shows in the sidebar, rolls up, and is queryable; prose goes stale).
 - Dependabot does not auto-rebase PRs when they fall behind `main`. After merging any PR in a batch, comment `@dependabot rebase` on each remaining open Dependabot PR via `gh pr comment <num> --body '@dependabot rebase'`.
 
-### Stacked PRs for discovered blockers
+### Stacked PRs for discovered work
 
-When feature work surfaces something that must be solved to deliver the feature but is not semantically part of it (a bug in existing code, a missing capability, a prerequisite refactor), do NOT fold it into the feature branch and do NOT defer it to an issue. Fix it immediately in its own stacked PR, then resume the feature. `/stack-pr` encodes the full flow; the shape is:
+When feature work surfaces something that must be solved to deliver the feature but is not semantically part of it (a bug in existing code, a missing capability, a prerequisite refactor), do NOT fold it into the feature branch and do NOT defer it to an issue. Isolate it in the next layer of a GitHub stacked PR (native support, public preview) and fix it now. `/stack-pr` encodes the full flow; the shape is:
 
-1. **Announce, don't ask.** State the blocker in one line and proceed with the stack. "Ask before significant changes" still applies to *how* an architecturally significant prerequisite is solved, never to *whether* it gets its own stacked PR.
-2. **Commit feature WIP** (a `wip:` commit is fine; squash-merge collapses it), then branch the prerequisite off `origin/main`, named for its parent: `feature/<feature>-prereq-<desc>`.
-3. **Implement the prerequisite to full standard**: TDD, build/test gates, changelog and docs if user-facing. Being unplanned lowers no bars.
-4. **Open its PR against `main` and queue it**: `gh pr create`, then `gh pr merge <n> --squash --delete-branch --auto`. Zero required approvals means the base of a stack should land in hours, not days.
-5. **Fold it into the feature branch and resume**: `git checkout feature/<feature> && git merge feature/<feature>-prereq-<desc>`.
-6. **Point the feature PR at the prerequisite branch** while the prerequisite is open (`gh pr create --base` / `gh pr edit --base feature/<feature>-prereq-<desc>`) so its diff shows only feature work.
-7. **Land bottom-up.** When the prerequisite squash-merges and its branch is deleted, GitHub retargets the feature PR back to `main`. Then `git merge origin/main` into the feature branch and push: the squash commit supersedes the prerequisite commits, any conflicts are content-identical and trivial, and the feature PR's diff returns to feature-only. Eyeball `CHANGELOG.md` `[Unreleased]` for a doubled bullet (the union driver can duplicate an entry that arrived via both the prerequisite branch and the squash) and tidy.
+1. **Announce, don't ask.** State the discovery in one line and proceed with the stack. "Ask before significant changes" still applies to *how* an architecturally significant piece is solved, never to *whether* it gets its own stack layer.
+2. **Commit feature WIP** (a `wip:` commit is fine; squash-merge collapses it), then create the new layer **off the current feature branch**: `git checkout -b feature/<feature-suffix>-stack-<desc>`. A stack is a sequential chain; each layer branches from the one below it, never from `main`.
+3. **Implement the layer to full standard**: TDD, build/test gates, changelog and docs if user-facing. Being unplanned lowers no bars.
+4. **Open the layer's PR with its base set to the branch below** (`gh pr create --base feature/<feature>`), then link the chain into a stack: GitHub shows a banner on aligned chains offering to convert, or use the `gh stack` CLI (`gh extension install github/gh-stack`). Reviewers and history get one clean diff per concern.
+5. **Continue work in the right layer.** Code may only depend on its own layer or lower ones, so remaining feature work that needs the fix goes in a new layer on top (`gh stack add`); feature work independent of the fix continues on the feature branch below, followed by a restack (the web "Rebase stack" button, or `gh stack rebase` + `gh stack push`).
+6. **Land bottom-up.** Any PR can merge once everything below it is green; merging an upper PR merges all unmerged PRs below it **atomically, in order, each recorded individually** - so the normal move is to merge from the top when the objective is complete. Every PR in the stack is evaluated against `main`'s protections (all seven required checks), regardless of its direct base.
 
-- Stacks may nest (a prerequisite of a prerequisite) using the same pattern; keep them shallow and always land the bottom first.
-- Prerequisite branches belong to the same session and objective as their parent feature branch; the `-prereq-` naming keeps the lineage visible across parallel sessions.
+- **Auto-merge is not supported for stacked PRs.** Do not `gh pr merge --auto` a stack layer; wait for green, then merge (see `/pr-merge`).
+- **Stacks require fully linear history**, so within a stack the merge-don't-rebase rule is inverted: restack with cascading rebase (`gh stack rebase`, then `gh stack push` to force-push the layers), never by merging one layer into another.
+- Layers stay shallow and single-concern; nest further layers the same way. Layer branches belong to the same session and objective as their parent feature branch; the `-stack-` naming keeps the lineage visible across parallel sessions.
 - GitHub issues remain only for genuine observations that are NOT needed to deliver the current objective (link them with native blocked-by/sub-issue relationships per the rules above).
 
 ### Bringing a feature branch up to date with `main`
@@ -222,7 +222,7 @@ git merge origin/main      # then git push (no force needed)
 
 - `CHANGELOG.md` carries a `merge=union` driver (`.gitattributes`), so concurrent `[Unreleased]` entries combine automatically rather than conflicting. After merging, eyeball that section for duplicated `###` headers or bullets and tidy if needed.
 - Only rebase when the user explicitly wants linear pre-squash history. If you do, and the merge backend reports a misleading "local changes would be overwritten" on a clean tree, `git -c rebase.backend=apply rebase origin/main` gets past it.
-- **Stacked feature PRs:** while a prerequisite PR is still open, the feature PR's base is the prerequisite branch, so "up to date" is measured against that branch (`git merge feature/<feature>-prereq-<desc>`), not `origin/main`. Once the prerequisite lands and the PR retargets to `main`, this section applies as normal.
+- **Stacked PRs are the exception:** a stack requires fully linear history between its layers, so a branch that is part of a stack is brought up to date by cascading rebase (`gh stack rebase` + `gh stack push`, or the web "Rebase stack" button), never by merging. This section's merge-don't-rebase rule applies only to ordinary, non-stacked feature branches.
 
 ### Merging via gh CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,8 @@ PRDs and plans share the same three-state lifecycle: created at the top level of
 
 - Always work on a feature branch; never commit directly to `main`
 - Branch naming: `feature/description`
-- **Reuse the existing feature branch; never create a new one because the current branch's name "doesn't fit" the task.** If you start work and find yourself already checked out on a feature branch (i.e. not `main`), commit your changes there. Do not create `feature/<something-else>` for an unrelated task. The user runs multiple chat sessions in parallel and tracks work by branch; spawning new branches makes commits invisible across sessions. If the scope has genuinely broadened, surface it: "this commit is unrelated to the current branch name; want me to rename the branch or stay on it?" and let the user decide. Only branch off `main` when the user explicitly asks, or when you have just merged/finished the previous branch and are starting fresh from a clean `main`.
-- Never automatically create a PR or merge to `main` - the user must explicitly instruct
+- **Reuse the existing feature branch; never create a new one because the current branch's name "doesn't fit" the task.** If you start work and find yourself already checked out on a feature branch (i.e. not `main`), commit your changes there. Do not create `feature/<something-else>` for an unrelated task. The user runs multiple chat sessions in parallel and tracks work by branch; spawning new branches makes commits invisible across sessions. If the scope has genuinely broadened, surface it: "this commit is unrelated to the current branch name; want me to rename the branch or stay on it?" and let the user decide. Only branch off `main` when the user explicitly asks, when you have just merged/finished the previous branch and are starting fresh from a clean `main`, or when creating a prerequisite branch for a stacked PR (see "Stacked PRs for discovered blockers" below; that is the one sanctioned mid-task branch creation).
+- Never automatically create a PR or merge to `main` - the user must explicitly instruct. One standing exception: prerequisite PRs in the stacked-PR flow below are pre-authorised; opening and auto-merging them is part of delivering the feature.
 - Build and test pass before commit (per Critical Rules); push and PR only when the user asks
 - Before filing a new GitHub issue, ALWAYS search existing open and closed issues for duplicates: `gh issue list --state all --search "<keywords>"`. Surface any close matches to the user before creating a new one.
 - **Record issue relationships with GitHub's native features, never as comments or body-text markers.** The plain `gh issue` commands have no flags for these; use the API directly:
@@ -194,6 +194,22 @@ PRDs and plans share the same three-state lifecycle: created at the top level of
   - Containment (epic → part): parent/sub-issue, via GraphQL `addSubIssue` / `removeSubIssue` mutations with the two issues' node ids (`--jq .node_id`).
   - Pick blocked-by for ordering and parent/sub-issue for hierarchy; they are not interchangeable. Issue bodies may state the *rationale* for a relationship, but the relationship itself must exist as the native link (it shows in the sidebar, rolls up, and is queryable; prose goes stale).
 - Dependabot does not auto-rebase PRs when they fall behind `main`. After merging any PR in a batch, comment `@dependabot rebase` on each remaining open Dependabot PR via `gh pr comment <num> --body '@dependabot rebase'`.
+
+### Stacked PRs for discovered blockers
+
+When feature work surfaces something that must be solved to deliver the feature but is not semantically part of it (a bug in existing code, a missing capability, a prerequisite refactor), do NOT fold it into the feature branch and do NOT defer it to an issue. Fix it immediately in its own stacked PR, then resume the feature. `/stack-pr` encodes the full flow; the shape is:
+
+1. **Announce, don't ask.** State the blocker in one line and proceed with the stack. "Ask before significant changes" still applies to *how* an architecturally significant prerequisite is solved, never to *whether* it gets its own stacked PR.
+2. **Commit feature WIP** (a `wip:` commit is fine; squash-merge collapses it), then branch the prerequisite off `origin/main`, named for its parent: `feature/<feature>-prereq-<desc>`.
+3. **Implement the prerequisite to full standard**: TDD, build/test gates, changelog and docs if user-facing. Being unplanned lowers no bars.
+4. **Open its PR against `main` and queue it**: `gh pr create`, then `gh pr merge <n> --squash --delete-branch --auto`. Zero required approvals means the base of a stack should land in hours, not days.
+5. **Fold it into the feature branch and resume**: `git checkout feature/<feature> && git merge feature/<feature>-prereq-<desc>`.
+6. **Point the feature PR at the prerequisite branch** while the prerequisite is open (`gh pr create --base` / `gh pr edit --base feature/<feature>-prereq-<desc>`) so its diff shows only feature work.
+7. **Land bottom-up.** When the prerequisite squash-merges and its branch is deleted, GitHub retargets the feature PR back to `main`. Then `git merge origin/main` into the feature branch and push: the squash commit supersedes the prerequisite commits, any conflicts are content-identical and trivial, and the feature PR's diff returns to feature-only. Eyeball `CHANGELOG.md` `[Unreleased]` for a doubled bullet (the union driver can duplicate an entry that arrived via both the prerequisite branch and the squash) and tidy.
+
+- Stacks may nest (a prerequisite of a prerequisite) using the same pattern; keep them shallow and always land the bottom first.
+- Prerequisite branches belong to the same session and objective as their parent feature branch; the `-prereq-` naming keeps the lineage visible across parallel sessions.
+- GitHub issues remain only for genuine observations that are NOT needed to deliver the current objective (link them with native blocked-by/sub-issue relationships per the rules above).
 
 ### Bringing a feature branch up to date with `main`
 
@@ -206,6 +222,7 @@ git merge origin/main      # then git push (no force needed)
 
 - `CHANGELOG.md` carries a `merge=union` driver (`.gitattributes`), so concurrent `[Unreleased]` entries combine automatically rather than conflicting. After merging, eyeball that section for duplicated `###` headers or bullets and tidy if needed.
 - Only rebase when the user explicitly wants linear pre-squash history. If you do, and the merge backend reports a misleading "local changes would be overwritten" on a clean tree, `git -c rebase.backend=apply rebase origin/main` gets past it.
+- **Stacked feature PRs:** while a prerequisite PR is still open, the feature PR's base is the prerequisite branch, so "up to date" is measured against that branch (`git merge feature/<feature>-prereq-<desc>`), not `origin/main`. Once the prerequisite lands and the PR retargets to `main`, this section applies as normal.
 
 ### Merging via gh CLI
 


### PR DESCRIPTION
## Description

Adds comprehensive documentation and tooling for GitHub native stacked PRs (public preview) as a sanctioned workflow for isolating discovered work mid-feature. This change formalizes the policy already stated in CLAUDE.md ("Stacked PRs for discovered work") into a complete, executable skill (`/stack-pr`) with step-by-step guidance, updates the devcontainer to install the `gh-stack` CLI extension, and extends `/pr-merge` to handle stack-specific landing mechanics.

**Why:** Feature work frequently surfaces bugs, missing capabilities, or prerequisite refactors that must be solved to deliver the objective but are not semantically part of the feature branch. Stacking isolates these discoveries into separate layers (each with its own PR, tests, and changelog entry) while keeping the chain reviewable, testable, and mergeable as a unit. This prevents feature branches from becoming catch-all buckets and keeps the commit history clean and single-concern.

## Type of change

- [x] New feature (stacked-PR workflow formalization and tooling)
- [x] Documentation update

## Testing

- [x] No code changes; documentation and configuration only
- [x] `setup.sh` changes are shell script configuration (build/test exception per CLAUDE.md)
- [x] Verified `gh-stack` extension install logic handles missing `gh` CLI gracefully and records pending action if auth is not yet complete

## Documentation

- [x] Public documentation: `.claude/skills/stack-pr/SKILL.md` (new, comprehensive workflow guide)
- [x] Engineering reference: `CLAUDE.md` updated with "Stacked PRs for discovered work" section (policy, rules, and rationale)
- [x] `.claude/skills/pr-merge/SKILL.md` updated with "Stacked PRs" section (landing mechanics, rebase vs. merge, auto-merge unsupported, bottom-up atomic merge)
- [x] `.devcontainer/README.md` updated to document `gh-stack` extension installation
- [x] `.devcontainer/setup.sh` updated to install `gh-stack` extension on devcontainer creation

## Checklist

- [x] Commit messages are descriptive
- [x] Documentation follows conventions in `engineering/CLAUDE.md` and `docs/CLAUDE.md`
- [x] User-facing text uses British English (en-GB)
- [x] No security-sensitive information included

## Additional context

**Key changes:**

1. **`.claude/skills/stack-pr/SKILL.md`** (new): Complete workflow skill covering one-time setup, parking current work, creating the layer, implementing to full standard, opening the PR with correct base, continuing work in the right layer, and landing. Includes notes on edge cases (shallow layers, nested discoveries, when stacking does NOT apply).

2. **`CLAUDE.md`** ("Stacked PRs for discovered work" section): Formalizes the policy with six-step summary, clarifies that "announce, don't ask" applies (pre-authorised by policy), explains the sequential chain structure, and notes that auto-merge is unsupported and stacks require fully linear history (rebase, not merge, within a stack).

3. **`.claude/skills/pr-merge/SKILL.md`** ("Stacked PRs" section): Extends `/pr-merge` with stack-aware landing: rebase to stay current (not merge), no auto-merge, bottom-up atomic merge (merging any PR also merges all unmerged PRs below it), and cleanup of layer branches.

4. **`.devcontainer/setup.sh`**: Adds step 11b to install `gh-stack` extension (requires `gh 2.90+`). Handles missing `gh` CLI gracefully and records a pending action if auth is not yet complete (extensions need auth to install).

5. **`.devcontainer/README.md`**: Documents `gh-stack` extension as part of the devcontainer tooling and notes it is installed by `setup.sh`.

**Rationale:**

- Stacked PRs are a GitHub native feature (public preview) that keep discovered work isolated, reviewable, and testable without deferring to issues or folding into the feature branch.
-

https://claude.ai/code/session_01UMuC1k2ardgVkpouxiAQK4