### PR TITLE
feat: detect related-table changes in watermark delta mode (#170)

### DIFF
--- a/src/JIM.Connectors/Sql/Providers/ISqlProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/ISqlProvider.cs
@@ -141,6 +141,13 @@ internal interface ISqlProvider
     /// </summary>
     string BuildKeysetPageCommandText(SqlKeysetPageRequest request);
 
+    /// <summary>
+    /// Renders the predicate selecting the rows a Delta Import considers changed: the source's own
+    /// watermark, or any of its related tables'. Shared by the page read and by the count that tells the
+    /// Activity how much this run is about to read, so the two can never disagree about what a change is.
+    /// </summary>
+    string BuildChangedRowsPredicate(SqlChangeFilter filter);
+
     #endregion
 
     #region Export

--- a/src/JIM.Connectors/Sql/Providers/SqlChangeFilter.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlChangeFilter.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Connectors.Sql.Providers;
+
+/// <summary>
+/// Everything a provider needs to render the predicate that selects the rows a Delta Import in Watermark
+/// Column mode considers changed: the source's own watermark column, and each related table that carries
+/// a watermark of its own.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A related table is a source of changes to the parent object, not to itself.</b> A group membership
+/// added or revoked, or a phone number replaced, changes the object without touching the object's own
+/// row, so the parent's watermark does not move and a predicate reading the primary source alone would
+/// never see it. The parent is therefore selected on either its own watermark or any of its related
+/// tables', which is why this exists as one filter rather than as a column comparison.
+/// </para>
+/// <para>
+/// <b>Correlated subqueries, never a join.</b> A join to a related table returns one parent row per
+/// matching related row, which turns one changed object into several import objects and inflates the
+/// page against the Run Profile's page size. EXISTS answers "is there such a row" once per parent and
+/// stops at the first match.
+/// </para>
+/// </remarks>
+internal sealed record SqlChangeFilter
+{
+    /// <summary>
+    /// The column on the source itself whose value moves whenever a row changes.
+    /// </summary>
+    internal required string ChangeColumn { get; init; }
+
+    /// <summary>
+    /// The parameter carrying the watermark <see cref="ChangeColumn"/> is compared against.
+    /// </summary>
+    internal required string ChangeParameterName { get; init; }
+
+    /// <summary>
+    /// The source's anchor columns, in key order, which each related table is correlated on.
+    /// </summary>
+    internal required IReadOnlyList<string> AnchorColumns { get; init; }
+
+    /// <summary>
+    /// The related tables whose own changes count as changes to the parent object. Empty where the
+    /// object type has none, which is the case the primary source's watermark alone answers.
+    /// </summary>
+    internal IReadOnlyList<SqlRelatedChangeSource> RelatedSources { get; init; } = [];
+
+    /// <summary>
+    /// True when a related table can select a parent whose own watermark has not moved, which is what
+    /// makes the source have to be aliased so a subquery can refer back to it.
+    /// </summary>
+    internal bool HasRelatedSources => RelatedSources.Count > 0;
+}
+
+/// <summary>
+/// One related table a Delta Import watches for changes to its parent object.
+/// </summary>
+internal sealed record SqlRelatedChangeSource
+{
+    /// <summary>
+    /// The prefix each related table's subquery alias is built from, suffixed by its position in the
+    /// filter. Chosen so no real object collides with it.
+    /// </summary>
+    internal const string AliasPrefix = "JIM_RELATED";
+
+    internal string? SchemaName { get; init; }
+
+    internal required string TableName { get; init; }
+
+    /// <summary>
+    /// The columns joining a related row back to its parent, one per anchor column and in the same
+    /// order. Correlating on fewer would attribute another object's changes to this one.
+    /// </summary>
+    internal required IReadOnlyList<string> JoinColumns { get; init; }
+
+    /// <summary>
+    /// The column on this related table whose value moves whenever one of its rows changes.
+    /// </summary>
+    internal required string WatermarkColumn { get; init; }
+
+    /// <summary>
+    /// The parameter carrying the watermark <see cref="WatermarkColumn"/> is compared against, or null
+    /// where JIM holds none for this related table yet. Null means every row of it counts as changed,
+    /// which is the only answer that cannot miss one.
+    /// </summary>
+    internal string? WatermarkParameterName { get; init; }
+}

--- a/src/JIM.Connectors/Sql/Providers/SqlKeysetPageRequest.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlKeysetPageRequest.cs
@@ -67,6 +67,13 @@ internal sealed record SqlKeysetPageRequest
     internal string? ChangeParameterName { get; init; }
 
     /// <summary>
+    /// The related tables whose own watermarks also select a row, so that a change confined to one of
+    /// them (a group membership added or revoked) is detected as a change to the object it belongs to.
+    /// Empty for a Full Import, for Change-Log Table mode, and for an object type with no related tables.
+    /// </summary>
+    internal IReadOnlyList<SqlRelatedChangeSource> RelatedChangeSources { get; init; } = [];
+
+    /// <summary>
     /// True when no previous anchor was supplied, so the page starts at the beginning of the ordered set.
     /// </summary>
     internal bool IsFirstPage => LastAnchorParameterNames.Count == 0;
@@ -75,4 +82,17 @@ internal sealed record SqlKeysetPageRequest
     /// True when the read is restricted to rows beyond a watermark.
     /// </summary>
     internal bool HasChangeFilter => ChangeColumn != null;
+
+    /// <summary>
+    /// The predicate this page's changed rows are selected by, or null where the page reads everything.
+    /// </summary>
+    internal SqlChangeFilter? ChangeFilter => HasChangeFilter
+        ? new SqlChangeFilter
+        {
+            ChangeColumn = ChangeColumn!,
+            ChangeParameterName = ChangeParameterName!,
+            AnchorColumns = AnchorColumns,
+            RelatedSources = RelatedChangeSources
+        }
+        : null;
 }

--- a/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
@@ -3,6 +3,7 @@
 
 using JIM.Models.Core;
 using System.Data.Common;
+using System.Globalization;
 using System.Text;
 
 namespace JIM.Connectors.Sql.Providers;
@@ -172,6 +173,33 @@ internal abstract class SqlProviderBase : ISqlProvider
             throw new ArgumentException(
                 "A keyset page restricted to changed rows needs both the column to compare and the parameter carrying the watermark; one without the other would read everything, or nothing.",
                 nameof(request));
+
+        if (request.RelatedChangeSources.Count > 0 && !request.HasChangeFilter)
+            throw new ArgumentException(
+                "A keyset page cannot watch related tables for changes without a watermark on the source itself: a page reading every row already includes every changed one.",
+                nameof(request));
+
+        ValidateRelatedChangeSources(request.RelatedChangeSources, request.AnchorColumns, nameof(request));
+    }
+
+    /// <summary>
+    /// Refuses a related change source that could not correlate to exactly one parent. Correlating on
+    /// fewer columns than the anchor has matches rows belonging to other objects, which would import a
+    /// stranger's changes as this object's without any error.
+    /// </summary>
+    private static void ValidateRelatedChangeSources(
+        IReadOnlyList<SqlRelatedChangeSource> relatedSources,
+        IReadOnlyList<string> anchorColumns,
+        string argumentName)
+    {
+        foreach (var relatedSource in relatedSources)
+        {
+            if (relatedSource.JoinColumns.Count != anchorColumns.Count)
+                throw new ArgumentException(
+                    $"Related change source '{relatedSource.TableName}' correlates on {relatedSource.JoinColumns.Count} column(s), but the anchor has {anchorColumns.Count}: " +
+                    "correlating on part of an anchor would attribute another object's changes to this one.",
+                    argumentName);
+        }
     }
 
     /// <summary>
@@ -186,8 +214,8 @@ internal abstract class SqlProviderBase : ISqlProvider
 
         // The watermark first: it is the more selective of the two, and on the first page of a run it is
         // the only thing standing between a Delta Import and a full table scan.
-        if (request.HasChangeFilter)
-            predicates.Add($"{QuoteIdentifier(request.ChangeColumn!)} > {GetParameterPlaceholder(request.ChangeParameterName!)}");
+        if (request.ChangeFilter is { } changeFilter)
+            predicates.Add(BuildChangedRowsPredicate(changeFilter));
 
         if (!request.IsFirstPage)
             predicates.Add(BuildKeysetPredicate(request.AnchorColumns, request.LastAnchorParameterNames));
@@ -195,16 +223,70 @@ internal abstract class SqlProviderBase : ISqlProvider
         return predicates.Count == 0 ? string.Empty : $" WHERE {string.Join(" AND ", predicates)}";
     }
 
+    public string BuildChangedRowsPredicate(SqlChangeFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ValidateRelatedChangeSources(filter.RelatedSources, filter.AnchorColumns, nameof(filter));
+
+        var ownWatermark = $"{QuoteIdentifier(filter.ChangeColumn)} > {GetParameterPlaceholder(filter.ChangeParameterName)}";
+
+        // Nothing else to consider, so the predicate is exactly what it was before related tables could
+        // select a row: a Full Import and Change-Log Table mode generate the statement they always did.
+        if (!filter.HasRelatedSources)
+            return ownWatermark;
+
+        var alternatives = filter.RelatedSources
+            .Select((relatedSource, index) => BuildRelatedChangeExistsPredicate(relatedSource, filter.AnchorColumns, index))
+            .Prepend(ownWatermark);
+
+        return $"({string.Join(" OR ", alternatives)})";
+    }
+
+    /// <summary>
+    /// Renders one related table's correlated existence test: is there a row of it belonging to this
+    /// parent whose own watermark has moved. A row removed from the related table is a change to the
+    /// parent too, and is detected wherever the customer's related table records its removal (a soft
+    /// delete, a tombstone row); a related table that hard-deletes its rows leaves nothing for any
+    /// watermark to compare, and that limitation is the documentation's to state.
+    /// </summary>
+    private string BuildRelatedChangeExistsPredicate(SqlRelatedChangeSource relatedSource, IReadOnlyList<string> anchorColumns, int index)
+    {
+        var alias = QuoteIdentifier(SqlRelatedChangeSource.AliasPrefix + index.ToString(CultureInfo.InvariantCulture));
+        var sourceAlias = QuoteIdentifier(SqlKeysetPageRequest.SourceAlias);
+
+        var correlation = relatedSource.JoinColumns.Select((joinColumn, columnIndex) =>
+            $"{alias}.{QuoteIdentifier(joinColumn)} = {sourceAlias}.{QuoteIdentifier(anchorColumns[columnIndex])}");
+
+        // No watermark for this related table yet means JIM cannot tell which of its rows are new, so
+        // every parent it holds a row for is read. One expensive run beats a missed change.
+        var predicates = relatedSource.WatermarkParameterName == null
+            ? correlation
+            : correlation.Append($"{alias}.{QuoteIdentifier(relatedSource.WatermarkColumn)} > {GetParameterPlaceholder(relatedSource.WatermarkParameterName)}");
+
+        return $"EXISTS (SELECT 1 FROM {QualifyObjectName(relatedSource.SchemaName, relatedSource.TableName)} {alias} WHERE {string.Join(" AND ", predicates)})";
+    }
+
     /// <summary>
     /// Renders what a keyset page reads from: a quoted, schema-qualified object name, or an
     /// administrator-supplied statement wrapped as a named derived table. Identical in both dialects,
     /// so it lives here rather than being written out twice.
     /// </summary>
