### PR TITLE
docs: show the SCIM 2.0 Connector as shipped in the diagrams

### DIFF
--- a/.github/diagrams/containers-dark.svg
+++ b/.github/diagrams/containers-dark.svg
@@ -5,6 +5,9 @@
 <!-- Strictly containers: Web Application, Worker Service, Scheduler Service, -->
 <!-- PostgreSQL and the PowerShell Module. In-process libraries (Application -->
 <!-- Layer, Connectors) are not containers; the Worker's annotation carries them. -->
+<!-- The boundary title is painted after the edges (SVG paints in document -->
+<!-- order) so the REST API spoke passes behind it, not through it; the -->
+<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -67,7 +70,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 .jim-diagram .jimdg-flow          { stroke: var(--jimdg-flow); stroke-width: 2; }
 .jim-diagram .jimdg-flow-arrow    { fill: var(--jimdg-flow); }
 .jim-diagram text { text-anchor: middle; }
-.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text); }
+.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text);
+                                   stroke: var(--jimdg-hub-fill); stroke-width: 5; stroke-linejoin: round;
+                                   paint-order: stroke fill; }
 .jim-diagram .jimdg-layer-title  { font-size: 14px; font-weight: 600; fill: var(--jimdg-layer-text); }
 .jim-diagram .jimdg-chip-label   { font-size: 13.5px; font-weight: 600; fill: var(--jimdg-chip-text); }
 .jim-diagram .jimdg-chip-sub     { font-size: 11px; fill: var(--jimdg-chip-text); opacity: 0.78; }
@@ -116,7 +121,6 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
   </g>
   <g id="jimdg-ct-boundary">
     <rect class="jimdg-hub" x="90" y="150" width="980" height="450" rx="8"/>
-    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
   <g id="jimdg-ct-containers">
     <rect class="jimdg-stage" x="140" y="225" width="220" height="80" rx="8"/>
@@ -161,6 +165,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-flow" x1="700" y1="470" x2="770" y2="470"/>
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(780,470) rotate(0)"/>
     <text class="jimdg-flow-label" x="706" y="458">task queue</text>
+  </g>
+  <g id="jimdg-ct-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
   <g id="jimdg-ct-links">
     <line class="jimdg-spoke" x1="480" y1="516" x2="120" y2="656"/>

--- a/.github/diagrams/containers-dark.svg
+++ b/.github/diagrams/containers-dark.svg
@@ -5,9 +5,10 @@
 <!-- Strictly containers: Web Application, Worker Service, Scheduler Service, -->
 <!-- PostgreSQL and the PowerShell Module. In-process libraries (Application -->
 <!-- Layer, Connectors) are not containers; the Worker's annotation carries them. -->
-<!-- The boundary title is painted after the edges (SVG paints in document -->
-<!-- order) so the REST API spoke passes behind it, not through it; the -->
-<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
+<!-- The boundary title is painted last (SVG paints in document order) so -->
+<!-- the REST API spoke and any data packet pass behind it, not over it; -->
+<!-- the knockout stroke on .jimdg-hub-title clears the gaps between -->
+<!-- glyphs. Keep it the final element if you add anything to this file. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -166,9 +167,6 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(780,470) rotate(0)"/>
     <text class="jimdg-flow-label" x="706" y="458">task queue</text>
   </g>
-  <g id="jimdg-ct-boundary-title">
-    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
-  </g>
   <g id="jimdg-ct-links">
     <line class="jimdg-spoke" x1="480" y1="516" x2="120" y2="656"/>
     <circle class="jimdg-link-end" cx="480" cy="516" r="3.5"/>
@@ -220,5 +218,8 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
       <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
+  </g>
+  <g id="jimdg-ct-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
 </svg>

--- a/.github/diagrams/containers-dark.svg
+++ b/.github/diagrams/containers-dark.svg
@@ -99,7 +99,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity planned.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity in development.</desc>
   <g id="jimdg-ct-people">
     <rect class="jimdg-stage" x="150" y="32" width="200" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="166" cy="53" r="6"/>
@@ -191,7 +191,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (in development)</text>
     <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>

--- a/.github/diagrams/containers-dark.svg
+++ b/.github/diagrams/containers-dark.svg
@@ -99,7 +99,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems and file systems, with enterprise database and cloud application connectivity planned.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity planned.</desc>
   <g id="jimdg-ct-people">
     <rect class="jimdg-stage" x="150" y="32" width="200" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="166" cy="53" r="6"/>
@@ -175,9 +175,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-spoke-planned" x1="630" y1="516" x2="810" y2="656"/>
     <circle class="jimdg-link-end-planned" cx="630" cy="516" r="3.5"/>
     <circle class="jimdg-link-end-planned" cx="810" cy="656" r="3.5"/>
-    <line class="jimdg-spoke-planned" x1="680" y1="516" x2="1040" y2="656"/>
-    <circle class="jimdg-link-end-planned" cx="680" cy="516" r="3.5"/>
-    <circle class="jimdg-link-end-planned" cx="1040" cy="656" r="3.5"/>
+    <line class="jimdg-spoke" x1="680" y1="516" x2="1040" y2="656"/>
+    <circle class="jimdg-link-end" cx="680" cy="516" r="3.5"/>
+    <circle class="jimdg-link-end" cx="1040" cy="656" r="3.5"/>
   </g>
   <g id="jimdg-ct-systems">
     <rect class="jimdg-system" x="20" y="656" width="200" height="64" rx="8"/>
@@ -190,11 +190,11 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <text class="jimdg-system-name" x="580" y="684">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="810" y="684">Databases</text>
+    <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="810" y="705">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="940" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1040" y="684">Applications</text>
-    <text class="jimdg-system-sub-planned" x="1040" y="705">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>
   </g>
   <g id="jimdg-ct-packets">
     <circle class="jimdg-packet" r="4.5">
@@ -208,6 +208,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M580,516 L580,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
   </g>
 </svg>

--- a/.github/diagrams/containers-light.svg
+++ b/.github/diagrams/containers-light.svg
@@ -5,6 +5,9 @@
 <!-- Strictly containers: Web Application, Worker Service, Scheduler Service, -->
 <!-- PostgreSQL and the PowerShell Module. In-process libraries (Application -->
 <!-- Layer, Connectors) are not containers; the Worker's annotation carries them. -->
+<!-- The boundary title is painted after the edges (SVG paints in document -->
+<!-- order) so the REST API spoke passes behind it, not through it; the -->
+<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -67,7 +70,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 .jim-diagram .jimdg-flow          { stroke: var(--jimdg-flow); stroke-width: 2; }
 .jim-diagram .jimdg-flow-arrow    { fill: var(--jimdg-flow); }
 .jim-diagram text { text-anchor: middle; }
-.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text); }
+.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text);
+                                   stroke: var(--jimdg-hub-fill); stroke-width: 5; stroke-linejoin: round;
+                                   paint-order: stroke fill; }
 .jim-diagram .jimdg-layer-title  { font-size: 14px; font-weight: 600; fill: var(--jimdg-layer-text); }
 .jim-diagram .jimdg-chip-label   { font-size: 13.5px; font-weight: 600; fill: var(--jimdg-chip-text); }
 .jim-diagram .jimdg-chip-sub     { font-size: 11px; fill: var(--jimdg-chip-text); opacity: 0.78; }
@@ -116,7 +121,6 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
   </g>
   <g id="jimdg-ct-boundary">
     <rect class="jimdg-hub" x="90" y="150" width="980" height="450" rx="8"/>
-    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
   <g id="jimdg-ct-containers">
     <rect class="jimdg-stage" x="140" y="225" width="220" height="80" rx="8"/>
@@ -161,6 +165,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-flow" x1="700" y1="470" x2="770" y2="470"/>
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(780,470) rotate(0)"/>
     <text class="jimdg-flow-label" x="706" y="458">task queue</text>
+  </g>
+  <g id="jimdg-ct-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
   <g id="jimdg-ct-links">
     <line class="jimdg-spoke" x1="480" y1="516" x2="120" y2="656"/>

--- a/.github/diagrams/containers-light.svg
+++ b/.github/diagrams/containers-light.svg
@@ -99,7 +99,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems and file systems, with enterprise database and cloud application connectivity planned.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity planned.</desc>
   <g id="jimdg-ct-people">
     <rect class="jimdg-stage" x="150" y="32" width="200" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="166" cy="53" r="6"/>
