### PR TITLE
feat: SQL Connector delta import (#170)

### DIFF
--- a/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
@@ -244,14 +244,13 @@ internal class OracleProvider : SqlProviderBase
 
         var select = $"SELECT {BuildColumnList(request.SelectColumns)}";
         var from = $"FROM {BuildFromClause(request)}";
+        var where = BuildKeysetWhereClause(request);
         var orderBy = BuildAnchorOrderByClause(request.AnchorColumns);
 
         // The row limiting clause accepts a bind variable, so the page size stays a bound value.
         var fetch = $"FETCH FIRST {GetParameterPlaceholder(request.PageSizeParameterName)} ROWS ONLY";
 
-        return request.IsFirstPage
-            ? $"{select} {from} {orderBy} {fetch}"
-            : $"{select} {from} WHERE {BuildKeysetPredicate(request.AnchorColumns, request.LastAnchorParameterNames)} {orderBy} {fetch}";
+        return $"{select} {from}{where} {orderBy} {fetch}";
     }
 
     #endregion

--- a/src/JIM.Connectors/Sql/Providers/SqlKeysetPageRequest.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlKeysetPageRequest.cs
@@ -54,7 +54,25 @@ internal sealed record SqlKeysetPageRequest
     internal IReadOnlyList<string> LastAnchorParameterNames { get; init; } = [];
 
     /// <summary>
+    /// The column a Delta Import restricts the read to, so that only rows beyond the persisted watermark
+    /// are returned: a change log's sequence, or a source's last-modified column. Null for a Full Import,
+    /// and null on a Delta Import that has no watermark yet and therefore reads from the beginning.
+    /// </summary>
+    internal string? ChangeColumn { get; init; }
+
+    /// <summary>
+    /// The parameter carrying the watermark <see cref="ChangeColumn"/> is compared against. Set exactly
+    /// when <see cref="ChangeColumn"/> is.
+    /// </summary>
+    internal string? ChangeParameterName { get; init; }
+
+    /// <summary>
     /// True when no previous anchor was supplied, so the page starts at the beginning of the ordered set.
     /// </summary>
     internal bool IsFirstPage => LastAnchorParameterNames.Count == 0;
+
+    /// <summary>
+    /// True when the read is restricted to rows beyond a watermark.
+    /// </summary>
+    internal bool HasChangeFilter => ChangeColumn != null;
 }

--- a/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
@@ -167,6 +167,32 @@ internal abstract class SqlProviderBase : ISqlProvider
             throw new ArgumentException(
                 $"A keyset page must supply one last-anchor parameter per anchor column: {request.AnchorColumns.Count} anchor column(s) but {request.LastAnchorParameterNames.Count} parameter(s).",
                 nameof(request));
+
+        if (string.IsNullOrWhiteSpace(request.ChangeColumn) != string.IsNullOrWhiteSpace(request.ChangeParameterName))
+            throw new ArgumentException(
+                "A keyset page restricted to changed rows needs both the column to compare and the parameter carrying the watermark; one without the other would read everything, or nothing.",
+                nameof(request));
+    }
+
+    /// <summary>
+    /// Renders everything a keyset page filters on: the seek past the previous page's last row, and the
+    /// restriction to rows beyond a Delta Import's watermark. Identical in both dialects, so it lives
+    /// here rather than being written out twice.
+    /// </summary>
+    /// <returns>The WHERE clause with its leading space, or an empty string where the page filters on nothing.</returns>
+    protected string BuildKeysetWhereClause(SqlKeysetPageRequest request)
+    {
+        var predicates = new List<string>(2);
+
+        // The watermark first: it is the more selective of the two, and on the first page of a run it is
+        // the only thing standing between a Delta Import and a full table scan.
+        if (request.HasChangeFilter)
+            predicates.Add($"{QuoteIdentifier(request.ChangeColumn!)} > {GetParameterPlaceholder(request.ChangeParameterName!)}");
+
+        if (!request.IsFirstPage)
+            predicates.Add(BuildKeysetPredicate(request.AnchorColumns, request.LastAnchorParameterNames));
+
+        return predicates.Count == 0 ? string.Empty : $" WHERE {string.Join(" AND ", predicates)}";
     }
 
     /// <summary>

--- a/src/JIM.Connectors/Sql/Providers/SqlServerProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlServerProvider.cs
@@ -141,11 +141,10 @@ internal class SqlServerProvider : SqlProviderBase
         // TOP takes a bound parameter, so the page size is a value like any other.
         var select = $"SELECT TOP ({GetParameterPlaceholder(request.PageSizeParameterName)}) {BuildColumnList(request.SelectColumns)}";
         var from = $"FROM {BuildFromClause(request)}";
+        var where = BuildKeysetWhereClause(request);
         var orderBy = BuildAnchorOrderByClause(request.AnchorColumns);
 
-        return request.IsFirstPage
-            ? $"{select} {from} {orderBy}"
-            : $"{select} {from} WHERE {BuildKeysetPredicate(request.AnchorColumns, request.LastAnchorParameterNames)} {orderBy}";
+        return $"{select} {from}{where} {orderBy}";
     }
 
     #endregion

--- a/src/JIM.Connectors/Sql/SqlConnector.cs
+++ b/src/JIM.Connectors/Sql/SqlConnector.cs
@@ -39,6 +39,7 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
     private ISqlProvider? _importProvider;
     private SqlSchemaConfiguration? _importConfiguration;
     private TimeZoneInfo _importDatabaseTimeZone = TimeZoneInfo.Utc;
+    private SqlDeltaImportMode _importDeltaMode = SqlDeltaImportMode.NotSet;
 
     /// <summary>
     /// The server certificate this Connector has decided to accept in addition to the operating system's
@@ -226,6 +227,19 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
                 Description = ObjectTypesSettingDescription,
                 Category = ConnectedSystemSettingCategory.Schema,
                 Type = ConnectedSystemSettingType.Text
+            },
+
+            new() { Name = "Delta Import", Category = ConnectedSystemSettingCategory.Schema, Type = ConnectedSystemSettingType.Heading },
+            new()
+            {
+                // Deliberately not required: a Connected System that only runs Full Imports is not
+                // obliged to answer this, and defaulting it would have JIM read changes from a table
+                // nobody has said exists.
+                Name = SqlConnectorConstants.SettingDeltaImportMode,
+                Description = DeltaImportModeSettingDescription,
+                Category = ConnectedSystemSettingCategory.Schema,
+                Type = ConnectedSystemSettingType.DropDown,
+                DropDownValues = new List<string> { SqlConnectorConstants.DeltaImportModeChangeLogTable, SqlConnectorConstants.DeltaImportModeWatermarkColumn }
             }
         };
     }
@@ -250,6 +264,25 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
         "that join a row back to its parent (one per anchor column, in the same order), plus 'referencesObjectType' where those values are references, as group membership is. " +
         "Every other column is discovered and typed automatically. Example:" + Environment.NewLine + Environment.NewLine +
         SqlConnectorConstants.ObjectTypesExample;
+
+    /// <summary>
+    /// The Delta Import Mode setting's description: what each mode reads, what each one can and cannot
+    /// observe, and what each needs adding to the Object Types document.
+    /// </summary>
+    /// <remarks>
+    /// The example lives in <see cref="SqlConnectorConstants.DeltaConfigurationExample"/> and is parsed
+    /// by the Connector's own unit tests, so it cannot drift out of step with what the parser accepts.
+    /// </remarks>
+    private static string DeltaImportModeSettingDescription =>
+        "How a Delta Import finds out what has changed. Leave this unanswered where this Connected System only runs Full Imports. " +
+        $"'{SqlConnectorConstants.DeltaImportModeChangeLogTable}' reads a table or view your database maintains, holding one row per change with the object's anchor, " +
+        "a change type and a monotonic sequence or timestamp. It is the recommended mode, and the only one that observes a deletion. " +
+        "Add a 'changeLog' to every object type naming that table, the columns carrying the anchor, the sequence column, the change type column, " +
+        "and which of your own change-type values mean a create, an update and a deletion. " +
+        $"'{SqlConnectorConstants.DeltaImportModeWatermarkColumn}' reads a last-modified or version column on the object type's own table or view, named as its 'watermarkColumn'. " +
+        "It needs nothing extra in the database, but it detects creates and updates only: a row that has been deleted has no column left to move, " +
+        "so deletions are found only by a Full Import. Example:" + Environment.NewLine + Environment.NewLine +
+        SqlConnectorConstants.DeltaConfigurationExample;
 
     /// <summary>
     /// Validates SqlConnector setting values using custom business logic.
@@ -317,8 +350,9 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
     /// be interpreted.
     /// </summary>
     /// <param name="persistedConnectorData">
-    /// Unused by a Full Import, which reads everything there is rather than resuming from a watermark.
-    /// A Delta Import is where it earns its place.
+    /// The watermark the last run left behind, which a Delta Import reads its changes from. A Full
+    /// Import reads everything there is regardless, but still records a new one where this Connected
+    /// System is configured for Delta Imports, so that the next one has a baseline.
     /// </param>
     /// <exception cref="InvalidSettingValuesException">A setting a connection cannot be made without is missing or unusable.</exception>
     /// <exception cref="SqlSchemaConfigurationException">The Object Types document is unusable.</exception>
@@ -339,6 +373,7 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
         _importProvider = provider;
         _importConfiguration = configuration;
         _importDatabaseTimeZone = databaseTimeZone;
+        _importDeltaMode = ResolveDeltaImportMode(settingValues);
     }
 
     /// <summary>
@@ -361,16 +396,13 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
         if (_importConnection == null || _importProvider == null || _importConfiguration == null)
             throw new InvalidOperationException("Must call OpenImportConnection() before ImportAsync()!");
 
-        var import = new SqlConnectorImport(_importProvider, _importConnection, _importConfiguration, _importDatabaseTimeZone,
-            connectedSystem, runProfile, paginationTokens, logger, cancellationToken, progress);
+        var import = new SqlConnectorImport(_importProvider, _importConnection, _importConfiguration, _importDatabaseTimeZone, _importDeltaMode,
+            connectedSystem, runProfile, paginationTokens, persistedConnectorData, logger, cancellationToken, progress);
 
         return runProfile.RunType switch
         {
             ConnectedSystemRunType.FullImport => import.GetFullImportObjectsAsync(),
-
-            // Delta Import is the next phase of this Connector's implementation plan; the capability is
-            // declared because the Connector will support it, and it is not reachable until then.
-            ConnectedSystemRunType.DeltaImport => throw new NotSupportedException("Delta Import is not yet implemented for the JIM SQL Connector."),
+            ConnectedSystemRunType.DeltaImport => import.GetDeltaImportObjectsAsync(),
             _ => throw new InvalidDataException($"Unsupported import run-type: {runProfile.RunType}")
         };
     }
@@ -379,8 +411,9 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
     /// Releases the import connection, whether the import succeeded or failed.
     /// </summary>
     /// <returns>
-    /// Always null: a Full Import has no state for JIM to carry into the next run, and a non-null return
-    /// would override state JIM already holds.
+    /// Always null. The only state this Connector carries between runs is the Delta Import watermark,
+    /// and that is returned from the first page of the run itself so JIM saves it only once every page
+    /// has been read. Returning it here would save it whether the run finished or not.
     /// </returns>
     public string? CloseImportConnection()
     {
@@ -389,6 +422,7 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
         _importProvider = null;
         _importConfiguration = null;
         _importDatabaseTimeZone = TimeZoneInfo.Utc;
+        _importDeltaMode = SqlDeltaImportMode.NotSet;
 
         return null;
     }
@@ -782,9 +816,24 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
     }
 
     /// <summary>
+    /// How this Connected System's Delta Imports find out what has changed, or
+    /// <see cref="SqlDeltaImportMode.NotSet"/> where nobody has said. Not set is an answer rather than a
+    /// failure: a Connected System that only runs Full Imports never needs one.
+    /// </summary>
+    private static SqlDeltaImportMode ResolveDeltaImportMode(List<ConnectedSystemSettingValue> settingValues)
+    {
+        return GetString(settingValues, SqlConnectorConstants.SettingDeltaImportMode) switch
+        {
+            SqlConnectorConstants.DeltaImportModeChangeLogTable => SqlDeltaImportMode.ChangeLogTable,
+            SqlConnectorConstants.DeltaImportModeWatermarkColumn => SqlDeltaImportMode.WatermarkColumn,
+            _ => SqlDeltaImportMode.NotSet
+        };
+    }
+
+    /// <summary>
     /// Checks that the Object Types document can be used, so that a Connected System is never saved