+    /// <remarks>
+    /// A table or view is named only where a correlated subquery needs to refer back to it. An alias
+    /// nothing refers to changes the statement a database administrator reads in a trace for no gain,
+    /// so every page that needed none yesterday still generates none. A statement standing in for a
+    /// table is always named, because a derived table has to be.
+    /// </remarks>
     protected string BuildFromClause(SqlKeysetPageRequest request)
     {
-        return string.IsNullOrWhiteSpace(request.SelectStatement)
-            ? QualifyObjectName(request.SchemaName, request.ObjectName!)
-            : $"({request.SelectStatement}) {QuoteIdentifier(SqlKeysetPageRequest.SourceAlias)}";
+        if (!string.IsNullOrWhiteSpace(request.SelectStatement))
+            return $"({request.SelectStatement}) {QuoteIdentifier(SqlKeysetPageRequest.SourceAlias)}";
+
+        var qualifiedObjectName = QualifyObjectName(request.SchemaName, request.ObjectName!);
+
+        return request.RelatedChangeSources.Count == 0
+            ? qualifiedObjectName
+            : $"{qualifiedObjectName} {QuoteIdentifier(SqlKeysetPageRequest.SourceAlias)}";
     }
 
     /// <summary>

--- a/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
@@ -192,14 +192,13 @@ internal abstract class SqlProviderBase : ISqlProvider
         IReadOnlyList<string> anchorColumns,
         string argumentName)
     {
-        foreach (var relatedSource in relatedSources)
-        {
-            if (relatedSource.JoinColumns.Count != anchorColumns.Count)
-                throw new ArgumentException(
-                    $"Related change source '{relatedSource.TableName}' correlates on {relatedSource.JoinColumns.Count} column(s), but the anchor has {anchorColumns.Count}: " +
-                    "correlating on part of an anchor would attribute another object's changes to this one.",
-                    argumentName);
-        }
+        var mismatched = relatedSources.FirstOrDefault(relatedSource => relatedSource.JoinColumns.Count != anchorColumns.Count);
+
+        if (mismatched != null)
+            throw new ArgumentException(
+                $"Related change source '{mismatched.TableName}' correlates on {mismatched.JoinColumns.Count} column(s), but the anchor has {anchorColumns.Count}: " +
+                "correlating on part of an anchor would attribute another object's changes to this one.",
+                argumentName);
     }
 
     /// <summary>

--- a/src/JIM.Connectors/Sql/SqlConnector.cs
+++ b/src/JIM.Connectors/Sql/SqlConnector.cs
@@ -279,7 +279,8 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
         "a change type and a monotonic sequence or timestamp. It is the recommended mode, and the only one that observes a deletion. " +
         "Add a 'changeLog' to every object type naming that table, the columns carrying the anchor, the sequence column, the change type column, " +
         "and which of your own change-type values mean a create, an update and a deletion. " +
-        $"'{SqlConnectorConstants.DeltaImportModeWatermarkColumn}' reads a last-modified or version column on the object type's own table or view, named as its 'watermarkColumn'. " +
+        $"'{SqlConnectorConstants.DeltaImportModeWatermarkColumn}' reads a last-modified or version column on the object type's own table or view, named as its 'watermarkColumn', " +
+        "and one on each of its related tables, named the same way, so that a phone number or a group membership changing is detected as a change to the object it belongs to. " +
         "It needs nothing extra in the database, but it detects creates and updates only: a row that has been deleted has no column left to move, " +
         "so deletions are found only by a Full Import. Example:" + Environment.NewLine + Environment.NewLine +
         SqlConnectorConstants.DeltaConfigurationExample;

--- a/src/JIM.Connectors/Sql/SqlConnectorConstants.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorConstants.cs
@@ -189,6 +189,16 @@ public static class SqlConnectorConstants
               "table": "V_EMPLOYEES",
               "anchorColumns": [ "EMPLOYEE_ID" ],
               "watermarkColumn": "LAST_MODIFIED",