@@ -175,9 +175,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-spoke-planned" x1="630" y1="516" x2="810" y2="656"/>
     <circle class="jimdg-link-end-planned" cx="630" cy="516" r="3.5"/>
     <circle class="jimdg-link-end-planned" cx="810" cy="656" r="3.5"/>
-    <line class="jimdg-spoke-planned" x1="680" y1="516" x2="1040" y2="656"/>
-    <circle class="jimdg-link-end-planned" cx="680" cy="516" r="3.5"/>
-    <circle class="jimdg-link-end-planned" cx="1040" cy="656" r="3.5"/>
+    <line class="jimdg-spoke" x1="680" y1="516" x2="1040" y2="656"/>
+    <circle class="jimdg-link-end" cx="680" cy="516" r="3.5"/>
+    <circle class="jimdg-link-end" cx="1040" cy="656" r="3.5"/>
   </g>
   <g id="jimdg-ct-systems">
     <rect class="jimdg-system" x="20" y="656" width="200" height="64" rx="8"/>
@@ -192,9 +192,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="810" y="705">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="940" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1040" y="684">Cloud Applications</text>
-    <text class="jimdg-system-sub-planned" x="1040" y="705">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>
   </g>
   <g id="jimdg-ct-packets">
     <circle class="jimdg-packet" r="4.5">
@@ -208,6 +208,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M580,516 L580,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
   </g>
 </svg>

--- a/.github/diagrams/containers-light.svg
+++ b/.github/diagrams/containers-light.svg
@@ -5,9 +5,10 @@
 <!-- Strictly containers: Web Application, Worker Service, Scheduler Service, -->
 <!-- PostgreSQL and the PowerShell Module. In-process libraries (Application -->
 <!-- Layer, Connectors) are not containers; the Worker's annotation carries them. -->
-<!-- The boundary title is painted after the edges (SVG paints in document -->
-<!-- order) so the REST API spoke passes behind it, not through it; the -->
-<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
+<!-- The boundary title is painted last (SVG paints in document order) so -->
+<!-- the REST API spoke and any data packet pass behind it, not over it; -->
+<!-- the knockout stroke on .jimdg-hub-title clears the gaps between -->
+<!-- glyphs. Keep it the final element if you add anything to this file. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -166,9 +167,6 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(780,470) rotate(0)"/>
     <text class="jimdg-flow-label" x="706" y="458">task queue</text>
   </g>
-  <g id="jimdg-ct-boundary-title">
-    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
-  </g>
   <g id="jimdg-ct-links">
     <line class="jimdg-spoke" x1="480" y1="516" x2="120" y2="656"/>
     <circle class="jimdg-link-end" cx="480" cy="516" r="3.5"/>
@@ -220,5 +218,8 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
       <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
+  </g>
+  <g id="jimdg-ct-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
 </svg>

--- a/.github/diagrams/containers-light.svg
+++ b/.github/diagrams/containers-light.svg
@@ -99,7 +99,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity planned.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity in development.</desc>
   <g id="jimdg-ct-people">
     <rect class="jimdg-stage" x="150" y="32" width="200" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="166" cy="53" r="6"/>
@@ -191,7 +191,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (in development)</text>
     <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>

--- a/.github/diagrams/system-context-dark.svg
+++ b/.github/diagrams/system-context-dark.svg
@@ -97,7 +97,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, and reads and writes file systems. Enterprise database connectivity over SQL and cloud application provisioning over SCIM 2.0 are planned.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is planned.</desc>
   <g id="jimdg-sc-people">
     <rect class="jimdg-stage" x="150" y="36" width="220" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="170" cy="57" r="6"/>
@@ -129,11 +129,11 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <text class="jimdg-system-name" x="580" y="548">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="805" y="548">Databases</text>
+    <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="805" y="569">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="930" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1030" y="548">Applications</text>
-    <text class="jimdg-system-sub-planned" x="1030" y="569">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>
   </g>
   <g id="jimdg-sc-edges">
     <line class="jimdg-spoke" x1="260" y1="100" x2="491.4" y2="235"/>
@@ -160,9 +160,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
     <text class="jimdg-spoke-label jimdg-anchor-end" x="688" y="430">SQL</text>
-    <line class="jimdg-spoke-planned" x1="700" y1="380" x2="1020.8" y2="516.1"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
-    <text class="jimdg-spoke-label jimdg-anchor-end" x="900" y="470">provisions · SCIM 2.0</text>
+    <line class="jimdg-spoke" x1="709.2" y1="383.9" x2="1020.8" y2="516.1"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,380) rotate(203)"/>
+    <text class="jimdg-spoke-label jimdg-anchor-end" x="870" y="474">SCIM 2.0</text>
   </g>
   <g id="jimdg-sc-packets">
     <circle class="jimdg-packet" r="4.5">

--- a/.github/diagrams/system-context-dark.svg
+++ b/.github/diagrams/system-context-dark.svg
@@ -174,5 +174,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
       <animateMotion dur="3s" begin="-1.5s" repeatCount="indefinite" path="M450,384 L140,516"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-1.5s" repeatCount="indefinite"/>
     </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M709,384 L1021,516"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
   </g>
 </svg>

--- a/.github/diagrams/system-context-dark.svg
+++ b/.github/diagrams/system-context-dark.svg
@@ -65,7 +65,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 .jim-diagram .jimdg-flow          { stroke: var(--jimdg-flow); stroke-width: 2; }
 .jim-diagram .jimdg-flow-arrow    { fill: var(--jimdg-flow); }
 .jim-diagram text { text-anchor: middle; }
-.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text); }
+.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text);
+                                   stroke: var(--jimdg-hub-fill); stroke-width: 5; stroke-linejoin: round;
+                                   paint-order: stroke fill; }
 .jim-diagram .jimdg-layer-title  { font-size: 14px; font-weight: 600; fill: var(--jimdg-layer-text); }
 .jim-diagram .jimdg-chip-label   { font-size: 13.5px; font-weight: 600; fill: var(--jimdg-chip-text); }
 .jim-diagram .jimdg-chip-sub     { font-size: 11px; fill: var(--jimdg-chip-text); opacity: 0.78; }

--- a/.github/diagrams/system-context-dark.svg
+++ b/.github/diagrams/system-context-dark.svg
@@ -97,7 +97,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is planned.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is in development.</desc>
   <g id="jimdg-sc-people">
     <rect class="jimdg-stage" x="150" y="36" width="220" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="170" cy="57" r="6"/>
@@ -130,7 +130,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (in development)</text>
     <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>

--- a/.github/diagrams/system-context-light.svg
+++ b/.github/diagrams/system-context-light.svg
@@ -97,7 +97,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, and reads and writes file systems. Enterprise database connectivity over SQL and cloud application provisioning over SCIM 2.0 are planned.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is planned.</desc>
   <g id="jimdg-sc-people">
     <rect class="jimdg-stage" x="150" y="36" width="220" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="170" cy="57" r="6"/>
@@ -131,9 +131,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="805" y="569">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="930" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1030" y="548">Cloud Applications</text>
-    <text class="jimdg-system-sub-planned" x="1030" y="569">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>
   </g>
   <g id="jimdg-sc-edges">
     <line class="jimdg-spoke" x1="260" y1="100" x2="491.4" y2="235"/>
@@ -160,9 +160,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
     <text class="jimdg-spoke-label jimdg-anchor-end" x="688" y="430">SQL</text>
-    <line class="jimdg-spoke-planned" x1="700" y1="380" x2="1020.8" y2="516.1"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
-    <text class="jimdg-spoke-label jimdg-anchor-end" x="900" y="470">provisions · SCIM 2.0</text>
+    <line class="jimdg-spoke" x1="709.2" y1="383.9" x2="1020.8" y2="516.1"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,380) rotate(203)"/>
+    <text class="jimdg-spoke-label jimdg-anchor-end" x="870" y="474">SCIM 2.0</text>
   </g>
   <g id="jimdg-sc-packets">
     <circle class="jimdg-packet" r="4.5">

--- a/.github/diagrams/system-context-light.svg
+++ b/.github/diagrams/system-context-light.svg
@@ -174,5 +174,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
       <animateMotion dur="3s" begin="-1.5s" repeatCount="indefinite" path="M450,384 L140,516"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-1.5s" repeatCount="indefinite"/>
     </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M709,384 L1021,516"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
   </g>
 </svg>