-    /// with configuration that schema discovery would then refuse. A missing document is left alone:
-    /// the setting is required, and the generic validator has already said so.
+    /// with configuration that schema discovery or a Delta Import would then refuse. A missing document
+    /// is left alone: the setting is required, and the generic validator has already said so.
     /// </summary>
     private static ConnectorSettingValueValidationResult? ValidateObjectTypes(List<ConnectedSystemSettingValue> settingValues)
     {
@@ -794,7 +843,16 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
 
         try
         {
-            SqlSchemaConfiguration.Parse(settingValue.StringValue);
+            var configuration = SqlSchemaConfiguration.Parse(settingValue.StringValue);
+
+            // The document is written without reference to the mode, so whether it can serve the one
+            // that is configured is a question only asked once both are in hand. Asked here, and not
+            // when a Delta Import runs, because an administrator finds out at the keyboard rather than
+            // from an overnight run.
+            var deltaImportMode = ResolveDeltaImportMode(settingValues);
+            if (deltaImportMode != SqlDeltaImportMode.NotSet)
+                configuration.ValidateDeltaImportMode(deltaImportMode);
+
             return null;
         }
         catch (SqlSchemaConfigurationException ex)

--- a/src/JIM.Connectors/Sql/SqlConnectorConstants.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorConstants.cs
@@ -87,6 +87,30 @@ public static class SqlConnectorConstants
 
     public const string SettingObjectTypes = "Object Types";
 
+    /// <summary>
+    /// How a Delta Import finds out what has changed. Deliberately a list rather than a checkbox: a
+    /// database has no single answer, and the members here are the two dialect-agnostic mechanisms every
+    /// estate can offer. Provider-native change detection joins this list rather than reshaping the
+    /// configuration around it.
+    /// </summary>
+    public const string SettingDeltaImportMode = "Delta Import Mode";
+
+    #endregion
+
+    #region Delta Import Mode drop-down values
+
+    /// <summary>
+    /// Changes read from a customer-maintained change-log table or view. The recommended mode, and the
+    /// only one that observes a deletion.
+    /// </summary>
+    public const string DeltaImportModeChangeLogTable = "Change-Log Table";
+
+    /// <summary>
+    /// Changes detected from a last-modified or version column on the object type's own source. Creates
+    /// and updates only; a row that is gone has no column left to move.
+    /// </summary>
+    public const string DeltaImportModeWatermarkColumn = "Watermark Column";
+
     #endregion
 
     #region Database Type drop-down values
@@ -145,6 +169,36 @@ public static class SqlConnectorConstants
                   "joinColumns": [ "EMPLOYEE_ID" ]
                 }
               ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// The same Object Types document with both Delta Import modes configured, shown in the Delta Import