+              "relatedTables": [
+                {
+                  "attributeName": "PhoneNumbers",
+                  "schema": "HR",
+                  "table": "EMPLOYEE_PHONES",
+                  "valueColumn": "PHONE_NUMBER",
+                  "joinColumns": [ "EMPLOYEE_ID" ],
+                  "watermarkColumn": "LAST_MODIFIED"
+                }
+              ],
               "changeLog": {
                 "schema": "HR",
                 "table": "IDM_CHANGE_LOG",

--- a/src/JIM.Connectors/Sql/SqlConnectorImport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorImport.cs
@@ -680,14 +680,16 @@ internal sealed class SqlConnectorImport
     {
         var relatedWatermarks = new Dictionary<string, SqlDeltaValue>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var relatedTable in plan.RelatedTables)
-        {
-            var configuration = relatedTable.Configuration;
-            if (configuration.WatermarkColumn == null)
-                continue;
+        // Only the related tables declaring a watermark column have one to capture. A Full Import reaches
+        // here with tables that do not, which is deliberate: see the remarks above.
+        var watermarked = plan.RelatedTables
+            .Select(relatedTable => relatedTable.Configuration)
+            .Where(configuration => configuration.WatermarkColumn != null);
 
+        foreach (var configuration in watermarked)
+        {
             var source = _provider.QualifyObjectName(configuration.SchemaName, configuration.TableName);
-            var described = SqlConnectorWatermark.Describe(await ReadHighestValueAsync(source, configuration.WatermarkColumn));
+            var described = SqlConnectorWatermark.Describe(await ReadHighestValueAsync(source, configuration.WatermarkColumn!));
 
             if (described != null)
                 relatedWatermarks[configuration.AttributeName] = described;

--- a/src/JIM.Connectors/Sql/SqlConnectorImport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorImport.cs
@@ -64,6 +64,13 @@ internal sealed class SqlConnectorImport
     internal const string WatermarkParameterName = "jimWatermark";
 
     /// <summary>
+    /// The bind variables carrying each related table's own watermark, suffixed by its position in the
+    /// Object Type's related tables. Named distinctly from <see cref="WatermarkParameterName"/> rather
+    /// than suffixing it, so neither name is a prefix of the other.
+    /// </summary>
+    internal const string RelatedWatermarkParameterPrefix = "jimRelatedWatermark";
+
+    /// <summary>
     /// How many bind variables one related-table gather may carry. Microsoft SQL Server caps a statement
     /// at 2,100 parameters, so a large page size against a composite anchor would otherwise fail at the
     /// server; a page beyond this is gathered in more than one query rather than one per row.
@@ -259,7 +266,7 @@ internal sealed class SqlConnectorImport
             var watermark = previous.ObjectTypes.GetValueOrDefault(plan.Name);
             var deltaPage = _deltaMode == SqlDeltaImportMode.ChangeLogTable
                 ? await ReadChangeLogPageAsync(plan, page, watermark)
-                : await ReadWatermarkColumnPageAsync(plan, page, watermark);
+                : await ReadWatermarkColumnPageAsync(plan, page, watermark, previous.RelatedTablesFor(plan.Name));
 
             result.ImportObjects.AddRange(deltaPage.ImportObjects);
             objectsRead += deltaPage.ImportObjects.Count;
@@ -554,19 +561,44 @@ internal sealed class SqlConnectorImport
     #region Delta import: watermark column
 
     /// <summary>
-    /// Reads a page of the rows whose own last-modified or version column has moved beyond the watermark.
+    /// Reads a page of the rows that have changed: those whose own last-modified or version column has
+    /// moved beyond the watermark, and those any of whose related tables holds a row for that has.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// <b>A related table is a source of changes to the parent object.</b> A group membership added or
+    /// revoked, or a phone number replaced, never touches the object's own row, so its watermark does not
+    /// move and reading the primary source alone would miss the change entirely. Each related table
+    /// carries a watermark column of its own, and a parent is selected on either its own evidence or any
+    /// of theirs; the object is then imported whole, exactly as a Full Import would deliver it.
+    /// </para>
+    /// <para>
     /// <b>This mode cannot observe a deletion, and nothing here is going to change that.</b> A row that
     /// has been deleted has no column left to move, so its absence never reaches the predicate; the same
     /// goes for a row that has fallen out of a view. Deletions need the change-log table, or a periodic
     /// Full Import. Every change is reported as an update, because a last-modified column cannot tell a
     /// create from one; JIM creates the Connected System Object where it holds none.
+    /// </para>
+    /// <para>
+    /// <b>The same limitation applies one level down, and the documentation must say so.</b> A row
+    /// removed from a related table is a change to the parent object and is detected wherever the
+    /// customer's table records the removal: a soft-delete flag, a tombstone row, or an update to the
+    /// row's own watermark. Where a related table hard-deletes its rows instead, there is nothing left
+    /// for any watermark to compare, so a revoked membership is invisible until the next Full Import.
+    /// </para>
     /// </remarks>
-    private async Task<SqlDeltaPage> ReadWatermarkColumnPageAsync(SqlImportPlan plan, SqlDeltaPagePosition page, SqlDeltaValue? watermark)
+    private async Task<SqlDeltaPage> ReadWatermarkColumnPageAsync(
+        SqlImportPlan plan,
+        SqlDeltaPagePosition page,
+        SqlDeltaValue? watermark,
+        IReadOnlyDictionary<string, SqlDeltaValue> relatedWatermarks)
     {
         var watermarkColumn = RequireWatermarkColumn(plan);
         var keysetColumns = plan.AnchorColumns.Select(anchorColumn => new SqlDeltaKeysetColumn(anchorColumn.Name, anchorColumn.Type)).ToList();
+
+        // With no watermark at all this object type is read from the beginning, which already includes
+        // everything a related table could have to say about it.
+        var relatedChanges = watermark == null ? [] : BuildRelatedChanges(plan, relatedWatermarks);
 
         var request = new SqlKeysetPageRequest
         {
@@ -578,10 +610,11 @@ internal sealed class SqlConnectorImport
             PageSizeParameterName = PageSizeParameterName,
             LastAnchorParameterNames = page.IsFirstPage ? [] : [.. Enumerable.Range(0, keysetColumns.Count).Select(AnchorParameterName)],
             ChangeColumn = watermark == null ? null : watermarkColumn,
-            ChangeParameterName = watermark == null ? null : WatermarkParameterName
+            ChangeParameterName = watermark == null ? null : WatermarkParameterName,
+            RelatedChangeSources = [.. relatedChanges.Select(relatedChange => relatedChange.Source)]
         };
 
-        var rows = await ReadDeltaPageAsync(plan, request, page, watermark, plan.SelectColumns);
+        var rows = await ReadDeltaPageAsync(plan, request, page, watermark, plan.SelectColumns, relatedChanges);
 
         var importObjects = BuildImportObjects(plan, rows, out var anchorKeys);
         await GatherRelatedAttributesAsync(plan, rows, importObjects, anchorKeys);
@@ -599,9 +632,13 @@ internal sealed class SqlConnectorImport
     #region Delta import: watermarks, counting and paging mechanics
 
     /// <summary>
-    /// Asks each object type's change source where it currently stands, which is what the next Delta
-    /// Import will read from.
+    /// Asks each object type's change source, and in Watermark Column mode each of its related tables,
+    /// where it currently stands, which is what the next Delta Import will read from.
     /// </summary>
+    /// <remarks>
+    /// One watermark per source, never one across them: see <see cref="SqlConnectorWatermark"/> for why
+    /// a single maximum would permanently skip whatever the slower-moving sources had recorded below it.
+    /// </remarks>
     private async Task<SqlConnectorWatermark> CaptureWatermarkAsync(IReadOnlyList<SqlImportPlan> plans)
     {
         var watermark = new SqlConnectorWatermark { Mode = _deltaMode };
@@ -610,18 +647,64 @@ internal sealed class SqlConnectorImport
         {
             var (source, changeColumn) = ResolveChangeSource(plan);
 
-            using var command = _provider.CreateCommand(_connection, $"SELECT MAX({_provider.QuoteIdentifier(changeColumn)}) FROM {source}");
-            var value = await command.ExecuteScalarAsync(_cancellationToken);
-
             // No highest value at all is what an empty change log, or a source nothing has been written
             // to, looks like. Recording nothing for it means the next run reads from the beginning,
             // which is the only answer that cannot miss a change.
-            var described = SqlConnectorWatermark.Describe(value);
+            var described = SqlConnectorWatermark.Describe(await ReadHighestValueAsync(source, changeColumn));
             if (described != null)
                 watermark.ObjectTypes[plan.Name] = described;
+
+            // Only Watermark Column mode reads a related table for changes; a change log states what
+            // happened to the object however it happened.
+            if (_deltaMode != SqlDeltaImportMode.WatermarkColumn)
+                continue;
+
+            var relatedWatermarks = await CaptureRelatedWatermarksAsync(plan);
+            if (relatedWatermarks.Count > 0)
+                watermark.RelatedTables[plan.Name] = relatedWatermarks;
         }
 
         return watermark;
+    }
+
+    /// <summary>
+    /// Asks each of an object type's related tables where it currently stands.
+    /// </summary>
+    /// <remarks>
+    /// A related table with no watermark column records nothing and is not refused here: this also runs
+    /// for a Full Import, which is both how a baseline is established and how JIM recovers from an
+    /// unusable watermark, and refusing it would take away the remedy. The next Delta Import refuses the
+    /// same configuration loudly, so nothing is hidden by leaving it alone now.
+    /// </remarks>
+    private async Task<Dictionary<string, SqlDeltaValue>> CaptureRelatedWatermarksAsync(SqlImportPlan plan)
+    {
+        var relatedWatermarks = new Dictionary<string, SqlDeltaValue>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var relatedTable in plan.RelatedTables)
+        {
+            var configuration = relatedTable.Configuration;
+            if (configuration.WatermarkColumn == null)
+                continue;
+
+            var source = _provider.QualifyObjectName(configuration.SchemaName, configuration.TableName);
+            var described = SqlConnectorWatermark.Describe(await ReadHighestValueAsync(source, configuration.WatermarkColumn));
+
+            if (described != null)
+                relatedWatermarks[configuration.AttributeName] = described;
+        }
+
+        return relatedWatermarks;
+    }
+
+    /// <summary>
+    /// The highest value a column currently holds, which is where a watermark comes from. No dialect
+    /// divergence to hide behind the provider seam: an aggregate over a source is the same statement in
+    /// both, built from the same quoting the seam already provides.
+    /// </summary>
+    private async Task<object?> ReadHighestValueAsync(string source, string column)
+    {
+        using var command = _provider.CreateCommand(_connection, $"SELECT MAX({_provider.QuoteIdentifier(column)}) FROM {source}");
+        return await command.ExecuteScalarAsync(_cancellationToken);
     }
 
     /// <summary>
@@ -638,25 +721,36 @@ internal sealed class SqlConnectorImport
     {
         long expected = 0;
         foreach (var plan in plans)
-            expected += await CountChangesAsync(plan, previous.ObjectTypes.GetValueOrDefault(plan.Name));
+            expected += await CountChangesAsync(plan, previous.ObjectTypes.GetValueOrDefault(plan.Name), previous.RelatedTablesFor(plan.Name));
 
         _logger.Debug("SqlConnectorImport: expecting up to {ExpectedObjectCount} changed object(s) across {ObjectTypeCount} Object Type(s)", expected, plans.Count);
 
         await _progress.ReportExpectedObjectCountAsync(expected > int.MaxValue ? int.MaxValue : (int)expected);
     }
 
-    private async Task<long> CountChangesAsync(SqlImportPlan plan, SqlDeltaValue? watermark)
+    /// <summary>
+    /// How many rows this object type's pages are about to return, counted against exactly the predicate
+    /// those pages read with, so that the count and the read can never disagree about what a change is.
+    /// </summary>
+    private async Task<long> CountChangesAsync(SqlImportPlan plan, SqlDeltaValue? watermark, IReadOnlyDictionary<string, SqlDeltaValue> relatedWatermarks)
     {
-        var (source, changeColumn) = ResolveChangeSource(plan);
+        var relatedChanges = watermark == null || _deltaMode != SqlDeltaImportMode.WatermarkColumn
+            ? []
+            : BuildRelatedChanges(plan, relatedWatermarks);
+
+        var (source, changeColumn) = ResolveChangeSource(plan, relatedChanges.Count > 0);
 
         var commandText = watermark == null
             ? $"SELECT COUNT(*) FROM {source}"
-            : $"SELECT COUNT(*) FROM {source} WHERE {_provider.QuoteIdentifier(changeColumn)} > {_provider.GetParameterPlaceholder(WatermarkParameterName)}";
+            : $"SELECT COUNT(*) FROM {source} WHERE {BuildChangedRowsPredicate(plan, changeColumn, relatedChanges)}";
 
         using var command = _provider.CreateCommand(_connection, commandText);
 
         if (watermark != null)
+        {
             command.Parameters.Add(_provider.CreateParameter(WatermarkParameterName, BindDeltaValue(plan, watermark, "watermark")));
+            BindRelatedWatermarks(command, plan, relatedChanges);
+        }
 
         var count = await command.ExecuteScalarAsync(_cancellationToken);
 
@@ -667,14 +761,78 @@ internal sealed class SqlConnectorImport
     /// What this object type's changes are read from, and the column that orders them, for whichever
     /// mode is configured.
     /// </summary>
-    private (string Source, string ChangeColumn) ResolveChangeSource(SqlImportPlan plan)
+    /// <param name="plan">The object type being read.</param>
+    /// <param name="aliased">Whether the source has to be named, which it does exactly when a correlated subquery refers back to its columns.</param>
+    private (string Source, string ChangeColumn) ResolveChangeSource(SqlImportPlan plan, bool aliased = false)
     {
         if (_deltaMode != SqlDeltaImportMode.ChangeLogTable)
-            return (BuildFromClause(plan), RequireWatermarkColumn(plan));
+            return (BuildFromClause(plan, aliased), RequireWatermarkColumn(plan));
 
         var changeLog = RequireChangeLog(plan);
         return (_provider.QualifyObjectName(changeLog.SchemaName, changeLog.TableName), changeLog.SequenceColumn);
     }
+
+    /// <summary>
+    /// The related tables this object type's changes may also come from, each paired with the watermark
+    /// JIM holds for it.
+    /// </summary>
+    /// <exception cref="SqlSchemaConfigurationException">A related table has no watermark column for this mode to read. Refused when the Connected System is saved; this is the backstop for configuration changed since.</exception>
+    private static List<SqlRelatedChange> BuildRelatedChanges(SqlImportPlan plan, IReadOnlyDictionary<string, SqlDeltaValue> relatedWatermarks)
+    {
+        return [.. plan.RelatedTables.Select((relatedTable, index) =>
+        {
+            var configuration = relatedTable.Configuration;
+            var watermark = relatedWatermarks.GetValueOrDefault(configuration.AttributeName);
+
+            var source = new SqlRelatedChangeSource
+            {
+                SchemaName = configuration.SchemaName,
+                TableName = configuration.TableName,
+                JoinColumns = configuration.JoinColumns,
+                WatermarkColumn = RequireRelatedWatermarkColumn(plan, configuration),
+
+                // No watermark for this related table yet (it was added to the document after the last
+                // run, or JIM last ran before it watched related tables at all) means every parent it
+                // holds a row for is read once. One expensive run beats a missed change.
+                WatermarkParameterName = watermark == null ? null : RelatedWatermarkParameterName(index)
+            };
+
+            return new SqlRelatedChange(source, watermark);
+        })];
+    }
+
+    /// <summary>
+    /// The predicate selecting the rows this object type considers changed, rendered by the dialect so
+    /// that no SQL of any dialect's is written here.
+    /// </summary>
+    private string BuildChangedRowsPredicate(SqlImportPlan plan, string changeColumn, IReadOnlyList<SqlRelatedChange> relatedChanges) =>
+        _provider.BuildChangedRowsPredicate(new SqlChangeFilter
+        {
+            ChangeColumn = changeColumn,
+            ChangeParameterName = WatermarkParameterName,
+            AnchorColumns = [.. plan.AnchorColumns.Select(anchorColumn => anchorColumn.Name)],
+            RelatedSources = [.. relatedChanges.Select(relatedChange => relatedChange.Source)]
+        });
+
+    /// <summary>
+    /// Binds each related table's own watermark, skipping the ones JIM holds none for: those have no
+    /// parameter in the statement because their predicate is existence alone.
+    /// </summary>
+    private void BindRelatedWatermarks(DbCommand command, SqlImportPlan plan, IReadOnlyList<SqlRelatedChange> relatedChanges)
+    {
+        foreach (var relatedChange in relatedChanges.Where(relatedChange => relatedChange.Source.WatermarkParameterName != null))
+            command.Parameters.Add(_provider.CreateParameter(
+                relatedChange.Source.WatermarkParameterName!,
+                BindDeltaValue(plan, relatedChange.Watermark!, $"watermark for related table '{relatedChange.Source.TableName}'")));
+    }
+
+    private static string RelatedWatermarkParameterName(int index) => $"{RelatedWatermarkParameterPrefix}{index}";
+
+    /// <exception cref="SqlSchemaConfigurationException">The Object Types document has nothing for the configured mode to read on this related table.</exception>
+    private static string RequireRelatedWatermarkColumn(SqlImportPlan plan, SqlRelatedTableConfiguration relatedTable) =>
+        relatedTable.WatermarkColumn ?? throw new SqlSchemaConfigurationException(
+            $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeWatermarkColumn}', but Object Type '{plan.Name}' has related table attribute '{relatedTable.AttributeName}' with no 'watermarkColumn' in {SqlConnectorConstants.SettingObjectTypes}. " +
+            $"A row added to or removed from '{relatedTable.TableName}' changes the object without touching its own row, so without one that change could never be detected.");
 
     /// <exception cref="SqlSchemaConfigurationException">The Object Types document has nothing for the configured mode to read. Refused when the Connected System is saved; this is the backstop for configuration changed since.</exception>
     private static SqlChangeLogConfiguration RequireChangeLog(SqlImportPlan plan) =>
@@ -695,13 +853,17 @@ internal sealed class SqlConnectorImport
         SqlKeysetPageRequest request,
         SqlDeltaPagePosition page,
         SqlDeltaValue? watermark,
-        IReadOnlyList<string> columns)
+        IReadOnlyList<string> columns,
+        IReadOnlyList<SqlRelatedChange>? relatedChanges = null)
     {
         using var command = _provider.CreateCommand(_connection, _provider.BuildKeysetPageCommandText(request));
         command.Parameters.Add(_provider.CreateParameter(PageSizeParameterName, _runProfile.PageSize));
 
         if (request.HasChangeFilter)
+        {
             command.Parameters.Add(_provider.CreateParameter(WatermarkParameterName, BindDeltaValue(plan, watermark!, "watermark")));
+            BindRelatedWatermarks(command, plan, relatedChanges ?? []);
+        }
 
         for (var index = 0; index < page.Position.Count; index++)
             command.Parameters.Add(_provider.CreateParameter(AnchorParameterName(index), BindDeltaValue(plan, page.Position[index], "pagination token")));
@@ -904,11 +1066,19 @@ internal sealed class SqlConnectorImport
         return count == null || count == DBNull.Value ? 0 : Convert.ToInt64(count, CultureInfo.InvariantCulture);
     }
 
-    private string BuildFromClause(SqlImportPlan plan)
+    /// <summary>
+    /// What an object type's rows are read from. A statement standing in for a table is always named,
+    /// because a derived table has to be; a table or view is named only where a correlated subquery
+    /// refers back to its columns, so every statement that needed no alias before still generates none.
+    /// </summary>
+    private string BuildFromClause(SqlImportPlan plan, bool aliased = false)
     {
-        return plan.Configuration.IsCustomSelect
-            ? $"({plan.Configuration.SelectStatement}) {_provider.QuoteIdentifier(SqlKeysetPageRequest.SourceAlias)}"
-            : _provider.QualifyObjectName(plan.Configuration.SchemaName, plan.Configuration.TableName!);
+        if (plan.Configuration.IsCustomSelect)
+            return $"({plan.Configuration.SelectStatement}) {_provider.QuoteIdentifier(SqlKeysetPageRequest.SourceAlias)}";
+
+        var qualifiedObjectName = _provider.QualifyObjectName(plan.Configuration.SchemaName, plan.Configuration.TableName!);
+
+        return aliased ? $"{qualifiedObjectName} {_provider.QuoteIdentifier(SqlKeysetPageRequest.SourceAlias)}" : qualifiedObjectName;
     }
 
     #endregion
@@ -1470,6 +1640,12 @@ internal sealed record SqlDeltaKeysetColumn(string Name, AttributeDataType? Type
 /// One change a change log records, reduced to what JIM acts on.
 /// </summary>
 internal sealed record SqlChangeLogEntry(string AnchorKey, object?[] AnchorValues, ObjectChangeType ChangeType, string? UnmappedChangeType);
+
+/// <summary>
+/// One related table a Watermark Column page watches for changes to its parent object, and the
+/// watermark it is compared against (null where JIM holds none for it yet).
+/// </summary>
+internal sealed record SqlRelatedChange(SqlRelatedChangeSource Source, SqlDeltaValue? Watermark);
 
 /// <summary>
 /// What one page of a Delta Import produced, and where the next one resumes from (null where this page

--- a/src/JIM.Connectors/Sql/SqlConnectorWatermark.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorWatermark.cs
@@ -57,6 +57,14 @@ internal sealed record SqlDeltaValue(string Value, AttributeDataType Type);
 /// System's declared time zone the way an imported date and time is. Interpreting it would move the
 /// boundary by the offset and re-read, or skip, whatever fell inside it.
 /// </para>
+/// <para>
+/// <b>Every source keeps its own watermark, never a single maximum across them.</b> In Watermark Column
+/// mode an object type's related tables are separate sources with separate columns: a version number
+/// here, a last-modified timestamp there, each moved by its own writers. One value taken across all of
+/// them would be the highest any of them had reached, and using it as the others' boundary would skip
+/// everything that had happened to them below it, permanently. Per-source watermarks cost a few bytes of
+/// persisted state and are the only arrangement that cannot lose a change.
+/// </para>
 /// </remarks>
 internal sealed record SqlConnectorWatermark
 {
@@ -80,6 +88,25 @@ internal sealed record SqlConnectorWatermark
     /// the beginning, which is the only answer that cannot miss one.
     /// </summary>
     public Dictionary<string, SqlDeltaValue> ObjectTypes { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The watermark per related table of each configured Object Type, keyed by the Object Type's name
+    /// and then by the attribute the related table supplies. Only Watermark Column mode records these:
+    /// a change log states what happened to the object however it happened, so its related tables have
+    /// nothing of their own to remember.
+    /// </summary>
+    /// <remarks>
+    /// A related table absent from here has no watermark yet, which is what a Connected System imported
+    /// before this Connector watched related tables looks like, and what a newly added related table
+    /// looks like. It reads from the beginning once, which is the only answer that cannot miss a change.
+    /// </remarks>
+    public Dictionary<string, Dictionary<string, SqlDeltaValue>> RelatedTables { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// What JIM holds for one Object Type's related tables, empty where it holds nothing for any of them.
+    /// </summary>
+    internal IReadOnlyDictionary<string, SqlDeltaValue> RelatedTablesFor(string objectTypeName) =>
+        RelatedTables.TryGetValue(objectTypeName, out var relatedTables) ? relatedTables : new Dictionary<string, SqlDeltaValue>(StringComparer.OrdinalIgnoreCase);
 
     internal string Serialise() => JsonSerializer.Serialize(this, SerialisationOptions);
 
@@ -109,9 +136,16 @@ internal sealed record SqlConnectorWatermark
         if (watermark == null || watermark.Mode == SqlDeltaImportMode.NotSet)
             return null;
 
-        // Object type names are matched the way they are everywhere else in this Connector, which the
-        // deserialiser's own ordinal dictionary would not do.
-        return watermark with { ObjectTypes = new Dictionary<string, SqlDeltaValue>(watermark.ObjectTypes, StringComparer.OrdinalIgnoreCase) };
+        // Object type and attribute names are matched the way they are everywhere else in this Connector,
+        // which the deserialiser's own ordinal dictionaries would not do.
+        return watermark with
+        {
+            ObjectTypes = new Dictionary<string, SqlDeltaValue>(watermark.ObjectTypes, StringComparer.OrdinalIgnoreCase),
+            RelatedTables = watermark.RelatedTables.ToDictionary(
+                objectType => objectType.Key,
+                objectType => new Dictionary<string, SqlDeltaValue>(objectType.Value, StringComparer.OrdinalIgnoreCase),
+                StringComparer.OrdinalIgnoreCase)
+        };
     }
 
     /// <summary>

--- a/src/JIM.Connectors/Sql/SqlObjectTypeConfiguration.cs
+++ b/src/JIM.Connectors/Sql/SqlObjectTypeConfiguration.cs
@@ -169,4 +169,16 @@ internal sealed record SqlRelatedTableConfiguration
     /// rather than data. Group membership is exactly this shape.
     /// </summary>
     internal string? ReferencesObjectType { get; init; }
+
+    /// <summary>
+    /// The column on this related table whose value moves whenever one of its rows changes. Read by
+    /// Delta Imports in Watermark Column mode, and ignored by every other mode.
+    /// </summary>
+    /// <remarks>
+    /// A change confined to a related table (a group membership added, a phone number revoked) never
+    /// touches the parent row, so the parent's own watermark does not move and the change would go
+    /// undetected. This is what lets the parent be selected on its related tables' evidence as well as
+    /// its own, which is why Watermark Column mode refuses a related table without one.
+    /// </remarks>
+    internal string? WatermarkColumn { get; init; }
 }

--- a/src/JIM.Connectors/Sql/SqlSchemaConfiguration.cs
+++ b/src/JIM.Connectors/Sql/SqlSchemaConfiguration.cs
@@ -230,9 +230,18 @@ internal sealed record SqlSchemaConfiguration
     /// same document is valid under one mode and unusable under the other.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Every object type has to be covered, not just some. A Delta Import that silently skips an object
     /// type reports success while leaving that type's objects to drift, and no administrator would read
     /// a green Activity as "except for Groups".
+    /// </para>
+    /// <para>
+    /// In Watermark Column mode that extends to every related table, for the same reason one step down:
+    /// a membership added or revoked never moves the parent row's own watermark, so a related table with
+    /// no watermark of its own is a source of changes JIM could never see. Permitting it would make
+    /// undetected drift the default rather than a fault, so it is refused at save time; the alternative
+    /// costs nothing to configure and everything to diagnose.
+    /// </para>
     /// </remarks>
     /// <exception cref="SqlSchemaConfigurationException">An Object Type has nothing for this mode to read.</exception>
     internal void ValidateDeltaImportMode(SqlDeltaImportMode mode)
@@ -250,8 +259,21 @@ internal sealed record SqlSchemaConfiguration
                     throw new SqlSchemaConfigurationException(
                         $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeWatermarkColumn}', but Object Type '{objectType.Name}' has no 'watermarkColumn'. " +
                         "A Delta Import that skipped an object type would report success while leaving its objects to drift, so every object type needs one.");
+
+                case SqlDeltaImportMode.WatermarkColumn:
+                    ValidateRelatedTableWatermarkColumns(objectType);
+                    break;
             }
         }