--- a/.github/diagrams/system-context-light.svg
+++ b/.github/diagrams/system-context-light.svg
@@ -65,7 +65,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 .jim-diagram .jimdg-flow          { stroke: var(--jimdg-flow); stroke-width: 2; }
 .jim-diagram .jimdg-flow-arrow    { fill: var(--jimdg-flow); }
 .jim-diagram text { text-anchor: middle; }
-.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text); }
+.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text);
+                                   stroke: var(--jimdg-hub-fill); stroke-width: 5; stroke-linejoin: round;
+                                   paint-order: stroke fill; }
 .jim-diagram .jimdg-layer-title  { font-size: 14px; font-weight: 600; fill: var(--jimdg-layer-text); }
 .jim-diagram .jimdg-chip-label   { font-size: 13.5px; font-weight: 600; fill: var(--jimdg-chip-text); }
 .jim-diagram .jimdg-chip-sub     { font-size: 11px; fill: var(--jimdg-chip-text); opacity: 0.78; }

--- a/.github/diagrams/system-context-light.svg
+++ b/.github/diagrams/system-context-light.svg
@@ -97,7 +97,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is planned.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is in development.</desc>
   <g id="jimdg-sc-people">
     <rect class="jimdg-stage" x="150" y="36" width="220" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="170" cy="57" r="6"/>
@@ -130,7 +130,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (in development)</text>
     <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>

--- a/docs/assets/diagrams/connector-components.svg
+++ b/docs/assets/diagrams/connector-components.svg
@@ -5,6 +5,9 @@
 <!-- from the external systems. -->
 <!-- Four columns on a 240px pitch centred on the JIM.Connectors boundary -->
 <!-- (90..1070), so the outer chips clear it by 25px on both sides. -->
+<!-- The boundary title is painted after the edges (SVG paints in document -->
+<!-- order) so the Worker's arrows pass behind it, not through it; the -->
+<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -22,7 +25,6 @@
   </g>
   <g id="jimdg-cc-boundary">
     <rect class="jimdg-hub" x="90" y="140" width="980" height="190" rx="8"/>
-    <text class="jimdg-hub-title" x="580" y="176">JIM.Connectors</text>
   </g>
   <g id="jimdg-cc-connectors">
     <rect class="jimdg-chip" x="115" y="220" width="210" height="70" rx="8"/>
@@ -72,6 +74,9 @@
     <line class="jimdg-spoke" x1="940" y1="300" x2="940" y2="400"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,290) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,410) rotate(90)"/>
+  </g>
+  <g id="jimdg-cc-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="176">JIM.Connectors</text>
   </g>
   <g id="jimdg-cc-packets">
     <circle class="jimdg-packet" r="4.5">

--- a/docs/assets/diagrams/connector-components.svg
+++ b/docs/assets/diagrams/connector-components.svg
@@ -5,9 +5,10 @@
 <!-- from the external systems. -->
 <!-- Four columns on a 240px pitch centred on the JIM.Connectors boundary -->
 <!-- (90..1070), so the outer chips clear it by 25px on both sides. -->
-<!-- The boundary title is painted after the edges (SVG paints in document -->
-<!-- order) so the Worker's arrows pass behind it, not through it; the -->
-<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
+<!-- The boundary title is painted last (SVG paints in document order) so -->
+<!-- the Worker's arrows and their data packets pass behind it, not over -->
+<!-- it; the knockout stroke on .jimdg-hub-title clears the gaps between -->
+<!-- glyphs. Keep it the final element if you add anything to this file. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -75,9 +76,6 @@
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,290) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,410) rotate(90)"/>
   </g>
-  <g id="jimdg-cc-boundary-title">
-    <text class="jimdg-hub-title" x="580" y="176">JIM.Connectors</text>
-  </g>
   <g id="jimdg-cc-packets">
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.2s" begin="0s" repeatCount="indefinite" path="M220,302 L220,398"/>
@@ -99,5 +97,8 @@
       <animateMotion dur="2.2s" begin="-1.7s" repeatCount="indefinite" path="M940,302 L940,398"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-1.7s" repeatCount="indefinite"/>
     </circle>
+  </g>
+  <g id="jimdg-cc-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="176">JIM.Connectors</text>
   </g>
 </svg>

--- a/docs/assets/diagrams/connector-components.svg
+++ b/docs/assets/diagrams/connector-components.svg
@@ -12,7 +12,7 @@
 <!-- expressed with <g> groups instead. -->
 <svg class="jim-diagram" viewBox="0 0 1160 500" role="img" aria-labelledby="jimdg-cc-title jimdg-cc-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-cc-title">Inside the Connectors library</title>
-  <desc id="jimdg-cc-desc">The JIM.Worker import and export processors invoke the connectors in the JIM.Connectors library. The LDAP Connector reads and writes Directory Services over LDAP and LDAPS; the File Connector reads and writes CSV and flat files, including HR exports. A Database Connector for SQL systems and a SCIM 2.0 Connector for cloud applications are planned.</desc>
+  <desc id="jimdg-cc-desc">The JIM.Worker import and export processors invoke the connectors in the JIM.Connectors library. The LDAP Connector reads and writes Directory Services over LDAP and LDAPS; the File Connector reads and writes CSV and flat files, including HR exports; the SCIM 2.0 Connector reads and writes cloud applications that publish a SCIM 2.0 service provider interface. A Database Connector for SQL systems is planned.</desc>
   <g id="jimdg-cc-worker">
     <rect class="jimdg-stage" x="430" y="20" width="300" height="64" rx="8"/>
     <text class="jimdg-stage-label" x="580" y="46">JIM.Worker</text>
@@ -32,9 +32,9 @@
     <rect class="jimdg-chip-planned" x="620" y="220" width="210" height="70" rx="8"/>
     <text class="jimdg-chip-label-planned" x="725" y="250">Database Connector</text>
     <text class="jimdg-chip-sub-planned" x="725" y="270">SQL (planned)</text>
-    <rect class="jimdg-chip-planned" x="865" y="220" width="210" height="70" rx="8"/>
-    <text class="jimdg-chip-label-planned" x="970" y="250">SCIM 2.0 Connector</text>
-    <text class="jimdg-chip-sub-planned" x="970" y="270">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-chip" x="865" y="220" width="210" height="70" rx="8"/>
+    <text class="jimdg-chip-label" x="970" y="250">SCIM 2.0 Connector</text>
+    <text class="jimdg-chip-sub" x="970" y="270">SCIM 2.0 · HTTPS</text>
   </g>
   <g id="jimdg-cc-systems">
     <rect class="jimdg-system" x="125" y="410" width="220" height="64" rx="8"/>
@@ -46,9 +46,9 @@
     <rect class="jimdg-system-planned" x="615" y="410" width="220" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="725" y="438">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="725" y="459">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="860" y="410" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="970" y="438">Cloud Applications</text>
-    <text class="jimdg-system-sub-planned" x="970" y="459">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="860" y="410" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="970" y="438">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="970" y="459">SCIM 2.0 service providers</text>
   </g>
   <g id="jimdg-cc-edges">
     <line class="jimdg-flow" x1="580" y1="84" x2="244.3" y2="216.3"/>
@@ -57,8 +57,8 @@
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(465,220) rotate(130.2)"/>
     <line class="jimdg-spoke-planned" x1="580" y1="84" x2="688.5" y2="212.4"/>
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(695,220) rotate(49.8)"/>
-    <line class="jimdg-spoke-planned" x1="580" y1="84" x2="915.7" y2="216.3"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(925,220) rotate(21.5)"/>
+    <line class="jimdg-flow" x1="580" y1="84" x2="915.7" y2="216.3"/>
+    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(925,220) rotate(21.5)"/>
     <line class="jimdg-spoke" x1="235" y1="300" x2="235" y2="400"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(235,290) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(235,410) rotate(90)"/>
@@ -67,8 +67,9 @@
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(480,410) rotate(90)"/>
     <line class="jimdg-spoke-planned" x1="725" y1="290" x2="725" y2="400"/>
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(725,410) rotate(90)"/>
-    <line class="jimdg-spoke-planned" x1="970" y1="290" x2="970" y2="400"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(970,410) rotate(90)"/>
+    <line class="jimdg-spoke" x1="970" y1="300" x2="970" y2="400"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(970,290) rotate(-90)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(970,410) rotate(90)"/>
   </g>
   <g id="jimdg-cc-packets">
     <circle class="jimdg-packet" r="4.5">
