### PR TITLE
fix: make export-created container auto-selection scope-aware (#351)

### DIFF
--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -2556,16 +2556,11 @@ public class ConnectedSystemServer
                     ? FindContainerByExternalId(partition.Containers, parentExternalId)
                     : null;
 
-                // Determine if any ancestor container is already selected.
-                // If so, this new container is already implicitly included via the ancestor's subtree search,
-                // so we should NOT select it separately (that would cause duplicate imports).
-                var hasSelectedAncestor = IsAnyAncestorSelected(parentContainer);
-
-                // Only auto-select if:
-                // 1. It's a top-level container in a selected partition, OR
-                // 2. No ancestor is selected (meaning this branch wasn't previously covered)
-                // In practice, if parent is selected, we do NOT select the child - it's already covered by subtree.
-                var shouldSelect = !hasSelectedAncestor && (parentContainer == null && partition.Selected);
+                // Whether the new container needs selecting turns on Container Scope: a selected Subtree ancestor's
+                // search already covers it (selecting it too would import the same objects twice), whereas a selected
+                // OneLevel ancestor stops short of it (leaving it unselected would mean the objects just provisioned
+                // into it are never imported). ConnectedSystemUtilities owns that rule for every caller.
+                var shouldSelect = ConnectedSystemUtilities.NewContainerNeedsSelecting(parentContainer, partition.Selected);
 
                 // Create the new container using connector's method to extract display name
                 var containerName = containerCreator.GetContainerDisplayName(containerExternalId);
@@ -2589,16 +2584,8 @@ public class ConnectedSystemServer
                 }
 
                 containersAdded++;
-                if (hasSelectedAncestor)
-                {
-                    Log.Information("RefreshAndAutoSelectContainersAsync: Added container {ContainerExternalId}, Selected: False (ancestor already selected, implicitly included via subtree)",
-                        containerExternalId);
-                }
-                else
-                {
-                    Log.Information("RefreshAndAutoSelectContainersAsync: Added container {ContainerExternalId}, Selected: {Selected}",
-                        containerExternalId, shouldSelect);
-                }
+                Log.Information("RefreshAndAutoSelectContainersAsync: Added container {ContainerExternalId}, Selected: {Selected}",
+                    containerExternalId, shouldSelect);
             }
             catch (Exception ex)
             {
@@ -2687,12 +2674,8 @@ public class ConnectedSystemServer
                     ? FindContainerByExternalId(partition.Containers, parentExternalId)
                     : null;
 
-                // Determine if any ancestor container is already selected.
-                // If so, this new container is already implicitly included via the ancestor's subtree search.
-                var hasSelectedAncestor = IsAnyAncestorSelected(parentContainer);
-
-                // Only auto-select if no ancestor is selected and it's a top-level container in a selected partition
-                var shouldSelect = !hasSelectedAncestor && (parentContainer == null && partition.Selected);
+                // Scope-aware coverage; see the sibling overload above for why a OneLevel ancestor does not cover this.
+                var shouldSelect = ConnectedSystemUtilities.NewContainerNeedsSelecting(parentContainer, partition.Selected);
 
                 // Create the new container using connector's method to extract display name
                 var containerName = containerCreator.GetContainerDisplayName(containerExternalId);
@@ -2716,16 +2699,8 @@ public class ConnectedSystemServer
                 }
 
                 containersAdded++;
-                if (hasSelectedAncestor)
-                {
-                    Log.Information("RefreshAndAutoSelectContainersWithTriadAsync: Added container {ContainerExternalId}, Selected: False (ancestor already selected)",
-                        containerExternalId);
-                }
-                else
-                {
-                    Log.Information("RefreshAndAutoSelectContainersWithTriadAsync: Added container {ContainerExternalId}, Selected: {Selected}",
-                        containerExternalId, shouldSelect);
-                }
+                Log.Information("RefreshAndAutoSelectContainersWithTriadAsync: Added container {ContainerExternalId}, Selected: {Selected}",
+                    containerExternalId, shouldSelect);
             }
             catch (Exception ex)
             {
@@ -3210,22 +3185,6 @@ public class ConnectedSystemServer
         return result;
     }
     #endregion