+    }
+
+    /// <exception cref="SqlSchemaConfigurationException">A related table has no watermark column for this mode to read.</exception>
+    private static void ValidateRelatedTableWatermarkColumns(SqlObjectTypeConfiguration objectType)
+    {
+        foreach (var relatedTable in objectType.RelatedTables.Where(relatedTable => relatedTable.WatermarkColumn == null))
+            throw new SqlSchemaConfigurationException(
+                $"{SqlConnectorConstants.SettingDeltaImportMode} is '{SqlConnectorConstants.DeltaImportModeWatermarkColumn}', but Object Type '{objectType.Name}' has related table attribute '{relatedTable.AttributeName}' with no 'watermarkColumn'. " +
+                $"A row added to or removed from '{relatedTable.TableName}' changes the object without touching its own row, so without a watermark column on the related table that change could never be detected.");
     }
 
     private static List<string> ReadAnchorColumns(ObjectTypeDocument document, string objectTypeName)
@@ -334,6 +356,9 @@ internal sealed record SqlSchemaConfiguration
             foreach (var joinColumn in relatedTable.JoinColumns)
                 ValidateIdentifier(joinColumn, objectTypeName, $"relatedTables['{attributeName}'].joinColumns");
 
+            if (!string.IsNullOrWhiteSpace(relatedTable.WatermarkColumn))
+                ValidateIdentifier(relatedTable.WatermarkColumn, objectTypeName, $"relatedTables['{attributeName}'].watermarkColumn");
+
             relatedTables.Add(new SqlRelatedTableConfiguration
             {
                 AttributeName = attributeName,
@@ -341,7 +366,8 @@ internal sealed record SqlSchemaConfiguration
                 TableName = relatedTable.Table!,
                 ValueColumn = relatedTable.ValueColumn!,
                 JoinColumns = [.. relatedTable.JoinColumns.Select(joinColumn => joinColumn!)],
-                ReferencesObjectType = string.IsNullOrWhiteSpace(relatedTable.ReferencesObjectType) ? null : relatedTable.ReferencesObjectType.Trim()
+                ReferencesObjectType = string.IsNullOrWhiteSpace(relatedTable.ReferencesObjectType) ? null : relatedTable.ReferencesObjectType.Trim(),
+                WatermarkColumn = string.IsNullOrWhiteSpace(relatedTable.WatermarkColumn) ? null : relatedTable.WatermarkColumn
             });
         }
 