@@ -86,6 +87,10 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.4s" begin="-1.6s" repeatCount="indefinite" path="M580,86 L470,212"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-1.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="2.2s" begin="-1.7s" repeatCount="indefinite" path="M970,302 L970,398"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-1.7s" repeatCount="indefinite"/>
     </circle>
   </g>
 </svg>

--- a/docs/assets/diagrams/connector-components.svg
+++ b/docs/assets/diagrams/connector-components.svg
@@ -3,6 +3,8 @@
 <!-- Inside the Connectors library (Developer Guide > Architecture): the -->
 <!-- Worker's processors invoke the connectors, which carry data to and -->
 <!-- from the external systems. -->
+<!-- Four columns on a 240px pitch centred on the JIM.Connectors boundary -->
+<!-- (90..1070), so the outer chips clear it by 25px on both sides. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -12,7 +14,7 @@
 <!-- expressed with <g> groups instead. -->
 <svg class="jim-diagram" viewBox="0 0 1160 500" role="img" aria-labelledby="jimdg-cc-title jimdg-cc-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-cc-title">Inside the Connectors library</title>
-  <desc id="jimdg-cc-desc">The JIM.Worker import and export processors invoke the connectors in the JIM.Connectors library. The LDAP Connector reads and writes Directory Services over LDAP and LDAPS; the File Connector reads and writes CSV and flat files, including HR exports; the SCIM 2.0 Connector reads and writes cloud applications that publish a SCIM 2.0 service provider interface. A Database Connector for SQL systems is planned.</desc>
+  <desc id="jimdg-cc-desc">The JIM.Worker import and export processors invoke the connectors in the JIM.Connectors library. The LDAP Connector reads and writes Directory Services over LDAP and LDAPS; the File Connector reads and writes CSV and flat files, including HR exports; the SCIM 2.0 Connector reads and writes cloud applications that publish a SCIM 2.0 service provider interface. A Database Connector for SQL systems is in development.</desc>
   <g id="jimdg-cc-worker">
     <rect class="jimdg-stage" x="430" y="20" width="300" height="64" rx="8"/>
     <text class="jimdg-stage-label" x="580" y="46">JIM.Worker</text>
@@ -23,73 +25,73 @@
     <text class="jimdg-hub-title" x="580" y="176">JIM.Connectors</text>
   </g>
   <g id="jimdg-cc-connectors">
-    <rect class="jimdg-chip" x="130" y="220" width="210" height="70" rx="8"/>
-    <text class="jimdg-chip-label" x="235" y="250">LDAP Connector</text>
-    <text class="jimdg-chip-sub" x="235" y="270">LDAP · LDAPS</text>
-    <rect class="jimdg-chip" x="375" y="220" width="210" height="70" rx="8"/>
-    <text class="jimdg-chip-label" x="480" y="250">File Connector</text>
-    <text class="jimdg-chip-sub" x="480" y="270">CSV &amp; flat files</text>
-    <rect class="jimdg-chip-planned" x="620" y="220" width="210" height="70" rx="8"/>
-    <text class="jimdg-chip-label-planned" x="725" y="250">Database Connector</text>
-    <text class="jimdg-chip-sub-planned" x="725" y="270">SQL (planned)</text>
-    <rect class="jimdg-chip" x="865" y="220" width="210" height="70" rx="8"/>
-    <text class="jimdg-chip-label" x="970" y="250">SCIM 2.0 Connector</text>
-    <text class="jimdg-chip-sub" x="970" y="270">SCIM 2.0 · HTTPS</text>
+    <rect class="jimdg-chip" x="115" y="220" width="210" height="70" rx="8"/>
+    <text class="jimdg-chip-label" x="220" y="250">LDAP Connector</text>
+    <text class="jimdg-chip-sub" x="220" y="270">LDAP · LDAPS</text>
+    <rect class="jimdg-chip" x="355" y="220" width="210" height="70" rx="8"/>
+    <text class="jimdg-chip-label" x="460" y="250">File Connector</text>
+    <text class="jimdg-chip-sub" x="460" y="270">CSV &amp; flat files</text>
+    <rect class="jimdg-chip-planned" x="595" y="220" width="210" height="70" rx="8"/>
+    <text class="jimdg-chip-label-planned" x="700" y="250">Database Connector</text>
+    <text class="jimdg-chip-sub-planned" x="700" y="270">SQL (in development)</text>
+    <rect class="jimdg-chip" x="835" y="220" width="210" height="70" rx="8"/>
+    <text class="jimdg-chip-label" x="940" y="250">SCIM 2.0 Connector</text>
+    <text class="jimdg-chip-sub" x="940" y="270">SCIM 2.0 · HTTPS</text>
   </g>
   <g id="jimdg-cc-systems">
-    <rect class="jimdg-system" x="125" y="410" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name" x="235" y="438">Directory Services</text>
-    <text class="jimdg-system-sub" x="235" y="459">LDAP · LDAPS</text>
-    <rect class="jimdg-system" x="370" y="410" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name" x="480" y="438">File Systems</text>
-    <text class="jimdg-system-sub" x="480" y="459">CSV · HR exports</text>
-    <rect class="jimdg-system-planned" x="615" y="410" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="725" y="438">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="725" y="459">SQL (planned)</text>
-    <rect class="jimdg-system" x="860" y="410" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name" x="970" y="438">Cloud Applications</text>
-    <text class="jimdg-system-sub" x="970" y="459">SCIM 2.0 service providers</text>
+    <rect class="jimdg-system" x="110" y="410" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="220" y="438">Directory Services</text>
+    <text class="jimdg-system-sub" x="220" y="459">LDAP · LDAPS</text>
+    <rect class="jimdg-system" x="350" y="410" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="460" y="438">File Systems</text>
+    <text class="jimdg-system-sub" x="460" y="459">CSV · HR exports</text>
+    <rect class="jimdg-system-planned" x="590" y="410" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name-planned" x="700" y="438">Enterprise Databases</text>
+    <text class="jimdg-system-sub-planned" x="700" y="459">SQL (in development)</text>
+    <rect class="jimdg-system" x="830" y="410" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="940" y="438">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="940" y="459">SCIM 2.0 service providers</text>
   </g>
   <g id="jimdg-cc-edges">
-    <line class="jimdg-flow" x1="580" y1="84" x2="244.3" y2="216.3"/>
-    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(235,220) rotate(158.5)"/>
-    <line class="jimdg-flow" x1="580" y1="84" x2="471.5" y2="212.4"/>
-    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(465,220) rotate(130.2)"/>
-    <line class="jimdg-spoke-planned" x1="580" y1="84" x2="688.5" y2="212.4"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(695,220) rotate(49.8)"/>
-    <line class="jimdg-flow" x1="580" y1="84" x2="915.7" y2="216.3"/>
-    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(925,220) rotate(21.5)"/>
-    <line class="jimdg-spoke" x1="235" y1="300" x2="235" y2="400"/>
-    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(235,290) rotate(-90)"/>
-    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(235,410) rotate(90)"/>
-    <line class="jimdg-spoke" x1="480" y1="300" x2="480" y2="400"/>
-    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(480,290) rotate(-90)"/>
-    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(480,410) rotate(90)"/>
-    <line class="jimdg-spoke-planned" x1="725" y1="290" x2="725" y2="400"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(725,410) rotate(90)"/>
-    <line class="jimdg-spoke" x1="970" y1="300" x2="970" y2="400"/>
-    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(970,290) rotate(-90)"/>
-    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(970,410) rotate(90)"/>
+    <line class="jimdg-flow" x1="580" y1="84" x2="229.4" y2="216.5"/>
+    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(220,220) rotate(159.3)"/>
+    <line class="jimdg-flow" x1="580" y1="84" x2="466.6" y2="212.5"/>
+    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(460,220) rotate(131.4)"/>
+    <line class="jimdg-spoke-planned" x1="580" y1="84" x2="693.4" y2="212.5"/>
+    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,220) rotate(48.6)"/>
+    <line class="jimdg-flow" x1="580" y1="84" x2="930.6" y2="216.5"/>
+    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,220) rotate(20.7)"/>
+    <line class="jimdg-spoke" x1="220" y1="300" x2="220" y2="400"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(220,290) rotate(-90)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(220,410) rotate(90)"/>
+    <line class="jimdg-spoke" x1="460" y1="300" x2="460" y2="400"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(460,290) rotate(-90)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(460,410) rotate(90)"/>
+    <line class="jimdg-spoke-planned" x1="700" y1="290" x2="700" y2="400"/>
+    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,410) rotate(90)"/>
+    <line class="jimdg-spoke" x1="940" y1="300" x2="940" y2="400"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,290) rotate(-90)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,410) rotate(90)"/>
   </g>
   <g id="jimdg-cc-packets">
     <circle class="jimdg-packet" r="4.5">
