### PR TITLE
fix: compact the Directory Capabilities table and shrink its label column

### DIFF
--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
@@ -44,12 +44,13 @@
 
     @if (_capabilities.Count > 0)
     {
-        <MudSimpleTable Class="mt-4" Dense="false" Hover="false" Striped="true" Elevation="0">
+        <MudSimpleTable Class="mt-4" Dense="true" Hover="false" Striped="true" Elevation="0">
             <tbody>
                 @foreach (var capability in _capabilities)
                 {
+                    @* width: 1% + nowrap shrinks the label column to its content, keeping values beside their labels *@
                     <tr>
-                        <td style="width: 40%;">@capability.Name</td>
+                        <td style="width: 1%; white-space: nowrap; padding-right: 2rem;">@capability.Name</td>
                         <td>@capability.Value</td>
                     </tr>
                 }


### PR DESCRIPTION
## Description

Follow-up polish to the Directory Capabilities card (#231 / PR #1178): the table now uses dense rows, and the label column sizes to its content (`width: 1%` + `nowrap`) so values sit directly beside their labels instead of far out to the right at the old 40% column split.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

UI-only Razor change: built with zero warnings and verified visually against the running stack with a populated card (dense rows, label column hugging its content). No behaviour change, so no new tests.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

Docs: n/a - cosmetic table layout tweak, no behaviour change

## Screenshots / output (if applicable)

Verified live: rows compact, labels and values adjacent.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9)_