### PR TITLE
Close MVO_COPY_BINARY_PERSISTENCE plan; record the updates conversion

### DIFF
--- a/engineering/plans/done/MVO_COPY_BINARY_PERSISTENCE.md
+++ b/engineering/plans/done/MVO_COPY_BINARY_PERSISTENCE.md
@@ -1,10 +1,11 @@
 # MVO COPY Binary Persistence
 
-- **Status:** Doing (creates complete, updates deferred)
+- **Status:** Done
+- **Note:** Creates and updates are both on raw SQL. The updates half, deferred when this plan was written, was subsequently implemented as `UpdateMetaverseObjectsBulkAsync` (batched `UPDATE ... FROM (VALUES ...)` plus attribute-value insert/delete reconciliation). [#436](https://github.com/TetronIO/JIM/issues/436) remains open for its other items (caching Future Considerations A, B and C), which were never part of this plan.
 - **Milestone**: v0.9-STABILISATION
 - **GitHub Issue**: [#436](https://github.com/TetronIO/JIM/issues/436)
-- **Parent**: [#338](https://github.com/TetronIO/JIM/issues/338) (closed; Phases 1–6 creates complete)
-- **Related**: [`docs/plans/done/WORKER_DATABASE_PERFORMANCE_OPTIMISATION.md`](../done/WORKER_DATABASE_PERFORMANCE_OPTIMISATION.md)
+- **Parent**: [#338](https://github.com/TetronIO/JIM/issues/338) (closed; Phases 1-6 creates complete)
+- **Related**: [`engineering/plans/done/WORKER_DATABASE_PERFORMANCE_OPTIMISATION.md`](WORKER_DATABASE_PERFORMANCE_OPTIMISATION.md)
 - **Created**: 2026-03-27
 
 ## Overview
@@ -44,7 +45,9 @@ Integration testing revealed that bypassing EF for MVO creates caused a `DbUpdat
 2. When `SaveChangesAsync` runs later (via `UpdateActivityAsync`), EF needs to track the parent MVO to discover and persist these child entities
 3. With COPY binary, MVOs were untracked; EF either missed the child entities or discovered the MVOs through navigation traversal with stale `xmin = 0`
 
-**Fix**: After COPY binary persistence, MVOs and their attribute values are attached to the EF change tracker as `Unchanged` with shadow FKs (`TypeId`, `MetaverseObjectId`) set explicitly. This is a **temporary bridge**: it will be removed when MVO change tracking and export evaluation are also converted to raw SQL.
+**Fix**: After COPY binary persistence, MVOs and their attribute values are attached to the EF change tracker as `Unchanged` with shadow FKs (`TypeId`, `MetaverseObjectId`) set explicitly. This was framed as a **temporary bridge**, to be removed when MVO change tracking and export evaluation are also converted to raw SQL.
+
+**Outcome:** the bridge is still in place, because `CreatePendingMvoChangeObjectsAsync` and `EvaluatePendingExportsAsync` still rely on EF to persist child entities added to MVO navigation collections. It is no longer a hazard: the tracked `xmin` stays 0 after COPY, but the update path is raw SQL keyed on `Id` with no `xmin` predicate, and it detaches the graph afterwards, so nothing on the sync write path reads the bogus value. EF-tracked writes elsewhere (UI / API edits) still enforce `xmin` against their own reads.
 
 ### Column Reference
 
@@ -97,11 +100,22 @@ The caller at `SyncTaskProcessorBase` relies on `cso.MetaverseObject.Id` being p
 
 ---
 
-## MVO Updates (deferred)
+## MVO Updates ✅
 
-`UpdateMetaverseObjectsAsync` remains on EF Core. Tracked under [#436](https://github.com/TetronIO/JIM/issues/436); tackle only when profiling shows MVO updates are a significant bottleneck in delta sync.
+Deferred when this plan was written, then implemented: `SyncRepository.UpdateMetaverseObjectsAsync` now routes to `UpdateMetaverseObjectsBulkAsync` in `SyncRepository.MvoOperations.cs`, entirely raw SQL.
 
-### Why updates are fundamentally harder than creates
+**Implementation:**
+
+- `BulkUpdateMvoRowsViaEfAsync`: batched `UPDATE "MetaverseObjects" ... FROM (VALUES ...)` over the mutable columns (`MvoBulkInsertColumns.MetaverseObjectsUpdate`), keyed solely on `Id` with **no `xmin` predicate**.
+- Attribute-value reconciliation by diffing the in-memory collection against `LoadExistingAttributeValueIdsAsync`: added values go through `BulkInsertMvoAttributeValuesViaEfAsync`, removed values through `DeleteMetaverseObjectAttributeValuesByIdsAsync`.
+- The whole batch (row update, inserts, deletes) commits in one transaction, so an MVO is never left half-updated.
+- `DetachPersistedMvoGraphs` detaches the persisted graph afterwards, so no later EF `SaveChangesAsync` in the same page flush can re-run an `xmin`-guarded update or re-insert attribute values already written as raw SQL.
+
+**What made the classification problem tractable:** the analysis below assumed the repository would have to recover the new/modified/deleted split without EF. In practice the sync engine models every attribute change as a removal plus an addition (`SyncEngine.ApplyPendingAttributeChanges`), so existing values are never mutated in place; only inserts and deletes are needed, and both are derivable by diffing against the database. MVOs on this path always carry their complete attribute-value set (unfiltered `Include`), so an absent value is genuinely a removal.
+
+**Why it was done ahead of the profiling data the recommendation below asked for:** dropping the `xmin` predicate closed a failure class, not just a performance gap. MVOs created via COPY are tracked with `xmin = 0`, so a subsequent EF update issued `... WHERE xmin = 0`, matched no rows, and threw an unhandled `DbUpdateConcurrencyException` that aborted the run (the pre-release Full Regression Scenario14-AttributePriority failure).
+
+### Why updates looked fundamentally harder than creates
 
 Creates are a single operation (INSERT rows). Updates involve **four distinct operations in one flush**:
 
@@ -131,11 +145,11 @@ MVOs arrive at `UpdateMetaverseObjectsAsync` in mixed states depending on the ca
 | Singular update (deletion marking) | Tracked | No AV changes | Enabled |
 | Singular update (out-of-scope disconnect) | Tracked | Removals applied | Enabled |
 
-The cross-page path is the dangerous one; `AutoDetectChangesEnabled = false` prevents `SaveChangesAsync` from walking navigation properties into shared `MetaverseAttribute`/`MetaverseObjectType` instances (which would cause identity conflicts). The current `UpdateDetachedSafe` + per-entity `Entry().State =` pattern was the result of 11 debugging attempts documented in `docs/notes/done/CROSS_PAGE_REFERENCE_IDENTITY_CONFLICT.md`.
+The cross-page path is the dangerous one; `AutoDetectChangesEnabled = false` prevents `SaveChangesAsync` from walking navigation properties into shared `MetaverseAttribute`/`MetaverseObjectType` instances (which would cause identity conflicts). The `UpdateDetachedSafe` + per-entity `Entry().State =` pattern was the result of 11 debugging attempts documented in [`engineering/notes/done/CROSS_PAGE_REFERENCE_IDENTITY_CONFLICT.md`](../../notes/done/CROSS_PAGE_REFERENCE_IDENTITY_CONFLICT.md). That pattern survives in `MetaverseRepository.UpdateMetaverseObjectsAsync`, which still serves the non-sync EF callers; the sync path no longer goes near it.
 
-### Recommendation
+### Recommendation (superseded)
 
-**Wait for profiling data.** Creates are the high-volume operation during initial sync (hundreds/thousands of MVOs per page). Updates are smaller per-page during delta sync, and the EF overhead is proportionally less significant. The complexity and regression risk of converting updates is not justified without evidence that it's a bottleneck.
+The original call was to **wait for profiling data**: creates are the high-volume operation during initial sync, updates are smaller per-page during delta sync, and the conversion carried real regression risk. It was overtaken by the `xmin` failure described above, which made the conversion a correctness fix rather than an optimisation.
 
 ---
 


### PR DESCRIPTION
## Description

Marks the MVO COPY Binary Persistence plan as complete and files it under `engineering/plans/done/`. The plan was left at "Doing (creates complete, updates deferred)", but the deferred half has since shipped.

**Changes:**
- Status updated from "Doing" to "Done", with a Note recording that #436 stays open for its other items (caching Future Considerations A, B and C), which were never part of this plan
- "MVO Updates (deferred)" section rewritten as implemented: `SyncRepository.UpdateMetaverseObjectsAsync` routes to `UpdateMetaverseObjectsBulkAsync` (batched `UPDATE ... FROM (VALUES ...)` keyed on `Id` with no `xmin` predicate, attribute-value insert/delete reconciliation by diffing against the database, all in one transaction, followed by `DetachPersistedMvoGraphs`)
- Records why the conversion happened ahead of the profiling data the original recommendation asked for: MVOs created via COPY are tracked with `xmin = 0`, so a subsequent EF update issued `... WHERE xmin = 0`, matched no rows, and threw an unhandled `DbUpdateConcurrencyException` (the pre-release Full Regression Scenario14-AttributePriority failure). That made it a correctness fix, not an optimisation
- Records that the create-path EF change-tracker bridge is still in place (change-object and pending-export code still relies on EF tracking) and why it is now harmless
- Notes that the `UpdateDetachedSafe` + per-entity `Entry().State` pattern survives in `MetaverseRepository` for the non-sync EF callers
- Fixes stale `docs/plans/…` and `docs/notes/…` link paths predating the move to `engineering/`

## Type of change

- [x] Documentation update

## Testing

N/A — documentation-only change; no code touched.

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale; page: `engineering/plans/done/MVO_COPY_BINARY_PERSISTENCE.md`

<!-- Docs: n/a - documentation-only change to an internal plan document; no user-facing behaviour change and no changelog entry -->

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information

## Additional context

Retroactive closure of a living plan document, verified against the code rather than taken from the plan's own status line. #436 is deliberately left open: it tracks the caching Future Considerations alongside the MVO update conversion, and only the latter is closed by this. Its body still links the plan at its old `engineering/plans/doing/…` path, which is now stale; left untouched here.

https://claude.ai/code/session_01V7UmksNu92PEauVC2rwUh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7UmksNu92PEauVC2rwUh9)_