-      <animateMotion dur="2.2s" begin="0s" repeatCount="indefinite" path="M235,302 L235,398"/>
+      <animateMotion dur="2.2s" begin="0s" repeatCount="indefinite" path="M220,302 L220,398"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="0s" repeatCount="indefinite"/>
     </circle>
     <circle class="jimdg-packet" r="4.5">
-      <animateMotion dur="2.2s" begin="-1.1s" repeatCount="indefinite" path="M235,398 L235,302"/>
+      <animateMotion dur="2.2s" begin="-1.1s" repeatCount="indefinite" path="M220,398 L220,302"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-1.1s" repeatCount="indefinite"/>
     </circle>
     <circle class="jimdg-packet" r="4.5">
-      <animateMotion dur="2.2s" begin="-0.6s" repeatCount="indefinite" path="M480,398 L480,302"/>
+      <animateMotion dur="2.2s" begin="-0.6s" repeatCount="indefinite" path="M460,398 L460,302"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-0.6s" repeatCount="indefinite"/>
     </circle>
     <circle class="jimdg-packet" r="4.5">
-      <animateMotion dur="2.4s" begin="-1.6s" repeatCount="indefinite" path="M580,86 L470,212"/>
+      <animateMotion dur="2.4s" begin="-1.6s" repeatCount="indefinite" path="M580,86 L468,211"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-1.6s" repeatCount="indefinite"/>
     </circle>
     <circle class="jimdg-packet" r="4.5">
-      <animateMotion dur="2.2s" begin="-1.7s" repeatCount="indefinite" path="M970,302 L970,398"/>
+      <animateMotion dur="2.2s" begin="-1.7s" repeatCount="indefinite" path="M940,302 L940,398"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-1.7s" repeatCount="indefinite"/>
     </circle>
   </g>

--- a/docs/assets/diagrams/containers.svg
+++ b/docs/assets/diagrams/containers.svg
@@ -4,6 +4,9 @@
 <!-- Strictly containers: Web Application, Worker Service, Scheduler Service, -->
 <!-- PostgreSQL and the PowerShell Module. In-process libraries (Application -->
 <!-- Layer, Connectors) are not containers; the Worker's annotation carries them. -->
+<!-- The boundary title is painted after the edges (SVG paints in document -->
+<!-- order) so the REST API spoke passes behind it, not through it; the -->
+<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -28,7 +31,6 @@
   </g>
   <g id="jimdg-ct-boundary">
     <rect class="jimdg-hub" x="90" y="150" width="980" height="450" rx="8"/>
-    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
   <g id="jimdg-ct-containers">
     <rect class="jimdg-stage" x="140" y="225" width="220" height="80" rx="8"/>
@@ -73,6 +75,9 @@
     <line class="jimdg-flow" x1="700" y1="470" x2="770" y2="470"/>
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(780,470) rotate(0)"/>
     <text class="jimdg-flow-label" x="706" y="458">task queue</text>
+  </g>
+  <g id="jimdg-ct-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
   <g id="jimdg-ct-links">
     <line class="jimdg-spoke" x1="480" y1="516" x2="120" y2="656"/>

--- a/docs/assets/diagrams/containers.svg
+++ b/docs/assets/diagrams/containers.svg
@@ -4,9 +4,10 @@
 <!-- Strictly containers: Web Application, Worker Service, Scheduler Service, -->
 <!-- PostgreSQL and the PowerShell Module. In-process libraries (Application -->
 <!-- Layer, Connectors) are not containers; the Worker's annotation carries them. -->
-<!-- The boundary title is painted after the edges (SVG paints in document -->
-<!-- order) so the REST API spoke passes behind it, not through it; the -->
-<!-- knockout stroke on .jimdg-hub-title clears the gaps between glyphs. -->
+<!-- The boundary title is painted last (SVG paints in document order) so -->
+<!-- the REST API spoke and any data packet pass behind it, not over it; -->
+<!-- the knockout stroke on .jimdg-hub-title clears the gaps between -->
+<!-- glyphs. Keep it the final element if you add anything to this file. -->
 <!-- Hand-authored inline SVG, themed by the .jimdg-* classes in -->
 <!-- docs/assets/stylesheets/custom.css (single source, light + dark). -->
 <!-- Visual language: engineering/DESIGN.md > Diagrams. -->
@@ -76,9 +77,6 @@
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(780,470) rotate(0)"/>
     <text class="jimdg-flow-label" x="706" y="458">task queue</text>
   </g>
-  <g id="jimdg-ct-boundary-title">
-    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
-  </g>
   <g id="jimdg-ct-links">
     <line class="jimdg-spoke" x1="480" y1="516" x2="120" y2="656"/>
     <circle class="jimdg-link-end" cx="480" cy="516" r="3.5"/>
@@ -130,5 +128,8 @@
       <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
+  </g>
+  <g id="jimdg-ct-boundary-title">
+    <text class="jimdg-hub-title" x="580" y="188">JIM</text>
   </g>
 </svg>

--- a/docs/assets/diagrams/containers.svg
+++ b/docs/assets/diagrams/containers.svg
@@ -11,7 +11,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 750" role="img" aria-labelledby="jimdg-ct-title jimdg-ct-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems and file systems, with enterprise database and cloud application connectivity planned.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity planned.</desc>
   <g id="jimdg-ct-people">
     <rect class="jimdg-stage" x="150" y="32" width="200" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="166" cy="53" r="6"/>
@@ -87,9 +87,9 @@
     <line class="jimdg-spoke-planned" x1="630" y1="516" x2="810" y2="656"/>
     <circle class="jimdg-link-end-planned" cx="630" cy="516" r="3.5"/>
     <circle class="jimdg-link-end-planned" cx="810" cy="656" r="3.5"/>
-    <line class="jimdg-spoke-planned" x1="680" y1="516" x2="1040" y2="656"/>
-    <circle class="jimdg-link-end-planned" cx="680" cy="516" r="3.5"/>
-    <circle class="jimdg-link-end-planned" cx="1040" cy="656" r="3.5"/>
+    <line class="jimdg-spoke" x1="680" y1="516" x2="1040" y2="656"/>
+    <circle class="jimdg-link-end" cx="680" cy="516" r="3.5"/>
+    <circle class="jimdg-link-end" cx="1040" cy="656" r="3.5"/>
   </g>
   <g id="jimdg-ct-systems">
     <rect class="jimdg-system" x="20" y="656" width="200" height="64" rx="8"/>
@@ -104,9 +104,9 @@
     <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="810" y="705">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="940" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1040" y="684">Cloud Applications</text>
-    <text class="jimdg-system-sub-planned" x="1040" y="705">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>
   </g>
   <g id="jimdg-ct-packets">
     <circle class="jimdg-packet" r="4.5">
@@ -120,6 +120,10 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M580,516 L580,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
   </g>
 </svg>

--- a/docs/assets/diagrams/containers.svg
+++ b/docs/assets/diagrams/containers.svg
@@ -11,7 +11,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 750" role="img" aria-labelledby="jimdg-ct-title jimdg-ct-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity planned.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity in development.</desc>
   <g id="jimdg-ct-people">
     <rect class="jimdg-stage" x="150" y="32" width="200" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="166" cy="53" r="6"/>
@@ -103,7 +103,7 @@
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (in development)</text>
     <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>

--- a/docs/assets/diagrams/hub-and-spoke.svg
+++ b/docs/assets/diagrams/hub-and-spoke.svg
@@ -10,7 +10,7 @@
 <!-- expressed with <g> groups instead. -->
 <svg class="jim-diagram" viewBox="0 0 1160 640" role="img" aria-labelledby="jimdg-hs-title jimdg-hs-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-hs-title">JIM hub-and-spoke synchronisation concept</title>
