### PR TITLE
Close the GUID_UUID_HANDLING and DELETION_RULES_DESIGN plans

### DIFF
--- a/engineering/DEVELOPER_GUIDE.md
+++ b/engineering/DEVELOPER_GUIDE.md
@@ -199,7 +199,7 @@ Rules:
 - **Never compare raw byte arrays from different sources** - parse to `Guid` first, then compare
 - **Use `Guid.ToByteArray()` only for Microsoft-format targets** (AD, SQL Server) - RFC 4122 systems need byte-swapped first 3 components
 
-For full details and connector-specific guidance, see [`docs/plans/doing/GUID_UUID_HANDLING.md`](plans/doing/GUID_UUID_HANDLING.md).
+For full details and connector-specific guidance, see [`engineering/plans/done/GUID_UUID_HANDLING.md`](plans/done/GUID_UUID_HANDLING.md).
 
 ### 3. Database & Migrations
 

--- a/engineering/plans/done/AUTHORITATIVE_SOURCE_TRIGGER_MODES.md
+++ b/engineering/plans/done/AUTHORITATIVE_SOURCE_TRIGGER_MODES.md
@@ -2,7 +2,7 @@
 
 - **Status:** Done
 - **Issue:** [#119](https://github.com/TetronIO/JIM/issues/119)
-- **Related design doc:** [`DELETION_RULES_DESIGN.md`](../doing/DELETION_RULES_DESIGN.md)
+- **Related design doc:** [`DELETION_RULES_DESIGN.md`](DELETION_RULES_DESIGN.md)
 
 ## Overview
 

--- a/engineering/plans/done/DELETION_RULES_DESIGN.md
+++ b/engineering/plans/done/DELETION_RULES_DESIGN.md
@@ -1,6 +1,7 @@
 # Deletion Rules Design
 
-- **Status:** Doing (#115 and #119 implemented; #116, #117, #118 and #126 remain open)
+- **Status:** Done
+- **Note:** Everything this document specified has shipped: #115 (authoritative source triggers) and, as of [#1194](https://github.com/TetronIO/JIM/pull/1194), #119 (all / specific trigger modes, designed in [`AUTHORITATIVE_SOURCE_TRIGGER_MODES.md`](AUTHORITATIVE_SOURCE_TRIGGER_MODES.md)). The further deletion options surveyed below are separate features with their own issues, not outstanding work in this plan: [#116](https://github.com/TetronIO/JIM/issues/116), [#117](https://github.com/TetronIO/JIM/issues/117) and [#118](https://github.com/TetronIO/JIM/issues/118) are open; #126 was closed as a duplicate on 2026-07-07. The survey stays here as the record of how they were assessed against each other.
 >
 > Design document for automatic Metaverse Object deletion based on connector disconnections.
 
@@ -209,9 +210,11 @@ All deletion rule features are now fully implemented:
 **Backend implementation details**: When a CSO is disconnected (obsolete or out-of-scope), `ProcessMvoDeletionRuleAsync()` evaluates the MVO type's deletion rule:
 - `Manual`: No automatic deletion
 - `WhenLastConnectorDisconnected`: Mark for deletion only when all CSOs are disconnected
-- `WhenAuthoritativeSourceDisconnected`: Mark for deletion when ANY authoritative source disconnects, regardless of remaining CSOs
+- `WhenAuthoritativeSourceDisconnected`: Mark for deletion when an authoritative source disconnects, regardless of remaining CSOs. Since #119 the trigger condition is mode-dependent: `SpecificSourcesDisconnect` fires on any one selected source disconnecting (the original behaviour, kept for existing configurations), `AllSourcesDisconnect` waits until every selected source has disconnected.
 
-### Required Changes
+> **Where the code lives now:** rule evaluation moved out of the task processor into `SyncEngine.EvaluateMvoDeletionRule`, which returns an `MvoDeletionDecision` rather than acting directly. The sketch below is kept as the record of what was specified; treat `SyncEngine` as the current source of truth.
+
+### Required Changes (implemented)
 
 In `SyncTaskProcessorBase.ProcessMvoDeletionRuleAsync()`:
 
@@ -288,8 +291,8 @@ The following GitHub issues define additional deletion rule features. This secti
 | #116 | ExcludedFromLastConnectorCheck | Open | P3 - Low |
 | #117 | Soft Delete / Recycle Bin | Open | P2 - Medium |
 | #118 | Conditional MVO Deletion (Attribute-Based) | Open | P2 - Medium |
-| #119 | Authoritative Source Trigger Modes (all / specific) | ✅ **Implemented** | P3 - Low |
-| #126 | CSO Deletion Behaviour Options | Open | P2 - Medium |
+| #119 | Authoritative Source Trigger Modes (all / specific) | ✅ **Closed** | P3 - Low |
+| #126 | CSO Deletion Behaviour Options | Closed as duplicate (2026-07-07) | P2 - Medium |
 
 ---
 
@@ -442,6 +445,8 @@ MetaverseObjectType:
 
 ### #126: CSO Deletion Behaviour Options
 
+> Closed as a duplicate on 2026-07-07; kept here because the assessment below informed the comparison.
+
 **Description**: Configurable behaviour for what happens to target system CSOs when MVO is deleted.
 
 **Current State**: MVP uses `JoinType = Provisioned` check - only provisioned CSOs are deleted, matched CSOs are disconnected.
@@ -485,7 +490,7 @@ MetaverseObjectType:
 |---------|-------|-----------|
 | Soft Delete / Recycle Bin | #117 | Enterprise compliance |
 | Conditional Deletion | #118 | Business rule enforcement |
-| CSO Deletion Behaviour | #126 | Admin control |
+| CSO Deletion Behaviour | #126 | Admin control (issue since closed as a duplicate) |
 
 #### Phase 3: Future (If Requested)
 | Feature | Issue | Rationale |

--- a/engineering/plans/done/GUID_UUID_HANDLING.md
+++ b/engineering/plans/done/GUID_UUID_HANDLING.md
@@ -1,6 +1,7 @@
 # GUID/UUID Handling Strategy
 
-- **Status:** Doing (Phases 1–4 complete)
+- **Status:** Done
+- **Note:** Phases 1-4 are complete and verified: `IdentifierParser` (`src/JIM.Utilities/IdentifierParser.cs`) with its unit tests, the connector migration onto it, and OpenLDAP `entryUUID` support. Phases 5 and 6 are not deferred by choice; they are blocked on database connectors, which do not exist yet (today: File, LDAP, SCIM, Mock). They unblock with [#170](https://github.com/TetronIO/JIM/issues/170) (SQL Database Connector) and should be picked up as part of it, which is why this plan is closed rather than left open indefinitely.
 - **Last Updated**: 2026-03-30
 - **Milestone**: Pre-connector expansion (before SCIM, database, or web service connectors)
 
@@ -249,7 +250,7 @@ Not needed for OpenLDAP (string-based identifiers). Will be implemented when SQL
 
 ---
 
-### Phase 5: SQL/Database Connector Binary UUID Support (When Database Connectors Built)
+### Phase 5: SQL/Database Connector Binary UUID Support (blocked on [#170](https://github.com/TetronIO/JIM/issues/170))
 
 Database connectors that store UUIDs in binary columns require byte order awareness. The `IdentifierParser` utility already provides `FromRfc4122Bytes()` and `ToRfc4122Bytes()`, but the connector layer needs metadata to determine which byte order a given target uses.
 
@@ -293,7 +294,7 @@ MySQL stores UUIDs in varying formats:
 
 ---
 
-### Phase 6: Cross-Connector Round-Trip Tests (After Database Connectors)
+### Phase 6: Cross-Connector Round-Trip Tests (blocked on [#170](https://github.com/TetronIO/JIM/issues/170))
 
 **6.1 Add round-trip integration tests**
 
@@ -305,6 +306,8 @@ Verify that a GUID imported from one connector type survives storage in JIM and 
 - Known GUID value: verify specific byte sequences at each stage
 
 **6.2 Add SCIM identifier tests (when SCIM connector built)**
+
+The SCIM connector now exists and reads `id` as an opaque string (`ScimConnectorExport.ReadId`, `ScimBulkExporter.ReadResourceId`), which is the behaviour this item asked for; only the round-trip matrix in 6.1 still waits on database connectors.
 
 - SCIM `id` stored as opaque string (not forced to Guid)
 - SCIM `externalId` populated with JIM's MVO ID
@@ -319,10 +322,10 @@ Verify that a GUID imported from one connector type survives storage in JIM and 
 2. ✅ `IdentifierParser` utility exists with comprehensive unit tests
 3. ✅ All connector code uses `IdentifierParser` instead of inline GUID operations
 4. ✅ OpenLDAP `entryUUID` is supported for import and export
-5. `GuidByteOrder` metadata allows connectors to declare their binary UUID format
-6. Database connectors (PostgreSQL, Oracle, SQL Server, MySQL) use correct byte order conversions
-7. GUID round-trip tests pass across all connector combinations
-8. No GUID-related data corruption when mixing connector types
+5. `GuidByteOrder` metadata allows connectors to declare their binary UUID format *(blocked on #170)*
+6. Database connectors (PostgreSQL, Oracle, SQL Server, MySQL) use correct byte order conversions *(blocked on #170)*
+7. GUID round-trip tests pass across all connector combinations *(blocked on #170)*
+8. No GUID-related data corruption when mixing connector types *(holds for the connectors that exist today; re-verify when #170 adds binary UUID columns)*
 
 ---
 


### PR DESCRIPTION
## Description

Closes the two remaining `doing/` plans whose work is finished, and files both under `engineering/plans/done/`.

### GUID/UUID Handling Strategy

- **Phases 1-4 verified:** `src/JIM.Utilities/IdentifierParser.cs` with `test/JIM.Models.Tests/Utilities/IdentifierParserTests.cs`, the connector migration onto it, and OpenLDAP `entryUUID` support.
- **Phases 5 and 6 are blocked, not chosen against.** They need database connectors, and the connector set today is File, LDAP, SCIM and Mock. Both phase headings and the affected success criteria now say so and point at #170 (SQL Database Connector), which is where the work belongs when it happens.
- **Phase 6.2 is partly satisfied already:** the SCIM connector landed since and reads `id` as an opaque string (`ScimConnectorExport.ReadId`, `ScimBulkExporter.ReadResourceId`), which is what that item asked for. Only 6.1's cross-connector round-trip matrix still waits on database connectors.
- Fixes a stale cross-reference in `engineering/DEVELOPER_GUIDE.md` pointing at `docs/plans/doing/GUID_UUID_HANDLING.md`, a path predating the move to `engineering/` and now doubly wrong.

### Deletion Rules Design

- **#119 merging as #1194 was the last item this document specified** (#115 shipped previously), so the plan is complete. The trigger-mode design itself lives in `AUTHORITATIVE_SOURCE_TRIGGER_MODES.md`, already filed under `done/`.
- **The further deletion options it surveys are separate features**, not outstanding work here: #116, #117 and #118 are open in their own right. #126 was closed as a duplicate on 2026-07-07, which the issue table still showed as open. The survey stays as the record of how the options were assessed against each other.
- **Corrects the "Required Changes" section**, which read as pending work despite describing what shipped, and records that rule evaluation has moved to `SyncEngine.EvaluateMvoDeletionRule` (returning an `MvoDeletionDecision`) rather than the task processor the sketch names.
- Fixes the inbound link from `AUTHORITATIVE_SOURCE_TRIGGER_MODES.md`, whose relative path changes with the move.

## Type of change

- [x] Documentation update

## Testing

N/A — documentation-only change; no code touched.

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale; pages: `engineering/plans/done/GUID_UUID_HANDLING.md`, `engineering/plans/done/DELETION_RULES_DESIGN.md`, `engineering/plans/done/AUTHORITATIVE_SOURCE_TRIGGER_MODES.md`, `engineering/DEVELOPER_GUIDE.md`

<!-- Docs: n/a - documentation-only change to internal engineering docs; no user-facing behaviour change and no changelog entry -->

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information

## Additional context

That leaves two plans in `doing/`, both correctly:

- **`CONFIGURATION_CHANGE_PREVIEW`** — in flight. `feature/preview-panel` exists, and Phase 3 is gated on the #1114 pilot adapter shipping on it.
- **`ATTRIBUTE_PRIORITY`** — genuinely incomplete. Its three open UI surfaces are absent from the codebase: no `NullIsValue`/precedence context in `SyncRuleAttributeFlowTab.razor`, no priority indicator on the Synchronisation Rule list, no Data Flow page.

https://claude.ai/code/session_01V7UmksNu92PEauVC2rwUh9