-
-    /// <summary>
-    /// Checks if any ancestor container in the hierarchy is selected.
-    /// Used to determine if a new child container is already implicitly included via a parent's subtree search.
-    /// </summary>
-    private static bool IsAnyAncestorSelected(ConnectedSystemContainer? container)
-    {
-        var current = container;
-        while (current != null)
-        {
-            if (current.Selected)
-                return true;
-            current = current.ParentContainer;
-        }
-        return false;
-    }
 
     private static ConnectedSystemContainer BuildConnectedSystemContainerTree(ConnectorContainer connectorContainer)
     {

--- a/src/JIM.Utilities/ConnectedSystemUtilities.cs
+++ b/src/JIM.Utilities/ConnectedSystemUtilities.cs
@@ -7,29 +7,6 @@ namespace JIM.Utilities;
 public static class ConnectedSystemUtilities
 {
     /// <summary>
-    /// Generates a list of all selected containers in a partition container hierarchy. Uses recursion to walk the hierarchy.
-    /// </summary>
-    public static List<ConnectedSystemContainer> GetAllSelectedContainers(ConnectedSystemPartition connectedSystemPartition)
-    {
-        if (connectedSystemPartition == null)
-            throw new ArgumentNullException(nameof(connectedSystemPartition));
-
-        if (connectedSystemPartition.Containers == null)
-            throw new ArgumentException("ConnectedSystemContainer.Containers is null", nameof(connectedSystemPartition.Containers));
-
-        var selectedContainers = new List<ConnectedSystemContainer>();
-        foreach (var rootContainer in connectedSystemPartition.Containers)
-        {
-            if (rootContainer.Selected)
-                selectedContainers.Add(rootContainer);
-
-            SearchForSelectedChildContainers(rootContainer, selectedContainers);
-        }
-
-        return selectedContainers;
-    }
-
-    /// <summary>
     /// Generates a list of the selected containers that each need searching in their own right, discarding those
     /// an ancestor's search already covers. Searching a container a selected ancestor already covers would import
     /// the same objects twice.
@@ -107,18 +84,47 @@ public static class ConnectedSystemUtilities
         }
     }
 
-    private static void SearchForSelectedChildContainers(ConnectedSystemContainer container, ICollection<ConnectedSystemContainer> selectedContainers)
+    /// <summary>
+    /// Whether a container newly discovered beneath <paramref name="parentContainer"/> needs selecting in its own
+    /// right for the objects held within it to be imported. Used when a Connector reports containers it created
+    /// during an export, so that objects provisioned into them are imported back.
+    /// </summary>
+    /// <param name="parentContainer">The new container's parent, or null when it sits at the top of a partition.</param>
+    /// <param name="partitionSelected">Whether the partition the new container belongs to is selected.</param>
+    /// <remarks>
+    /// Two rules combine, and the scope of each ancestor decides which applies:
+    /// <list type="bullet">
+    /// <item>A selected Subtree ancestor's search already returns everything beneath it, so selecting the new
+    /// container as well would import the same objects twice.</item>
+    /// <item>A selected OneLevel ancestor returns only the objects held directly within it, so it does not reach
+    /// into the new container. Leaving the new container unselected there would mean the objects just provisioned
+    /// into it are never imported, silently and with nothing to see in the portal.</item>
+    /// </list>
+    /// Beyond coverage, the new container is only wanted where the administrator has already asked for the branch it
+    /// sits in: directly beneath a selected container, or at the top of a selected partition. A container created
+    /// somewhere the administrator never selected must not put itself into scope.
+    /// </remarks>
+    public static bool NewContainerNeedsSelecting(ConnectedSystemContainer? parentContainer, bool partitionSelected)
     {
-        if (container.ChildContainers.Count == 0)
-            return;
+        if (IsCoveredByAnAncestorSearch(parentContainer))
+            return false;
 
-        foreach (var childContainer in container.ChildContainers)
+        return parentContainer?.Selected ?? partitionSelected;
+    }
+
+    /// <summary>
+    /// Whether some ancestor's search already returns the objects held beneath <paramref name="container"/>, walking
+    /// up from <paramref name="container"/> itself.
+    /// </summary>
+    private static bool IsCoveredByAnAncestorSearch(ConnectedSystemContainer? container)
+    {
+        for (var ancestor = container; ancestor != null; ancestor = ancestor.ParentContainer)
         {
-            if (childContainer.Selected)
-                selectedContainers.Add(childContainer);
-
-            SearchForSelectedChildContainers(childContainer, selectedContainers);
+            if (CoversDescendants(ancestor))
+                return true;
         }
+
+        return false;
     }
 
     private static void SearchForTopLevelSelectedChildContainers(ConnectedSystemContainer container, ICollection<ConnectedSystemContainer> selectedContainers)