@@ -481,6 +507,8 @@ internal sealed record SqlSchemaConfiguration
         public List<string?>? JoinColumns { get; set; }
 
         public string? ReferencesObjectType { get; set; }
+
+        public string? WatermarkColumn { get; set; }
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
@@ -199,6 +199,83 @@ public class OracleProviderTests
         });
     }
 
+    [Test]
+    public void BuildKeysetPageCommandText_WatermarkPageWithARelatedTable_AlsoSelectsParentsWhoseRelatedRowsChanged()
+    {
+        var request = new SqlKeysetPageRequest
+        {
+            SchemaName = "HR",
+            ObjectName = "EMPLOYEES",
+            SelectColumns = ["EMPLOYEE_ID", "FIRST_NAME"],
+            AnchorColumns = ["EMPLOYEE_ID"],
+            PageSizeParameterName = "pageSize",
+            ChangeColumn = "LAST_MODIFIED",
+            ChangeParameterName = "watermark",
+            RelatedChangeSources =
+            [
+                new SqlRelatedChangeSource
+                {
+                    SchemaName = "HR",
+                    TableName = "EMPLOYEE_PHONES",
+                    JoinColumns = ["EMPLOYEE_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark0"
+                }
+            ]
+        };
+
+        var sql = _provider.BuildKeysetPageCommandText(request);
+
+        Assert.That(sql, Is.EqualTo(
+            "SELECT \"EMPLOYEE_ID\", \"FIRST_NAME\" FROM \"HR\".\"EMPLOYEES\" \"JIM_SOURCE\" " +
+            "WHERE (\"LAST_MODIFIED\" > :watermark OR EXISTS (SELECT 1 FROM \"HR\".\"EMPLOYEE_PHONES\" \"JIM_RELATED0\" " +
+            "WHERE \"JIM_RELATED0\".\"EMPLOYEE_ID\" = \"JIM_SOURCE\".\"EMPLOYEE_ID\" AND \"JIM_RELATED0\".\"ROW_CHANGED\" > :relatedWatermark0)) " +
+            "ORDER BY \"EMPLOYEE_ID\" FETCH FIRST :pageSize ROWS ONLY"),
+            "A membership added or revoked never moves the parent row's own watermark, so the parent has to be selectable on its related table's evidence too.");
+    }
+
+    [Test]
+    public void BuildKeysetPageCommandText_WatermarkPageWithTwoRelatedTables_OrsOneExistsPerRelatedTable()
+    {
+        var request = new SqlKeysetPageRequest
+        {
+            ObjectName = "EMPLOYEES",
+            SelectColumns = ["EMPLOYEE_ID"],
+            AnchorColumns = ["EMPLOYEE_ID"],
+            PageSizeParameterName = "pageSize",
+            ChangeColumn = "LAST_MODIFIED",
+            ChangeParameterName = "watermark",
+            RelatedChangeSources =
+            [
+                new SqlRelatedChangeSource
+                {
+                    TableName = "EMPLOYEE_PHONES",
+                    JoinColumns = ["EMPLOYEE_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark0"
+                },
+                new SqlRelatedChangeSource
+                {
+                    TableName = "EMPLOYEE_GROUPS",
+                    JoinColumns = ["EMPLOYEE_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark1"
+                }
+            ]
+        };
+
+        var sql = _provider.BuildKeysetPageCommandText(request);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sql, Does.Contain("EXISTS (SELECT 1 FROM \"EMPLOYEE_PHONES\" \"JIM_RELATED0\" WHERE \"JIM_RELATED0\".\"EMPLOYEE_ID\" = \"JIM_SOURCE\".\"EMPLOYEE_ID\" AND \"JIM_RELATED0\".\"ROW_CHANGED\" > :relatedWatermark0)"));
+            Assert.That(sql, Does.Contain("EXISTS (SELECT 1 FROM \"EMPLOYEE_GROUPS\" \"JIM_RELATED1\" WHERE \"JIM_RELATED1\".\"EMPLOYEE_ID\" = \"JIM_SOURCE\".\"EMPLOYEE_ID\" AND \"JIM_RELATED1\".\"ROW_CHANGED\" > :relatedWatermark1)"),
+                "Each related table carries its own watermark, so each one gets its own correlated subquery rather than being folded into a single join.");
+            Assert.That(sql, Does.Not.Contain("JOIN"),
+                "A join would return one parent row per matching related row, which is how a page silently turns into duplicate objects.");
+        });
+    }
+
     #endregion
 
     #region Generated keys

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
@@ -68,6 +68,113 @@ public class SqlConnectorDeltaImportTests
         }
         """;
 
+    /// <summary>
+    /// The same object type again, with a multi-valued attribute in a related table that carries a
+    /// watermark column of its own.
+    /// </summary>
+    private const string WatermarkWithRelatedTableDocument = """
+        {
+          "objectTypes": [
+            {
+              "name": "Person",
+              "schema": "HR",
+              "table": "EMPLOYEES",
+              "anchorColumns": [ "EMPLOYEE_ID" ],
+              "watermarkColumn": "LAST_MODIFIED",
+              "relatedTables": [
+                {
+                  "attributeName": "PhoneNumbers",
+                  "schema": "HR",
+                  "table": "EMPLOYEE_PHONES",
+                  "valueColumn": "PHONE_NUMBER",
+                  "joinColumns": [ "EMPLOYEE_ID" ],
+                  "watermarkColumn": "ROW_CHANGED"
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// Two related tables, each with a watermark column of its own, which is the shape a Person with
+    /// phone numbers and group memberships has.
+    /// </summary>
+    private const string WatermarkWithTwoRelatedTablesDocument = """
+        {
+          "objectTypes": [
+            {
+              "name": "Person",
+              "schema": "HR",
+              "table": "EMPLOYEES",
+              "anchorColumns": [ "EMPLOYEE_ID" ],
+              "watermarkColumn": "LAST_MODIFIED",
+              "relatedTables": [
+                {
+                  "attributeName": "PhoneNumbers",
+                  "schema": "HR",
+                  "table": "EMPLOYEE_PHONES",
+                  "valueColumn": "PHONE_NUMBER",
+                  "joinColumns": [ "EMPLOYEE_ID" ],
+                  "watermarkColumn": "ROW_CHANGED"
+                },
+                {
+                  "attributeName": "GroupNames",
+                  "schema": "HR",
+                  "table": "EMPLOYEE_GROUPS",
+                  "valueColumn": "GROUP_NAME",
+                  "joinColumns": [ "EMPLOYEE_ID" ],
+                  "watermarkColumn": "ROW_CHANGED"
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// A related table with no watermark column, which Watermark Column mode refuses.
+    /// </summary>
+    private const string WatermarkWithUnwatchedRelatedTableDocument = """
+        {
+          "objectTypes": [
+            {
+              "name": "Person",
+              "schema": "HR",
+              "table": "EMPLOYEES",
+              "anchorColumns": [ "EMPLOYEE_ID" ],
+              "watermarkColumn": "LAST_MODIFIED",
+              "relatedTables": [
+                {
+                  "attributeName": "PhoneNumbers",
+                  "schema": "HR",
+                  "table": "EMPLOYEE_PHONES",
+                  "valueColumn": "PHONE_NUMBER",
+                  "joinColumns": [ "EMPLOYEE_ID" ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// Before the watermark every test below reads from; a row carrying this has not changed.
+    /// </summary>
+    private static readonly DateTime BeforeTheWatermark = new(2026, 7, 15, 9, 0, 0, DateTimeKind.Unspecified);
+
+    /// <summary>
+    /// After the watermark every test below reads from; a row carrying this has changed.
+    /// </summary>
+    private static readonly DateTime AfterTheWatermark = new(2026, 7, 16, 9, 0, 0, DateTimeKind.Unspecified);
+
+    /// <summary>
+    /// Later still, so a test can tell one source's highest value from another's.
+    /// </summary>
+    private static readonly DateTime LaterStill = new(2026, 7, 20, 9, 0, 0, DateTimeKind.Unspecified);
+
+    private const string TheWatermark = "2026-07-15T12:00:00.0000000Z";
+
     #endregion
 
     private ILogger _logger = null!;
@@ -354,6 +461,133 @@ public class SqlConnectorDeltaImportTests
                 "Watermark Column mode detects creates and updates only; deletions need the change-log table, or a periodic Full Import.");
             Assert.That(AnchorValues(run), Is.EqualTo(new[] { 2 }));
         });
+    }
+
+    #endregion
+
+    #region Watermark column mode: related tables
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeRelatedRowChangedButTheParentDidNot_ImportsTheParentWithItsMultiValuedAttributes()
+    {
+        // Ada's phone number changed; her own row did not, so her LAST_MODIFIED has not moved.
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", BeforeTheWatermark], [2, "Grace", BeforeTheWatermark]],
+            phones: [[1, "0100", AfterTheWatermark], [1, "0101", BeforeTheWatermark], [2, "0200", BeforeTheWatermark]]);
+
+        var run = await RunWatermarkDeltaAsync(provider, WatermarkWithRelatedTableDocument, RelatedWatermarkSystem(),
+            PersonWatermark(TheWatermark, ("PhoneNumbers", TheWatermark)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1 }),
+                "A phone number added or replaced is a change to the person it belongs to, and it never moves the person's own row.");
+            Assert.That(AttributeOf(run.ImportObjects[0], "PhoneNumbers").StringValues, Is.EquivalentTo(new[] { "0100", "0101" }),
+                "The object is imported whole, so its multi-valued attributes are gathered as they now stand rather than only the values that moved.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeSeveralRelatedTables_SelectsAParentChangedInAnyOfThem()
+    {
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", BeforeTheWatermark], [2, "Grace", BeforeTheWatermark], [3, "Katherine", BeforeTheWatermark]],
+            phones: [[1, "0100", AfterTheWatermark], [2, "0200", BeforeTheWatermark]],
+            groups: [[2, "Payroll", AfterTheWatermark], [3, "Research", BeforeTheWatermark]]);
+
+        var run = await RunWatermarkDeltaAsync(provider, WatermarkWithTwoRelatedTablesDocument, RelatedWatermarkSystem(withGroups: true),
+            PersonWatermark(TheWatermark, ("PhoneNumbers", TheWatermark), ("GroupNames", TheWatermark)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1, 2 }),
+                "Each related table is evidence of a change on its own; Katherine's rows are all older than the watermark, so nothing about her changed.");
+            Assert.That(AttributeOf(ObjectWithAnchor(run, 2), "GroupNames").StringValues, Is.EqualTo(new[] { "Payroll" }));
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeRelatedTableWithNoChanges_DoesNotSelectTheParent()
+    {
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", BeforeTheWatermark], [2, "Grace", BeforeTheWatermark]],
+            phones: [[1, "0100", BeforeTheWatermark], [2, "0200", BeforeTheWatermark]]);
+
+        var run = await RunWatermarkDeltaAsync(provider, WatermarkWithRelatedTableDocument, RelatedWatermarkSystem(),
+            PersonWatermark(TheWatermark, ("PhoneNumbers", TheWatermark)));
+
+        Assert.That(run.ImportObjects, Is.Empty,
+            "Watching a related table must not turn every Delta Import into a Full Import: a parent is selected only where something beyond the watermark exists.");
+    }
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeParentAndItsRelatedTableBothChanged_ImportsTheObjectOnce()
+    {
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", AfterTheWatermark]],
+            phones: [[1, "0100", AfterTheWatermark], [1, "0101", AfterTheWatermark]]);
+
+        var run = await RunWatermarkDeltaAsync(provider, WatermarkWithRelatedTableDocument, RelatedWatermarkSystem(),
+            PersonWatermark(TheWatermark, ("PhoneNumbers", TheWatermark)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(run.ImportObjects, Has.Count.EqualTo(1),
+                "The page selects parent rows, so an object changed in two places at once is still one object; a join to the related table would have produced one per matching row.");
+            Assert.That(AttributeOf(run.ImportObjects[0], "PhoneNumbers").StringValues, Is.EquivalentTo(new[] { "0100", "0101" }));
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeWithRelatedTables_CapturesAWatermarkForEachSourceSeparately()
+    {
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", AfterTheWatermark]],
+            phones: [[1, "0100", LaterStill]]);
+
+        var store = Store(PersonWatermark(TheWatermark, ("PhoneNumbers", TheWatermark)));
+        await RunWatermarkDeltaAsync(provider, WatermarkWithRelatedTableDocument, RelatedWatermarkSystem(), store);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(PersonWatermarkValueOf(store.Value), Is.EqualTo(TokenFor(AfterTheWatermark)),
+                "Each source's watermark comes from its own column. A single maximum across all of them would push the primary source's boundary past changes nobody has read, and lose them for ever.");
+            Assert.That(RelatedWatermarkValueOf(store.Value, "PhoneNumbers"), Is.EqualTo(TokenFor(LaterStill)),
+                "Without a watermark of its own, a related table would either be re-read in full on every run for ever, or never re-read at all.");
+        });
+    }
+
+    [Test]
+    public async Task ImportAsync_WatermarkColumnModeMoreRelatedChangesThanOnePage_PagesThroughThemAndStops()
+    {
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", BeforeTheWatermark], [2, "Grace", BeforeTheWatermark], [3, "Katherine", BeforeTheWatermark]],
+            phones: [[1, "0100", AfterTheWatermark], [2, "0200", AfterTheWatermark], [3, "0300", AfterTheWatermark]]);
+
+        var run = await RunWatermarkDeltaAsync(provider, WatermarkWithRelatedTableDocument, RelatedWatermarkSystem(),
+            PersonWatermark(TheWatermark, ("PhoneNumbers", TheWatermark)), pageSize: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AnchorValues(run), Is.EqualTo(new[] { 1, 2, 3 }),
+                "Every changed object arrives exactly once, which is only true if each page seeked past the last anchor of the one before it.");
+            Assert.That(run.Pages, Has.Count.EqualTo(4), "Three changes at one per page is three full pages and a short one.");
+            Assert.That(run.Pages[^1].PaginationTokens, Is.Empty,
+                "An empty pagination token list is how JIM is told there is no more data; returning one forever is an infinite import.");
+        });
+    }
+
+    [Test]
+    public void ImportAsync_WatermarkColumnModeRelatedTableWithNoWatermarkColumn_RefusesToRun()
+    {
+        var provider = RelatedWatermarkProvider(
+            employees: [[1, "Ada", BeforeTheWatermark]],
+            phones: [[1, "0100", AfterTheWatermark]]);
+
+        Assert.That(async () => await RunWatermarkDeltaAsync(provider, WatermarkWithUnwatchedRelatedTableDocument, RelatedWatermarkSystem(),
+                PersonWatermark(TheWatermark)),
+            Throws.TypeOf<SqlSchemaConfigurationException>().With.Message.Contains("PhoneNumbers"),
+            "Save-time validation refuses this configuration, and a run reaching it anyway (the document was changed since) must fail rather than quietly stop detecting membership changes.");
     }
 
     #endregion
@@ -742,10 +976,61 @@ public class SqlConnectorDeltaImportTests
         return provider;
     }
 