-  <desc id="jimdg-hs-desc">Source systems on the left and target systems on the right connect to JIM in the centre. Inside JIM, Connectors pass imported data through the Import, Synchronise and Export pipeline, which correlates and projects identities into the Metaverse, the authoritative data store for fused identities. Every flow passes through JIM; no data moves directly between Connected Systems. Enterprise database connectivity is planned.</desc>
+  <desc id="jimdg-hs-desc">Source systems on the left and target systems on the right connect to JIM in the centre. Inside JIM, Connectors pass imported data through the Import, Synchronise and Export pipeline, which correlates and projects identities into the Metaverse, the authoritative data store for fused identities. Every flow passes through JIM; no data moves directly between Connected Systems. Enterprise database connectivity is in development.</desc>
   <g id="jimdg-hs-hub">
     <rect class="jimdg-hub" x="300" y="28" width="560" height="584" rx="8"/>
     <text class="jimdg-hub-title" x="580" y="66">JIM</text>
@@ -23,7 +23,7 @@
       <text class="jimdg-chip-label" x="520" y="157">File / CSV</text>
       <rect class="jimdg-chip-planned" x="584" y="130" width="112" height="44" rx="8"/>
       <text class="jimdg-chip-label-planned" x="640" y="148">SQL</text>
-      <text class="jimdg-chip-sub-planned" x="640" y="164">(planned)</text>
+      <text class="jimdg-chip-sub-planned" x="640" y="164">(in development)</text>
       <rect class="jimdg-chip" x="704" y="130" width="112" height="44" rx="8"/>
       <text class="jimdg-chip-label" x="760" y="157">SCIM 2.0</text>
     </g>
@@ -66,7 +66,7 @@
     <text class="jimdg-system-sub" x="130" y="337">LDAP</text>
     <rect class="jimdg-system-planned" x="20" y="458" width="220" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="130" y="486">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="130" y="507">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="130" y="507">SQL (in development)</text>
   </g>
   <g id="jimdg-hs-targets">
     <rect class="jimdg-system" x="920" y="118" width="220" height="64" rx="8"/>

--- a/docs/assets/diagrams/hub-and-spoke.svg
+++ b/docs/assets/diagrams/hub-and-spoke.svg
@@ -10,7 +10,7 @@
 <!-- expressed with <g> groups instead. -->
 <svg class="jim-diagram" viewBox="0 0 1160 640" role="img" aria-labelledby="jimdg-hs-title jimdg-hs-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-hs-title">JIM hub-and-spoke synchronisation concept</title>
-  <desc id="jimdg-hs-desc">Source systems on the left and target systems on the right connect to JIM in the centre. Inside JIM, Connectors pass imported data through the Import, Synchronise and Export pipeline, which correlates and projects identities into the Metaverse, the authoritative data store for fused identities. Every flow passes through JIM; no data moves directly between Connected Systems. Enterprise database and cloud application connectivity are planned.</desc>
+  <desc id="jimdg-hs-desc">Source systems on the left and target systems on the right connect to JIM in the centre. Inside JIM, Connectors pass imported data through the Import, Synchronise and Export pipeline, which correlates and projects identities into the Metaverse, the authoritative data store for fused identities. Every flow passes through JIM; no data moves directly between Connected Systems. Enterprise database connectivity is planned.</desc>
   <g id="jimdg-hs-hub">
     <rect class="jimdg-hub" x="300" y="28" width="560" height="584" rx="8"/>
     <text class="jimdg-hub-title" x="580" y="66">JIM</text>
@@ -24,9 +24,8 @@
       <rect class="jimdg-chip-planned" x="584" y="130" width="112" height="44" rx="8"/>
       <text class="jimdg-chip-label-planned" x="640" y="148">SQL</text>
       <text class="jimdg-chip-sub-planned" x="640" y="164">(planned)</text>
-      <rect class="jimdg-chip-planned" x="704" y="130" width="112" height="44" rx="8"/>
-      <text class="jimdg-chip-label-planned" x="760" y="148">SCIM 2.0</text>
-      <text class="jimdg-chip-sub-planned" x="760" y="164">(planned)</text>
+      <rect class="jimdg-chip" x="704" y="130" width="112" height="44" rx="8"/>
+      <text class="jimdg-chip-label" x="760" y="157">SCIM 2.0</text>
     </g>
     <g id="jimdg-hs-pipeline">
       <rect class="jimdg-stage" x="330" y="262" width="140" height="56" rx="8"/>
@@ -76,9 +75,9 @@
     <rect class="jimdg-system" x="920" y="288" width="220" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="316">Business Application</text>
     <text class="jimdg-system-sub" x="1030" y="337">CSV</text>
-    <rect class="jimdg-system-planned" x="920" y="458" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1030" y="486">Cloud Applications</text>
-    <text class="jimdg-system-sub-planned" x="1030" y="507">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="920" y="458" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1030" y="486">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1030" y="507">SCIM 2.0</text>
   </g>
   <g id="jimdg-hs-spokes">
     <line class="jimdg-spoke" x1="240" y1="150" x2="290" y2="150"/>
@@ -92,8 +91,8 @@
     <polygon class="jimdg-arrow" points="920,150 910,144.5 910,155.5"/>
     <line class="jimdg-spoke" x1="860" y1="320" x2="910" y2="320"/>
     <polygon class="jimdg-arrow" points="920,320 910,314.5 910,325.5"/>
-    <line class="jimdg-spoke-planned" x1="860" y1="490" x2="910" y2="490"/>
-    <polygon class="jimdg-arrow-planned" points="920,490 910,484.5 910,495.5"/>
+    <line class="jimdg-spoke" x1="860" y1="490" x2="910" y2="490"/>
+    <polygon class="jimdg-arrow" points="920,490 910,484.5 910,495.5"/>
   </g>
   <g id="jimdg-hs-packets">
     <circle class="jimdg-packet" r="4.5">
@@ -139,6 +138,10 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.4s" begin="-1.7s" repeatCount="indefinite" path="M860,320 L909,320"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-1.7s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="2.4s" begin="-0.5s" repeatCount="indefinite" path="M860,490 L909,490"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-0.5s" repeatCount="indefinite"/>
     </circle>
   </g>
 </svg>

--- a/docs/assets/diagrams/system-context.svg
+++ b/docs/assets/diagrams/system-context.svg
@@ -9,7 +9,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 630" role="img" aria-labelledby="jimdg-sc-title jimdg-sc-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, and reads and writes file systems. Enterprise database connectivity over SQL and cloud application provisioning over SCIM 2.0 are planned.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is planned.</desc>
   <g id="jimdg-sc-people">
     <rect class="jimdg-stage" x="150" y="36" width="220" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="170" cy="57" r="6"/>
@@ -43,9 +43,9 @@
     <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
     <text class="jimdg-system-sub-planned" x="805" y="569">SQL (planned)</text>
-    <rect class="jimdg-system-planned" x="930" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="1030" y="548">Cloud Applications</text>
-    <text class="jimdg-system-sub-planned" x="1030" y="569">SCIM 2.0 (planned)</text>
+    <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
+    <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>
   </g>
   <g id="jimdg-sc-edges">
     <line class="jimdg-spoke" x1="260" y1="100" x2="491.4" y2="235"/>
@@ -72,9 +72,10 @@
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
     <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
     <text class="jimdg-spoke-label jimdg-anchor-end" x="688" y="430">SQL</text>
-    <line class="jimdg-spoke-planned" x1="700" y1="380" x2="1020.8" y2="516.1"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
-    <text class="jimdg-spoke-label jimdg-anchor-end" x="900" y="470">provisions · SCIM 2.0</text>
+    <line class="jimdg-spoke" x1="709.2" y1="383.9" x2="1020.8" y2="516.1"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,380) rotate(203)"/>
+    <text class="jimdg-spoke-label jimdg-anchor-end" x="870" y="474">SCIM 2.0</text>
   </g>
   <g id="jimdg-sc-packets">
     <circle class="jimdg-packet" r="4.5">

--- a/docs/assets/diagrams/system-context.svg
+++ b/docs/assets/diagrams/system-context.svg
@@ -86,5 +86,9 @@
       <animateMotion dur="3s" begin="-1.5s" repeatCount="indefinite" path="M450,384 L140,516"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-1.5s" repeatCount="indefinite"/>
     </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M709,384 L1021,516"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
   </g>
 </svg>