--- a/test/JIM.Utilities.Tests/ConnectedSystemUtilitiesTests.cs
+++ b/test/JIM.Utilities.Tests/ConnectedSystemUtilitiesTests.cs
@@ -15,114 +15,76 @@ public class ConnectedSystemUtilitiesTests
         _nextId = 1;
     }
 
-    #region GetAllSelectedContainers Tests
+    #region NewContainerNeedsSelecting Tests
 
     [Test]
-    public void GetAllSelectedContainers_WithNullPartition_ThrowsArgumentNullException()
+    public void NewContainerNeedsSelecting_AtTheTopOfASelectedPartition_ReturnsTrue()
     {
-        // Arrange
-        ConnectedSystemPartition? partition = null;
-
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            ConnectedSystemUtilities.GetAllSelectedContainers(partition!));
+        // A container with no parent is covered by nothing, so the partition's own selection decides.
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(null, partitionSelected: true), Is.True);
     }
 
     [Test]
-    public void GetAllSelectedContainers_WithNullContainers_ThrowsArgumentException()
+    public void NewContainerNeedsSelecting_AtTheTopOfAnUnselectedPartition_ReturnsFalse()
     {
-        // Arrange
-        var partition = new ConnectedSystemPartition { Containers = null };
-
-        // Act & Assert
-        Assert.Throws<ArgumentException>(() =>
-            ConnectedSystemUtilities.GetAllSelectedContainers(partition));
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(null, partitionSelected: false), Is.False);
     }
 
     [Test]
-    public void GetAllSelectedContainers_WithNoSelectedContainers_ReturnsEmptyList()
+    public void NewContainerNeedsSelecting_BeneathASelectedSubtreeParent_ReturnsFalse()
     {
-        // Arrange
-        var partition = CreatePartitionWithContainers(
-            CreateContainer("Root1", false),
-            CreateContainer("Root2", false));
+        // The parent's search already returns the new container's objects; selecting it too would import them twice.
+        var parent = CreateContainer("Parent", true);
 
-        // Act
-        var result = ConnectedSystemUtilities.GetAllSelectedContainers(partition);
-
-        // Assert
-        Assert.That(result, Is.Empty);
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(parent, partitionSelected: true), Is.False);
     }
 
     [Test]
-    public void GetAllSelectedContainers_WithSelectedRootContainer_ReturnsRootContainer()
+    public void NewContainerNeedsSelecting_BeneathASelectedOneLevelParent_ReturnsTrue()
     {
-        // Arrange
-        var partition = CreatePartitionWithContainers(
-            CreateContainer("Root1", true),
-            CreateContainer("Root2", false));
+        // The parent's search stops at the objects held directly within it, so it never reaches the new container.
+        var parent = CreateContainer("Parent", true, ConnectedSystemContainerScope.OneLevel);
 
-        // Act
-        var result = ConnectedSystemUtilities.GetAllSelectedContainers(partition);
-
-        // Assert
-        Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result[0].Name, Is.EqualTo("Root1"));
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(parent, partitionSelected: true), Is.True);
     }
 
     [Test]
-    public void GetAllSelectedContainers_WithSelectedChildContainer_ReturnsChildContainer()
+    public void NewContainerNeedsSelecting_BeneathAnUnselectedParent_ReturnsFalse()
     {
-        // Arrange
-        var child1 = CreateContainer("Child1", true);
-        var child2 = CreateContainer("Child2", false);
-        var root = CreateContainer("Root", false, child1, child2);
-        var partition = CreatePartitionWithContainers(root);
+        // Nothing beneath an unselected parent is in scope, so a new container there must not put itself in scope.
+        var parent = CreateContainer("Parent", false);
 
-        // Act
-        var result = ConnectedSystemUtilities.GetAllSelectedContainers(partition);
-
-        // Assert
-        Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result[0].Name, Is.EqualTo("Child1"));
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(parent, partitionSelected: true), Is.False);
     }
 
     [Test]