+    /// Mode setting's Description. Only the mode actually chosen is read, but showing both together is
+    /// what makes the difference between them legible. Parsed by the Connector's own unit tests, so it
+    /// cannot drift out of step with what the parser accepts.
+    /// </summary>
+    public const string DeltaConfigurationExample = """
+        {
+          "objectTypes": [
+            {
+              "name": "Person",
+              "schema": "HR",
+              "table": "V_EMPLOYEES",
+              "anchorColumns": [ "EMPLOYEE_ID" ],
+              "watermarkColumn": "LAST_MODIFIED",
+              "changeLog": {
+                "schema": "HR",
+                "table": "IDM_CHANGE_LOG",
+                "anchorColumns": [ "EMPLOYEE_ID" ],
+                "sequenceColumn": "CHANGED_AT",
+                "changeTypeColumn": "CHANGE_TYPE",
+                "createValues": [ "I" ],
+                "updateValues": [ "U" ],
+                "deleteValues": [ "D" ]
+              }
             }
           ]
         }

--- a/src/JIM.Connectors/Sql/SqlConnectorImport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorImport.cs
@@ -2,7 +2,10 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Connectors.Sql.Providers;
+using JIM.Models.Activities;
 using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Exceptions;
 using JIM.Models.Interfaces;
 using JIM.Models.Staging;
 using JIM.Utilities;
@@ -10,13 +13,15 @@ using Serilog;
 using System.Data.Common;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace JIM.Connectors.Sql;
 
 /// <summary>
-/// Reads objects out of a database for a Full Import: a page of rows at a time per configured Object
-/// Type, ordered and seeked on the anchor, with each object type's multi-valued attributes gathered from
-/// its related tables in one query per page.
+/// Reads objects out of a database: everything there is for a Full Import, and only what has changed
+/// for a Delta Import. Either way a page of rows at a time per configured Object Type, ordered and
+/// seeked on the anchor, with each object type's multi-valued attributes gathered from its related
+/// tables in one query per page.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -54,6 +59,11 @@ internal sealed class SqlConnectorImport
     internal const string JoinParameterPrefix = "jimJoin";
 
     /// <summary>
+    /// The bind variable carrying the watermark a Delta Import reads changes beyond.
+    /// </summary>
+    internal const string WatermarkParameterName = "jimWatermark";
+
+    /// <summary>
     /// How many bind variables one related-table gather may carry. Microsoft SQL Server caps a statement
     /// at 2,100 parameters, so a large page size against a composite anchor would otherwise fail at the
     /// server; a page beyond this is gathered in more than one query rather than one per row.
@@ -67,6 +77,8 @@ internal sealed class SqlConnectorImport
     private readonly ConnectedSystem _connectedSystem;
     private readonly ConnectedSystemRunProfile _runProfile;
     private readonly List<ConnectedSystemPaginationToken> _paginationTokens;
+    private readonly SqlDeltaImportMode _deltaMode;
+    private readonly string? _persistedConnectorData;
     private readonly ILogger _logger;
     private readonly CancellationToken _cancellationToken;
     private readonly IConnectorProgress _progress;
@@ -76,9 +88,11 @@ internal sealed class SqlConnectorImport
         DbConnection connection,
         SqlSchemaConfiguration configuration,
         TimeZoneInfo databaseTimeZone,
+        SqlDeltaImportMode deltaMode,
         ConnectedSystem connectedSystem,
         ConnectedSystemRunProfile runProfile,
         List<ConnectedSystemPaginationToken> paginationTokens,
+        string? persistedConnectorData,
         ILogger logger,
         CancellationToken cancellationToken,
         IConnectorProgress progress)
@@ -87,9 +101,11 @@ internal sealed class SqlConnectorImport
         _connection = connection;
         _configuration = configuration;
         _databaseTimeZone = databaseTimeZone;
+        _deltaMode = deltaMode;
         _connectedSystem = connectedSystem;
         _runProfile = runProfile;
         _paginationTokens = paginationTokens;
+        _persistedConnectorData = persistedConnectorData;
         _logger = logger;
         _cancellationToken = cancellationToken;
         _progress = progress;
@@ -108,10 +124,19 @@ internal sealed class SqlConnectorImport
             return result;
         }
 
-        // Only on the initial call: the count is the whole run's, JIM keeps it, and asking again on
-        // every page would make an expensive query the price of paging.
+        // Only on the initial call: both of these are the whole run's, JIM keeps them, and asking again
+        // on every page would make an expensive query the price of paging.
         if (_paginationTokens.Count == 0)
+        {
+            // A Full Import is how a Delta Import's baseline is established, so where this Connected
+            // System is configured for one, it records where the changes stood before a single row was
+            // read. Reading first would leave anything changed during the run behind the watermark and
+            // therefore unread for ever.
+            if (_deltaMode != SqlDeltaImportMode.NotSet)
+                result.PersistedConnectorData = (await CaptureWatermarkAsync(plans)).Serialise();
+
             await ReportExpectedObjectCountAsync(plans);
+        }
 
         var objectsRead = 0;
 
@@ -153,6 +178,583 @@ internal sealed class SqlConnectorImport
 
         return result;
     }
+
+    #region Delta import
+
+    /// <summary>
+    /// Reads what has changed since JIM last looked, in whichever way this Connected System is
+    /// configured to find out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The watermark is captured before a single change is read, and returned from the first page
+    /// only.</b> JIM replays the run's original watermark to every page and saves the new one after the
+    /// last page, so a run that dies half way through re-reads its changes rather than skipping them.
+    /// A later page returning a watermark of its own would move the run's own starting point mid-run.
+    /// </para>
+    /// <para>
+    /// <b>Nothing is read up to an upper bound.</b> A change arriving while the run is in flight is read
+    /// by this run or the next one, and possibly both; re-importing an object that has not changed since
+    /// costs a comparison and produces no change, whereas an upper bound would silently drop anything
+    /// committed inside it. The same trade the LDAP Connector makes, for the same reason.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="CannotPerformDeltaImportException">No Delta Import Mode has been chosen, so there is nothing to read changes from.</exception>
+    internal async Task<ConnectedSystemImportResult> GetDeltaImportObjectsAsync()
+    {
+        if (_deltaMode == SqlDeltaImportMode.NotSet)
+            throw new CannotPerformDeltaImportException(
+                $"No {SqlConnectorConstants.SettingDeltaImportMode} has been chosen for this Connected System, so JIM has no way of finding out what has changed. " +
+                "Choose one, and configure it in the Object Types document.");
+
+        var plans = BuildPlans();
+
+        if (plans.Count == 0)
+        {
+            _logger.Warning("SqlConnectorImport: no configured Object Type has been selected for synchronisation, so there is nothing to import");
+            return new ConnectedSystemImportResult();
+        }
+
+        var previous = SqlConnectorWatermark.TryRead(_persistedConnectorData);
+
+        if (previous == null)
+            return await FallBackToFullImportAsync(string.IsNullOrWhiteSpace(_persistedConnectorData)
+                ? "JIM holds no watermark for this Connected System, and a Delta Import reads its changes from one"
+                : "the watermark JIM holds for this Connected System cannot be read");
+
+        if (previous.Mode != _deltaMode)
+            return await FallBackToFullImportAsync(
+                $"the {SqlConnectorConstants.SettingDeltaImportMode} has changed since the watermark JIM holds was written, and a watermark taken from one mechanism says nothing about another");
+
+        var result = new ConnectedSystemImportResult();
+
+        if (_paginationTokens.Count == 0)
+        {
+            await _progress.EnterPhaseAsync(SqlConnectorPhases.QueryChanges, "Querying changes...");
+
+            result.PersistedConnectorData = (await CaptureWatermarkAsync(plans)).Serialise();
+            await ReportExpectedChangeCountAsync(plans, previous);
+        }
+
+        var objectsRead = 0;
+
+        foreach (var plan in plans)
+        {
+            if (_cancellationToken.IsCancellationRequested)
+            {
+                _logger.Debug("SqlConnectorImport: cancellation requested. Stopping between pages");
+                return result;
+            }
+
+            var token = _paginationTokens.SingleOrDefault(paginationToken => paginationToken.Name == plan.TokenName);
+
+            // No token on a subsequent call means this object type was drained by an earlier one.
+            if (_paginationTokens.Count > 0 && token == null)
+                continue;
+
+            var page = SqlDeltaPagePosition.FromToken(token, plan);
+
+            await _progress.EnterPhaseAsync(SqlConnectorPhases.Fetch, $"Fetching changed {plan.Name} objects (page {page.PageNumber})...");
+
+            var watermark = previous.ObjectTypes.GetValueOrDefault(plan.Name);
+            var deltaPage = _deltaMode == SqlDeltaImportMode.ChangeLogTable
+                ? await ReadChangeLogPageAsync(plan, page, watermark)
+                : await ReadWatermarkColumnPageAsync(plan, page, watermark);
+
+            result.ImportObjects.AddRange(deltaPage.ImportObjects);
+            objectsRead += deltaPage.ImportObjects.Count;
+
+            // One call drains a page per configured Object Type, so the Activity's counters move while
+            // the call is still in flight rather than only when it returns.
+            await _progress.ReportObjectsReadAsync(objectsRead);
+
+            if (deltaPage.NextPosition != null)
+                result.PaginationTokens.Add(deltaPage.NextPosition.ToToken(plan));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Runs a Full Import in place of the Delta Import that was asked for, and says so.
+    /// </summary>
+    /// <remarks>
+    /// A missing or unusable watermark is a state problem with exactly one remedy, and it is one JIM can
+    /// apply itself: a Full Import delivers the right data and leaves the baseline the next Delta Import
+    /// needs. Refusing would fail the run and leave an administrator to do by hand what JIM has just
+    /// worked out is needed. A missing Delta Import Mode is refused instead, because that is a question
+    /// nobody has answered rather than a state to recover from, and a scheduled Delta Import quietly
+    /// costing a Full Import every cycle would hide it for ever.
+    /// <para>
+    /// The Full Import narrates its counting step, which a Delta Import never declared. The narration
+    /// still reaches the Activity; only the stepper stays on the steps this run said it would perform,
+    /// which is better than every Delta Import carrying a step it almost never reaches.
+    /// </para>
+    /// </remarks>
+    private async Task<ConnectedSystemImportResult> FallBackToFullImportAsync(string reason)
+    {
+        _logger.Warning("SqlConnectorImport: a Delta Import was requested, but {Reason}. Falling back to a Full Import to establish a baseline", reason);
+
+        var result = await GetFullImportObjectsAsync();
+
+        result.WarningMessage =
+            $"A Delta Import was requested, but {reason}. A Full Import was performed instead, which has established the watermark, so the next Delta Import should run normally.";
+        result.WarningErrorType = ActivityRunProfileExecutionItemErrorType.DeltaImportFallbackToFullImport;
+
+        return result;
+    }
+
+    #endregion
+
+    #region Delta import: change-log table
+
+    /// <summary>
+    /// Reads a page of an object type's change log, and turns it into the objects those changes are
+    /// about: a deletion carries the anchor alone, and everything else is read back from the object
+    /// type's own source as it now stands.
+    /// </summary>
+    private async Task<SqlDeltaPage> ReadChangeLogPageAsync(SqlImportPlan plan, SqlDeltaPagePosition page, SqlDeltaValue? watermark)
+    {
+        var changeLog = RequireChangeLog(plan);
+        var keysetColumns = BuildChangeLogKeysetColumns(plan, changeLog);
+
+        var selectColumns = keysetColumns.Select(keysetColumn => keysetColumn.Name)
+            .Append(changeLog.ChangeTypeColumn)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var request = new SqlKeysetPageRequest
+        {
+            SchemaName = changeLog.SchemaName,
+            ObjectName = changeLog.TableName,
+            SelectColumns = selectColumns,
+            AnchorColumns = [.. keysetColumns.Select(keysetColumn => keysetColumn.Name)],
+            PageSizeParameterName = PageSizeParameterName,
+            LastAnchorParameterNames = page.IsFirstPage ? [] : [.. Enumerable.Range(0, keysetColumns.Count).Select(AnchorParameterName)],
+            ChangeColumn = watermark == null ? null : changeLog.SequenceColumn,
+            ChangeParameterName = watermark == null ? null : WatermarkParameterName
+        };
+
+        var rows = await ReadDeltaPageAsync(plan, request, page, watermark, selectColumns);
+        var changes = CollapseChanges(plan, changeLog, rows, selectColumns);
+
+        // A deletion has no row left to read, and a change type the configuration does not account for
+        // has nothing to say what to read it as; both are answered by the anchor alone.
+        var importObjects = changes
+            .Where(change => change.ChangeType == ObjectChangeType.Deleted || change.UnmappedChangeType != null)
+            .Select(change => BuildChangedObjectIdentity(plan, changeLog, change))
+            .ToList();
+
+        // An unmapped value leaves the change type unset, so this is everything the anchor alone did not
+        // already answer.
+        var changed = changes.Where(change => change.ChangeType is ObjectChangeType.Added or ObjectChangeType.Updated).ToList();
+        importObjects.AddRange(await ReadChangedObjectsAsync(plan, changed));
+
+        return new SqlDeltaPage(
+            importObjects,
+            rows.Count == _runProfile.PageSize ? page.Advance(DescribeKeyset(plan, keysetColumns, rows[^1], selectColumns)) : null);
+    }
+
+    /// <summary>
+    /// The columns a change-log page is ordered and seeked on: the sequence first, because that is the
+    /// order changes happened in, then the anchor so that two changes sharing a sequence value still
+    /// have a total order and neither is read twice nor skipped.
+    /// </summary>
+    private static List<SqlDeltaKeysetColumn> BuildChangeLogKeysetColumns(SqlImportPlan plan, SqlChangeLogConfiguration changeLog)
+    {
+        // The sequence column belongs to the change log, which is not part of the Connected System's
+        // schema, so its type is read from the value the database returns rather than declared.
+        var keysetColumns = new List<SqlDeltaKeysetColumn> { new(changeLog.SequenceColumn, null) };
+
+        keysetColumns.AddRange(changeLog.AnchorColumns.Select((anchorColumn, index) =>
+            new SqlDeltaKeysetColumn(anchorColumn, plan.AnchorColumns[index].Type)));
+
+        return keysetColumns;
+    }
+
+    /// <summary>
+    /// Reduces a page of change-log rows to one entry per object: the last change a page records for an
+    /// object is what that object's fate now is, and importing the earlier ones as well would be work
+    /// that the later one immediately undoes.
+    /// </summary>
+    private List<SqlChangeLogEntry> CollapseChanges(
+        SqlImportPlan plan,
+        SqlChangeLogConfiguration changeLog,
+        IReadOnlyList<object?[]> rows,
+        IReadOnlyList<string> selectColumns)
+    {
+        var changeTypeOrdinal = IndexOfColumn(selectColumns, changeLog.ChangeTypeColumn);
+        var anchorOrdinals = changeLog.AnchorColumns.Select(anchorColumn => IndexOfColumn(selectColumns, anchorColumn)).ToArray();
+
+        var entries = new List<SqlChangeLogEntry>(rows.Count);
+        var latestByAnchor = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var row in rows)
+        {
+            var anchorValues = anchorOrdinals.Select(ordinal => row[ordinal]).ToArray();
+            var anchorKey = ComposeChangeAnchorKey(plan, changeLog, anchorValues);
+            var rawChangeType = row[changeTypeOrdinal];
+
+            // A change type is what a row is for, so a NULL one is as unusable as an unrecognised value
+            // and is reported the same way.
+            var changeTypeValue = rawChangeType == null ? null : Convert.ToString(rawChangeType, CultureInfo.InvariantCulture);
+            var mapped = changeTypeValue != null && changeLog.ChangeTypes.TryGetValue(changeTypeValue, out var changeType);
+
+            latestByAnchor[anchorKey] = entries.Count;
+            entries.Add(new SqlChangeLogEntry(
+                anchorKey,
+                anchorValues,
+                mapped ? changeLog.ChangeTypes[changeTypeValue!] : ObjectChangeType.NotSet,
+                mapped ? null : changeTypeValue ?? "NULL"));
+        }
+
+        return [.. entries.Where((entry, index) => latestByAnchor[entry.AnchorKey] == index)];
+    }
+
+    /// <summary>
+    /// The changed object's anchor as one string, rendered exactly as the object type's own anchor is so
+    /// that the two identify the same object.
+    /// </summary>
+    /// <exception cref="InvalidDataException">A change-log row does not say which object it is about, which no amount of reading further can recover from.</exception>
+    private static string ComposeChangeAnchorKey(SqlImportPlan plan, SqlChangeLogConfiguration changeLog, IReadOnlyList<object?> anchorValues)
+    {
+        var parts = new string[anchorValues.Count];
+
+        for (var index = 0; index < anchorValues.Count; index++)
+        {
+            var value = anchorValues[index] ?? throw new InvalidDataException(
+                $"Object Type '{plan.Name}' has a change-log row with a NULL value in anchor column '{changeLog.AnchorColumns[index]}', so there is no way to tell which object it is about.");
+
+            parts[index] = SqlAnchorValue.ToTokenString(value, plan.AnchorColumns[index].Type);
+        }
+
+        return string.Join(SqlConnectorSchema.ComposedAnchorSeparator, parts);
+    }
+
+    /// <summary>
+    /// Builds what JIM needs to act on a change with no row behind it: the object type and the anchor,
+    /// which together are enough to find the Connected System Object the change is about.
+    /// </summary>
+    private ConnectedSystemImportObject BuildChangedObjectIdentity(SqlImportPlan plan, SqlChangeLogConfiguration changeLog, SqlChangeLogEntry entry)
+    {
+        var importObject = new ConnectedSystemImportObject
+        {
+            ObjectType = plan.Name,
+            ChangeType = entry.ChangeType
+        };
+
+        if (plan.ComposedAnchorName != null)
+        {
+            importObject.Attributes.Add(new ConnectedSystemImportObjectAttribute
+            {
+                Name = plan.ComposedAnchorName,
+                Type = AttributeDataType.Text,
+                StringValues = [entry.AnchorKey]
+            });
+        }
+        else
+        {
+            var anchorColumn = plan.AnchorColumns[0];
+            var attribute = new ConnectedSystemImportObjectAttribute { Name = anchorColumn.Name, Type = anchorColumn.Type };
+            ApplyTypedValue(attribute, anchorColumn.Type, entry.AnchorValues[0]!);
+            importObject.Attributes.Add(attribute);
+        }
+
+        if (entry.UnmappedChangeType != null)
+        {
+            importObject.ErrorType = ConnectedSystemImportObjectError.AttributeValueError;
+            importObject.ErrorMessage =
+                $"Column '{changeLog.ChangeTypeColumn}' holds '{entry.UnmappedChangeType}', which the change-log configuration for Object Type '{plan.Name}' does not account for. " +
+                "Add it to 'createValues', 'updateValues' or 'deleteValues'.";
+
+            _logger.Warning("SqlConnectorImport: Object Type {ObjectType} has a change-log row whose {Column} value is not configured", plan.Name, changeLog.ChangeTypeColumn);
+        }
+
+        return importObject;
+    }
+
+    /// <summary>
+    /// Reads the objects a page's creates and updates are about, as they now stand, in one query per
+    /// batch of anchors rather than one per object.
+    /// </summary>
+    /// <remarks>
+    /// A change whose row is no longer there produces nothing. The row was deleted after its change was
+    /// logged, so the change log holds a deletion for it further on; emitting a half-built object now
+    /// would be worse than waiting one page for the truth.
+    /// </remarks>
+    private async Task<List<ConnectedSystemImportObject>> ReadChangedObjectsAsync(SqlImportPlan plan, IReadOnlyList<SqlChangeLogEntry> changes)
+    {
+        if (changes.Count == 0)
+            return [];
+
+        var changeTypesByAnchor = changes.ToDictionary(change => change.AnchorKey, change => change.ChangeType, StringComparer.Ordinal);
+        var rows = await ReadRowsByAnchorAsync(plan, [.. changes.Select(change => change.AnchorValues)]);
+
+        if (rows.Count < changes.Count)
+            _logger.Debug("SqlConnectorImport: Object Type {ObjectType} has {MissingCount} change(s) whose row is no longer in the source; their deletions will arrive from the change log",
+                plan.Name, changes.Count - rows.Count);
+
+        var importObjects = BuildImportObjects(plan, rows, out var anchorKeys);
+        await GatherRelatedAttributesAsync(plan, rows, importObjects, anchorKeys);
+
+        for (var index = 0; index < importObjects.Count; index++)
+            importObjects[index].ChangeType = changeTypesByAnchor[anchorKeys[index]];
+
+        return importObjects;
+    }
+
+    /// <summary>
+    /// Reads the rows a set of anchors identifies, in batches small enough that no dialect refuses the
+    /// statement for the number of bind variables it carries.
+    /// </summary>
+    private async Task<List<object?[]>> ReadRowsByAnchorAsync(SqlImportPlan plan, IReadOnlyList<object?[]> anchors)
+    {
+        var rows = new List<object?[]>(anchors.Count);
+        var anchorsPerQuery = Math.Max(1, MaxJoinParametersPerQuery / plan.AnchorColumns.Count);
+
+        for (var offset = 0; offset < anchors.Count; offset += anchorsPerQuery)
+        {
+            var batch = anchors.Skip(offset).Take(anchorsPerQuery).ToList();
+
+            using var command = _provider.CreateCommand(_connection, BuildAnchorLookupCommandText(plan, batch.Count));
+
+            for (var anchorIndex = 0; anchorIndex < batch.Count; anchorIndex++)
+            {
+                for (var columnIndex = 0; columnIndex < plan.AnchorColumns.Count; columnIndex++)
+                    command.Parameters.Add(_provider.CreateParameter(JoinParameterName(anchorIndex, columnIndex), batch[anchorIndex][columnIndex]));
+            }
+
+            rows.AddRange(await ReadRowsAsync(command, plan.SelectColumns));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Selects the rows a set of anchors identifies. Standard SQL in both dialects, built from the
+    /// quoting and parameter rendering the provider seam supplies; values are never interpolated.
+    /// </summary>
+    private string BuildAnchorLookupCommandText(SqlImportPlan plan, int anchorCount)
+    {
+        var columns = plan.SelectColumns.Select(_provider.QuoteIdentifier);
+
+        var predicates = Enumerable.Range(0, anchorCount).Select(anchorIndex =>
+        {
+            var terms = plan.AnchorColumns.Select((anchorColumn, columnIndex) =>
+                $"{_provider.QuoteIdentifier(anchorColumn.Name)} = {_provider.GetParameterPlaceholder(JoinParameterName(anchorIndex, columnIndex))}");
+
+            return $"({string.Join(" AND ", terms)})";
+        });
+
+        return $"SELECT {string.Join(", ", columns)} FROM {BuildFromClause(plan)} WHERE {string.Join(" OR ", predicates)}";
+    }
+
+    #endregion
+
+    #region Delta import: watermark column
+
+    /// <summary>
+    /// Reads a page of the rows whose own last-modified or version column has moved beyond the watermark.
+    /// </summary>
+    /// <remarks>
+    /// <b>This mode cannot observe a deletion, and nothing here is going to change that.</b> A row that
+    /// has been deleted has no column left to move, so its absence never reaches the predicate; the same
+    /// goes for a row that has fallen out of a view. Deletions need the change-log table, or a periodic
+    /// Full Import. Every change is reported as an update, because a last-modified column cannot tell a
+    /// create from one; JIM creates the Connected System Object where it holds none.
+    /// </remarks>
+    private async Task<SqlDeltaPage> ReadWatermarkColumnPageAsync(SqlImportPlan plan, SqlDeltaPagePosition page, SqlDeltaValue? watermark)
+    {
+        var watermarkColumn = RequireWatermarkColumn(plan);
+        var keysetColumns = plan.AnchorColumns.Select(anchorColumn => new SqlDeltaKeysetColumn(anchorColumn.Name, anchorColumn.Type)).ToList();
+
+        var request = new SqlKeysetPageRequest
+        {
+            SchemaName = plan.Configuration.SchemaName,
+            ObjectName = plan.Configuration.TableName,
+            SelectStatement = plan.Configuration.SelectStatement,
+            SelectColumns = plan.SelectColumns,
+            AnchorColumns = [.. keysetColumns.Select(keysetColumn => keysetColumn.Name)],
+            PageSizeParameterName = PageSizeParameterName,
+            LastAnchorParameterNames = page.IsFirstPage ? [] : [.. Enumerable.Range(0, keysetColumns.Count).Select(AnchorParameterName)],
+            ChangeColumn = watermark == null ? null : watermarkColumn,
+            ChangeParameterName = watermark == null ? null : WatermarkParameterName
+        };
+
+        var rows = await ReadDeltaPageAsync(plan, request, page, watermark, plan.SelectColumns);
+
+        var importObjects = BuildImportObjects(plan, rows, out var anchorKeys);
+        await GatherRelatedAttributesAsync(plan, rows, importObjects, anchorKeys);
+
+        foreach (var importObject in importObjects)
+            importObject.ChangeType = ObjectChangeType.Updated;
+
+        return new SqlDeltaPage(
+            importObjects,
+            rows.Count == _runProfile.PageSize ? page.Advance(DescribeKeyset(plan, keysetColumns, rows[^1], plan.SelectColumns)) : null);
+    }
+
+    #endregion
+
+    #region Delta import: watermarks, counting and paging mechanics
+
+    /// <summary>
+    /// Asks each object type's change source where it currently stands, which is what the next Delta
+    /// Import will read from.
+    /// </summary>
+    private async Task<SqlConnectorWatermark> CaptureWatermarkAsync(IReadOnlyList<SqlImportPlan> plans)
+    {
+        var watermark = new SqlConnectorWatermark { Mode = _deltaMode };
+
+        foreach (var plan in plans)
+        {
+            var (source, changeColumn) = ResolveChangeSource(plan);
+
+            using var command = _provider.CreateCommand(_connection, $"SELECT MAX({_provider.QuoteIdentifier(changeColumn)}) FROM {source}");
+            var value = await command.ExecuteScalarAsync(_cancellationToken);
+
+            // No highest value at all is what an empty change log, or a source nothing has been written
+            // to, looks like. Recording nothing for it means the next run reads from the beginning,
+            // which is the only answer that cannot miss a change.
+            var described = SqlConnectorWatermark.Describe(value);
+            if (described != null)
+                watermark.ObjectTypes[plan.Name] = described;
+        }
+
+        return watermark;
+    }
+
+    /// <summary>
+    /// Asks the database how much this Delta Import is about to read, which is what turns the fetch into
+    /// a percentage and a time remaining rather than a number counting up.
+    /// </summary>
+    /// <remarks>
+    /// In change-log mode this counts change rows rather than objects, so it is an upper bound: an
+    /// object changed three times is three rows and one object. Counting objects instead would need a
+    /// DISTINCT over a composite anchor, which the two dialects do not express the same way, for a
+    /// number that is already right in the overwhelmingly common case.
+    /// </remarks>
+    private async Task ReportExpectedChangeCountAsync(IReadOnlyList<SqlImportPlan> plans, SqlConnectorWatermark previous)
+    {
+        long expected = 0;
+        foreach (var plan in plans)
+            expected += await CountChangesAsync(plan, previous.ObjectTypes.GetValueOrDefault(plan.Name));
+
+        _logger.Debug("SqlConnectorImport: expecting up to {ExpectedObjectCount} changed object(s) across {ObjectTypeCount} Object Type(s)", expected, plans.Count);
+
+        await _progress.ReportExpectedObjectCountAsync(expected > int.MaxValue ? int.MaxValue : (int)expected);
+    }
+
+    private async Task<long> CountChangesAsync(SqlImportPlan plan, SqlDeltaValue? watermark)
+    {
+        var (source, changeColumn) = ResolveChangeSource(plan);
+
+        var commandText = watermark == null
+            ? $"SELECT COUNT(*) FROM {source}"
+            : $"SELECT COUNT(*) FROM {source} WHERE {_provider.QuoteIdentifier(changeColumn)} > {_provider.GetParameterPlaceholder(WatermarkParameterName)}";
+
+        using var command = _provider.CreateCommand(_connection, commandText);
+
+        if (watermark != null)
+            command.Parameters.Add(_provider.CreateParameter(WatermarkParameterName, BindDeltaValue(plan, watermark, "watermark")));
+
+        var count = await command.ExecuteScalarAsync(_cancellationToken);
+
+        return count == null || count == DBNull.Value ? 0 : Convert.ToInt64(count, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// What this object type's changes are read from, and the column that orders them, for whichever
+    /// mode is configured.
+    /// </summary>
+    private (string Source, string ChangeColumn) ResolveChangeSource(SqlImportPlan plan)
+    {
+        if (_deltaMode != SqlDeltaImportMode.ChangeLogTable)
+            return (BuildFromClause(plan), RequireWatermarkColumn(plan));
+
+        var changeLog = RequireChangeLog(plan);
+        return (_provider.QualifyObjectName(changeLog.SchemaName, changeLog.TableName), changeLog.SequenceColumn);
+    }
+
+    /// <exception cref="SqlSchemaConfigurationException">The Object Types document has nothing for the configured mode to read. Refused when the Connected System is saved; this is the backstop for configuration changed since.</exception>
+    private static SqlChangeLogConfiguration RequireChangeLog(SqlImportPlan plan) =>
+        plan.Configuration.ChangeLog ?? throw new SqlSchemaConfigurationException(
+            $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeChangeLogTable}', but Object Type '{plan.Name}' has no 'changeLog' in {SqlConnectorConstants.SettingObjectTypes}.");
+
+    /// <exception cref="SqlSchemaConfigurationException">The Object Types document has nothing for the configured mode to read.</exception>
+    private static string RequireWatermarkColumn(SqlImportPlan plan) =>
+        plan.Configuration.WatermarkColumn ?? throw new SqlSchemaConfigurationException(
+            $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeWatermarkColumn}', but Object Type '{plan.Name}' has no 'watermarkColumn' in {SqlConnectorConstants.SettingObjectTypes}.");
+
+    /// <summary>
+    /// Runs one page of a Delta Import's keyset read, binding the run's watermark and the position the
+    /// previous page ended at.
+    /// </summary>
+    private async Task<List<object?[]>> ReadDeltaPageAsync(
+        SqlImportPlan plan,
+        SqlKeysetPageRequest request,
+        SqlDeltaPagePosition page,
+        SqlDeltaValue? watermark,
+        IReadOnlyList<string> columns)
+    {
+        using var command = _provider.CreateCommand(_connection, _provider.BuildKeysetPageCommandText(request));
+        command.Parameters.Add(_provider.CreateParameter(PageSizeParameterName, _runProfile.PageSize));
+
+        if (request.HasChangeFilter)
+            command.Parameters.Add(_provider.CreateParameter(WatermarkParameterName, BindDeltaValue(plan, watermark!, "watermark")));
+
+        for (var index = 0; index < page.Position.Count; index++)
+            command.Parameters.Add(_provider.CreateParameter(AnchorParameterName(index), BindDeltaValue(plan, page.Position[index], "pagination token")));
+
+        return await ReadRowsAsync(command, columns);
+    }
+
+    /// <summary>
+    /// Turns a value carried between pages, or between runs, back into what a predicate compares against.
+    /// </summary>
+    /// <exception cref="InvalidDataException">The value cannot be read for the type it was written with, which would otherwise resume from the wrong place.</exception>
+    private object BindDeltaValue(SqlImportPlan plan, SqlDeltaValue deltaValue, string description)
+    {
+        if (!SqlAnchorValue.TryFromTokenString(deltaValue.Value, deltaValue.Type, out var value) || value == null)
+            throw new InvalidDataException(
+                $"Object Type '{plan.Name}' was replayed a {description} whose value '{deltaValue.Value}' cannot be read as a {deltaValue.Type}. Run a Full Import to re-establish the baseline.");
+
+        // The byte order a GUID is bound in is dialect-specific, so it goes back through the provider
+        // rather than being handed to the driver as it came out of the token.
+        return deltaValue.Type == AttributeDataType.Guid ? _provider.ConvertFromGuid((Guid)value) : value;
+    }
+
+    /// <summary>
+    /// Describes where a page ended, so the next one resumes immediately after it.
+    /// </summary>
+    /// <exception cref="InvalidDataException">A page ended on a row with nothing to resume from, which would restart the read from the beginning for ever.</exception>
+    private static List<SqlDeltaValue> DescribeKeyset(
+        SqlImportPlan plan,
+        IReadOnlyList<SqlDeltaKeysetColumn> keysetColumns,
+        object?[] lastRow,
+        IReadOnlyList<string> columns)
+    {
+        return [.. keysetColumns.Select(keysetColumn =>
+        {
+            var value = lastRow[IndexOfColumn(columns, keysetColumn.Name)] ?? throw new InvalidDataException(
+                $"Object Type '{plan.Name}' read a page ending on a row with a NULL value in '{keysetColumn.Name}', which orders the page, so there is nothing to resume the next one from.");
+
+            return keysetColumn.Type == null
+                ? SqlConnectorWatermark.Describe(value)!
+                : new SqlDeltaValue(SqlAnchorValue.ToTokenString(value, keysetColumn.Type.Value), keysetColumn.Type.Value);
+        })];
+    }
+
+    private static int IndexOfColumn(IReadOnlyList<string> columns, string columnName)
+    {
+        for (var index = 0; index < columns.Count; index++)
+            if (string.Equals(columns[index], columnName, StringComparison.OrdinalIgnoreCase))
+                return index;
+
+        throw new SqlSchemaConfigurationException($"Column '{columnName}' was not returned by the query that was supposed to read it.");
+    }
+
+    #endregion
 
     #region Planning
 
@@ -332,10 +934,19 @@ internal sealed class SqlConnectorImport
         for (var index = 0; index < page.LastAnchor.Count; index++)
             command.Parameters.Add(_provider.CreateParameter(AnchorParameterName(index), BindAnchorValue(plan, index, page.LastAnchor[index])));
 
+        return await ReadRowsAsync(command, plan.SelectColumns);
+    }
+
+    /// <summary>
+    /// Materialises a result set as rows in the caller's column order, so that everything downstream
+    /// addresses a row by the position it asked for rather than by whatever ordinal the driver used.
+    /// </summary>
+    private async Task<List<object?[]>> ReadRowsAsync(DbCommand command, IReadOnlyList<string> columns)
+    {
         var rows = new List<object?[]>();
 
         using var reader = await command.ExecuteReaderAsync(_cancellationToken);
-        var ordinals = plan.SelectColumns.Select(reader.GetOrdinal).ToArray();
+        var ordinals = columns.Select(reader.GetOrdinal).ToArray();
 
         while (await reader.ReadAsync(_cancellationToken))
         {
@@ -847,3 +1458,79 @@ internal sealed record SqlImportPagePosition
 /// A pagination token's contents as they are written and read back.
 /// </summary>
 internal sealed record SqlImportPageToken(List<string> Anchor, int Page);
+
+/// <summary>
+/// A column a Delta Import's page is ordered and seeked on, and the type its values are carried as. A
+/// null type means the column is not part of the Connected System's schema (a change log's own columns
+/// are not), so its type is read from the value the database returns.
+/// </summary>
+internal sealed record SqlDeltaKeysetColumn(string Name, AttributeDataType? Type);
+
+/// <summary>
+/// One change a change log records, reduced to what JIM acts on.
+/// </summary>
+internal sealed record SqlChangeLogEntry(string AnchorKey, object?[] AnchorValues, ObjectChangeType ChangeType, string? UnmappedChangeType);
+
+/// <summary>
+/// What one page of a Delta Import produced, and where the next one resumes from (null where this page
+/// was the last).
+/// </summary>
+internal sealed record SqlDeltaPage(List<ConnectedSystemImportObject> ImportObjects, SqlDeltaPagePosition? NextPosition);
+
+/// <summary>
+/// Where one Object Type's Delta Import has got to: the values the previous page ended on, and which
+/// page is being read, so the narration can say so.
+/// </summary>
+/// <remarks>
+/// Each value carries its own type, which a Full Import's token does not have to: a Full Import seeks on
+/// the anchor alone, whose type the Connected System's schema states, while a Delta Import also seeks on
+/// a change log's sequence column, which belongs to no object type and is therefore described by what
+/// the database returned rather than by anything declared.
+/// </remarks>
+internal sealed record SqlDeltaPagePosition
+{
+    private static readonly JsonSerializerOptions TokenOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    internal IReadOnlyList<SqlDeltaValue> Position { get; init; } = [];
+
+    internal int PageNumber { get; init; } = 1;
+
+    internal bool IsFirstPage => Position.Count == 0;
+
+    /// <exception cref="InvalidDataException">The token cannot be read for this configuration, which would otherwise resume the page from the wrong row.</exception>
+    internal static SqlDeltaPagePosition FromToken(ConnectedSystemPaginationToken? token, SqlImportPlan plan)
+    {
+        if (string.IsNullOrEmpty(token?.StringValue))
+            return new SqlDeltaPagePosition();
+
+        SqlDeltaPageToken? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<SqlDeltaPageToken>(token.StringValue, TokenOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException($"Object Type '{plan.Name}' was replayed a pagination token JIM cannot read. Run the Run Profile again to start from the beginning.", ex);
+        }
+
+        if (parsed?.Position == null || parsed.Position.Count == 0)
+            throw new InvalidDataException(
+                $"Object Type '{plan.Name}' was replayed a pagination token holding nothing to resume from. The configuration changed mid-run; run the Run Profile again.");
+
+        return new SqlDeltaPagePosition { Position = parsed.Position, PageNumber = parsed.Page };
+    }
+
+    internal SqlDeltaPagePosition Advance(List<SqlDeltaValue> position) => new() { Position = position, PageNumber = PageNumber + 1 };
+
+    internal ConnectedSystemPaginationToken ToToken(SqlImportPlan plan) =>
+        new(plan.TokenName, JsonSerializer.Serialize(new SqlDeltaPageToken([.. Position], PageNumber), TokenOptions));
+}
+
+/// <summary>
+/// A Delta Import pagination token's contents as they are written and read back.
+/// </summary>
+internal sealed record SqlDeltaPageToken(List<SqlDeltaValue> Position, int Page);

--- a/src/JIM.Connectors/Sql/SqlConnectorWatermark.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorWatermark.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JIM.Connectors.Sql;
+
+/// <summary>
+/// How a Delta Import finds out what has changed. An enumeration rather than a pair of flags, because
+/// the mechanisms are alternatives: an estate uses one of them, and a third (provider-native change
+/// detection) joins the list without any of this configuration changing shape.
+/// </summary>
+internal enum SqlDeltaImportMode
+{
+    /// <summary>
+    /// No mode has been chosen, so Delta Imports cannot run.
+    /// </summary>
+    NotSet = 0,
+
+    /// <summary>
+    /// Changes read from a customer-maintained change-log table or view, carrying the anchor, a change
+    /// type and a monotonic sequence. The only mode that observes a deletion.
+    /// </summary>
+    ChangeLogTable = 1,
+
+    /// <summary>
+    /// Changes detected from a last-modified or version column on the object type's own source. Creates
+    /// and updates only.
+    /// </summary>
+    WatermarkColumn = 2
+}
+
+/// <summary>
+/// A value read out of a database and carried between runs as text: a watermark, or a delta page's
+/// position. The type travels with it because the column it came from is not part of the Connected
+/// System's schema (a change log is not an object type), so there is nothing else to say how the string
+/// is to be read back and bound.
+/// </summary>
+internal sealed record SqlDeltaValue(string Value, AttributeDataType Type);
+
+/// <summary>
+/// Where each Object Type's Delta Import had got to when the last run began, persisted between runs in
+/// <see cref="JIM.Models.Staging.ConnectedSystemImportResult.PersistedConnectorData"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The mode is recorded with the values, and is what makes them meaningful.</b> A change log's
+/// sequence number says nothing about a last-modified column, so a watermark written in one mode must
+/// never be compared against the other; a Connected System whose mode has changed is re-baselined
+/// rather than trusted.
+/// </para>
+/// <para>
+/// <b>The watermark is a marker, not a point in time.</b> Where it holds a date, that date is compared
+/// against the column's own values and nothing else, so it is never interpreted in the Connected
+/// System's declared time zone the way an imported date and time is. Interpreting it would move the
+/// boundary by the offset and re-read, or skip, whatever fell inside it.
+/// </para>
+/// </remarks>
+internal sealed record SqlConnectorWatermark
+{
+    private static readonly JsonSerializerOptions SerialisationOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+
+        // The persisted value is written to the diagnostic log by the Worker and read by whoever is
+        // investigating a Delta Import, so the mode and the types read as their own names rather than
+        // as numbers whose meaning lives in a source file.
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    // Public members of an internal type: nothing is exposed outside this assembly, and the serialiser
+    // only writes what it can see.
+    public required SqlDeltaImportMode Mode { get; init; }
+
+    /// <summary>
+    /// The watermark per configured Object Type, keyed by its name. An Object Type absent from here has
+    /// no watermark yet (it was added to the document after the last run), and reads its changes from
+    /// the beginning, which is the only answer that cannot miss one.
+    /// </summary>
+    public Dictionary<string, SqlDeltaValue> ObjectTypes { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    internal string Serialise() => JsonSerializer.Serialize(this, SerialisationOptions);
+
+    /// <summary>
+    /// Reads a watermark JIM persisted from an earlier run.
+    /// </summary>
+    /// <returns>
+    /// The watermark, or null where there is none to read or it cannot be read. Null is an answer rather
+    /// than a failure: it is what a Connected System that has never been imported looks like, and the
+    /// caller decides what to do about it.
+    /// </returns>
+    internal static SqlConnectorWatermark? TryRead(string? persistedConnectorData)
+    {
+        if (string.IsNullOrWhiteSpace(persistedConnectorData))
+            return null;
+
+        SqlConnectorWatermark? watermark;
+        try
+        {
+            watermark = JsonSerializer.Deserialize<SqlConnectorWatermark>(persistedConnectorData, SerialisationOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (watermark == null || watermark.Mode == SqlDeltaImportMode.NotSet)
+            return null;
+
+        // Object type names are matched the way they are everywhere else in this Connector, which the
+        // deserialiser's own ordinal dictionary would not do.
+        return watermark with { ObjectTypes = new Dictionary<string, SqlDeltaValue>(watermark.ObjectTypes, StringComparer.OrdinalIgnoreCase) };
+    }
+
+    /// <summary>
+    /// Describes a value a database handed back, so it can be carried as text and bound back later.
+    /// </summary>
+    /// <returns>The described value, or null where the column had none (an empty change log has no highest sequence).</returns>
+    /// <exception cref="NotSupportedException">The value's type cannot order a change set, so it could never be a watermark.</exception>
+    internal static SqlDeltaValue? Describe(object? value)
+    {
+        if (value == null || value == DBNull.Value)
+            return null;
+
+        var type = value switch
+        {
+            // A value carrying its own offset is normalised to UTC before it is rendered, exactly as an
+            // anchor is, so the same instant always produces the same text.
+            DateTimeOffset or DateTime => AttributeDataType.DateTime,
+            byte[] => AttributeDataType.Binary,
+            Guid => AttributeDataType.Guid,
+            string => AttributeDataType.Text,
+            decimal or float or double => AttributeDataType.Decimal,
+            long or ulong => AttributeDataType.LongNumber,
+            int or uint or short or ushort or byte or sbyte => AttributeDataType.Number,
+            _ => throw new NotSupportedException($"A {value.GetType().Name} value cannot order a change set, so it cannot be used as a Delta Import watermark.")
+        };
+
+        var normalised = value is DateTimeOffset dateTimeOffset ? dateTimeOffset.UtcDateTime : value;
+        return new SqlDeltaValue(SqlAnchorValue.ToTokenString(normalised, type), type);
+    }
+}

--- a/src/JIM.Connectors/Sql/SqlObjectTypeConfiguration.cs
+++ b/src/JIM.Connectors/Sql/SqlObjectTypeConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using JIM.Models.Enums;
+
 namespace JIM.Connectors.Sql;
 
 /// <summary>
@@ -59,10 +61,64 @@ internal sealed record SqlObjectTypeConfiguration
     internal IReadOnlyList<SqlRelatedTableConfiguration> RelatedTables { get; init; } = [];
 
     /// <summary>
+    /// The column on this object type's own source whose value moves whenever a row changes: a
+    /// last-modified timestamp, or a version. Read by Delta Imports in Watermark Column mode, and
+    /// ignored by every other mode.
+    /// </summary>
+    internal string? WatermarkColumn { get; init; }
+
+    /// <summary>
+    /// Where this object type's changes are recorded, for Delta Imports in Change-Log Table mode.
+    /// </summary>
+    internal SqlChangeLogConfiguration? ChangeLog { get; init; }
+
+    /// <summary>
     /// Whether objects of this type come from a statement rather than a table or view, which is what
     /// decides how discovery learns the shape and whether constraint metadata exists at all.
     /// </summary>
     internal bool IsCustomSelect => SelectStatement != null;
+}
+
+/// <summary>
+/// A customer-maintained table or view recording what has happened to an object type's objects: one row
+/// per change, carrying the anchor, what kind of change it was, and where it sits in a monotonic
+/// sequence.
+/// </summary>
+/// <remarks>
+/// This is the only delta mechanism that observes a deletion, because it is the only one where the
+/// record of a change outlives the row the change happened to. Everything about it is the customer's to
+/// design, including what they call a create, an update and a deletion, which is why the vocabulary is
+/// declared rather than assumed.
+/// </remarks>
+internal sealed record SqlChangeLogConfiguration
+{
+    internal string? SchemaName { get; init; }
+
+    internal required string TableName { get; init; }
+
+    /// <summary>
+    /// The columns carrying the changed object's anchor, one per the object type's own anchor columns
+    /// and in the same order. Joining on fewer would attribute a change to some other object.
+    /// </summary>
+    internal IReadOnlyList<string> AnchorColumns { get; init; } = [];
+
+    /// <summary>
+    /// The monotonic sequence or timestamp that orders the change log and positions the watermark. It
+    /// has to be monotonic: a value that can go backwards would leave changes behind the watermark and
+    /// therefore unread for ever.
+    /// </summary>
+    internal required string SequenceColumn { get; init; }
+
+    /// <summary>
+    /// The column saying what kind of change a row records.
+    /// </summary>
+    internal required string ChangeTypeColumn { get; init; }
+
+    /// <summary>
+    /// What each of the customer's own change-type values means, matched without regard to case. A value
+    /// that is not in here is one the configuration does not account for, and errors that one object.
+    /// </summary>
+    internal required IReadOnlyDictionary<string, ObjectChangeType> ChangeTypes { get; init; }
 }
 
 /// <summary>

--- a/src/JIM.Connectors/Sql/SqlSchemaConfiguration.cs
+++ b/src/JIM.Connectors/Sql/SqlSchemaConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Connectors.Sql.Providers;
+using JIM.Models.Enums;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -113,6 +114,9 @@ internal sealed record SqlSchemaConfiguration
 
         var anchorColumns = ReadAnchorColumns(document, name);
 
+        if (!string.IsNullOrWhiteSpace(document.WatermarkColumn))
+            ValidateIdentifier(document.WatermarkColumn, name, "watermarkColumn");
+
         return new SqlObjectTypeConfiguration
         {
             Name = name,
@@ -121,8 +125,133 @@ internal sealed record SqlSchemaConfiguration
             SelectStatement = hasSelect ? document.Select!.Trim() : null,
             AnchorColumns = anchorColumns,
             Columns = ReadColumns(document, name),
-            RelatedTables = ReadRelatedTables(document, name, anchorColumns.Count)
+            RelatedTables = ReadRelatedTables(document, name, anchorColumns.Count),
+            WatermarkColumn = string.IsNullOrWhiteSpace(document.WatermarkColumn) ? null : document.WatermarkColumn,
+            ChangeLog = ReadChangeLog(document.ChangeLog, name, anchorColumns.Count)
         };
+    }
+
+    /// <summary>
+    /// Reads an object type's change-log configuration. Validated whichever Delta Import mode is
+    /// configured, so a document that could not work in Change-Log Table mode is refused at save time
+    /// rather than on the night the mode is switched on.
+    /// </summary>
+    private static SqlChangeLogConfiguration? ReadChangeLog(ChangeLogDocument? document, string objectTypeName, int anchorColumnCount)
+    {
+        if (document == null)
+            return null;
+
+        ValidateIdentifier(document.Table, objectTypeName, "changeLog.table");
+        ValidateIdentifier(document.SequenceColumn, objectTypeName, "changeLog.sequenceColumn");
+        ValidateIdentifier(document.ChangeTypeColumn, objectTypeName, "changeLog.changeTypeColumn");
+
+        if (!string.IsNullOrWhiteSpace(document.Schema))
+            ValidateIdentifier(document.Schema, objectTypeName, "changeLog.schema");
+
+        if (document.AnchorColumns == null || document.AnchorColumns.Count != anchorColumnCount)
+            throw new SqlSchemaConfigurationException(
+                $"Object Type '{objectTypeName}' identifies its change-log rows by {document.AnchorColumns?.Count ?? 0} column(s), but the object type's anchor has {anchorColumnCount}. " +
+                "A change attributed by part of an anchor belongs to some other object, so 'changeLog.anchorColumns' must name one column per anchor column, in the same order.");
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var anchorColumn in document.AnchorColumns)
+        {
+            ValidateIdentifier(anchorColumn, objectTypeName, "changeLog.anchorColumns");
+
+            if (!seen.Add(anchorColumn!))
+                throw new SqlSchemaConfigurationException($"Object Type '{objectTypeName}' lists change-log anchor column '{anchorColumn}' more than once.");
+        }
+
+        return new SqlChangeLogConfiguration
+        {
+            SchemaName = string.IsNullOrWhiteSpace(document.Schema) ? null : document.Schema,
+            TableName = document.Table!,
+            AnchorColumns = [.. document.AnchorColumns.Select(anchorColumn => anchorColumn!)],
+            SequenceColumn = document.SequenceColumn!,
+            ChangeTypeColumn = document.ChangeTypeColumn!,
+            ChangeTypes = ReadChangeTypes(document, objectTypeName)
+        };
+    }
+
+    /// <summary>
+    /// Turns the customer's own change-type vocabulary into what each value means to JIM.
+    /// </summary>
+    private static Dictionary<string, ObjectChangeType> ReadChangeTypes(ChangeLogDocument document, string objectTypeName)
+    {
+        var changeTypes = new Dictionary<string, ObjectChangeType>(StringComparer.OrdinalIgnoreCase);
+
+        AddChangeTypeValues(changeTypes, document.CreateValues, ObjectChangeType.Added, objectTypeName, "createValues");
+        AddChangeTypeValues(changeTypes, document.UpdateValues, ObjectChangeType.Updated, objectTypeName, "updateValues");
+        AddChangeTypeValues(changeTypes, document.DeleteValues, ObjectChangeType.Deleted, objectTypeName, "deleteValues");
+
+        // Deletions are the whole reason this mode is the recommended one, and a change log with no way
+        // of stating one detects strictly less than a watermark column does at more cost.
+        if (!changeTypes.ContainsValue(ObjectChangeType.Deleted))
+            throw new SqlSchemaConfigurationException(
+                $"Object Type '{objectTypeName}' has a change log with no 'deleteValues'. Observing deletions is what a change-log table is for; if this database cannot record them, use Watermark Column mode instead.");
+
+        if (!changeTypes.ContainsValue(ObjectChangeType.Added) && !changeTypes.ContainsValue(ObjectChangeType.Updated))
+            throw new SqlSchemaConfigurationException(
+                $"Object Type '{objectTypeName}' has a change log with neither 'createValues' nor 'updateValues', so nothing but deletions could ever be imported from it.");
+
+        return changeTypes;
+    }
+
+    private static void AddChangeTypeValues(
+        Dictionary<string, ObjectChangeType> changeTypes,
+        List<string?>? values,
+        ObjectChangeType changeType,
+        string objectTypeName,
+        string fieldName)
+    {
+        if (values == null)
+            return;
+
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new SqlSchemaConfigurationException($"Object Type '{objectTypeName}' has an empty value in 'changeLog.{fieldName}'. A change-log row's change type is matched against these exactly, so a blank one could never match.");
+
+            var trimmed = value.Trim();
+
+            // Values are matched without regard to case, so a value meaning two things is ambiguous even
+            // where the two spellings differ, and guessing which the administrator meant is not JIM's to do.
+            if (changeTypes.TryGetValue(trimmed, out var existing))
+                throw new SqlSchemaConfigurationException(
+                    $"Object Type '{objectTypeName}' has change-log value '{trimmed}' meaning both {existing} and {changeType}. Each value can only mean one kind of change.");
+
+            changeTypes[trimmed] = changeType;
+        }
+    }
+
+    /// <summary>
+    /// Checks that every configured Object Type carries what the chosen Delta Import mode needs, which
+    /// the parser cannot do on its own: the document is written without reference to the mode, and the
+    /// same document is valid under one mode and unusable under the other.
+    /// </summary>
+    /// <remarks>
+    /// Every object type has to be covered, not just some. A Delta Import that silently skips an object
+    /// type reports success while leaving that type's objects to drift, and no administrator would read
+    /// a green Activity as "except for Groups".
+    /// </remarks>
+    /// <exception cref="SqlSchemaConfigurationException">An Object Type has nothing for this mode to read.</exception>
+    internal void ValidateDeltaImportMode(SqlDeltaImportMode mode)
+    {
+        foreach (var objectType in ObjectTypes)
+        {
+            switch (mode)
+            {
+                case SqlDeltaImportMode.ChangeLogTable when objectType.ChangeLog == null:
+                    throw new SqlSchemaConfigurationException(
+                        $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeChangeLogTable}', but Object Type '{objectType.Name}' has no 'changeLog'. " +
+                        "A Delta Import that skipped an object type would report success while leaving its objects to drift, so every object type needs one.");
+
+                case SqlDeltaImportMode.WatermarkColumn when objectType.WatermarkColumn == null:
+                    throw new SqlSchemaConfigurationException(
+                        $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeWatermarkColumn}', but Object Type '{objectType.Name}' has no 'watermarkColumn'. " +
+                        "A Delta Import that skipped an object type would report success while leaving its objects to drift, so every object type needs one.");
+            }
+        }
     }
 
     private static List<string> ReadAnchorColumns(ObjectTypeDocument document, string objectTypeName)
@@ -304,6 +433,30 @@ internal sealed record SqlSchemaConfiguration
         public List<ColumnDocument>? Columns { get; set; }
 
         public List<RelatedTableDocument>? RelatedTables { get; set; }
+
+        public string? WatermarkColumn { get; set; }
+
+        public ChangeLogDocument? ChangeLog { get; set; }
+    }
+
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+    private sealed class ChangeLogDocument
+    {
+        public string? Schema { get; set; }
+
+        public string? Table { get; set; }
+
+        public List<string?>? AnchorColumns { get; set; }
+
+        public string? SequenceColumn { get; set; }
+
+        public string? ChangeTypeColumn { get; set; }
+
+        public List<string?>? CreateValues { get; set; }
+
+        public List<string?>? UpdateValues { get; set; }
+
+        public List<string?>? DeleteValues { get; set; }
     }
 
     [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
@@ -1,0 +1,732 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors.Sql;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Exceptions;
+using JIM.Models.Staging;
+using NUnit.Framework;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// Covers the JIM SQL Connector's Delta Import in both of its modes: what each one can and cannot
+/// observe, how a customer's own change-type vocabulary is mapped, how the watermark round-trips
+/// between runs, and what happens when there is no usable watermark to read. No test here touches a
+/// database server; the dialect seam and its connection, command and reader are substituted instead.
+/// </summary>
+[TestFixture]
+public class SqlConnectorDeltaImportTests
+{
+    #region Documents
+
+    /// <summary>
+    /// One object type reading its changes from a customer-maintained change-log table. The shape most
+    /// of the change-log tests vary from.
+    /// </summary>
+    private const string ChangeLogDocument = """
+        {
+          "objectTypes": [
+            {
+              "name": "Person",
+              "schema": "HR",
+              "table": "EMPLOYEES",
+              "anchorColumns": [ "EMPLOYEE_ID" ],
+              "changeLog": {
+                "schema": "HR",
+                "table": "EMPLOYEE_CHANGES",
+                "anchorColumns": [ "EMPLOYEE_ID" ],
+                "sequenceColumn": "CHANGE_NUMBER",
+                "changeTypeColumn": "CHANGE_TYPE",
+                "createValues": [ "I" ],
+                "updateValues": [ "U" ],
+                "deleteValues": [ "D" ]
+              }
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// The same object type detecting changes from a last-modified column on its own table.
+    /// </summary>
+    private const string WatermarkDocument = """
+        {
+          "objectTypes": [
+            {
+              "name": "Person",
+              "schema": "HR",
+              "table": "EMPLOYEES",
+              "anchorColumns": [ "EMPLOYEE_ID" ],
+              "watermarkColumn": "LAST_MODIFIED"
+            }
+          ]
+        }
+        """;
+
+    #endregion
+
+    private ILogger _logger = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = new LoggerConfiguration().CreateLogger();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_logger as IDisposable)?.Dispose();
+    }
+
+    #region Change-log mode
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeWithCreatesUpdatesAndDeletes_PropagatesEveryChangeTypeIncludingDeletions()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"]],
+            changes: [[1, 1, "I"], [2, 2, "U"], [3, 3, "D"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ChangeTypeOf(run, 1), Is.EqualTo(ObjectChangeType.Added));
+            Assert.That(ChangeTypeOf(run, 2), Is.EqualTo(ObjectChangeType.Updated));
+            Assert.That(ChangeTypeOf(run, 3), Is.EqualTo(ObjectChangeType.Deleted),
+                "The change-log table is the only mode that observes a deletion, which is the whole reason it is the recommended one.");
+
+            Assert.That(AttributeOf(ObjectWithAnchor(run, 1), "DISPLAY_NAME").StringValues, Is.EqualTo(new[] { "Ada" }),
+                "A create carries the row as it now stands, read back from the object type's own source.");
+
+            var deleted = ObjectWithAnchor(run, 3);
+            Assert.That(deleted.ObjectType, Is.EqualTo("Person"));
+            Assert.That(AttributeOf(deleted, "EMPLOYEE_ID").IntValues, Is.EqualTo(new[] { 3 }),
+                "A deletion carries the anchor and nothing else, because the anchor is all JIM needs to find the object it is about.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeCustomChangeTypeValues_MapsThemOntoJimsOwnChangeTypes()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "schema": "HR",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "changeLog": {
+                    "schema": "HR",
+                    "table": "EMPLOYEE_CHANGES",
+                    "anchorColumns": [ "EMPLOYEE_ID" ],
+                    "sequenceColumn": "CHANGE_NUMBER",
+                    "changeTypeColumn": "CHANGE_TYPE",
+                    "createValues": [ "NEW", "JOINER" ],
+                    "updateValues": [ "MOD" ],
+                    "deleteValues": [ "REM" ]
+                  }
+                }
+              ]
+            }
+            """;
+
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"]],
+            changes: [[1, 1, "JOINER"], [2, 2, "MOD"], [3, 3, "rem"]]);
+
+        var run = await RunDeltaAsync(provider, document, PersonSystem(), pageSize: 10, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ChangeTypeOf(run, 1), Is.EqualTo(ObjectChangeType.Added), "No two estates spell a change type the same way, so the vocabulary is the administrator's to declare.");
+            Assert.That(ChangeTypeOf(run, 2), Is.EqualTo(ObjectChangeType.Updated));
+            Assert.That(ChangeTypeOf(run, 3), Is.EqualTo(ObjectChangeType.Deleted),
+                "Values are matched without regard to case, because a column holding 'D' holds 'd' just as often.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeUnmappedChangeTypeValue_ErrorsThatObjectAloneRatherThanTheRun()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"]],
+            changes: [[1, 1, "I"], [2, 2, "X"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ChangeTypeOf(run, 1), Is.EqualTo(ObjectChangeType.Added), "One unrecognisable row must not cost the whole run.");
+
+            var errored = ObjectWithAnchor(run, 2);
+            Assert.That(errored.ErrorType, Is.EqualTo(ConnectedSystemImportObjectError.AttributeValueError));
+            Assert.That(errored.ErrorMessage, Does.Contain("CHANGE_TYPE").And.Contain("X"),
+                "The administrator needs to know which value in which column their configuration does not account for.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeSameObjectChangedTwiceInAPage_EmitsOnlyItsLatestChange()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"]],
+            changes: [[1, 1, "I"], [2, 1, "U"], [3, 1, "D"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.ImportObjects, Has.Count.EqualTo(1), "An object that changed three times is still one object to synchronise.");
+            Assert.That(run.ImportObjects[0].ChangeType, Is.EqualTo(ObjectChangeType.Deleted), "The change-log rows are read in sequence order, so the last one is what the object's fate now is.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogMode_ReadsOnlyChangesBeyondThePersistedWatermark()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"], [3, "Katherine"]],
+            changes: [[1, 1, "U"], [2, 2, "U"], [3, 3, "U"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "2")));
+
+        Assert.That(AnchorValues(run), Is.EqualTo(new[] { 3 }),
+            "A Delta Import reads what changed since it last looked, which is the entire point of persisting a watermark.");
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeCreateWhoseRowHasSinceGone_EmitsNothingForIt()
+    {
+        // Employee 2 was created and then deleted; only the create has been read so far.
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"]],
+            changes: [[1, 1, "U"], [2, 2, "I"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1 }),
+            "A row that is no longer in the source cannot be read, and inventing an object for it would be worse than waiting for its deletion to arrive.");
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeMoreChangesThanOnePage_ReplaysTheTokenUntilAShortPageEndsTheRun()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"], [3, "Katherine"], [4, "Dorothy"], [5, "Mary"]],
+            changes: [[1, 1, "U"], [2, 2, "U"], [3, 3, "U"], [4, 4, "U"], [5, 5, "U"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 2, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.Pages, Has.Count.EqualTo(3), "Five changes at two per page is two full pages and a short one.");
+            Assert.That(run.Pages[^1].PaginationTokens, Is.Empty,
+                "An empty pagination token list is how JIM is told there is no more data; returning one forever is an infinite import.");
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1, 2, 3, 4, 5 }),
+                "Every change arrives exactly once, in sequence order, which is only true if every page was read against the run's original watermark.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_ChangeLogModeFirstCall_ReportsWhatItIsAboutToRead()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"]],
+            changes: [[1, 1, "U"], [2, 2, "U"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 1, Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.Progress.ExpectedObjectCounts, Is.EqualTo(new[] { 2 }),
+                "A database states the size of a change set cheaply, so the Activity shows a percentage rather than a number counting up.");
+            Assert.That(run.Progress.PhaseKeys.First(), Is.EqualTo(SqlConnectorPhases.QueryChanges));
+            Assert.That(run.Progress.PhaseKeys, Does.Contain(SqlConnectorPhases.Fetch));
+            Assert.That(run.Progress.PhaseKeys.Count(key => key == SqlConnectorPhases.QueryChanges), Is.EqualTo(1),
+                "Asking again on every page would make an extra query the price of paging.");
+        });
+    }
+
+    #endregion
+
+    #region Watermark round trip
+
+    [Test]
+    public async Task ImportAsync_DeltaAcrossSeveralPages_ReturnsTheNewWatermarkFromTheFirstPageOnly()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"], [3, "Katherine"]],
+            changes: [[1, 1, "U"], [2, 2, "U"], [3, 3, "U"]]);
+
+        var store = Store(PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0"));
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 1, store);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.Pages[0].PersistedConnectorData, Is.Not.Null, "The new watermark is captured before any change is read, and returned from the first page.");
+            Assert.That(run.Pages.Skip(1).Select(page => page.PersistedConnectorData), Is.All.Null,
+                "A later page returning a watermark would overwrite the run's own starting point mid-run.");
+            Assert.That(PersonWatermarkValueOf(store.Value), Is.EqualTo("3"),
+                "The watermark advances to where the change log stood when the run began; anything logged since is read by the next run.");
+        });
+    }
+
+    [Test]
+    public void ImportAsync_RunThatFailsPartWay_LeavesThePersistedWatermarkUntouched()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"], [3, "Katherine"]],
+            changes: [[1, 1, "U"], [2, 2, "U"], [3, 3, "U"]]);
+
+        // Enough commands for the first page to complete and return the new watermark, and not enough
+        // for the run to finish.
+        provider.FailAfterCommandCount = 5;
+
+        var original = PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "0");
+        var store = Store(original);
+
+        Assert.That(async () => await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 1, store),
+            Throws.InstanceOf<Exception>());
+
+        Assert.That(store.Value, Is.EqualTo(original),
+            "JIM saves the watermark only once every page has been read, so a run that dies half way through re-reads its changes rather than skipping them.");
+    }
+
+    [Test]
+    public async Task ImportAsync_FullImportWithADeltaImportModeConfigured_EstablishesTheWatermarkForTheNextDelta()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"]],
+            changes: [[1, 1, "I"], [2, 2, "I"]]);
+
+        var store = Store(null);
+        await RunFullImportAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, store);
+
+        Assert.That(PersonWatermarkValueOf(store.Value), Is.EqualTo("2"),
+            "A Full Import is how a Delta Import's baseline is established, so it records where the change log stood when it ran.");
+    }
+
+    #endregion
+
+    #region Watermark column mode
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnMode_PropagatesCreatesAndUpdates()
+    {
+        var provider = WatermarkProvider(
+            [1, "Ada", new DateTime(2026, 7, 15, 9, 0, 0, DateTimeKind.Unspecified)],
+            [2, "Grace", new DateTime(2026, 7, 16, 9, 0, 0, DateTimeKind.Unspecified)]);
+
+        var watermark = PersonWatermark(SqlDeltaImportMode.WatermarkColumn, "2026-07-15T12:00:00.0000000Z", AttributeDataType.DateTime);
+        var run = await RunDeltaAsync(provider, WatermarkDocument, WatermarkSystem(), pageSize: 10, Store(watermark), SqlConnectorConstants.DeltaImportModeWatermarkColumn);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 2 }), "Only the row whose last-modified column moved beyond the watermark has changed.");
+            Assert.That(run.ImportObjects[0].ChangeType, Is.EqualTo(ObjectChangeType.Updated),
+                "A last-modified column cannot tell a create from an update, so the Connector says what it knows and JIM creates the object where it has none.");
+            Assert.That(AttributeOf(run.ImportObjects[0], "DISPLAY_NAME").StringValues, Is.EqualTo(new[] { "Grace" }));
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeRowDeletedFromTheSource_DoesNotDetectTheDeletion()
+    {
+        // Ada was deleted from the source outright. A row that is gone has no last-modified column left
+        // to move, so nothing about its absence can reach the watermark's predicate.
+        var provider = WatermarkProvider(
+            [2, "Grace", new DateTime(2026, 7, 16, 9, 0, 0, DateTimeKind.Unspecified)]);
+
+        var watermark = PersonWatermark(SqlDeltaImportMode.WatermarkColumn, "2026-07-15T12:00:00.0000000Z", AttributeDataType.DateTime);
+        var run = await RunDeltaAsync(provider, WatermarkDocument, WatermarkSystem(), pageSize: 10, Store(watermark), SqlConnectorConstants.DeltaImportModeWatermarkColumn);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.ImportObjects.Any(importObject => importObject.ChangeType == ObjectChangeType.Deleted), Is.False,
+                "Watermark Column mode detects creates and updates only; deletions need the change-log table, or a periodic Full Import.");
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 2 }));
+        });
+    }
+
+    #endregion
+
+    #region Fallback and refusal
+
+    [Test]
+    public async Task ImportAsync_DeltaWithNoPersistedWatermark_FallsBackToAFullImportWithTheStandardWarning()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"], [2, "Grace"]],
+            changes: [[1, 1, "I"]]);
+
+        var store = Store(null);
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, store);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1, 2 }), "A Full Import both delivers the right data and establishes the baseline the next Delta Import needs.");
+            Assert.That(run.Pages[0].WarningErrorType, Is.EqualTo(ActivityRunProfileExecutionItemErrorType.DeltaImportFallbackToFullImport));
+            Assert.That(run.Pages[0].WarningMessage, Is.Not.Null.And.Not.Empty);
+            Assert.That(run.ImportObjects.Select(importObject => importObject.ChangeType), Is.All.EqualTo(ObjectChangeType.NotSet),
+                "The run really is a Full Import, so what is a create and what is an update stays JIM's to work out.");
+            Assert.That(PersonWatermarkValueOf(store.Value), Is.EqualTo("1"), "Falling back forever would be the worst of both; the fallback leaves a watermark behind.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_DeltaWithUnreadablePersistedWatermark_FallsBackToAFullImportWithTheStandardWarning()
+    {
+        var provider = ChangeLogProvider(
+            employees: [[1, "Ada"]],
+            changes: [[1, 1, "I"]]);
+
+        var run = await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store("{ this is not a watermark"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.Pages[0].WarningErrorType, Is.EqualTo(ActivityRunProfileExecutionItemErrorType.DeltaImportFallbackToFullImport));
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1 }));
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_DeltaAfterTheDeltaImportModeChanged_FallsBackToAFullImportWithTheStandardWarning()
+    {
+        var provider = WatermarkProvider([1, "Ada", new DateTime(2026, 7, 16, 9, 0, 0, DateTimeKind.Unspecified)]);
+
+        // A change-log sequence number means nothing to a last-modified column, so a watermark written
+        // in the other mode cannot be compared against this one.
+        var watermark = PersonWatermark(SqlDeltaImportMode.ChangeLogTable, "42");
+        var run = await RunDeltaAsync(provider, WatermarkDocument, WatermarkSystem(), pageSize: 10, Store(watermark), SqlConnectorConstants.DeltaImportModeWatermarkColumn);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.Pages[0].WarningErrorType, Is.EqualTo(ActivityRunProfileExecutionItemErrorType.DeltaImportFallbackToFullImport));
+            Assert.That(run.Pages[0].WarningMessage, Does.Contain(SqlConnectorConstants.SettingDeltaImportMode));
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1 }));
+        });
+    }
+
+    [Test]
+    public void ImportAsync_DeltaWithNoDeltaImportModeConfigured_RefusesToRun()
+    {
+        var provider = ChangeLogProvider(employees: [[1, "Ada"]], changes: [[1, 1, "I"]]);
+
+        Assert.That(async () => await RunDeltaAsync(provider, ChangeLogDocument, PersonSystem(), pageSize: 10, Store(null), deltaMode: null),
+            Throws.TypeOf<CannotPerformDeltaImportException>(),
+            "An unanswered configuration question is not something to work around: silently running a Full Import on every scheduled Delta Import would hide it for ever.");
+    }
+
+    #endregion
+
+    #region Save-time configuration validation
+
+    [Test]
+    public void ValidateSettingValues_TheDocumentedDeltaExample_IsAccepted()
+    {
+        var connector = new SqlConnector { ProviderFactory = _ => new FakeSqlProvider() };
+        var settingValues = DeltaSettingValues(connector, SqlConnectorConstants.DeltaConfigurationExample, SqlConnectorConstants.DeltaImportModeChangeLogTable);
+
+        Assert.That(connector.ValidateSettingValues(settingValues, _logger), Is.Empty,
+            "The example in the setting's own description is the first thing an administrator will paste in, so it has to be one the Connector accepts.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_ChangeLogWithNoDeleteValues_IsRefused()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "changeLog": {
+                    "table": "EMPLOYEE_CHANGES",
+                    "anchorColumns": [ "EMPLOYEE_ID" ],
+                    "sequenceColumn": "CHANGE_NUMBER",
+                    "changeTypeColumn": "CHANGE_TYPE",
+                    "updateValues": [ "U" ]
+                  }
+                }
+              ]
+            }
+            """;
+
+        Assert.That(ValidationMessageFor(document, SqlConnectorConstants.DeltaImportModeChangeLogTable), Does.Contain("deleteValues"),
+            "A change log that cannot say an object was deleted is the one thing this mode exists to provide.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_ChangeLogAnchorColumnCountNotMatchingTheObjectTypesAnchor_IsRefused()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "COMPANY_ID", "EMPLOYEE_ID" ],
+                  "changeLog": {
+                    "table": "EMPLOYEE_CHANGES",
+                    "anchorColumns": [ "EMPLOYEE_ID" ],
+                    "sequenceColumn": "CHANGE_NUMBER",
+                    "changeTypeColumn": "CHANGE_TYPE",
+                    "deleteValues": [ "D" ]
+                  }
+                }
+              ]
+            }
+            """;
+
+        Assert.That(ValidationMessageFor(document, SqlConnectorConstants.DeltaImportModeChangeLogTable), Does.Contain("anchor"),
+            "A change-log row identified by part of an anchor names some other object, without any error.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_AChangeTypeValueMeaningTwoDifferentThings_IsRefused()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "changeLog": {
+                    "table": "EMPLOYEE_CHANGES",
+                    "anchorColumns": [ "EMPLOYEE_ID" ],
+                    "sequenceColumn": "CHANGE_NUMBER",
+                    "changeTypeColumn": "CHANGE_TYPE",
+                    "updateValues": [ "D" ],
+                    "deleteValues": [ "D" ]
+                  }
+                }
+              ]
+            }
+            """;
+
+        Assert.That(ValidationMessageFor(document, SqlConnectorConstants.DeltaImportModeChangeLogTable), Does.Contain("'D'"),
+            "One value cannot mean both an update and a deletion, and guessing which the administrator meant is not JIM's to do.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_ChangeLogModeWithAnObjectTypeThatHasNoChangeLog_IsRefused()
+    {
+        Assert.That(ValidationMessageFor(WatermarkDocument, SqlConnectorConstants.DeltaImportModeChangeLogTable),
+            Does.Contain("Person").And.Contain("changeLog"),
+            "A Delta Import that silently skips an object type is a data-integrity trap, so the configuration is refused before it can be saved.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_WatermarkColumnModeWithAnObjectTypeThatHasNoWatermarkColumn_IsRefused()
+    {
+        Assert.That(ValidationMessageFor(ChangeLogDocument, SqlConnectorConstants.DeltaImportModeWatermarkColumn),
+            Does.Contain("Person").And.Contain("watermarkColumn"));
+    }
+
+    [Test]
+    public void ValidateSettingValues_ADeltaConfigurationWithNoModeChosen_IsAccepted()
+    {
+        var connector = new SqlConnector { ProviderFactory = _ => new FakeSqlProvider() };
+        var settingValues = DeltaSettingValues(connector, ChangeLogDocument, deltaMode: null);
+
+        Assert.That(connector.ValidateSettingValues(settingValues, _logger), Is.Empty,
+            "A Connected System that only runs Full Imports is not obliged to answer the Delta Import question.");
+    }
+
+    #endregion
+
+    #region Test helpers
+
+    /// <summary>
+    /// Stands in for the Connected System's persisted connector data, which the Worker replays to every
+    /// page of a run and only writes back once every page has been read.
+    /// </summary>
+    private sealed class PersistedConnectorDataStore
+    {
+        internal string? Value { get; set; }
+    }
+
+    private static PersistedConnectorDataStore Store(string? value) => new() { Value = value };
+
+    /// <summary>
+    /// Everything one import run produced: each call's result in order, and what it narrated.
+    /// </summary>
+    private sealed record SqlDeltaRun(List<ConnectedSystemImportResult> Pages, RecordingConnectorProgress Progress)
+    {
+        internal List<ConnectedSystemImportObject> ImportObjects => [.. Pages.SelectMany(page => page.ImportObjects)];
+    }
+
+    private Task<SqlDeltaRun> RunDeltaAsync(
+        FakeSqlProvider provider,
+        string objectTypesDocument,
+        ConnectedSystem connectedSystem,
+        int pageSize,
+        PersistedConnectorDataStore store,
+        string? deltaMode = SqlConnectorConstants.DeltaImportModeChangeLogTable,
+        int callLimit = 25) =>
+        RunAsync(provider, objectTypesDocument, connectedSystem, ConnectedSystemRunType.DeltaImport, pageSize, store, deltaMode, callLimit);
+
+    private Task<SqlDeltaRun> RunFullImportAsync(
+        FakeSqlProvider provider,
+        string objectTypesDocument,
+        ConnectedSystem connectedSystem,
+        int pageSize,
+        PersistedConnectorDataStore store,
+        string? deltaMode = SqlConnectorConstants.DeltaImportModeChangeLogTable,
+        int callLimit = 25) =>
+        RunAsync(provider, objectTypesDocument, connectedSystem, ConnectedSystemRunType.FullImport, pageSize, store, deltaMode, callLimit);
+
+    /// <summary>
+    /// Drives an import to completion exactly the way the Worker does: the persisted connector data the
+    /// run started with is replayed to every page, the new value is taken from the first page that
+    /// offers one, and it is written back only once every page has been read.
+    /// </summary>
+    private async Task<SqlDeltaRun> RunAsync(
+        FakeSqlProvider provider,
+        string objectTypesDocument,
+        ConnectedSystem connectedSystem,
+        ConnectedSystemRunType runType,
+        int pageSize,
+        PersistedConnectorDataStore store,
+        string? deltaMode,
+        int callLimit)
+    {
+        var progress = new RecordingConnectorProgress();
+        var pages = new List<ConnectedSystemImportResult>();
+
+        // Disposal releases the import connection, so the Connector needs no explicit close here.
+        using var connector = new SqlConnector { ProviderFactory = _ => provider };
+        var settingValues = DeltaSettingValues(connector, objectTypesDocument, deltaMode);
+
+        var originalPersistedData = store.Value;
+        connector.OpenImportConnection(settingValues, originalPersistedData, _logger);
+
+        var runProfile = new ConnectedSystemRunProfile { Name = runType.ToString(), RunType = runType, PageSize = pageSize };
+        var paginationTokens = new List<ConnectedSystemPaginationToken>();
+        var initialPage = true;
+        string? newPersistedData = null;
+
+        while (initialPage || paginationTokens.Count > 0)
+        {
+            initialPage = false;
+
+            var result = await connector.ImportAsync(connectedSystem, runProfile, paginationTokens, originalPersistedData, _logger, CancellationToken.None, progress);
+            pages.Add(result);
+            paginationTokens = result.PaginationTokens;
+            newPersistedData ??= result.PersistedConnectorData;
+
+            Assert.That(pages, Has.Count.LessThanOrEqualTo(callLimit),
+                "The import never stopped returning pagination tokens, which is an infinite import.");
+        }
+
+        if (newPersistedData != null)
+            store.Value = newPersistedData;
+
+        return new SqlDeltaRun(pages, progress);
+    }
+
+    private static List<ConnectedSystemSettingValue> DeltaSettingValues(SqlConnector connector, string objectTypesDocument, string? deltaMode)
+    {
+        var settingValues = SqlConnectorSettingValues.CreateSqlServer(connector);
+        SqlConnectorSettingValues.SetString(settingValues, SqlConnectorConstants.SettingObjectTypes, objectTypesDocument);
+        SqlConnectorSettingValues.SetString(settingValues, SqlConnectorConstants.SettingDeltaImportMode, deltaMode);
+        return settingValues;
+    }
+
+    private string ValidationMessageFor(string objectTypesDocument, string deltaMode)
+    {
+        var connector = new SqlConnector { ProviderFactory = _ => new FakeSqlProvider() };
+        var results = connector.ValidateSettingValues(DeltaSettingValues(connector, objectTypesDocument, deltaMode), _logger);
+
+        Assert.That(results, Has.Count.EqualTo(1), "Configuration that cannot work is refused before it can be saved.");
+        Assert.That(results[0].IsValid, Is.False);
+
+        return results[0].ErrorMessage ?? string.Empty;
+    }
+
+    /// <summary>
+    /// A stand-in database holding an object type's rows and its change log.
+    /// </summary>
+    private static FakeSqlProvider ChangeLogProvider(object?[][] employees, object?[][] changes)
+    {
+        var provider = new FakeSqlProvider();
+        provider.Catalogue.AddRows("HR", "EMPLOYEES", ["EMPLOYEE_ID", "DISPLAY_NAME"], employees);
+        provider.Catalogue.AddRows("HR", "EMPLOYEE_CHANGES", ["CHANGE_NUMBER", "EMPLOYEE_ID", "CHANGE_TYPE"], changes);
+        return provider;
+    }
+
+    /// <summary>
+    /// A stand-in database holding an object type whose rows carry their own last-modified column.
+    /// </summary>
+    private static FakeSqlProvider WatermarkProvider(params object?[][] employees)
+    {
+        var provider = new FakeSqlProvider();
+        provider.Catalogue.AddRows("HR", "EMPLOYEES", ["EMPLOYEE_ID", "DISPLAY_NAME", "LAST_MODIFIED"], employees);
+        return provider;
+    }
+
+    private static string PersonWatermark(SqlDeltaImportMode mode, string value, AttributeDataType type = AttributeDataType.Number)
+    {
+        var watermark = new SqlConnectorWatermark { Mode = mode };
+        watermark.ObjectTypes["Person"] = new SqlDeltaValue(value, type);
+        return watermark.Serialise();
+    }
+
+    private static string? PersonWatermarkValueOf(string? persistedConnectorData)
+    {
+        var watermark = SqlConnectorWatermark.TryRead(persistedConnectorData);
+        return watermark != null && watermark.ObjectTypes.TryGetValue("Person", out var value) ? value.Value : null;
+    }
+
+    private static ConnectedSystem PersonSystem() => new()
+    {
+        Name = "HR Database",
+        ObjectTypes =
+        [
+            ObjectType("Person",
+                Attribute("EMPLOYEE_ID", AttributeDataType.Number, isExternalId: true),
+                Attribute("DISPLAY_NAME", AttributeDataType.Text))
+        ]
+    };
+
+    private static ConnectedSystem WatermarkSystem() => new()
+    {
+        Name = "HR Database",
+        ObjectTypes =
+        [
+            ObjectType("Person",
+                Attribute("EMPLOYEE_ID", AttributeDataType.Number, isExternalId: true),
+                Attribute("DISPLAY_NAME", AttributeDataType.Text),
+                Attribute("LAST_MODIFIED", AttributeDataType.DateTime, selected: false))
+        ]
+    };
+
+    private static ConnectedSystemObjectType ObjectType(string name, params ConnectedSystemObjectTypeAttribute[] attributes) =>
+        new() { Name = name, Selected = true, Attributes = [.. attributes] };
+
+    private static ConnectedSystemObjectTypeAttribute Attribute(string name, AttributeDataType type, bool isExternalId = false, bool selected = true) =>
+        new() { Name = name, Type = type, Selected = selected, IsExternalId = isExternalId, AttributePlurality = AttributePlurality.SingleValued };
+
+    private static ConnectedSystemImportObjectAttribute AttributeOf(ConnectedSystemImportObject importObject, string name) =>
+        importObject.Attributes.Single(attribute => attribute.Name == name);
+
+    private static ConnectedSystemImportObject ObjectWithAnchor(SqlDeltaRun run, int anchor) =>
+        run.ImportObjects.Single(importObject => AttributeOf(importObject, "EMPLOYEE_ID").IntValues.Single() == anchor);
+
+    private static ObjectChangeType ChangeTypeOf(SqlDeltaRun run, int anchor) => ObjectWithAnchor(run, anchor).ChangeType;
+
+    private static List<int> AnchorValues(SqlDeltaRun run) =>
+        [.. run.ImportObjects.Select(importObject => AttributeOf(importObject, "EMPLOYEE_ID").IntValues.Single()).Order()];
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
@@ -54,6 +54,12 @@ internal sealed class FakeSqlProvider : SqlProviderBase
     internal List<string> ExecutedCommandTexts { get; } = [];
 
     /// <summary>
+    /// When set, every command beyond this many fails, which is how a database that goes away part way
+    /// through a run is expressed here.
+    /// </summary>
+    internal int? FailAfterCommandCount { get; set; }
+
+    /// <summary>
     /// Every connection string built through this provider, so a test can assert what the Connector
     /// asked for without a driver parsing it first.
     /// </summary>
@@ -140,11 +146,10 @@ internal sealed class FakeSqlProvider : SqlProviderBase
 
         var select = $"SELECT TOP ({GetParameterPlaceholder(request.PageSizeParameterName)}) {BuildColumnList(request.SelectColumns)}";
         var from = $"FROM {BuildFromClause(request)}";
+        var where = BuildKeysetWhereClause(request);
         var orderBy = BuildAnchorOrderByClause(request.AnchorColumns);
 
-        return request.IsFirstPage
-            ? $"{select} {from} {orderBy}"
-            : $"{select} {from} WHERE {BuildKeysetPredicate(request.AnchorColumns, request.LastAnchorParameterNames)} {orderBy}";
+        return $"{select} {from}{where} {orderBy}";
     }
 
     public override string BuildInsertReturningGeneratedKeyCommandText(SqlInsertCommand command) => throw new NotSupportedException();
@@ -466,20 +471,47 @@ internal sealed class FakeDbCommand : DbCommand
 
     public override int ExecuteNonQuery()
     {
-        _provider.ExecutedCommandTexts.Add(CommandText);
+        Record();
         return 0;
     }
 
     public override object? ExecuteScalar()
     {
-        _provider.ExecutedCommandTexts.Add(CommandText);
+        Record();
 
-        // A count over a source this stand-in holds rows for; anything else is the connectivity query.
+        var dataTable = ResolveDataTable();
+
+        // A count over a source this stand-in holds rows for, honouring any watermark the command
+        // restricted it to, so that a Delta Import's expected count is the one it actually reads.
         if (CommandText.StartsWith("SELECT COUNT", StringComparison.OrdinalIgnoreCase))
-            return ResolveDataTable()?.Rows.Count
-                ?? throw new FakeDbException($"This stand-in database has nothing to count for: {CommandText}");
+            return dataTable == null
+                ? throw new FakeDbException($"This stand-in database has nothing to count for: {CommandText}")
+                : FilterByChangeColumn(dataTable, dataTable.Rows).Count;
+
+        // The highest value a column holds, which is where a Delta Import's watermark comes from.
+        var maxColumn = MaxColumnPattern.Match(CommandText);
+        if (maxColumn.Success)
+        {
+            if (dataTable == null)
+                throw new FakeDbException($"This stand-in database has nothing to read a maximum from for: {CommandText}");
+
+            var ordinal = dataTable.IndexOf(maxColumn.Groups["column"].Value);
+            return dataTable.Rows.Count == 0 ? null : dataTable.Rows.Max(row => row[ordinal]);
+        }
 
         return _provider.ConnectivityTestResult;
+    }
+
+    /// <summary>
+    /// Records what this command was asked to run, and fails where the stand-in database has been told
+    /// to stop answering.
+    /// </summary>
+    private void Record()
+    {
+        _provider.ExecutedCommandTexts.Add(CommandText);
+
+        if (_provider.FailAfterCommandCount is { } limit && _provider.ExecutedCommandTexts.Count > limit)
+            throw new FakeDbException("The connection to the stand-in database was lost.");
     }
 
     public override void Prepare()
@@ -496,7 +528,7 @@ internal sealed class FakeDbCommand : DbCommand
     /// </summary>
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
-        _provider.ExecutedCommandTexts.Add(CommandText);
+        Record();
         var catalogue = _provider.Catalogue;
 
         if (CommandText == _provider.TablesCommandText)
@@ -583,7 +615,7 @@ internal sealed class FakeDbCommand : DbCommand
         var anchorOrdinals = anchorColumns.Select(dataTable.IndexOf).ToArray();
         var lastAnchor = BoundValuesWithPrefix(SqlConnectorImport.AnchorParameterPrefix);
 
-        var rows = dataTable.Rows
+        var rows = FilterByChangeColumn(dataTable, dataTable.Rows)
             .Where(row => lastAnchor.Count == 0 || CompareAnchors(row, anchorOrdinals, lastAnchor) > 0)
             .ToList();
 
@@ -692,9 +724,33 @@ internal sealed class FakeDbCommand : DbCommand
             or TypeCode.Single or TypeCode.Double or TypeCode.Decimal;
     }
 
+    /// <summary>
+    /// Applies the watermark a Delta Import restricted its read to, so that a test can tell a command
+    /// that asked for changes from one that read everything.
+    /// </summary>
+    private List<object?[]> FilterByChangeColumn(FakeSqlDataTable dataTable, IEnumerable<object?[]> rows)
+    {
+        var changePredicate = ChangePredicatePattern.Match(CommandText);
+        if (!changePredicate.Success)
+            return [.. rows];
+
+        var ordinal = dataTable.IndexOf(changePredicate.Groups["column"].Value);
+        var watermark = BoundValue(SqlConnectorImport.WatermarkParameterName);
+
+        return [.. rows.Where(row => CompareValues(row[ordinal], watermark) > 0)];
+    }
+
     private static readonly Regex JoinPredicatePattern = new(
         @"\[(?<column>[^\]]+)\]\s*=\s*@(?<parameter>" + SqlConnectorImport.JoinParameterPrefix + @"\d+_\d+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ChangePredicatePattern = new(
+        @"\[(?<column>[^\]]+)\]\s*>\s*@" + SqlConnectorImport.WatermarkParameterName,
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex MaxColumnPattern = new(
+        @"^SELECT MAX\(\[(?<column>[^\]]+)\]\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     #endregion
 }


### PR DESCRIPTION
## Summary
Phase 5 of [the SQL Connector plan](https://github.com/TetronIO/JIM/blob/main/engineering/plans/SQL_DATABASE_CONNECTOR.md), following #1244.

- **Change-log table mode**, the recommended one and the only one that observes deletions. A customer-maintained table carrying the anchor, a change type and a monotonic sequence; the change-type values are the customer's own vocabulary, mapped in configuration, since no two estates spell them the same way.
- **Watermark column mode**, detecting creates and updates only. Its no-delete semantics are asserted by test rather than merely documented.
- **The watermark is taken before a single change is read**, and returned from the first page only, so a change committing mid-run is read next run rather than stranded behind the watermark for ever. It advances only once the whole run completes, which is asserted by failing a run part way and checking the stored value is untouched.
- **A missing or unreadable watermark, or a mode that has changed since the watermark was written, falls back to a full import** with the standard warning, because JIM can apply the remedy itself in the same run. A Connected System with no delta mode chosen instead throws, because a scheduled delta quietly costing a full import every cycle would hide the unanswered question for ever.
- Partial configuration is refused at save time: once a mode is chosen, an Object Type lacking that mode's configuration is an error rather than a warning, since a delta that silently skips an Object Type is a data-integrity trap.

**Also fixes a gap in #1244**: full import established no baseline at all, so "run a Full Import first" was not actually a remedy and every delta would have fallen back for ever. A full import now records the watermark where a delta mode is configured.

## Known limitation
Watermark column mode reads the primary source only, so a related-table change (a group membership added) that does not move the parent row's watermark is not detected. The PRD's requirement 11 includes related tables; closing that needs a correlated `EXISTS` in the generated page and is additive on top of this. Flagged for a decision rather than left silent. Change-log mode is unaffected.

## Test plan
- [x] `dotnet build JIM.sln` clean, zero warnings
- [x] `dotnet test JIM.sln` clean (whole solution green; Worker suite 4170 passed)
- [x] Creates, updates and deletes propagated in change-log mode; deletion demonstrably not detected in watermark mode
- [x] Watermark persisted from the first page only, replayed on later pages, and left untouched by a run that fails part way
- [x] Custom change-type value mapping, paging and termination in delta mode, and malformed delta configuration refused at save time

Docs: n/a - the Connector is not yet registered, so it is unreachable by administrators; public documentation ships with the completed feature per the plan's Phase 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)