+    /// <summary>
+    /// The same, with one or two related tables whose rows carry a last-modified column of their own.
+    /// </summary>
+    private static FakeSqlProvider RelatedWatermarkProvider(object?[][] employees, object?[][] phones, object?[][]? groups = null)
+    {
+        var provider = WatermarkProvider(employees);
+        provider.Catalogue.AddRows("HR", "EMPLOYEE_PHONES", ["EMPLOYEE_ID", "PHONE_NUMBER", "ROW_CHANGED"], phones);
+
+        if (groups != null)
+            provider.Catalogue.AddRows("HR", "EMPLOYEE_GROUPS", ["EMPLOYEE_ID", "GROUP_NAME", "ROW_CHANGED"], groups);
+
+        return provider;
+    }
+
+    /// <summary>
+    /// Drives a Delta Import in Watermark Column mode to completion.
+    /// </summary>
+    private Task<SqlDeltaRun> RunWatermarkDeltaAsync(
+        FakeSqlProvider provider,
+        string objectTypesDocument,
+        ConnectedSystem connectedSystem,
+        string persistedConnectorData,
+        int pageSize = 10) =>
+        RunWatermarkDeltaAsync(provider, objectTypesDocument, connectedSystem, Store(persistedConnectorData), pageSize);
+
+    private Task<SqlDeltaRun> RunWatermarkDeltaAsync(
+        FakeSqlProvider provider,
+        string objectTypesDocument,
+        ConnectedSystem connectedSystem,
+        PersistedConnectorDataStore store,
+        int pageSize = 10) =>
+        RunDeltaAsync(provider, objectTypesDocument, connectedSystem, pageSize, store, SqlConnectorConstants.DeltaImportModeWatermarkColumn);
+
     private static string PersonWatermark(SqlDeltaImportMode mode, string value, AttributeDataType type = AttributeDataType.Number)
     {
         var watermark = new SqlConnectorWatermark { Mode = mode };
         watermark.ObjectTypes["Person"] = new SqlDeltaValue(value, type);
+        return watermark.Serialise();
+    }
+
+    /// <summary>
+    /// A Watermark Column mode watermark: one for the object type's own source, and one for each related
+    /// table JIM has already read.
+    /// </summary>
+    private static string PersonWatermark(string value, params (string AttributeName, string Value)[] relatedTables)
+    {
+        var watermark = new SqlConnectorWatermark { Mode = SqlDeltaImportMode.WatermarkColumn };
+        watermark.ObjectTypes["Person"] = new SqlDeltaValue(value, AttributeDataType.DateTime);
+
+        if (relatedTables.Length > 0)
+            watermark.RelatedTables["Person"] = relatedTables.ToDictionary(
+                relatedTable => relatedTable.AttributeName,
+                relatedTable => new SqlDeltaValue(relatedTable.Value, AttributeDataType.DateTime),
+                StringComparer.OrdinalIgnoreCase);
+
         return watermark.Serialise();
     }
 
@@ -754,6 +1039,20 @@ public class SqlConnectorDeltaImportTests
         var watermark = SqlConnectorWatermark.TryRead(persistedConnectorData);
         return watermark != null && watermark.ObjectTypes.TryGetValue("Person", out var value) ? value.Value : null;
     }
+
+    private static string? RelatedWatermarkValueOf(string? persistedConnectorData, string attributeName)
+    {
+        var watermark = SqlConnectorWatermark.TryRead(persistedConnectorData);
+        return watermark != null && watermark.RelatedTables.TryGetValue("Person", out var relatedTables) && relatedTables.TryGetValue(attributeName, out var value)
+            ? value.Value
+            : null;
+    }
+
+    /// <summary>
+    /// A date and time as a watermark carries it, so a test states the value it expects rather than its
+    /// rendering.
+    /// </summary>
+    private static string? TokenFor(DateTime value) => SqlConnectorWatermark.Describe(value)?.Value;
 
     private static ConnectedSystem PersonSystem() => new()
     {
@@ -778,11 +1077,35 @@ public class SqlConnectorDeltaImportTests
         ]
     };
 
+    /// <summary>
+    /// The same object type again, with the multi-valued attributes its related tables supply.
+    /// </summary>
+    private static ConnectedSystem RelatedWatermarkSystem(bool withGroups = false)
+    {
+        var attributes = new List<ConnectedSystemObjectTypeAttribute>
+        {
+            Attribute("EMPLOYEE_ID", AttributeDataType.Number, isExternalId: true),
+            Attribute("DISPLAY_NAME", AttributeDataType.Text),
+            Attribute("LAST_MODIFIED", AttributeDataType.DateTime, selected: false),
+            Attribute("PhoneNumbers", AttributeDataType.Text, plurality: AttributePlurality.MultiValued)
+        };
+
+        if (withGroups)
+            attributes.Add(Attribute("GroupNames", AttributeDataType.Text, plurality: AttributePlurality.MultiValued));
+
+        return new ConnectedSystem { Name = "HR Database", ObjectTypes = [ObjectType("Person", [.. attributes])] };
+    }
+
     private static ConnectedSystemObjectType ObjectType(string name, params ConnectedSystemObjectTypeAttribute[] attributes) =>
         new() { Name = name, Selected = true, Attributes = [.. attributes] };
 