-    public void GetAllSelectedContainers_WithSelectedParentAndChild_ReturnsBoth()
+    public void NewContainerNeedsSelecting_BeneathAOneLevelParentUnderASubtreeGrandparent_ReturnsFalse()
     {
-        // Arrange
-        var child = CreateContainer("Child", true);
-        var parent = CreateContainer("Parent", true, child);
-        var partition = CreatePartitionWithContainers(parent);
+        // Coverage is inherited from any Subtree ancestor, not only the immediate parent.
+        var parent = CreateContainer("Parent", true, ConnectedSystemContainerScope.OneLevel);
+        CreateContainer("Grandparent", true, ConnectedSystemContainerScope.Subtree, parent);
 
-        // Act
-        var result = ConnectedSystemUtilities.GetAllSelectedContainers(partition);
-
-        // Assert
-        Assert.That(result, Has.Count.EqualTo(2));
-        Assert.That(result.Select(c => c.Name), Contains.Item("Parent"));
-        Assert.That(result.Select(c => c.Name), Contains.Item("Child"));
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(parent, partitionSelected: true), Is.False);
     }
 
     [Test]
-    public void GetAllSelectedContainers_WithDeepHierarchy_ReturnsAllSelected()
+    public void NewContainerNeedsSelecting_BeneathAnUnselectedParentUnderASelectedOneLevelGrandparent_ReturnsFalse()
     {
-        // Arrange - Create a 4-level hierarchy with some selected at each level
-        var level4a = CreateContainer("Level4a", false);
-        var level3a = CreateContainer("Level3a", true, level4a);
-        var level2a = CreateContainer("Level2a", false, level3a);
-        var level2b = CreateContainer("Level2b", true);
-        var level1 = CreateContainer("Level1", true, level2a, level2b);
-        var partition = CreatePartitionWithContainers(level1);
+        // The grandparent's OneLevel search does not reach the parent, so the whole branch is out of scope.
+        var parent = CreateContainer("Parent", false);
+        CreateContainer("Grandparent", true, ConnectedSystemContainerScope.OneLevel, parent);
 
-        // Act
-        var result = ConnectedSystemUtilities.GetAllSelectedContainers(partition);
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(parent, partitionSelected: true), Is.False);
+    }
 
-        // Assert
-        Assert.That(result, Has.Count.EqualTo(3));
-        Assert.That(result.Select(c => c.Name), Contains.Item("Level1"));
-        Assert.That(result.Select(c => c.Name), Contains.Item("Level2b"));
-        Assert.That(result.Select(c => c.Name), Contains.Item("Level3a"));
+    [Test]
+    public void NewContainerNeedsSelecting_BeneathAnUnselectedParentUnderASelectedSubtreeGrandparent_ReturnsFalse()
+    {
+        // The grandparent's Subtree search reaches every level beneath it, including the new container.
+        var parent = CreateContainer("Parent", false);
+        CreateContainer("Grandparent", true, ConnectedSystemContainerScope.Subtree, parent);
+
+        Assert.That(ConnectedSystemUtilities.NewContainerNeedsSelecting(parent, partitionSelected: true), Is.False);
     }
 
     #endregion
@@ -604,13 +566,17 @@ public class ConnectedSystemUtilitiesTests
         return partition;
     }
 
