### PR TITLE
fix: in-panel Save Changes spacing, and pluralise the Pending Exports button

### DIFF
--- a/src/JIM.Web/Pages/Admin/ApiKeyDetail.razor
+++ b/src/JIM.Web/Pages/Admin/ApiKeyDetail.razor
@@ -39,7 +39,8 @@
                     <MudTextField T="string" @bind-Value="_apiKey.Description" Label="Description" Required="false"
                         Lines="2" MaxLines="6" Sizing="InputSizing.Auto" Variant="Variant.Outlined" Class="mt-5" />
                 </MudForm>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_detailsFormValid)" Class="mt-5" OnClick="HandleSaveDetailsAsync" DropShadow="false">Save Changes</MudButton>
+                @* mt-3: see ConnectedSystemDetailsTab, same in-panel button spacing *@
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_detailsFormValid)" Class="mt-3" OnClick="HandleSaveDetailsAsync" DropShadow="false">Save Changes</MudButton>
             </MudPaper>
 
             <MudPaper Class="pa-4 mt-6" Outlined="true">

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
@@ -20,7 +20,7 @@
                    Size="Size.Small"
                    StartIcon="@Icons.Material.Filled.Outbox"
                    Href="@($"/admin/connected-systems/{ConnectedSystem.Id}/pending-exports")">
-            Pending Export @(PendingExportCount > 0 ? $"({PendingExportCount.ToString("N0")})" : "")
+            Pending Exports @(PendingExportCount > 0 ? $"({PendingExportCount.ToString("N0")})" : "")
         </MudButton>
     </MudStack>
     <MudForm @bind-IsValid="@IsDetailsFormValid" @bind-Errors="@DetailsFormErrors">

--- a/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/ConnectedSystemDetailsTab.razor
@@ -29,7 +29,8 @@
         <MudTextField T="string" Label="Name" @bind-Value="ConnectedSystem.Name" Required="true" RequiredError="A name is required" Immediate="true" Variant="Variant.Outlined" Class="mt-5" />
         <MudTextField T="string" Label="Description" Required="false" @bind-Value="ConnectedSystem.Description" Lines="5" MaxLines="10" Sizing="InputSizing.Auto" Variant="Variant.Outlined" Class="mt-5" />
     </MudForm>
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!IsDetailsFormValid)" Class="mt-5" OnClick="HandleValidDetailsSubmitAsync" DropShadow="false">Save Changes</MudButton>
+    @* mt-3 (+ the input control's own 4px bottom margin) gives a 16px gap, matching the panel's pa-4 padding below the button so it sits symmetrically inside the panel *@
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!IsDetailsFormValid)" Class="mt-3" OnClick="HandleValidDetailsSubmitAsync" DropShadow="false">Save Changes</MudButton>
 </MudPaper>
 
 @* ─── Directory Capabilities (hidden entirely when the Connector cannot detect capabilities) ─── *@


### PR DESCRIPTION
## Description

Two pieces of UI polish on the Connected System Details tab.

**1. In-panel Save Changes spacing.** `mt-5` on a Save Changes button that sits inside its panel left a 24px gap above it but only the panel's own 16px `pa-4` padding below, so the button read as sitting low in the panel. `mt-3` (plus the input control's own 4px bottom margin) gives 16px above, matching the padding below. Applied to both places with this shape, so they stay consistent: the Connected System Details tab (follow-up to #231 / PR #1181) and the API Key details panel, which uses the identical `pa-4` panel → `MudForm` → button markup.

Measured in the browser rather than eyeballed: gap above the button is now 16px, matching the 16px below; the 24px field-to-field rhythm inside the form is unchanged.

**2. "Pending Export" → "Pending Exports".** The button leads to a list; the destination page title, its breadcrumb and its route (`/pending-exports`) were all plural already, so only the button was singular.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

UI-only Razor changes: built with zero warnings, verified visually and by measuring the rendered gaps against the running stack. No behaviour change, so no new tests.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

Docs: n/a - cosmetic spacing and label tweaks, no behaviour change

## Screenshots / output (if applicable)

Verified live: Save Changes sits symmetrically inside the details panel (16px above, 16px below).

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

Both spacing call sites carry a short comment explaining the 16px arithmetic, so a future edit does not silently revert to `mt-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvqMHM6tCnQVs62ycH1Nb9