-    private static ConnectedSystemObjectTypeAttribute Attribute(string name, AttributeDataType type, bool isExternalId = false, bool selected = true) =>
-        new() { Name = name, Type = type, Selected = selected, IsExternalId = isExternalId, AttributePlurality = AttributePlurality.SingleValued };
+    private static ConnectedSystemObjectTypeAttribute Attribute(
+        string name,
+        AttributeDataType type,
+        bool isExternalId = false,
+        bool selected = true,
+        AttributePlurality plurality = AttributePlurality.SingleValued) =>
+        new() { Name = name, Type = type, Selected = selected, IsExternalId = isExternalId, AttributePlurality = plurality };
 
     private static ConnectedSystemImportObjectAttribute AttributeOf(ConnectedSystemImportObject importObject, string name) =>
         importObject.Attributes.Single(attribute => attribute.Name == name);

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
@@ -440,6 +440,73 @@ public class SqlConnectorDeltaImportTests
     }
 
     [Test]
+    public void ValidateSettingValues_TheDocumentedDeltaExampleInWatermarkColumnMode_IsAccepted()
+    {
+        var connector = new SqlConnector { ProviderFactory = _ => new FakeSqlProvider() };
+        var settingValues = DeltaSettingValues(connector, SqlConnectorConstants.DeltaConfigurationExample, SqlConnectorConstants.DeltaImportModeWatermarkColumn);
+
+        Assert.That(connector.ValidateSettingValues(settingValues, _logger), Is.Empty,
+            "The example shows both modes, so it has to be complete under either one, related tables included.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_WatermarkColumnModeWithARelatedTableThatHasNoWatermarkColumn_IsRefused()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "watermarkColumn": "LAST_MODIFIED",
+                  "relatedTables": [
+                    { "attributeName": "PhoneNumbers", "table": "EMPLOYEE_PHONES", "valueColumn": "PHONE_NUMBER", "joinColumns": [ "EMPLOYEE_ID" ] }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        Assert.That(ValidationMessageFor(document, SqlConnectorConstants.DeltaImportModeWatermarkColumn),
+            Does.Contain("Person").And.Contain("PhoneNumbers").And.Contain("watermarkColumn"),
+            "A related table with no watermark column can never report a change of its own, and a membership that changes without JIM noticing is exactly the silent drift this mode must not have.");
+    }
+
+    [Test]
+    public void ValidateSettingValues_ChangeLogModeWithARelatedTableThatHasNoWatermarkColumn_IsAccepted()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "relatedTables": [
+                    { "attributeName": "PhoneNumbers", "table": "EMPLOYEE_PHONES", "valueColumn": "PHONE_NUMBER", "joinColumns": [ "EMPLOYEE_ID" ] }
+                  ],
+                  "changeLog": {
+                    "table": "EMPLOYEE_CHANGES",
+                    "anchorColumns": [ "EMPLOYEE_ID" ],
+                    "sequenceColumn": "CHANGE_NUMBER",
+                    "changeTypeColumn": "CHANGE_TYPE",
+                    "createValues": [ "I" ],
+                    "updateValues": [ "U" ],
+                    "deleteValues": [ "D" ]
+                  }
+                }
+              ]
+            }
+            """;
+
+        var connector = new SqlConnector { ProviderFactory = _ => new FakeSqlProvider() };
+
+        Assert.That(connector.ValidateSettingValues(DeltaSettingValues(connector, document, SqlConnectorConstants.DeltaImportModeChangeLogTable), _logger), Is.Empty,
+            "A change log records what happened to the object however it happened, so a related table needs no watermark of its own in that mode.");
+    }
+
+    [Test]
     public void ValidateSettingValues_ChangeLogWithNoDeleteValues_IsRefused()
     {
         const string document = """

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
@@ -574,24 +574,40 @@ internal sealed class FakeDbCommand : DbCommand
 
     /// <summary>
     /// Which source this command reads, found by matching the dialect's own qualified name against the
-    /// command text. The longest match wins, so EMPLOYEE_PHONES is never mistaken for EMPLOYEES.
+    /// command text. The source a statement returns rows from is the one its first FROM names: a
+    /// Watermark Column page names its related tables further on, inside correlated subqueries, and
+    /// those decide which parents are returned rather than what is returned.
     /// </summary>
     private FakeSqlDataTable? ResolveDataTable()
     {
         FakeSqlDataTable? match = null;
-        var matchedLength = 0;
+        var matchedIndex = int.MaxValue;
 
         foreach (var dataTable in _provider.Catalogue.DataTables)
         {
-            var qualifiedName = _provider.QualifyObjectName(dataTable.SchemaName, dataTable.ObjectName);
-            if (CommandText.Contains(qualifiedName, StringComparison.Ordinal) && qualifiedName.Length > matchedLength)
+            // Matched with its FROM, so EMPLOYEE_PHONES is never mistaken for EMPLOYEES and neither is
+            // taken from a subquery that merely mentions it.
+            var index = CommandText.IndexOf($"FROM {_provider.QualifyObjectName(dataTable.SchemaName, dataTable.ObjectName)}", StringComparison.Ordinal);
+
+            if (index >= 0 && index < matchedIndex)
             {
                 match = dataTable;
-                matchedLength = qualifiedName.Length;
+                matchedIndex = index;
             }
         }
 
         return match;
+    }
+
+    /// <summary>
+    /// Finds the table a related-table existence test reads, by the qualified name the command text
+    /// gave it.
+    /// </summary>
+    private FakeSqlDataTable ResolveRelatedDataTable(string qualifiedName)
+    {
+        return _provider.Catalogue.DataTables.FirstOrDefault(dataTable =>
+                   string.Equals(_provider.QualifyObjectName(dataTable.SchemaName, dataTable.ObjectName), qualifiedName, StringComparison.Ordinal))
+               ?? throw new FakeDbException($"This stand-in database holds no related table called {qualifiedName}.");
     }
 
     /// <summary>
@@ -726,7 +742,9 @@ internal sealed class FakeDbCommand : DbCommand
 
     /// <summary>
     /// Applies the watermark a Delta Import restricted its read to, so that a test can tell a command