-    private static ConnectedSystemContainer CreateContainer(string name, bool selected, params ConnectedSystemContainer[] children)
+    private static ConnectedSystemContainer CreateContainer(string name, bool selected, params ConnectedSystemContainer[] children) =>
+        CreateContainer(name, selected, ConnectedSystemContainerScope.Subtree, children);
+
+    private static ConnectedSystemContainer CreateContainer(string name, bool selected, ConnectedSystemContainerScope scope, params ConnectedSystemContainer[] children)
     {
         var container = new ConnectedSystemContainer
         {
             Id = _nextId++,
             Name = name,
             Selected = selected,
+            Scope = scope,
             ExternalId = $"OU={name}"
         };
 

--- a/test/JIM.Worker.Tests/Servers/ExportCreatedContainerAutoSelectionTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ExportCreatedContainerAutoSelectionTests.cs
@@ -1,0 +1,299 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Text;
+using JIM.Application;
+using JIM.Application.Interfaces;
+using JIM.Connectors;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Interfaces;
+using JIM.Models.Security;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Covers whether a Container created during export is auto-selected, which decides whether the objects provisioned
+/// into it ever import back.
+/// </summary>
+/// <remarks>
+/// The rule turns on Container Scope. A selected Subtree ancestor's search already returns everything beneath it, so
+/// selecting the new Container as well would import those objects twice. A selected OneLevel ancestor returns only the
+/// objects held directly within it, so it does NOT reach into the new Container: leaving the new Container unselected
+/// there means its objects are never imported and the export silently writes into a hole. Both auto-selection entry
+/// points (the initiator-pair and the initiator-triad overloads) must apply the same rule.
+/// </remarks>
+[TestFixture]
+public class ExportCreatedContainerAutoSelectionTests
+{
+    private Mock<IRepository> _repo = null!;
+    private Mock<IActivityRepository> _activityRepo = null!;
+    private Mock<IServiceSettingsRepository> _settingsRepo = null!;
+    private Mock<IConnectedSystemRepository> _csRepo = null!;
+    private FakeProtection _protection = null!;
+    private JimApplication _jim = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _repo = new Mock<IRepository>();
+        _activityRepo = new Mock<IActivityRepository>();
+        _settingsRepo = new Mock<IServiceSettingsRepository>();
+        _csRepo = new Mock<IConnectedSystemRepository>();
+        _repo.Setup(r => r.Activity).Returns(_activityRepo.Object);
+        _repo.Setup(r => r.ServiceSettings).Returns(_settingsRepo.Object);
+        _repo.Setup(r => r.ConnectedSystems).Returns(_csRepo.Object);
+
+        _activityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<Activity>())).Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<Activity>())).Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.GetMaxConfigurationChangeVersionAsync(It.IsAny<ActivityTargetType>(), It.IsAny<int>())).ReturnsAsync(1);
+        _activityRepo.Setup(r => r.GetLatestConfigurationChangeSnapshotAsync(It.IsAny<ActivityTargetType>(), It.IsAny<int>())).ReturnsAsync((string?)null);
+
+        _csRepo.Setup(r => r.UpdateConnectedSystemAsync(It.IsAny<ConnectedSystem>())).Returns(Task.CompletedTask);
+        _csRepo.Setup(r => r.GetConnectedSystemAsync(1, It.IsAny<bool>())).ReturnsAsync(BuildConnectedSystem);
+
+        _protection = new FakeProtection();
+        _jim = new JimApplication(_repo.Object) { CredentialProtection = _protection };
+
+        SetupTrackingSetting();
+        SetupHashKeySetting();
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    // -- the OneLevel case: the ancestor's search does not reach the new Container -----------------------------------
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersAsync_BeneathASelectedOneLevelContainer_SelectsTheNewContainerAsync()
+    {
+        var corp = SelectedContainer("OU=Corp,DC=corp,DC=local", "Corp", ConnectedSystemContainerScope.OneLevel);
+        var connectedSystem = SystemWithContainers(corp);
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,OU=Corp,DC=corp,DC=local"], initiatedByUser: NewUser());
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,OU=Corp,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null, "the container created during export must be added to the hierarchy");
+        Assert.That(newContainer!.Selected, Is.True,
+            "OU=Corp is selected OneLevel, so its search stops at the objects directly within it; leaving the new child unselected " +
+            "means the objects just provisioned into it would never be imported back");
+    }
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersWithTriadAsync_BeneathASelectedOneLevelContainer_SelectsTheNewContainerAsync()
+    {
+        var corp = SelectedContainer("OU=Corp,DC=corp,DC=local", "Corp", ConnectedSystemContainerScope.OneLevel);
+        var connectedSystem = SystemWithContainers(corp);
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersWithTriadAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,OU=Corp,DC=corp,DC=local"],
+            ActivityInitiatorType.System, null, "Infrastructure Key");
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,OU=Corp,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null);
+        Assert.That(newContainer!.Selected, Is.True,
+            "both auto-selection overloads must apply the same scope-aware coverage rule");
+    }
+
+    // -- the Subtree cases: the ancestor's search already covers the new Container -----------------------------------
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersAsync_BeneathASelectedSubtreeContainer_DoesNotSelectTheNewContainerAsync()
+    {
+        var corp = SelectedContainer("OU=Corp,DC=corp,DC=local", "Corp", ConnectedSystemContainerScope.Subtree);
+        var connectedSystem = SystemWithContainers(corp);
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,OU=Corp,DC=corp,DC=local"], initiatedByUser: NewUser());
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,OU=Corp,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null);
+        Assert.That(newContainer!.Selected, Is.False,
+            "OU=Corp's Subtree search already returns the new container's objects; selecting it as well would import them twice");
+    }
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersAsync_BeneathAOneLevelParentUnderASubtreeGrandparent_DoesNotSelectTheNewContainerAsync()
+    {
+        // The grandparent's Subtree search reaches every level beneath it, whatever the intermediate containers say.
+        var corp = SelectedContainer("OU=Corp,DC=corp,DC=local", "Corp", ConnectedSystemContainerScope.Subtree);
+        var teams = SelectedContainer("OU=Teams,OU=Corp,DC=corp,DC=local", "Teams", ConnectedSystemContainerScope.OneLevel);
+        corp.AddChildContainer(teams);
+        var connectedSystem = SystemWithContainers(corp);
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,OU=Teams,OU=Corp,DC=corp,DC=local"], initiatedByUser: NewUser());
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,OU=Teams,OU=Corp,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null);
+        Assert.That(newContainer!.Selected, Is.False,
+            "coverage is inherited from any Subtree ancestor, not just the immediate parent");
+    }
+
+    // -- branches the administrator has not asked for stay out of scope ----------------------------------------------
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersAsync_BeneathAnUnselectedContainer_DoesNotSelectTheNewContainerAsync()
+    {
+        var corp = SelectedContainer("OU=Corp,DC=corp,DC=local", "Corp", ConnectedSystemContainerScope.Subtree);
+        corp.Selected = false;
+        var connectedSystem = SystemWithContainers(corp);
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,OU=Corp,DC=corp,DC=local"], initiatedByUser: NewUser());
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,OU=Corp,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null);
+        Assert.That(newContainer!.Selected, Is.False,
+            "nothing beneath OU=Corp is in scope, so a container created there must not put itself in scope");
+    }
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersAsync_BeneathAnUnselectedParentOfAOneLevelGrandparent_DoesNotSelectTheNewContainerAsync()
+    {
+        // OU=Teams sits outside OU=Corp's OneLevel search, so the branch is out of scope entirely.
+        var corp = SelectedContainer("OU=Corp,DC=corp,DC=local", "Corp", ConnectedSystemContainerScope.OneLevel);
+        var teams = SelectedContainer("OU=Teams,OU=Corp,DC=corp,DC=local", "Teams", ConnectedSystemContainerScope.Subtree);
+        teams.Selected = false;
+        corp.AddChildContainer(teams);
+        var connectedSystem = SystemWithContainers(corp);
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,OU=Teams,OU=Corp,DC=corp,DC=local"], initiatedByUser: NewUser());
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,OU=Teams,OU=Corp,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null);
+        Assert.That(newContainer!.Selected, Is.False,
+            "a selected OneLevel grandparent does not put its grandchildren in scope");
+    }
+
+    [Test]
+    public async Task RefreshAndAutoSelectContainersAsync_AtTheTopOfASelectedPartition_SelectsTheNewContainerAsync()
+    {
+        var connectedSystem = SystemWithContainers();
+
+        await _jim.ConnectedSystems.RefreshAndAutoSelectContainersAsync(
+            connectedSystem, new FakeContainerCreatingConnector(), ["OU=NewTeam,DC=corp,DC=local"], initiatedByUser: NewUser());
+
+        var newContainer = FindContainer(connectedSystem, "OU=NewTeam,DC=corp,DC=local");
+        Assert.That(newContainer, Is.Not.Null);
+        Assert.That(newContainer!.Selected, Is.True,
+            "a top-level container in a selected partition has no ancestor covering it, so it needs selecting in its own right");
+    }
+
+    // -- helpers -----------------------------------------------------------------------------------------------------
+
+    private static ConnectedSystemContainer SelectedContainer(string externalId, string name, ConnectedSystemContainerScope scope) =>
+        new() { ExternalId = externalId, Name = name, Selected = true, Scope = scope };
+
+    private static ConnectedSystem SystemWithContainers(params ConnectedSystemContainer[] rootContainers)
+    {
+        var connectedSystem = BuildConnectedSystem();
+        connectedSystem.Partitions =
+        [
+            new ConnectedSystemPartition
+            {
+                Id = 20,
+                ExternalId = "DC=corp,DC=local",
+                Name = "corp.local",
+                Selected = true,
+                Containers = [.. rootContainers]
+            }
+        ];
+        return connectedSystem;
+    }
+
+    private static ConnectedSystemContainer? FindContainer(ConnectedSystem connectedSystem, string externalId) =>
+        (connectedSystem.Partitions ?? [])
+            .SelectMany(p => Flatten(p.Containers ?? []))
+            .SingleOrDefault(c => c.ExternalId == externalId);
+
+    private static IEnumerable<ConnectedSystemContainer> Flatten(IEnumerable<ConnectedSystemContainer> containers) =>
+        containers.SelectMany(c => new[] { c }.Concat(Flatten(c.ChildContainers)));
+
+    private static ConnectedSystem BuildConnectedSystem() => new()
+    {
+        Id = 1,
+        Name = "Identity Directory",
+        ConnectorDefinition = new ConnectorDefinition { Name = ConnectorConstants.FileConnectorName },
+        SettingValues =
+        [
+            new ConnectedSystemSettingValue
+            {
+                Id = 10,
+                Setting = new ConnectorDefinitionSetting { Id = 100, Name = "File Path", Required = true, Type = ConnectedSystemSettingType.File },
+                StringValue = "/data/users.csv"
+            },
+            new ConnectedSystemSettingValue
+            {
+                Id = 11,
+                Setting = new ConnectorDefinitionSetting { Id = 101, Name = "Mode", Required = true, Type = ConnectedSystemSettingType.DropDown },
+                StringValue = "Import Only"
+            }
+        ],
+        RunProfiles = [],
+        ObjectTypes = [],
+        Partitions = []
+    };
+
+    private void SetupTrackingSetting() =>
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled,
+                DisplayName = "Track configuration changes",
+                ValueType = ServiceSettingValueType.Boolean,
+                Value = "true"
+            });
+
+    private void SetupHashKeySetting() =>
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ConfigurationChangeHashKey))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ConfigurationChangeHashKey,
+                DisplayName = "Configuration change hash key",
+                ValueType = ServiceSettingValueType.StringEncrypted,
+                Value = _protection.Protect(Convert.ToBase64String(new byte[32]))
+            });
+
+    private static MetaverseObject NewUser() => new() { Id = Guid.NewGuid(), CachedDisplayName = "Admin User" };
+
+    /// <summary>A connector test double that reports container-creation support for the auto-selection path.</summary>
+    private sealed class FakeContainerCreatingConnector : IConnector, IConnectorContainerCreation
+    {
+        public string Name => "Fake Directory";
+        public string? Description => null;
+        public string? Url => null;
+        public IReadOnlyList<string> CreatedContainerExternalIds { get; } = [];
+        public Task<bool> VerifyContainerExistsAsync(string containerExternalId) => Task.FromResult(true);
+        public string? GetParentContainerExternalId(string containerExternalId) =>
+            containerExternalId.Contains(',') ? containerExternalId[(containerExternalId.IndexOf(',') + 1)..] : null;
+        public string GetContainerDisplayName(string containerExternalId) =>
+            containerExternalId.Split(',')[0].Split('=')[^1];
+    }
+
+    /// <summary>A round-trip credential-protection test double using a recognisable encrypted-value prefix.</summary>
+    private sealed class FakeProtection : ICredentialProtectionService
+    {
+        private const string Prefix = "$JIM$v1$";
+
+        public string? Protect(string? plainText) =>
+            string.IsNullOrEmpty(plainText) ? plainText : Prefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText));
+
+        public string? Unprotect(string? protectedData) =>
+            string.IsNullOrEmpty(protectedData) || !IsProtected(protectedData)
+                ? protectedData
+                : Encoding.UTF8.GetString(Convert.FromBase64String(protectedData[Prefix.Length..]));
+
+        public bool IsProtected(string? value) =>
+            !string.IsNullOrEmpty(value) && value.StartsWith(Prefix, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Description

Closes the last outstanding item of #351: the interaction between Container Scope and the Containers a Connector reports having created during an export.

`ConnectedSystemServer` decided whether to select a newly created Container with `IsAnyAncestorSelected`, which reads `Selected` and ignores `Scope`. Beneath a selected One Level Container that is the wrong answer: the ancestor's search stops at the objects held directly within it, so it never reaches the new Container, and leaving it unselected would mean the objects just provisioned into it are not imported back.

The rule now lives in `ConnectedSystemUtilities.NewContainerNeedsSelecting`, beside the coverage rule that the import search roots and the portal's `Included` display flag already share, so all three consumers answer "does an ancestor's search cover this?" the same way. Both auto-selection overloads call it.

**Scope of the effect, stated plainly: nothing an administrator can observe changes today.** On the LDAP path the export scope guard added by #1250 refuses an export beneath a One Level Container before any Container is created there (`CheckTargetIsWithinManagedScope` runs ahead of `ProcessCreate`, so `_createdContainerExternalIds` is still empty when the first object into that branch is judged), so the case cannot currently arise. What this fixes is the invariant that guard states and relies on:

> A container created during this run is selected by JIM the moment the run finishes ... It is selected as a subtree, which is what JIM's own auto-selection records.

That promise was not kept under a One Level parent. The guard and the auto-selection were cancelling each other out rather than agreeing, which is not a property to leave resting on the order two independent mechanisms happen to run in. `IConnectorContainerCreation` and `IConnectorManagedScope` are also independent interfaces, so a Connector implementing the first without the second reaches auto-selection with no guard in front of it.

Also removes `ConnectedSystemUtilities.GetAllSelectedContainers`, which #351 asked to be decided on either way rather than left as-is. It had no production callers (tests only) and was scope-blind, so it was a trap for the next caller to reach for it.

Closes #351

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment

13 new tests, written test-first. The red run was red for the right reason: of the 7 server-level tests, exactly the two One Level cases failed before the fix, and the 5 Subtree / unselected-parent / top-of-partition guards passed both before and after, which is what pins that no pre-existing configuration changes behaviour.

- `ExportCreatedContainerAutoSelectionTests` (new, `JIM.Worker.Tests`): both auto-selection overloads, covering a selected One Level parent, a selected Subtree parent, a One Level parent under a Subtree grandparent, an unselected parent, an unselected parent under a One Level grandparent, and the top of a selected partition.
- `ConnectedSystemUtilitiesTests`: 6 tests for `NewContainerNeedsSelecting` replacing the deleted `GetAllSelectedContainers` region.

Not manually validated at runtime, because the path is unreachable from the portal or an export run today, for the reason set out above. The behaviour is fully determined by the two auto-selection methods, which the server-level tests drive directly.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

<!-- Docs: n/a - no observable behaviour change; the public Container Scope documentation added in #1263 remains accurate. -->

No changelog entry either, for the same reason: there is nothing an administrator can observe.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

One thing this surfaced that is **not** fixed here: the export guard's refusal message tells the administrator to "select the container on the Partitions & Containers tab", but beneath a One Level parent the actual remedy is to widen that parent's scope, or to select the child Container in its own right. The message does not distinguish those two cases. Worth a follow-up if it proves confusing in practice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfeypW7jcRid2SyWLEDzdp)_