### PR TITLE
ci: deploy the docs site via the GitHub Actions Pages pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,18 @@
 name: docs
+
+# Build and publish the documentation site to GitHub Pages on every docs change.
+#
+# The site is deployed via the GitHub Actions Pages pipeline (Settings > Pages >
+# Source: GitHub Actions), NOT by pushing to a gh-pages branch. The branch-based
+# route handed the deploy to a GitHub-generated "pages build and deployment"
+# workflow we could neither see nor configure, and its fixed 10-minute timeout
+# failed a deploy that GitHub actually completed a minute later. Owning the
+# deploy step here lets us set that timeout ourselves and drops the extra
+# gh-pages round-trip.
+#
+# publish-api-reference.yml and release.yml publish the same site the same way;
+# all three share the "pages" concurrency group so deploys queue rather than race.
+
 on:
   push:
     branches:
@@ -6,17 +20,17 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+  workflow_dispatch:
+
 permissions:
-  contents: write
+  contents: read
+
 jobs:
-  deploy:
+  build:
+    name: Build site
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
@@ -34,4 +48,31 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install "mkdocs>=1.6,<2" "mkdocs-material>=9.7,<10" "mkdocs-glightbox>=0.4,<1"
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+        with:
+          # 20 minutes, double the action's default. A real deploy of this site
+          # takes seconds, but GitHub's Pages backend has been observed taking
+          # 11 minutes under load, which the default 10-minute timeout failed.
+          timeout: 1200000

--- a/.github/workflows/publish-api-reference.yml
+++ b/.github/workflows/publish-api-reference.yml
@@ -12,26 +12,25 @@ name: Publish API Reference
 #
 # The release workflow automatically updates the reference on every release by
 # extracting the baked-in OpenAPI JSON from the released jim-web Docker image.
+#
+# Deployment goes through the GitHub Actions Pages pipeline rather than a
+# gh-pages branch push; see the header of docs.yml for why, and note that all
+# three publishing workflows share the "pages" concurrency group.
 
 on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  publish:
-    name: Generate and publish
+  build:
+    name: Generate and build
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
-
-      - name: Configure Git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
@@ -49,5 +48,32 @@ jobs:
       - name: Install MkDocs
         run: pip install "mkdocs>=1.6,<2" "mkdocs-material>=9.7,<10" "mkdocs-glightbox>=0.4,<1"
 
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
+    steps:
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+        with:
+          # See docs.yml for why this is raised above the action's 10-minute default.
+          timeout: 1200000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,19 +249,23 @@ jobs:
   # drops it into the docs/ tree, builds the MkDocs site, and deploys to GitHub Pages.
   # This ensures the public API reference at https://docs.junctional.io/api/reference/
   # always matches the latest stable release.
+  #
+  # Deployment goes through the GitHub Actions Pages pipeline rather than a gh-pages
+  # branch push; see the header of docs.yml for why. The deploy-docs job below shares
+  # the "pages" concurrency group with docs.yml and publish-api-reference.yml.
   publish-docs:
     name: Publish Documentation Site
     runs-on: ubuntu-latest
     needs: [validate, build-containers]
+    # Narrower than the workflow-level grant: this job only reads the repo and pulls
+    # the released image. The Pages write happens in deploy-docs.
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
-
-      - name: Configure Git
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Set image prefix
         id: prefix
@@ -295,8 +299,36 @@ jobs:
       - name: Install MkDocs
         run: pip install "mkdocs>=1.6,<2" "mkdocs-material>=9.7,<10" "mkdocs-glightbox>=0.4,<1"
 
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: site
+
+  # Job 3b: Deploy the built documentation site to GitHub Pages.
+  deploy-docs:
+    name: Deploy Documentation Site
+    runs-on: ubuntu-latest
+    needs: publish-docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
+    steps:
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+        with:
+          # See docs.yml for why this is raised above the action's 10-minute default.
+          timeout: 1200000
 
   # Job 4: Publish PowerShell module to PSGallery
   # Depends on build-containers to ensure nothing publishes if Docker builds fail


### PR DESCRIPTION
## Why

The docs site was published by pushing to a `gh-pages` branch, which handed the actual deployment to a GitHub-generated *"pages build and deployment"* workflow we could neither see nor configure. Its fixed 10-minute timeout [failed the deploy for `9c61dc2e`](https://github.com/TetronIO/JIM/actions/runs/31111316113) even though GitHub completed the publish a minute later, leaving a red deployment against a site that was in fact live and current.

## What changed

The site is built here and the artifact deployed directly, so the timeout is ours to set (raised to 20 minutes) and the `gh-pages` round-trip disappears.

All three publishing workflows move together; leaving any one on `gh-deploy` would have made it silently stop deploying once the Pages source changes:

| Workflow | Change |
|---|---|
| `docs.yml` | Split into `build` + `deploy`; gains `workflow_dispatch` for manual republishing |
| `publish-api-reference.yml` | Same split |
| `release.yml` | `publish-docs` builds and uploads; new `deploy-docs` job deploys |

All three share the `pages` concurrency group so deploys queue rather than race.

`contents: write` is no longer needed anywhere: `docs.yml` and `publish-api-reference.yml` drop to `contents: read`, and `release.yml`'s `publish-docs` narrows the workflow-level grant to `contents: read` + `packages: read`.

## Deployment step required

**Settings → Pages → Source must be set to "GitHub Actions"** immediately after this merges. Between merge and flip, a docs push to `main` would build but not deploy; the live site keeps serving throughout either way. The `gh-pages` branch is left in place as a rollback path.

## Verification

- `mkdocs build` produces `site/` with `CNAME` and `api/reference/v1.json` intact (160 files)
- All three workflow files parse as valid YAML with the expected job graphs

Docs: n/a - CI/CD only, no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)