-    /// that asked for changes from one that read everything.
+    /// that asked for changes from one that read everything. A row qualifies on its own watermark or on
+    /// any of the related-table existence tests the command carries, which is exactly the OR the
+    /// Connector asked the database for.
     /// </summary>
     private List<object?[]> FilterByChangeColumn(FakeSqlDataTable dataTable, IEnumerable<object?[]> rows)
     {
@@ -736,8 +754,54 @@ internal sealed class FakeDbCommand : DbCommand
 
         var ordinal = dataTable.IndexOf(changePredicate.Groups["column"].Value);
         var watermark = BoundValue(SqlConnectorImport.WatermarkParameterName);
+        var relatedChanges = ParseRelatedChangePredicates();
 
-        return [.. rows.Where(row => CompareValues(row[ordinal], watermark) > 0)];
+        return [.. rows.Where(row =>
+            CompareValues(row[ordinal], watermark) > 0 ||
+            relatedChanges.Any(relatedChange => HasChangedRelatedRow(dataTable, row, relatedChange)))];
+    }
+
+    /// <summary>
+    /// The related-table existence tests a Watermark Column page carries, read back out of the command
+    /// text it generated: which table, how it correlates to the parent, and which watermark (if any) its
+    /// rows are compared against.
+    /// </summary>
+    private List<FakeRelatedChangePredicate> ParseRelatedChangePredicates()
+    {
+        var predicates = new Dictionary<string, FakeRelatedChangePredicate>(StringComparer.Ordinal);
+
+        foreach (Match match in RelatedSourcePattern.Matches(CommandText))
+            predicates[match.Groups["alias"].Value] = new FakeRelatedChangePredicate(match.Groups["source"].Value);
+
+        foreach (Match match in RelatedCorrelationPattern.Matches(CommandText))
+            predicates[match.Groups["alias"].Value].Correlations.Add((match.Groups["related"].Value, match.Groups["parent"].Value));
+
+        foreach (Match match in RelatedWatermarkPattern.Matches(CommandText))
+        {
+            var predicate = predicates[match.Groups["alias"].Value];
+            predicate.WatermarkColumn = match.Groups["column"].Value;
+            predicate.Watermark = BoundValue(match.Groups["parameter"].Value);
+        }
+
+        return [.. predicates.Values];
+    }
+
+    /// <summary>
+    /// Whether a related table holds a row belonging to this parent that has changed beyond the
+    /// watermark bound for it. A predicate carrying no watermark is satisfied by the row existing at
+    /// all, which is what JIM asks for where it holds no watermark for that related table yet.
+    /// </summary>
+    private bool HasChangedRelatedRow(FakeSqlDataTable parentTable, object?[] parentRow, FakeRelatedChangePredicate predicate)
+    {
+        var relatedTable = ResolveRelatedDataTable(predicate.Source);
+
+        Assert.That(predicate.Correlations, Is.Not.Empty,
+            "A related table must be correlated to the parent it belongs to, or it would select every object whenever anything changed in it.");
+
+        return relatedTable.Rows.Any(relatedRow =>
+            predicate.Correlations.All(correlation =>
+                Equals(relatedRow[relatedTable.IndexOf(correlation.RelatedColumn)], parentRow[parentTable.IndexOf(correlation.ParentColumn)])) &&
+            (predicate.WatermarkColumn == null || CompareValues(relatedRow[relatedTable.IndexOf(predicate.WatermarkColumn)], predicate.Watermark) > 0));
     }
 
     private static readonly Regex JoinPredicatePattern = new(
@@ -745,7 +809,19 @@ internal sealed class FakeDbCommand : DbCommand
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex ChangePredicatePattern = new(
-        @"\[(?<column>[^\]]+)\]\s*>\s*@" + SqlConnectorImport.WatermarkParameterName,
+        @"\[(?<column>[^\]]+)\]\s*>\s*@" + SqlConnectorImport.WatermarkParameterName + @"(?!\d)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex RelatedSourcePattern = new(
+        @"FROM (?<source>\[[^\]]+\](?:\.\[[^\]]+\])?) \[(?<alias>" + SqlRelatedChangeSource.AliasPrefix + @"\d+)\]",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex RelatedCorrelationPattern = new(
+        @"\[(?<alias>" + SqlRelatedChangeSource.AliasPrefix + @"\d+)\]\.\[(?<related>[^\]]+)\] = \[" + SqlKeysetPageRequest.SourceAlias + @"\]\.\[(?<parent>[^\]]+)\]",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex RelatedWatermarkPattern = new(
+        @"\[(?<alias>" + SqlRelatedChangeSource.AliasPrefix + @"\d+)\]\.\[(?<column>[^\]]+)\] > @(?<parameter>\w+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex MaxColumnPattern = new(
@@ -753,6 +829,35 @@ internal sealed class FakeDbCommand : DbCommand
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     #endregion
+}
+
+/// <summary>
+/// One related-table existence test, as a <see cref="FakeDbCommand"/> reads it back out of the command
+/// text it was given.
+/// </summary>
+internal sealed class FakeRelatedChangePredicate
+{
+    internal FakeRelatedChangePredicate(string source)
+    {
+        Source = source;
+    }
+
+    /// <summary>
+    /// The related table's qualified name, exactly as the dialect rendered it.
+    /// </summary>
+    internal string Source { get; }
+
+    /// <summary>
+    /// How a related row is matched to its parent: the related table's column, and the parent's.
+    /// </summary>
+    internal List<(string RelatedColumn, string ParentColumn)> Correlations { get; } = [];
+
+    /// <summary>
+    /// The related table's own watermark column, or null where the test is existence alone.
+    /// </summary>
+    internal string? WatermarkColumn { get; set; }
+
+    internal object? Watermark { get; set; }
 }
 
 /// <summary>

--- a/test/JIM.Worker.Tests/Connectors/SqlObjectTypeConfigurationTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlObjectTypeConfigurationTests.cs
@@ -109,6 +109,63 @@ public class SqlObjectTypeConfigurationTests
     }
 
     [Test]
+    public void Parse_ARelatedTableWithItsOwnWatermarkColumn_ReadsIt()
+    {
+        var configuration = SqlSchemaConfiguration.Parse("""
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "watermarkColumn": "LAST_MODIFIED",
+                  "relatedTables": [
+                    {
+                      "attributeName": "PhoneNumbers",
+                      "table": "EMPLOYEE_PHONES",
+                      "valueColumn": "PHONE_NUMBER",
+                      "joinColumns": [ "EMPLOYEE_ID" ],
+                      "watermarkColumn": "ROW_CHANGED"
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+        Assert.That(configuration.ObjectTypes.Single().RelatedTables.Single().WatermarkColumn, Is.EqualTo("ROW_CHANGED"),
+            "A change confined to a related table never moves the parent row's own watermark, so the related table needs one of its own.");
+    }
+
+    [Test]
+    public void Parse_ARelatedTableWatermarkColumnThatCannotNameAColumn_IsRefused()
+    {
+        var exception = Assert.Throws<SqlSchemaConfigurationException>(() => SqlSchemaConfiguration.Parse("""
+            {
+              "objectTypes": [
+                {
+                  "name": "Person",
+                  "table": "EMPLOYEES",
+                  "anchorColumns": [ "EMPLOYEE_ID" ],
+                  "relatedTables": [
+                    {
+                      "attributeName": "PhoneNumbers",
+                      "table": "EMPLOYEE_PHONES",
+                      "valueColumn": "PHONE_NUMBER",
+                      "joinColumns": [ "EMPLOYEE_ID" ],
+                      "watermarkColumn": " ROW_CHANGED"
+                    }
+                  ]
+                }
+              ]
+            }
+            """));
+
+        Assert.That(exception!.Message, Does.Contain("PhoneNumbers").And.Contain("watermarkColumn"),
+            "A related table's watermark column is validated exactly as every other identifier in the document is.");
+    }
+
+    [Test]
     public void Parse_AReferenceColumn_NamesTheObjectTypeItPointsAt()
     {
         var configuration = SqlSchemaConfiguration.Parse("""

--- a/test/JIM.Worker.Tests/Connectors/SqlServerProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlServerProviderTests.cs
@@ -233,6 +233,110 @@ public class SqlServerProviderTests
     }
 
     [Test]
+    public void BuildKeysetPageCommandText_WatermarkPageWithARelatedTable_AlsoSelectsParentsWhoseRelatedRowsChanged()
+    {
+        var request = new SqlKeysetPageRequest
+        {
+            SchemaName = "dbo",
+            ObjectName = "EMPLOYEES",
+            SelectColumns = ["EMPLOYEE_ID", "FIRST_NAME"],
+            AnchorColumns = ["EMPLOYEE_ID"],
+            PageSizeParameterName = "pageSize",
+            ChangeColumn = "LAST_MODIFIED",
+            ChangeParameterName = "watermark",
+            RelatedChangeSources =
+            [
+                new SqlRelatedChangeSource
+                {
+                    SchemaName = "dbo",
+                    TableName = "EMPLOYEE_PHONES",
+                    JoinColumns = ["EMPLOYEE_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark0"
+                }
+            ]
+        };
+
+        var sql = _provider.BuildKeysetPageCommandText(request);
+
+        Assert.That(sql, Is.EqualTo(
+            "SELECT TOP (@pageSize) [EMPLOYEE_ID], [FIRST_NAME] FROM [dbo].[EMPLOYEES] [JIM_SOURCE] " +
+            "WHERE ([LAST_MODIFIED] > @watermark OR EXISTS (SELECT 1 FROM [dbo].[EMPLOYEE_PHONES] [JIM_RELATED0] " +
+            "WHERE [JIM_RELATED0].[EMPLOYEE_ID] = [JIM_SOURCE].[EMPLOYEE_ID] AND [JIM_RELATED0].[ROW_CHANGED] > @relatedWatermark0)) " +
+            "ORDER BY [EMPLOYEE_ID]"),
+            "A membership added or revoked never moves the parent row's own watermark, so the parent has to be selectable on its related table's evidence too.");
+    }
+
+    [Test]
+    public void BuildKeysetPageCommandText_WatermarkPageWithTwoRelatedTables_OrsOneExistsPerRelatedTable()
+    {
+        var request = new SqlKeysetPageRequest
+        {
+            ObjectName = "EMPLOYEES",
+            SelectColumns = ["EMPLOYEE_ID"],
+            AnchorColumns = ["EMPLOYEE_ID"],
+            PageSizeParameterName = "pageSize",
+            ChangeColumn = "LAST_MODIFIED",
+            ChangeParameterName = "watermark",
+            RelatedChangeSources =
+            [
+                new SqlRelatedChangeSource
+                {
+                    TableName = "EMPLOYEE_PHONES",
+                    JoinColumns = ["EMPLOYEE_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark0"
+                },
+                new SqlRelatedChangeSource
+                {
+                    TableName = "EMPLOYEE_GROUPS",
+                    JoinColumns = ["EMPLOYEE_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark1"
+                }
+            ]
+        };
+
+        var sql = _provider.BuildKeysetPageCommandText(request);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sql, Does.Contain("EXISTS (SELECT 1 FROM [EMPLOYEE_PHONES] [JIM_RELATED0] WHERE [JIM_RELATED0].[EMPLOYEE_ID] = [JIM_SOURCE].[EMPLOYEE_ID] AND [JIM_RELATED0].[ROW_CHANGED] > @relatedWatermark0)"));
+            Assert.That(sql, Does.Contain("EXISTS (SELECT 1 FROM [EMPLOYEE_GROUPS] [JIM_RELATED1] WHERE [JIM_RELATED1].[EMPLOYEE_ID] = [JIM_SOURCE].[EMPLOYEE_ID] AND [JIM_RELATED1].[ROW_CHANGED] > @relatedWatermark1)"),
+                "Each related table carries its own watermark, so each one gets its own correlated subquery rather than being folded into a single join.");
+            Assert.That(sql, Does.Not.Contain("JOIN"),
+                "A join would return one parent row per matching related row, which is how a page silently turns into duplicate objects.");
+        });
+    }
+
+    [Test]
+    public void BuildKeysetPageCommandText_RelatedChangeSourceJoiningOnFewerColumnsThanTheAnchorHas_Throws()
+    {
+        var request = new SqlKeysetPageRequest
+        {
+            ObjectName = "ENROLMENTS",
+            SelectColumns = ["STUDENT_ID", "COURSE_ID"],
+            AnchorColumns = ["STUDENT_ID", "COURSE_ID"],
+            PageSizeParameterName = "pageSize",
+            ChangeColumn = "LAST_MODIFIED",
+            ChangeParameterName = "watermark",
+            RelatedChangeSources =
+            [
+                new SqlRelatedChangeSource
+                {
+                    TableName = "ENROLMENT_GRADES",
+                    JoinColumns = ["STUDENT_ID"],
+                    WatermarkColumn = "ROW_CHANGED",
+                    WatermarkParameterName = "relatedWatermark0"
+                }
+            ]
+        };
+
+        Assert.Throws<ArgumentException>(() => _provider.BuildKeysetPageCommandText(request),
+            "Correlating on part of an anchor would attribute another object's changes to this one, so it must fail loudly instead.");
+    }
+
+    [Test]
     public void BuildKeysetPageCommandText_NoAnchorColumns_Throws()
     {
         var request = new SqlKeysetPageRequest


### PR DESCRIPTION
## Summary
Completes the watermark column delta mode landed in #1254, which read the primary source only. A group membership added or removed lives in a related table and does not move the parent row's watermark, so it went undetected: a delta mode that silently misses membership changes is not shippable, and PRD requirement 11 specifies the watermark column on the primary table **and on related tables**.

- A related table now declares its own watermark column, and a page selects a parent row when either the parent's watermark moved **or** any of its related tables holds a changed row for that parent.
- Expressed as a correlated `EXISTS` per related table behind the provider seam, never a join, so a parent changed in two places is still one row. Both dialects generate their own syntax; neither dialect file changed.
- **One watermark per source** rather than a single maximum across them. The sources are independent columns with independent writers, so a global maximum used as a slower source's boundary would permanently skip everything recorded below it. Capture still happens before any change is read.
- **A related table without a watermark column is refused at save time** in this mode, naming the Object Type, attribute and table. Silent non-detection is the defect being fixed, so permitting it quietly would defeat the change. Full Import deliberately does not refuse, because it reads everything anyway and is the recovery route from an unusable watermark.
- The Activity's expected count and the pages share one predicate, so they agree.

## Still not detectable in this mode
A row **removed** from a related table is detected wherever the customer's table records the removal (a soft-delete flag, a tombstone, or the row's watermark being touched). Where a related table **hard-deletes**, nothing remains for a watermark to compare and a revoked membership stays invisible until a Full Import. Parent-row deletions remain undetected in watermark mode, unchanged. Change-log table mode observes all of these; the Phase 8 documentation must state this plainly.

## Test plan
- [x] `dotnet build JIM.sln` clean, zero warnings
- [x] `dotnet test JIM.sln` clean (whole solution green; Worker suite 4193 passed)
- [x] Headline case covered: a related row whose watermark moved, with the parent's watermark unchanged, imports the parent with its multi-valued attributes gathered
- [x] Multiple related tables, an unchanged related table not selecting the parent, and no duplicate object when both moved
- [x] Full Import and change-log SQL verified unchanged: no diff to either dialect provider, and their exact-SQL tests pass unedited

Docs: n/a - the Connector is not yet registered, so it is unreachable by administrators; public documentation ships with the completed feature per the plan's Phase 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)