--- a/docs/assets/diagrams/system-context.svg
+++ b/docs/assets/diagrams/system-context.svg
@@ -9,7 +9,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 630" role="img" aria-labelledby="jimdg-sc-title jimdg-sc-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is planned.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is in development.</desc>
   <g id="jimdg-sc-people">
     <rect class="jimdg-stage" x="150" y="36" width="220" height="64" rx="8"/>
     <circle class="jimdg-person-glyph" cx="170" cy="57" r="6"/>
@@ -42,7 +42,7 @@
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
     <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (planned)</text>
+    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (in development)</text>
     <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>

--- a/docs/assets/diagrams/worker-components.svg
+++ b/docs/assets/diagrams/worker-components.svg
@@ -9,7 +9,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 690" role="img" aria-labelledby="jimdg-wk-title jimdg-wk-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-wk-title">Inside the Worker Service</title>
-  <desc id="jimdg-wk-desc">The Worker Host polls the PostgreSQL task queue and dispatches processors for import, synchronisation and export; the service reads and writes staged and Metaverse data in the same database. Import processors stage data arriving through the Connectors; synchronisation processors use the Sync Engine to apply projection, attribute flow, and deletion and matching rules; the export processor sends outbound changes back through the Connectors to Connected Systems. The Connectors layer hosts the LDAP, File/CSV and SCIM 2.0 connectors, with a SQL connector planned.</desc>
+  <desc id="jimdg-wk-desc">The Worker Host polls the PostgreSQL task queue and dispatches processors for import, synchronisation and export; the service reads and writes staged and Metaverse data in the same database. Import processors stage data arriving through the Connectors; synchronisation processors use the Sync Engine to apply projection, attribute flow, and deletion and matching rules; the export processor sends outbound changes back through the Connectors to Connected Systems. The Connectors layer hosts the LDAP, File/CSV and SCIM 2.0 connectors, with a SQL connector in development.</desc>
   <g id="jimdg-wk-db">
     <path class="jimdg-stage" d="M20,96 A110,16 0 0 1 240,96 L240,264 A110,16 0 0 1 20,264 Z"/>
     <ellipse class="jimdg-stage" cx="130" cy="96" rx="110" ry="16"/>
@@ -52,7 +52,7 @@
     <text class="jimdg-chip-label" x="629" y="573">File / CSV</text>
     <rect class="jimdg-chip-planned" x="741" y="546" width="160" height="44" rx="8"/>
     <text class="jimdg-chip-label-planned" x="821" y="564">SQL</text>
-    <text class="jimdg-chip-sub-planned" x="821" y="580">(planned)</text>
+    <text class="jimdg-chip-sub-planned" x="821" y="580">(in development)</text>
     <rect class="jimdg-chip" x="934" y="546" width="160" height="44" rx="8"/>
     <text class="jimdg-chip-label" x="1014" y="573">SCIM 2.0</text>
   </g>

--- a/docs/assets/diagrams/worker-components.svg
+++ b/docs/assets/diagrams/worker-components.svg
@@ -9,7 +9,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 690" role="img" aria-labelledby="jimdg-wk-title jimdg-wk-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-wk-title">Inside the Worker Service</title>
-  <desc id="jimdg-wk-desc">The Worker Host polls the PostgreSQL task queue and dispatches processors for import, synchronisation and export; the service reads and writes staged and Metaverse data in the same database. Import processors stage data arriving through the Connectors; synchronisation processors use the Sync Engine to apply projection, attribute flow, and deletion and matching rules; the export processor sends outbound changes back through the Connectors to Connected Systems. The Connectors layer hosts the LDAP and File/CSV connectors, with SQL and SCIM 2.0 connectors planned.</desc>
+  <desc id="jimdg-wk-desc">The Worker Host polls the PostgreSQL task queue and dispatches processors for import, synchronisation and export; the service reads and writes staged and Metaverse data in the same database. Import processors stage data arriving through the Connectors; synchronisation processors use the Sync Engine to apply projection, attribute flow, and deletion and matching rules; the export processor sends outbound changes back through the Connectors to Connected Systems. The Connectors layer hosts the LDAP, File/CSV and SCIM 2.0 connectors, with a SQL connector planned.</desc>
   <g id="jimdg-wk-db">
     <path class="jimdg-stage" d="M20,96 A110,16 0 0 1 240,96 L240,264 A110,16 0 0 1 20,264 Z"/>
     <ellipse class="jimdg-stage" cx="130" cy="96" rx="110" ry="16"/>
@@ -53,9 +53,8 @@
     <rect class="jimdg-chip-planned" x="741" y="546" width="160" height="44" rx="8"/>
     <text class="jimdg-chip-label-planned" x="821" y="564">SQL</text>
     <text class="jimdg-chip-sub-planned" x="821" y="580">(planned)</text>
-    <rect class="jimdg-chip-planned" x="934" y="546" width="160" height="44" rx="8"/>
-    <text class="jimdg-chip-label-planned" x="1014" y="564">SCIM 2.0</text>
-    <text class="jimdg-chip-sub-planned" x="1014" y="580">(planned)</text>
+    <rect class="jimdg-chip" x="934" y="546" width="160" height="44" rx="8"/>
+    <text class="jimdg-chip-label" x="1014" y="573">SCIM 2.0</text>
   </g>
   <g id="jimdg-wk-flows">
     <line class="jimdg-flow" x1="465" y1="168" x2="465" y2="218"/>

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -613,7 +613,9 @@ body:has(.jim-home) .md-content__button {
 
 /* Text: sizes in SVG user units; the viewBox scales them with the diagram */
 .jim-diagram text { text-anchor: middle; }
-.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text); }
+.jim-diagram .jimdg-hub-title    { font-size: 22px; font-weight: 700; fill: var(--jimdg-hub-text);
+                                   stroke: var(--jimdg-hub-fill); stroke-width: 5; stroke-linejoin: round;
+                                   paint-order: stroke fill; }
 .jim-diagram .jimdg-layer-title  { font-size: 14px; font-weight: 600; fill: var(--jimdg-layer-text); }
 .jim-diagram .jimdg-chip-label   { font-size: 13.5px; font-weight: 600; fill: var(--jimdg-chip-text); }
 .jim-diagram .jimdg-chip-sub     { font-size: 11px; fill: var(--jimdg-chip-text); opacity: 0.78; }

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -23,7 +23,7 @@ The following diagram shows JIM in the context of the systems and users it inter
 
 --8<-- "assets/diagrams/system-context.svg"
 
