### PR TITLE
ci: exclude unit test projects from CodeQL alerting

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -32,6 +32,33 @@
 #   deployment-level controls (file permissions, log retention, SIEM
 #   access controls) which are outside CodeQL's visibility.
 
+#
+# Excluded paths (with rationale):
+#
+#   test/JIM.*.Tests/** (unit and component test projects)
+#   ------------------------------------------------------
+#   CodeQL's taint analysis treats environment-variable reads as sensitive
+#   sources, so tests that read fixture values such as JIM_TEST_LDAP_HOST
+#   and store them in plain fields are repeatedly flagged as "clear-text
+#   storage of sensitive information". These are test hostnames and fixture
+#   data, not secrets, and the alerts re-mint on every push that touches
+#   the files (dismissals do not carry across analyses), producing a
+#   recurring false-positive dance on any PR touching connector tests
+#   (first seen on PR #1169, five alerts).
+#
+#   The exclusion is deliberately scoped to the unit/component test
+#   projects only, not the whole test/ tree: integration scripts under
+#   test/integration/ can handle real credentials for a running stack, so
+#   anything scannable there stays in scope. Test project code never ships
+#   in a JIM deployment.
+#
+#   Note: for compiled languages (C#) paths-ignore cannot limit what gets
+#   built and extracted; it filters the alerts produced. That is exactly
+#   the intent here.
+
+paths-ignore:
+  - test/JIM.*.Tests/**
+
 query-filters:
   - exclude:
       id: cs/exposure-of-sensitive-information


### PR DESCRIPTION
## Description

Adds a `paths-ignore` entry to `.github/codeql/codeql-config.yml` so CodeQL stops raising alerts for the unit and component test projects (`test/JIM.*.Tests/**`).

CodeQL's taint analysis treats environment-variable reads as sensitive sources, so tests reading fixture values such as `JIM_TEST_LDAP_HOST` and storing them in plain fields are repeatedly flagged as "clear-text storage of sensitive information". These are test hostnames, not secrets, and the alerts re-mint on every push that touches the files (dismissals do not carry across analyses); PR #1169 produced five such alerts, all dismissed as false positives.

The exclusion is deliberately narrow: `test/integration/` stays in scope because integration scripts can handle real credentials for a running stack, and test project code never ships in a JIM deployment. For compiled languages `paths-ignore` filters alerts rather than limiting extraction, which is exactly the intent; the three required `Analyze (*)` checks continue to run unchanged.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [x] Other (CI/CD configuration)

## Testing

- [ ] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment

CI/CD configuration only; no .NET code changes, so the build/test gates do not apply. The CodeQL runs on this PR itself validate the config parses and the checks still complete.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

Docs: n/a - CI/CD configuration change with no user-facing behaviour

## Screenshots / output (if applicable)

n/a

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

The rationale is recorded as a comment block in the config file itself, matching the existing style used for the `cs/exposure-of-sensitive-information` query filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9)_