### PR TITLE
fix: move Save Changes inside the details pane on the Connected System Details tab

### DIFF
--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
@@ -29,8 +29,8 @@
         <MudTextField T="string" Label="Name" @bind-Value="ConnectedSystem.Name" Required="true" RequiredError="A name is required" Immediate="true" Variant="Variant.Outlined" Class="mt-5" />
         <MudTextField T="string" Label="Description" Required="false" @bind-Value="ConnectedSystem.Description" Lines="5" MaxLines="10" Sizing="InputSizing.Auto" Variant="Variant.Outlined" Class="mt-5" />
     </MudForm>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!IsDetailsFormValid)" Class="mt-5" OnClick="HandleValidDetailsSubmitAsync" DropShadow="false">Save Changes</MudButton>
 </MudPaper>
-<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!IsDetailsFormValid)" Class="mt-5" OnClick="HandleValidDetailsSubmitAsync" DropShadow="false">Save Changes</MudButton>
 
 @* ─── Directory Capabilities (hidden entirely when the Connector cannot detect capabilities) ─── *@
 @if (_capabilities != null)


### PR DESCRIPTION
## Description

Moves the Save Changes button up into the details `MudPaper`, so the editable details form and the read-only Directory Capabilities card below it read as two clearly separate panels. Follow-up polish to #231 / PRs #1178 and #1180.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

UI-only Razor change: built with zero warnings and verified visually against the running stack (button renders inside the outlined details panel, gating behaviour unchanged). No behaviour change, so no new tests.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

Docs: n/a - cosmetic layout tweak, no behaviour change

## Screenshots / output (if applicable)

Verified live: Save Changes now inside the details panel border, Directory Capabilities standing alone beneath it.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9)_