-<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems. Dashed elements indicate planned connectivity.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 ## Containers
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -6,7 +6,7 @@ For per-object documentation (Connected Systems, Synchronisation Rules, Schedule
 
 --8<-- "assets/diagrams/hub-and-spoke.svg"
 
-<p class="jim-diagram-caption">The Connected Systems shown are illustrative examples. Dashed elements indicate planned connectivity.<span class="jimdg-caption-motion"> Moving dots trace identity data flowing through JIM.</span></p>
+<p class="jim-diagram-caption">The Connected Systems shown are illustrative examples. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data flowing through JIM.</span></p>
 
 ## 🏗️ Architecture
 

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -14,7 +14,7 @@ When a connector imports data from an external system, it does not write directl
 
 --8<-- "assets/diagrams/hub-and-spoke.svg"
 
-<p class="jim-diagram-caption">Connectors sit at JIM's edge, carrying data between Connected Systems and the synchronisation pipeline; every flow passes through the Metaverse, never directly between systems. Dashed elements indicate planned connectors.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">Connectors sit at JIM's edge, carrying data between Connected Systems and the synchronisation pipeline; every flow passes through the Metaverse, never directly between systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 Each Connected System in JIM has:
 
@@ -36,9 +36,9 @@ JIM ships with the following built-in connectors:
 | [JIM LDAP Connector](jim-ldap-connector.md) | Active Directory, OpenLDAP, 389 Directory Server, and other RFC 4512-compliant directories | Full Import, Delta Import, Export |
 | [JIM SCIM 2.0 Client Connector](jim-scim-connector.md) | Any system exposing a SCIM 2.0 service provider interface (RFC 7643/7644) | Full Import, Delta Import, Export |
 
-## 🗺️ Planned Connectors
+## 🗺️ Upcoming Connectors
 
-For planned connectors including SQL databases, PowerShell, and REST APIs, see the [Roadmap](../reference/roadmap.md).
+A Database Connector for SQL Server, PostgreSQL, MySQL and Oracle is in development. PowerShell and REST API connectors are planned. See the [Roadmap](../reference/roadmap.md) for the full picture.
 
 ## 🧩 Custom Connectors
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -10,7 +10,7 @@ JIM implements an enterprise identity management system using the metaverse patt
 
 --8<-- "assets/diagrams/system-context.svg"
 
-<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems. Dashed elements indicate planned connectivity.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 ## Layered Architecture
 
@@ -77,7 +77,7 @@ The component views use the docs site's hand-authored diagram system and are sim
 
 --8<-- "assets/diagrams/connector-components.svg"
 
-<p class="jim-diagram-caption">The Worker's import and export processors invoke the connectors, which carry data to and from the external systems. Dashed elements indicate planned connectors.<span class="jimdg-caption-motion"> Moving dots trace data in flight.</span></p>
+<p class="jim-diagram-caption">The Worker's import and export processors invoke the connectors, which carry data to and from the external systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace data in flight.</span></p>
 
 ### Scheduler Service
 

--- a/docs/developer/diagrams/CONNECTOR_LIFECYCLE.md
+++ b/docs/developer/diagrams/CONNECTOR_LIFECYCLE.md
@@ -34,10 +34,12 @@ flowchart TD
 
     MatchName -->|LdapConnectorName| CreateLdap[new LdapConnector]
     MatchName -->|FileConnectorName| CreateFile[new FileConnector]
+    MatchName -->|ScimClientConnectorName| CreateScim[new ScimConnector]
     MatchName -->|Unknown| ThrowError[throw NotSupportedException<br/>Activity fails with error]
 
     CreateLdap --> GetRunProfile[Resolve RunProfile<br/>from ConnectedSystem.RunProfiles]
     CreateFile --> GetRunProfile
+    CreateScim --> GetRunProfile
 
     GetRunProfile --> RouteByType{RunProfile<br/>RunType?}
     RouteByType -->|FullImport<br/>DeltaImport| ImportProcessor[SyncImportTaskProcessor<br/>ISyncServer + ISyncRepository]

--- a/docs/developer/diagrams/WORKER_TASK_LIFECYCLE.md
+++ b/docs/developer/diagrams/WORKER_TASK_LIFECYCLE.md
@@ -54,7 +54,7 @@ flowchart TD
     SetExecuted --> TaskType{WorkerTask<br/>type?}
 
     %% --- Sync task ---
-    TaskType -->|SynchronisationWorkerTask| ResolveConnector[Resolve connector<br/>LDAP / File / ...]
+    TaskType -->|SynchronisationWorkerTask| ResolveConnector[Resolve connector<br/>LDAP / File / SCIM / ...]
     ResolveConnector --> ResolveRP[Get RunProfile from<br/>ConnectedSystem.RunProfiles]
     ResolveRP --> RunType{RunProfile<br/>RunType?}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hide:
 
 --8<-- "assets/diagrams/system-context.svg"
 
-<p class="jim-diagram-caption">JIM in context: administrators and automation work through its UI and API while it synchronises identity data with your systems. Dashed elements indicate planned connectivity.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">JIM in context: administrators and automation work through its UI and API while it synchronises identity data with your systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 ## ✨ Key Features
 

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -19,19 +19,19 @@ The first stable release, delivering a production-ready identity lifecycle platf
 
 ## 🌳 v1.x -- Connector Ecosystem
 
-Expanding the range of systems JIM can connect to out of the box.
+Expanding the range of systems JIM can connect to out of the box. The SCIM 2.0 Client Connector has already shipped and is listed here for continuity.
 
-| Connector | Description | Target |
+| Connector | Description | Status |
 |---|---|---|
-| JIM SQL Server Connector | Microsoft SQL Server databases | v1.x |
-| JIM PostgreSQL Connector | PostgreSQL databases | v1.x |
-| JIM MySQL Connector | MySQL databases | v1.x |
-| JIM Oracle Connector | Oracle databases | v1.x |
-| JIM PowerShell Connector | PowerShell Core scripts | v1.x |
-| JIM SCIM Connector | SCIM 2.0 endpoints | v1.x |
-| JIM REST Connector | REST API web services | v1.x |
+| [JIM SCIM 2.0 Client Connector](../connectors/jim-scim-connector.md) | SCIM 2.0 endpoints | ✅ Available |
+| JIM SQL Server Connector | Microsoft SQL Server databases | 🚧 In development |
+| JIM PostgreSQL Connector | PostgreSQL databases | 🚧 In development |
+| JIM MySQL Connector | MySQL databases | 🚧 In development |
+| JIM Oracle Connector | Oracle databases | 🚧 In development |
+| JIM PowerShell Connector | PowerShell Core scripts | Planned |
+| JIM REST Connector | REST API web services | Planned |
 
-Each connector will follow JIM's established connector architecture, supporting schema discovery, full and delta import, and export with the same reliability guarantees as the built-in connectors.
+Each connector follows JIM's established connector architecture, supporting schema discovery, full and delta import, and export with the same reliability guarantees as the built-in connectors.
 
 ---
 


### PR DESCRIPTION
## Description

The SCIM 2.0 Client Connector shipped in #545, but every diagram that lists connectors still drew it dashed and labelled "(planned)", including the two exported for the GitHub README. This corrects their status and fixes two layout defects found while doing so.

**SCIM 2.0 status:**

- Five hand-authored SVGs (`system-context`, `containers`, `connector-components`, `worker-components`, `hub-and-spoke`) now draw the SCIM nodes, chips and edges as live, with their `<desc>` alt text rewritten to match. The System Context and Connectors spokes are bidirectional, like LDAP, because the connector imports as well as exports.
- The four baked README copies under `.github/diagrams/` were regenerated with `scripts/Export-ReadmeDiagrams.ps1`.
- `CONNECTOR_LIFECYCLE.md`'s Connector Resolution flow was missing the `ScimClientConnectorName` branch, so it listed two of the three branches `ConnectorFactory.Create` actually dispatches. `WORKER_TASK_LIFECYCLE.md` now names SCIM in its connector-resolution step.

**SQL Database Connector status:**

- The Database Connector (#170) has a PRD in `engineering/prd/doing`, so "planned" understated it. It keeps its single dashed state (the question a diagram reader can act on is binary: can I connect to this today?) and is relabelled "in development" across the five diagrams.
- The six page captions now read "Dashed elements are not yet available" rather than "indicate planned connectivity", which stays true whether a dashed connector is planned or in development.
- The roadmap's v1.x connector table gains a Status column, marks the four database connectors as in development, and records the SCIM 2.0 Client Connector as available rather than upcoming.

**Layout fixes:**

- `connector-components`: the four columns sit on a 240px pitch centred on the JIM.Connectors boundary, so the SCIM chip clears it by the same 25px as LDAP does on the left. It previously overhung the boundary by 5px.
- `connector-components` and `containers`: the boundary titles are now the last element in each file, so edges and their data packets pass behind rather than over them (the REST API spoke ran straight through "JIM"). `.jimdg-hub-title` gains a `paint-order` knockout stroke so no line shows through the gaps between glyphs.

Diagrams deliberately left unchanged: `sync-cycle`, `sync-pipeline`, `metaverse-anatomy` and `layered-architecture` name systems as illustrative examples rather than listing the connector inventory.

## Type of change

- [x] Documentation update

## Testing

- [x] Every changed SVG re-rendered in Chromium and checked in both themes, including frames timed to the data-packet animation to confirm the packets pass behind the boundary titles
- [x] All SVGs validated as well-formed XML
- [x] `scripts/Export-ReadmeDiagrams.ps1` re-run; baked README copies match their sources

`dotnet build` / `dotnet test` not run: this PR touches only SVGs, Markdown and CSS, which the CLAUDE.md build/test exception covers.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `index.md`, `concepts/index.md`, `concepts/architecture.md`, `connectors/index.md`, `developer/architecture.md`, `reference/roadmap.md`, `developer/diagrams/CONNECTOR_LIFECYCLE.md`, `developer/diagrams/WORKER_TASK_LIFECYCLE.md`, plus the diagrams under `assets/diagrams/`

<!-- Docs: n/a - this PR is itself a documentation change; no changelog entry, so no docs coupling to satisfy -->

## Screenshots / output

Before/after comparison of all five diagrams, flippable in place: https://claude.ai/code/artifact/f0058369-83a6-4fb8-9b17-2c2359bc6126

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

No `CHANGELOG.md` entry: docs-only changes are excluded per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mor6MBpysFHpBsu4Z8JDWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mor6MBpysFHpBsu4Z8JDWJ)_