### PR TITLE
fix: compose an anchor token through the dialect's own byte order (#170)

### DIFF
--- a/src/JIM.Connectors/Sql/SqlAnchorValue.cs
+++ b/src/JIM.Connectors/Sql/SqlAnchorValue.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using JIM.Connectors.Sql.Providers;
 using JIM.Models.Core;
 using JIM.Utilities;
 using System.Globalization;
@@ -8,14 +9,27 @@ using System.Globalization;
 namespace JIM.Connectors.Sql;
 
 /// <summary>
-/// Converts a keyset-pagination anchor between its database value and the string form carried in a
-/// Connected System Pagination Token.
+/// The single crossing point between a value as a database driver hands it over and the string form JIM
+/// carries it as: an anchor part of an external ID, a Connected System Pagination Token, or a Delta
+/// Import watermark.
 /// <para>
-/// The token is the only thing that positions the next page, and it survives a round trip through the
-/// database as text, so every conversion here is invariant-culture and lossless. Decimal anchors are
-/// the case that matters most in practice: an Oracle primary key is typically a NUMBER, which JIM maps
-/// to Decimal, so routing one through <c>double</c> or a culture-sensitive format would drop digits
-/// or write "1,5", and the next page would resume from the wrong row without any error.
+/// The token is the only thing that identifies an object between an export and its confirming import,
+/// and the only thing that positions the next page, so every conversion here is invariant-culture and
+/// lossless, and there is exactly one routine per direction. Two routines that happen to agree today is
+/// how an Oracle table whose key is <c>RAW(16) DEFAULT SYS_GUID()</c> came to compose its key as a
+/// hyphenated GUID on the way in and as hex on the way out, leaving an exported object that no import
+/// could ever find again.
+/// </para>
+/// <para>
+/// Decimal anchors are the case that matters most in practice: an Oracle primary key is typically a
+/// NUMBER, which JIM maps to Decimal, so routing one through <c>double</c> or a culture-sensitive format
+/// would drop digits or write "1,5", and the next page would resume from the wrong row without any error.
+/// </para>
+/// <para>
+/// <b>The dialect seam is crossed here, not at the call site.</b> A GUID's byte order is the database
+/// server's own (Oracle stores RAW(16) big-endian, Microsoft SQL Server stores <c>uniqueidentifier</c>
+/// with its first three components little-endian), so the provider converts it. Taking the provider as a
+/// parameter is what makes that impossible to forget: there is no way to compose a token without one.
 /// </para>
 /// </summary>
 internal static class SqlAnchorValue
@@ -26,11 +40,15 @@ internal static class SqlAnchorValue
     private const string DateTimeTokenFormat = "O";
 
     /// <summary>
-    /// Renders an anchor value for a Connected System Pagination Token.
+    /// Renders a value a driver handed back, or one about to be bound, as the string JIM carries it as.
     /// </summary>
-    /// <exception cref="NotSupportedException">The attribute type cannot order a keyset page.</exception>
-    internal static string ToTokenString(object value, AttributeDataType type)
+    /// <param name="provider">The dialect the value came from, which decides how a GUID's bytes are read.</param>
+    /// <param name="value">The value, exactly as the driver returned it or as it will be bound.</param>
+    /// <param name="type">The JIM attribute type of the column it belongs to.</param>
+    /// <exception cref="NotSupportedException">The attribute type cannot identify an object or order a keyset page.</exception>
+    internal static string ToTokenString(ISqlProvider provider, object value, AttributeDataType type)
     {
+        ArgumentNullException.ThrowIfNull(provider);
         ArgumentNullException.ThrowIfNull(value);
 
         return type switch
@@ -41,49 +59,30 @@ internal static class SqlAnchorValue
 
             // The single source of truth for decimal string form; never a plain ToString.
             AttributeDataType.Decimal => DecimalAttributeValue.ToCanonicalString(Convert.ToDecimal(value, CultureInfo.InvariantCulture)),
-            AttributeDataType.Guid => ToGuid(value).ToString("D", CultureInfo.InvariantCulture),
-            AttributeDataType.DateTime => ToUtc(Convert.ToDateTime(value, CultureInfo.InvariantCulture)).ToString(DateTimeTokenFormat, CultureInfo.InvariantCulture),
+
+            // Byte order is the dialect's, and reading it with the wrong one transposes the first three
+            // components silently, so the value crosses the seam before it is ever rendered.
+            AttributeDataType.Guid => provider.ConvertToGuid(value).ToString("D", CultureInfo.InvariantCulture),
+            AttributeDataType.DateTime => ToUtc(value).ToString(DateTimeTokenFormat, CultureInfo.InvariantCulture),
             AttributeDataType.Binary => Convert.ToHexString(ToBytes(value)),
-            _ => throw new NotSupportedException($"A {type} column cannot be a keyset pagination anchor; an anchor must impose a total order on the rows.")
+            _ => throw new NotSupportedException($"A {type} column cannot identify an object or order a keyset page; an anchor must impose a total order on the rows.")
         };
     }
 
     /// <summary>
-    /// Renders an anchor value whose JIM attribute type is not in hand, from what the driver returned.
+    /// Turns a token back into the value this dialect's driver binds, which is the exact inverse of
+    /// <see cref="ToTokenString"/>. Returns false rather than throwing so the caller can turn a corrupt
+    /// or stale token into a clear run error; it must never round, truncate or guess.
     /// </summary>
     /// <remarks>
-    /// The one caller is an export create against a database-generated key: the value arrives from an
-    /// identity or a sequence, and JIM holds no schema for a column it has never imported. Every branch
-    /// renders exactly as the typed overload above would for the same value, so the external ID this
-    /// produces is the one the confirming import composes for the same row.
+    /// The value handed back is in the shape the driver expects, not necessarily the shape JIM holds it
+    /// in: a GUID goes back through the provider, so against Oracle it emerges as the RAW(16) bytes the
+    /// column takes. Binding what came out of the token unconverted is how a page resumes from a
+    /// transposed identifier and silently re-reads or skips rows.
     /// </remarks>
-    internal static string ToTokenString(object value)
+    internal static bool TryFromTokenString(ISqlProvider provider, string? token, AttributeDataType type, out object? value)
     {
-        ArgumentNullException.ThrowIfNull(value);
-
-        return value switch
-        {
-            string text => text,
-            Guid guid => guid.ToString("D", CultureInfo.InvariantCulture),
-            byte[] bytes => Convert.ToHexString(bytes),
-            DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime.ToString(DateTimeTokenFormat, CultureInfo.InvariantCulture),
-            DateTime dateTime => ToUtc(dateTime).ToString(DateTimeTokenFormat, CultureInfo.InvariantCulture),
-
-            // Never a plain ToString for a number the database generated: 5.00 and 5.0 have to produce
-            // the same string, or a confirming import reads them as two different objects.
-            decimal number => DecimalAttributeValue.ToCanonicalString(number),
-            float or double => DecimalAttributeValue.ToCanonicalString(Convert.ToDecimal(value, CultureInfo.InvariantCulture)),
-            _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
-        };
-    }
-
-    /// <summary>
-    /// Parses an anchor value back out of a Connected System Pagination Token. Returns false rather
-    /// than throwing so the caller can turn a corrupt or stale token into a clear run error; it must
-    /// never round, truncate or guess.
-    /// </summary>
-    internal static bool TryFromTokenString(string? token, AttributeDataType type, out object? value)
-    {
+        ArgumentNullException.ThrowIfNull(provider);
         value = null;
 
         if (string.IsNullOrEmpty(token))
@@ -116,7 +115,7 @@ internal static class SqlAnchorValue
             case AttributeDataType.Guid:
                 if (!IdentifierParser.TryFromString(token, out var guidValue))
                     return false;
-                value = guidValue;
+                value = provider.ConvertFromGuid(guidValue);
                 return true;
 
             case AttributeDataType.DateTime:
@@ -142,27 +141,30 @@ internal static class SqlAnchorValue
     }
 
     /// <summary>
-    /// JIM holds every DateTime in UTC. An unspecified kind is taken to be UTC already rather than
-    /// converted from the host's local time, which would silently move the watermark by the offset of
-    /// whichever machine ran the import.
+    /// JIM holds every DateTime in UTC. A value carrying its own offset (which is what a driver returns
+    /// for a <c>datetimeoffset</c> or a <c>TIMESTAMP WITH TIME ZONE</c> column) is taken at the instant
+    /// it names; a value carrying no offset at all is taken to be UTC already rather than converted from
+    /// the host's local time, which would silently move the watermark by the offset of whichever machine
+    /// ran the import.
     /// </summary>
-    private static DateTime ToUtc(DateTime value)
+    /// <remarks>
+    /// <see cref="DateTimeOffset"/> is handled here rather than left to <see cref="Convert.ToDateTime(object?, IFormatProvider?)"/>,
+    /// which throws for it: the type does not implement <see cref="IConvertible"/>. A date and time is a
+    /// pathological primary key and a perfectly ordinary Delta Import watermark, and both reach this
+    /// method, so refusing the offset-bearing case would take away the second to punish the first.
+    /// </remarks>
+    private static DateTime ToUtc(object value)
     {
-        return value.Kind switch
-        {
-            DateTimeKind.Utc => value,
-            DateTimeKind.Local => value.ToUniversalTime(),
-            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
-        };
-    }
+        if (value is DateTimeOffset dateTimeOffset)
+            return dateTimeOffset.UtcDateTime;
 
-    private static Guid ToGuid(object value)
-    {
-        return value switch
+        var dateTime = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
+
+        return dateTime.Kind switch
         {
-            Guid guid => guid,
-            string text => IdentifierParser.FromString(text),
-            _ => throw new ArgumentException($"A Guid anchor cannot be built from a {value.GetType().Name} value; byte order is dialect-specific, so bytes must be converted through the provider first.", nameof(value))
+            DateTimeKind.Utc => dateTime,
+            DateTimeKind.Local => dateTime.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
         };
     }
 

--- a/src/JIM.Connectors/Sql/SqlConnectorExport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorExport.cs
@@ -645,24 +645,29 @@ internal sealed class SqlConnectorExport
     /// </remarks>
     private Dictionary<string, AttributeDataType> ResolveAnchorTypes(SqlExportPlan plan)
     {
-        var anchorTypes = new Dictionary<string, AttributeDataType>(StringComparer.OrdinalIgnoreCase);
+        return plan.AnchorColumns.ToDictionary(
+            anchorColumn => anchorColumn,
+            anchorColumn => ResolveAnchorType(plan, anchorColumn),
+            StringComparer.OrdinalIgnoreCase);
+    }
 
-        foreach (var anchorColumn in plan.AnchorColumns)
+    /// <summary>
+    /// The JIM attribute type of one anchor column.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The column's SQL type maps onto no JIM attribute type, so no external ID could be composed from it.</exception>
+    private AttributeDataType ResolveAnchorType(SqlExportPlan plan, string anchorColumn)
+    {
+        var columnType = plan.ParentColumns.Require(anchorColumn);
+
+        try
         {
-            var columnType = plan.ParentColumns.Require(anchorColumn);
-
-            try
-            {
-                anchorTypes[anchorColumn] = _provider.MapColumnType(columnType, _typeMappingOptions);
-            }
-            catch (SqlTypeMappingException ex)
-            {
-                throw new InvalidOperationException(
-                    $"Object Type '{plan.Name}' is identified by column '{anchorColumn}' of type '{columnType.TypeName}', which JIM has no attribute type for, so there is no external ID it could compose that the confirming import would recognise. {ex.Message}", ex);
-            }
+            return _provider.MapColumnType(columnType, _typeMappingOptions);
         }
-
-        return anchorTypes;
+        catch (SqlTypeMappingException ex)
+        {
+            throw new InvalidOperationException(
+                $"Object Type '{plan.Name}' is identified by column '{anchorColumn}' of type '{columnType.TypeName}', which JIM has no attribute type for, so there is no external ID it could compose that the confirming import would recognise. {ex.Message}", ex);
+        }
     }
 
     #endregion

--- a/src/JIM.Connectors/Sql/SqlConnectorExport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorExport.cs
@@ -208,9 +208,14 @@ internal sealed class SqlConnectorExport
         var columnValues = BuildParentColumnValues(plan, pendingExport, forCreate: true);
         var suppliedAnchor = ResolveSuppliedAnchor(plan, columnValues);
 
+        // Resolved before a row is written: the external ID is what JIM will identify the new object by
+        // for the rest of its life, so an anchor column this export could not compose one from fails the
+        // object while there is still nothing to undo.
+        var anchorTypes = ResolveAnchorTypes(plan);
+
         var (externalId, anchor) = suppliedAnchor == null
-            ? await InsertReturningGeneratedKeyAsync(plan, columnValues, transaction, cancellationToken)
-            : await InsertWithSuppliedAnchorAsync(plan, columnValues, suppliedAnchor, transaction, cancellationToken);
+            ? await InsertReturningGeneratedKeyAsync(plan, anchorTypes, columnValues, transaction, cancellationToken)
+            : await InsertWithSuppliedAnchorAsync(plan, anchorTypes, columnValues, suppliedAnchor, transaction, cancellationToken);
 
         await ApplyRelatedChangesAsync(plan, anchor, pendingExport, transaction, cancellationToken);
 
@@ -223,6 +228,7 @@ internal sealed class SqlConnectorExport
     /// </summary>
     private async Task<(string ExternalId, IReadOnlyList<SqlExportColumnValue> Anchor)> InsertWithSuppliedAnchorAsync(
         SqlExportPlan plan,
+        IReadOnlyDictionary<string, AttributeDataType> anchorTypes,
         IReadOnlyList<SqlExportColumnValue> columnValues,
         IReadOnlyList<SqlExportColumnValue> suppliedAnchor,
         DbTransaction transaction,
@@ -240,7 +246,7 @@ internal sealed class SqlConnectorExport
         if (rowsAffected == 0)
             throw new InvalidOperationException(InsertWroteNothingMessage(plan.QualifiedTableName));
 
-        return (ComposeExternalId(plan, suppliedAnchor), suppliedAnchor);
+        return (ComposeExternalId(anchorTypes, suppliedAnchor), suppliedAnchor);
     }
 
     /// <summary>
@@ -249,6 +255,7 @@ internal sealed class SqlConnectorExport
     /// </summary>
     private async Task<(string ExternalId, IReadOnlyList<SqlExportColumnValue> Anchor)> InsertReturningGeneratedKeyAsync(
         SqlExportPlan plan,
+        IReadOnlyDictionary<string, AttributeDataType> anchorTypes,
         IReadOnlyList<SqlExportColumnValue> columnValues,
         DbTransaction transaction,
         CancellationToken cancellationToken)
@@ -281,7 +288,7 @@ internal sealed class SqlConnectorExport
         }
         else
         {
-            var keyParameter = _provider.CreateGeneratedKeyParameter(GeneratedKeyParameterName, ResolveAnchorType(plan, anchorColumn))
+            var keyParameter = _provider.CreateGeneratedKeyParameter(GeneratedKeyParameterName, anchorTypes[anchorColumn])
                 ?? throw new NotSupportedException($"The {_provider.DisplayName} provider returns a generated key through a bound parameter but supplied none for it.");
 
             command.Parameters.Add(keyParameter);
@@ -300,7 +307,7 @@ internal sealed class SqlConnectorExport
                 "Nothing would identify the new object, so the write is being rolled back; check that the column is backed by an identity, a sequence or a default.");
 
         var anchor = new[] { new SqlExportColumnValue(anchorColumn, AnchorParameterName(0), generatedKey) };
-        return (ComposeExternalId(plan, anchor), anchor);
+        return (ComposeExternalId(anchorTypes, anchor), anchor);
     }
 
     /// <summary>
@@ -618,27 +625,44 @@ internal sealed class SqlConnectorExport
     /// <see cref="ISqlProvider.ConvertToGuid"/>, which is the same round trip the row itself makes.
     /// </para>
     /// </remarks>
-    private string ComposeExternalId(SqlExportPlan plan, IReadOnlyList<SqlExportColumnValue> anchor)
+    private string ComposeExternalId(IReadOnlyDictionary<string, AttributeDataType> anchorTypes, IReadOnlyList<SqlExportColumnValue> anchor)
     {
         return string.Join(SqlConnectorSchema.ComposedAnchorSeparator, anchor.Select(columnValue => columnValue.Value == null
             ? string.Empty
-            : SqlAnchorValue.ToTokenString(_provider, columnValue.Value, ResolveAnchorType(plan, columnValue.ColumnName))));
+            : SqlAnchorValue.ToTokenString(_provider, columnValue.Value, anchorTypes[columnValue.ColumnName])));
     }
 
     /// <summary>
-    /// The JIM attribute type of one anchor column, which decides both how a database-generated key is
+    /// The JIM attribute type of each anchor column, which decides both how a database-generated key is
     /// returned and how the external ID is composed from it.
     /// </summary>
     /// <remarks>
     /// Taken from the database's own catalogue, as every other type this export binds by is (see the
     /// remarks on this class). That is also where the recorded schema an import composes by came from, so
     /// the two agree by construction rather than by coincidence. An anchor column JIM has no attribute
-    /// type for fails the object here, naming it: guessing an exact numeric because identities and
-    /// sequences usually generate one is how a GUID key came to be rendered as hex.
+    /// type for fails the object here, naming it: assuming an exact numeric because identities and
+    /// sequences usually generate one is how a GUID key came to be recorded as hex.
     /// </remarks>
-    private AttributeDataType ResolveAnchorType(SqlExportPlan plan, string anchorColumn)
+    private Dictionary<string, AttributeDataType> ResolveAnchorTypes(SqlExportPlan plan)
     {
-        return MapColumnType(anchorColumn, anchorColumn, plan.ParentColumns.Require(anchorColumn));
+        var anchorTypes = new Dictionary<string, AttributeDataType>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var anchorColumn in plan.AnchorColumns)
+        {
+            var columnType = plan.ParentColumns.Require(anchorColumn);
+
+            try
+            {
+                anchorTypes[anchorColumn] = _provider.MapColumnType(columnType, _typeMappingOptions);
+            }
+            catch (SqlTypeMappingException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Object Type '{plan.Name}' is identified by column '{anchorColumn}' of type '{columnType.TypeName}', which JIM has no attribute type for, so there is no external ID it could compose that the confirming import would recognise. {ex.Message}", ex);
+            }
+        }
+
+        return anchorTypes;
     }
 
     #endregion

--- a/src/JIM.Connectors/Sql/SqlConnectorExport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorExport.cs
@@ -209,7 +209,7 @@ internal sealed class SqlConnectorExport
         var suppliedAnchor = ResolveSuppliedAnchor(plan, columnValues);
 
         var (externalId, anchor) = suppliedAnchor == null
-            ? await InsertReturningGeneratedKeyAsync(plan, pendingExport, columnValues, transaction, cancellationToken)
+            ? await InsertReturningGeneratedKeyAsync(plan, columnValues, transaction, cancellationToken)
             : await InsertWithSuppliedAnchorAsync(plan, columnValues, suppliedAnchor, transaction, cancellationToken);
 
         await ApplyRelatedChangesAsync(plan, anchor, pendingExport, transaction, cancellationToken);
@@ -240,7 +240,7 @@ internal sealed class SqlConnectorExport
         if (rowsAffected == 0)
             throw new InvalidOperationException(InsertWroteNothingMessage(plan.QualifiedTableName));
 
-        return (ComposeExternalId(suppliedAnchor), suppliedAnchor);
+        return (ComposeExternalId(plan, suppliedAnchor), suppliedAnchor);
     }
 
     /// <summary>
@@ -249,7 +249,6 @@ internal sealed class SqlConnectorExport
     /// </summary>
     private async Task<(string ExternalId, IReadOnlyList<SqlExportColumnValue> Anchor)> InsertReturningGeneratedKeyAsync(
         SqlExportPlan plan,
-        PendingExport pendingExport,
         IReadOnlyList<SqlExportColumnValue> columnValues,
         DbTransaction transaction,
         CancellationToken cancellationToken)
@@ -282,7 +281,7 @@ internal sealed class SqlConnectorExport
         }
         else
         {
-            var keyParameter = _provider.CreateGeneratedKeyParameter(GeneratedKeyParameterName, ResolveGeneratedKeyType(plan, pendingExport))
+            var keyParameter = _provider.CreateGeneratedKeyParameter(GeneratedKeyParameterName, ResolveAnchorType(plan, anchorColumn))
                 ?? throw new NotSupportedException($"The {_provider.DisplayName} provider returns a generated key through a bound parameter but supplied none for it.");
 
             command.Parameters.Add(keyParameter);
@@ -300,7 +299,8 @@ internal sealed class SqlConnectorExport
                 $"Object Type '{plan.Name}' inserted a row, but the database returned no value for its anchor column '{anchorColumn}'. " +
                 "Nothing would identify the new object, so the write is being rolled back; check that the column is backed by an identity, a sequence or a default.");
 
-        return (SqlAnchorValue.ToTokenString(generatedKey), [new SqlExportColumnValue(anchorColumn, AnchorParameterName(0), generatedKey)]);
+        var anchor = new[] { new SqlExportColumnValue(anchorColumn, AnchorParameterName(0), generatedKey) };
+        return (ComposeExternalId(plan, anchor), anchor);
     }
 
     /// <summary>
@@ -604,28 +604,41 @@ internal sealed class SqlConnectorExport
     /// The new object's external ID, composed from its anchor exactly as an import of the same row would
     /// compose it.
     /// </summary>
-    private static string ComposeExternalId(IReadOnlyList<SqlExportColumnValue> anchor)
+    /// <remarks>
+    /// <para>
+    /// Rendered by <see cref="SqlAnchorValue"/>, the same routine and the same anchor types an import
+    /// uses, because an external ID composed any other way is one the confirming import never matches:
+    /// JIM would see a create it had already made, for ever. An Oracle table keyed on
+    /// <c>RAW(16) DEFAULT SYS_GUID()</c> is the case that proves it, where the driver hands back bytes on
+    /// both sides and only the attribute type says they are a GUID rather than a digest.
+    /// </para>
+    /// <para>
+    /// The values are the ones bound to the statement, so a GUID has already been through
+    /// <see cref="ISqlProvider.ConvertFromGuid"/>; rendering takes it back through
+    /// <see cref="ISqlProvider.ConvertToGuid"/>, which is the same round trip the row itself makes.
+    /// </para>
+    /// </remarks>
+    private string ComposeExternalId(SqlExportPlan plan, IReadOnlyList<SqlExportColumnValue> anchor)
     {
-        return string.Join(SqlConnectorSchema.ComposedAnchorSeparator,
-            anchor.Select(columnValue => columnValue.Value == null ? string.Empty : SqlAnchorValue.ToTokenString(columnValue.Value)));
+        return string.Join(SqlConnectorSchema.ComposedAnchorSeparator, anchor.Select(columnValue => columnValue.Value == null
+            ? string.Empty
+            : SqlAnchorValue.ToTokenString(_provider, columnValue.Value, ResolveAnchorType(plan, columnValue.ColumnName))));
     }
 
     /// <summary>
-    /// The type a database-generated key comes back as, for the dialects that bind an output parameter
-    /// to receive it.
+    /// The JIM attribute type of one anchor column, which decides both how a database-generated key is
+    /// returned and how the external ID is composed from it.
     /// </summary>
     /// <remarks>
-    /// An export holds no schema for the Connected System beyond what the Pending Export carries, so the
-    /// Connected System Object's own type is consulted where it brought its attributes with it. Failing
-    /// that, an exact numeric is assumed: an identity column and a sequence both generate one, and they
-    /// are what a database-generated key is in practice.
+    /// Taken from the database's own catalogue, as every other type this export binds by is (see the
+    /// remarks on this class). That is also where the recorded schema an import composes by came from, so
+    /// the two agree by construction rather than by coincidence. An anchor column JIM has no attribute
+    /// type for fails the object here, naming it: guessing an exact numeric because identities and
+    /// sequences usually generate one is how a GUID key came to be rendered as hex.
     /// </remarks>
-    private static AttributeDataType ResolveGeneratedKeyType(SqlExportPlan plan, PendingExport pendingExport)
+    private AttributeDataType ResolveAnchorType(SqlExportPlan plan, string anchorColumn)
     {
-        var attribute = pendingExport.ConnectedSystemObject?.Type?.Attributes
-            .FirstOrDefault(candidate => string.Equals(candidate.Name, plan.AnchorColumns[0], StringComparison.OrdinalIgnoreCase));
-
-        return attribute?.Type ?? AttributeDataType.Decimal;
+        return MapColumnType(anchorColumn, anchorColumn, plan.ParentColumns.Require(anchorColumn));
     }
 
     #endregion

--- a/src/JIM.Connectors/Sql/SqlConnectorImport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorImport.cs
@@ -180,7 +180,7 @@ internal sealed class SqlConnectorImport
             // A short page is the end of this object type; a full one may or may not be, and there is no
             // way to tell without asking, so one empty read at the end is unavoidable.
             if (rows.Count == _runProfile.PageSize)
-                result.PaginationTokens.Add(page.ToToken(plan, rows[^1]));
+                result.PaginationTokens.Add(page.ToToken(_provider, plan, rows[^1]));
         }
 
         return result;
@@ -423,7 +423,7 @@ internal sealed class SqlConnectorImport
     /// that the two identify the same object.
     /// </summary>
     /// <exception cref="InvalidDataException">A change-log row does not say which object it is about, which no amount of reading further can recover from.</exception>
-    private static string ComposeChangeAnchorKey(SqlImportPlan plan, SqlChangeLogConfiguration changeLog, IReadOnlyList<object?> anchorValues)
+    private string ComposeChangeAnchorKey(SqlImportPlan plan, SqlChangeLogConfiguration changeLog, IReadOnlyList<object?> anchorValues)
     {
         var parts = new string[anchorValues.Count];
 
@@ -432,7 +432,7 @@ internal sealed class SqlConnectorImport
             var value = anchorValues[index] ?? throw new InvalidDataException(
                 $"Object Type '{plan.Name}' has a change-log row with a NULL value in anchor column '{changeLog.AnchorColumns[index]}', so there is no way to tell which object it is about.");
 
-            parts[index] = SqlAnchorValue.ToTokenString(value, plan.AnchorColumns[index].Type);
+            parts[index] = SqlAnchorValue.ToTokenString(_provider, value, plan.AnchorColumns[index].Type);
         }
 
         return string.Join(SqlConnectorSchema.ComposedAnchorSeparator, parts);
@@ -650,7 +650,7 @@ internal sealed class SqlConnectorImport
             // No highest value at all is what an empty change log, or a source nothing has been written
             // to, looks like. Recording nothing for it means the next run reads from the beginning,
             // which is the only answer that cannot miss a change.
-            var described = SqlConnectorWatermark.Describe(await ReadHighestValueAsync(source, changeColumn));
+            var described = SqlConnectorWatermark.Describe(_provider, await ReadHighestValueAsync(source, changeColumn));
             if (described != null)
                 watermark.ObjectTypes[plan.Name] = described;
 
@@ -689,7 +689,7 @@ internal sealed class SqlConnectorImport
         foreach (var configuration in watermarked)
         {
             var source = _provider.QualifyObjectName(configuration.SchemaName, configuration.TableName);
-            var described = SqlConnectorWatermark.Describe(await ReadHighestValueAsync(source, configuration.WatermarkColumn!));
+            var described = SqlConnectorWatermark.Describe(_provider, await ReadHighestValueAsync(source, configuration.WatermarkColumn!));
 
             if (described != null)
                 relatedWatermarks[configuration.AttributeName] = described;
@@ -879,20 +879,19 @@ internal sealed class SqlConnectorImport
     /// <exception cref="InvalidDataException">The value cannot be read for the type it was written with, which would otherwise resume from the wrong place.</exception>
     private object BindDeltaValue(SqlImportPlan plan, SqlDeltaValue deltaValue, string description)
     {
-        if (!SqlAnchorValue.TryFromTokenString(deltaValue.Value, deltaValue.Type, out var value) || value == null)
+        // The token comes back in the shape this dialect's driver binds, GUID byte order included.
+        if (!SqlAnchorValue.TryFromTokenString(_provider, deltaValue.Value, deltaValue.Type, out var value) || value == null)
             throw new InvalidDataException(
                 $"Object Type '{plan.Name}' was replayed a {description} whose value '{deltaValue.Value}' cannot be read as a {deltaValue.Type}. Run a Full Import to re-establish the baseline.");
 
-        // The byte order a GUID is bound in is dialect-specific, so it goes back through the provider
-        // rather than being handed to the driver as it came out of the token.
-        return deltaValue.Type == AttributeDataType.Guid ? _provider.ConvertFromGuid((Guid)value) : value;
+        return value;
     }
 
     /// <summary>
     /// Describes where a page ended, so the next one resumes immediately after it.
     /// </summary>
     /// <exception cref="InvalidDataException">A page ended on a row with nothing to resume from, which would restart the read from the beginning for ever.</exception>
-    private static List<SqlDeltaValue> DescribeKeyset(
+    private List<SqlDeltaValue> DescribeKeyset(
         SqlImportPlan plan,
         IReadOnlyList<SqlDeltaKeysetColumn> keysetColumns,
         object?[] lastRow,
@@ -904,8 +903,8 @@ internal sealed class SqlConnectorImport
                 $"Object Type '{plan.Name}' read a page ending on a row with a NULL value in '{keysetColumn.Name}', which orders the page, so there is nothing to resume the next one from.");
 
             return keysetColumn.Type == null
-                ? SqlConnectorWatermark.Describe(value)!
-                : new SqlDeltaValue(SqlAnchorValue.ToTokenString(value, keysetColumn.Type.Value), keysetColumn.Type.Value);
+                ? SqlConnectorWatermark.Describe(_provider, value)!
+                : new SqlDeltaValue(SqlAnchorValue.ToTokenString(_provider, value, keysetColumn.Type.Value), keysetColumn.Type.Value);
         })];
     }
 
@@ -1142,13 +1141,12 @@ internal sealed class SqlConnectorImport
     {
         var anchorColumn = plan.AnchorColumns[index];
 
-        if (!SqlAnchorValue.TryFromTokenString(tokenValue, anchorColumn.Type, out var value) || value == null)
+        // The token comes back in the shape this dialect's driver binds, GUID byte order included.
+        if (!SqlAnchorValue.TryFromTokenString(_provider, tokenValue, anchorColumn.Type, out var value) || value == null)
             throw new InvalidDataException(
                 $"Object Type '{plan.Name}' was replayed a pagination token whose anchor value for column '{anchorColumn.Name}' cannot be read as a {anchorColumn.Type}. Run a Full Import again to start from the beginning.");
 
-        // The byte order a GUID is bound in is dialect-specific, so it goes back through the provider
-        // rather than being handed to the driver as it came out of the token.
-        return anchorColumn.Type == AttributeDataType.Guid ? _provider.ConvertFromGuid((Guid)value) : value;
+        return value;
     }
 
     #endregion
@@ -1222,7 +1220,7 @@ internal sealed class SqlConnectorImport
 
             try
             {
-                parts[index] = SqlAnchorValue.ToTokenString(value, anchorColumn.Type);
+                parts[index] = SqlAnchorValue.ToTokenString(_provider, value, anchorColumn.Type);
             }
             catch (Exception ex) when (IsValueConversionFailure(ex))
             {
@@ -1248,7 +1246,7 @@ internal sealed class SqlConnectorImport
         // anchor attribute will be.
         if (plan.ReferenceColumns.TryGetValue(column.Name, out var referencedAnchorType))
         {
-            attribute.ReferenceValues.Add(SqlAnchorValue.ToTokenString(value, referencedAnchorType));
+            attribute.ReferenceValues.Add(SqlAnchorValue.ToTokenString(_provider, value, referencedAnchorType));
             return;
         }
 
@@ -1456,7 +1454,7 @@ internal sealed class SqlConnectorImport
 
         if (relatedTable.ReferencedAnchorType != null)
         {
-            attribute.ReferenceValues.Add(SqlAnchorValue.ToTokenString(value, relatedTable.ReferencedAnchorType.Value));
+            attribute.ReferenceValues.Add(SqlAnchorValue.ToTokenString(_provider, value, relatedTable.ReferencedAnchorType.Value));
             return;
         }
 
@@ -1467,7 +1465,7 @@ internal sealed class SqlConnectorImport
     /// The parent this related row belongs to, rendered exactly as the parent's own anchor was so the
     /// two match. Null where a join column is NULL, which can never identify a parent.
     /// </summary>
-    private static string? ComposeRelatedAnchorKey(SqlImportPlan plan, DbDataReader reader, int[] joinOrdinals)
+    private string? ComposeRelatedAnchorKey(SqlImportPlan plan, DbDataReader reader, int[] joinOrdinals)
     {
         var parts = new string[joinOrdinals.Length];
 
@@ -1476,7 +1474,7 @@ internal sealed class SqlConnectorImport
             if (reader.IsDBNull(joinOrdinals[index]))
                 return null;
 
-            parts[index] = SqlAnchorValue.ToTokenString(reader.GetValue(joinOrdinals[index]), plan.AnchorColumns[index].Type);
+            parts[index] = SqlAnchorValue.ToTokenString(_provider, reader.GetValue(joinOrdinals[index]), plan.AnchorColumns[index].Type);
         }
 
         return string.Join(SqlConnectorSchema.ComposedAnchorSeparator, parts);
@@ -1616,10 +1614,10 @@ internal sealed record SqlImportPagePosition
         return new SqlImportPagePosition { LastAnchor = parsed.Anchor, PageNumber = parsed.Page };
     }
 
-    internal ConnectedSystemPaginationToken ToToken(SqlImportPlan plan, object?[] lastRow)
+    internal ConnectedSystemPaginationToken ToToken(ISqlProvider provider, SqlImportPlan plan, object?[] lastRow)
     {
         var anchor = plan.AnchorColumns
-            .Select(anchorColumn => SqlAnchorValue.ToTokenString(lastRow[plan.ColumnIndex(anchorColumn.Name)]!, anchorColumn.Type))
+            .Select(anchorColumn => SqlAnchorValue.ToTokenString(provider, lastRow[plan.ColumnIndex(anchorColumn.Name)]!, anchorColumn.Type))
             .ToList();
 
         return new ConnectedSystemPaginationToken(plan.TokenName, JsonSerializer.Serialize(new SqlImportPageToken(anchor, PageNumber + 1)));

--- a/src/JIM.Connectors/Sql/SqlConnectorWatermark.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorWatermark.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Tetron Limited. All rights reserved.
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
+using JIM.Connectors.Sql.Providers;
 using JIM.Models.Core;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -151,16 +152,22 @@ internal sealed record SqlConnectorWatermark
     /// <summary>
     /// Describes a value a database handed back, so it can be carried as text and bound back later.
     /// </summary>
+    /// <remarks>
+    /// A watermark column is not part of the Connected System's schema, so there is no recorded attribute
+    /// type to render it by and the type is taken from what the driver returned. The rendering itself is
+    /// still <see cref="SqlAnchorValue"/>'s, which is what keeps a watermark and an anchor of the same
+    /// type in the same string form.
+    /// </remarks>
     /// <returns>The described value, or null where the column had none (an empty change log has no highest sequence).</returns>
     /// <exception cref="NotSupportedException">The value's type cannot order a change set, so it could never be a watermark.</exception>
-    internal static SqlDeltaValue? Describe(object? value)
+    internal static SqlDeltaValue? Describe(ISqlProvider provider, object? value)
     {
         if (value == null || value == DBNull.Value)
             return null;
 
         var type = value switch
         {
-            // A value carrying its own offset is normalised to UTC before it is rendered, exactly as an
+            // A value carrying its own offset is normalised to UTC as it is rendered, exactly as an
             // anchor is, so the same instant always produces the same text.
             DateTimeOffset or DateTime => AttributeDataType.DateTime,
             byte[] => AttributeDataType.Binary,
@@ -172,7 +179,6 @@ internal sealed record SqlConnectorWatermark
             _ => throw new NotSupportedException($"A {value.GetType().Name} value cannot order a change set, so it cannot be used as a Delta Import watermark.")
         };
 
-        var normalised = value is DateTimeOffset dateTimeOffset ? dateTimeOffset.UtcDateTime : value;
-        return new SqlDeltaValue(SqlAnchorValue.ToTokenString(normalised, type), type);
+        return new SqlDeltaValue(SqlAnchorValue.ToTokenString(provider, value, type), type);
     }
 }

--- a/test/JIM.Worker.Tests/Connectors/SqlAnchorTokenAgreementTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlAnchorTokenAgreementTests.cs
@@ -1,0 +1,302 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Connectors.Sql;
+using JIM.Connectors.Sql.Providers;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+using JIM.Utilities;
+using NUnit.Framework;
+using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace JIM.Worker.Tests.Connectors;
+
+/// <summary>
+/// Covers the one invariant that ties the JIM SQL Connector's export to its import: the external ID an
+/// export composes for a row it created is byte-for-byte the one an import of that same row composes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This Connector confirms its exports automatically, so nothing reads the row back to check. If the two
+/// sides render an anchor differently, JIM records a Connected System Object under an external ID no
+/// import ever produces: the next import sees an object it has never met, provisioning runs again, and
+/// the pair never converges. Nothing raises an error at any point.
+/// </para>
+/// <para>
+/// An Oracle table keyed on <c>RAW(16) DEFAULT SYS_GUID()</c> is where the two genuinely disagreed: the
+/// driver hands back bytes on both sides, and only the anchor's attribute type says whether they are a
+/// GUID or a digest.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class SqlAnchorTokenAgreementTests
+{
+    private const string GuidAnchorDocument = """
+        {
+          "objectTypes": [
+            { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "STAFF_GUID" ] }
+          ]
+        }
+        """;
+
+    private const string CompositeGuidAnchorDocument = """
+        {
+          "objectTypes": [
+            { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "COMPANY_ID", "STAFF_GUID" ] }
+          ]
+        }
+        """;
+
+    private static readonly Guid Identifier = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+    private ILogger _logger = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = new LoggerConfiguration().CreateLogger();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_logger as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public async Task AnOracleRaw16GeneratedKey_ComposesTheSameExternalIdOnExportAndOnImport()
+    {
+        var raw16 = IdentifierParser.ToRfc4122Bytes(Identifier);
+
+        var exported = await ExportACreateAsync(SqlDatabaseType.Oracle, GuidAnchorDocument, OracleTable(),
+            generatedKey: raw16,
+            Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"));
+
+        var imported = await ImportTheRowAsync(SqlDatabaseType.Oracle, GuidAnchorDocument, OracleTable(),
+            GuidAnchorSystem(),
+            ["STAFF_GUID", "DISPLAY_NAME"],
+            [raw16, "Ada"]);
+
+        var importedIdentifier = imported.Attributes.Single(attribute => attribute.Name == "STAFF_GUID").GuidValues.Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(importedIdentifier, Is.EqualTo(Identifier), "The row's key is the identifier the bytes mean in Oracle's own byte order.");
+            Assert.That(exported, Is.EqualTo(importedIdentifier.ToString("D")),
+                "JIM caches a Connected System Object under the external ID string the export returned, and looks it up by the one the import composes; two forms of the same key means the object is never found again.");
+        }
+    }
+
+    [Test]
+    public async Task AnOracleCompositeAnchorEndingInARaw16_ComposesTheSameExternalIdOnExportAndOnImport()
+    {
+        var raw16 = IdentifierParser.ToRfc4122Bytes(Identifier);
+
+        var exported = await ExportACreateAsync(SqlDatabaseType.Oracle, CompositeGuidAnchorDocument, OracleTable(),
+            generatedKey: null,
+            Change("COMPANY_ID", AttributeDataType.Number, number: 7),
+            Change("STAFF_GUID", AttributeDataType.Guid, guid: Identifier),
+            Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"));
+
+        var imported = await ImportTheRowAsync(SqlDatabaseType.Oracle, CompositeGuidAnchorDocument, OracleTable(),
+            CompositeGuidAnchorSystem(),
+            ["COMPANY_ID", "STAFF_GUID", "DISPLAY_NAME"],
+            [7, raw16, "Ada"]);
+
+        var composed = imported.Attributes.Single(attribute => attribute.Name == "COMPANY_ID+STAFF_GUID").StringValues.Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(composed, Is.EqualTo($"7+{Identifier:D}"));
+            Assert.That(exported, Is.EqualTo(composed),
+                "A composed external ID is stored as text and matched as text, so every part of it has to be rendered the same way on both sides.");
+        }
+    }
+
+    [Test]
+    public async Task ASqlServerUniqueidentifierGeneratedKey_ComposesTheSameExternalIdOnExportAndOnImport()
+    {
+        // The regression guard for the dialect this Connector already worked against: SqlClient returns
+        // a Guid on both sides, and neither side's rendering may move.
+        var exported = await ExportACreateAsync(SqlDatabaseType.SqlServer, GuidAnchorDocument, SqlServerTable(),
+            generatedKey: Identifier,
+            Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"));
+
+        var imported = await ImportTheRowAsync(SqlDatabaseType.SqlServer, GuidAnchorDocument, SqlServerTable(),
+            GuidAnchorSystem(),
+            ["STAFF_GUID", "DISPLAY_NAME"],
+            [Identifier, "Ada"]);
+
+        var importedIdentifier = imported.Attributes.Single(attribute => attribute.Name == "STAFF_GUID").GuidValues.Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exported, Is.EqualTo("550e8400-e29b-41d4-a716-446655440000"), "The hyphenated form is what this dialect has always composed.");
+            Assert.That(exported, Is.EqualTo(importedIdentifier.ToString("D")));
+        }
+    }
+
+    #region Driving the Connector
+
+    /// <summary>
+    /// Applies one create and answers with the external ID it composed for the new row.
+    /// </summary>
+    /// <param name="generatedKey">The key the database generates, or null where the create supplies its own anchor.</param>
+    private static async Task<string?> ExportACreateAsync(
+        SqlDatabaseType dialect,
+        string objectTypesDocument,
+        FakeCatalogueColumn[] columns,
+        object? generatedKey,
+        params PendingExportAttributeValueChange[] changes)
+    {
+        var provider = new FakeSqlProvider
+        {
+            DialectUnderTest = dialect,
+
+            // Oracle's mechanism, so that a RAW(16) key comes back the way its driver returns one.
+            GeneratedKeyRetrievalMode = dialect == SqlDatabaseType.Oracle ? SqlGeneratedKeyRetrieval.OutputParameter : SqlGeneratedKeyRetrieval.ResultSet,
+            GeneratedKey = generatedKey
+        };
+
+        provider.Catalogue.AddTable("HR", "EMPLOYEES", columns);
+
+        using var connector = new SqlConnector { ProviderFactory = _ => provider };
+        connector.OpenExportConnection(SettingValues(connector, objectTypesDocument), null);
+
+        try
+        {
+            var pendingExport = new PendingExport
+            {
+                Id = Guid.NewGuid(),
+                ChangeType = PendingExportChangeType.Create,
+                ConnectedSystemObject = new ConnectedSystemObject
+                {
+                    Id = Guid.NewGuid(),
+                    Type = new ConnectedSystemObjectType { Id = 1, Name = "Person" },
+                    TypeId = 1
+                },
+                AttributeValueChanges = [.. changes]
+            };
+
+            var results = await connector.ExportAsync([pendingExport], CancellationToken.None, new RecordingConnectorProgress());
+
+            Assert.That(results[0].Success, Is.True, results[0].ErrorMessage);
+            return results[0].ExternalId;
+        }
+        finally
+        {
+            connector.CloseExportConnection();
+        }
+    }
+
+    /// <summary>
+    /// Imports the one row a table holds and answers with the Connected System Import Object for it.
+    /// </summary>
+    private async Task<ConnectedSystemImportObject> ImportTheRowAsync(
+        SqlDatabaseType dialect,
+        string objectTypesDocument,
+        FakeCatalogueColumn[] columns,
+        ConnectedSystem connectedSystem,
+        string[] rowColumns,
+        object?[] row)
+    {
+        var provider = new FakeSqlProvider { DialectUnderTest = dialect };
+        provider.Catalogue.AddTable("HR", "EMPLOYEES", columns);
+        provider.Catalogue.AddRows("HR", "EMPLOYEES", rowColumns, row);
+
+        using var connector = new SqlConnector { ProviderFactory = _ => provider };
+        connector.OpenImportConnection(SettingValues(connector, objectTypesDocument), null, _logger);
+
+        var runProfile = new ConnectedSystemRunProfile { Name = "Full Import", RunType = ConnectedSystemRunType.FullImport, PageSize = 10 };
+        var result = await connector.ImportAsync(connectedSystem, runProfile, [], null, _logger, CancellationToken.None, new RecordingConnectorProgress());
+
+        return result.ImportObjects.Single();
+    }
+
+    private static List<ConnectedSystemSettingValue> SettingValues(SqlConnector connector, string objectTypesDocument)
+    {
+        var settingValues = SqlConnectorSettingValues.CreateSqlServer(connector);
+        SqlConnectorSettingValues.SetString(settingValues, SqlConnectorConstants.SettingObjectTypes, objectTypesDocument);
+
+        // RAW(16) is as commonly a digest as a GUID, so reading one as a GUID is an administrator's
+        // opt-in that schema discovery, import and export all have to honour identically.
+        SqlConnectorSettingValues.SetCheckbox(settingValues, SqlConnectorConstants.SettingTreatRaw16AsGuid, true);
+        return settingValues;
+    }
+
+    #endregion
+
+    #region Schema
+
+    private static FakeCatalogueColumn[] OracleTable() =>
+    [
+        new FakeCatalogueColumn("COMPANY_ID", "NUMBER", Precision: 10, Scale: 0, IsNullable: false),
+        new FakeCatalogueColumn("STAFF_GUID", "RAW", MaxLength: 16, IsNullable: false),
+        new FakeCatalogueColumn("DISPLAY_NAME", "NVARCHAR2", MaxLength: 200)
+    ];
+
+    private static FakeCatalogueColumn[] SqlServerTable() =>
+    [
+        new FakeCatalogueColumn("COMPANY_ID", "int", IsNullable: false),
+        new FakeCatalogueColumn("STAFF_GUID", "uniqueidentifier", IsNullable: false),
+        new FakeCatalogueColumn("DISPLAY_NAME", "nvarchar", MaxLength: 200)
+    ];
+
+    private static ConnectedSystem GuidAnchorSystem() => new()
+    {
+        Name = "HR Database",
+        ObjectTypes =
+        [
+            ObjectType(
+                Attribute("STAFF_GUID", AttributeDataType.Guid, isExternalId: true),
+                Attribute("DISPLAY_NAME", AttributeDataType.Text))
+        ]
+    };
+
+    private static ConnectedSystem CompositeGuidAnchorSystem() => new()
+    {
+        Name = "HR Database",
+        ObjectTypes =
+        [
+            ObjectType(
+                Attribute("COMPANY_ID", AttributeDataType.Number),
+                Attribute("STAFF_GUID", AttributeDataType.Guid),
+                Attribute("DISPLAY_NAME", AttributeDataType.Text),
+                Attribute("COMPANY_ID+STAFF_GUID", AttributeDataType.Text, isExternalId: true))
+        ]
+    };
+
+    private static ConnectedSystemObjectType ObjectType(params ConnectedSystemObjectTypeAttribute[] attributes) =>
+        new() { Name = "Person", Selected = true, Attributes = [.. attributes] };
+
+    private static ConnectedSystemObjectTypeAttribute Attribute(string name, AttributeDataType type, bool isExternalId = false) =>
+        new() { Name = name, Type = type, Selected = true, IsExternalId = isExternalId };
+
+    private static int _attributeId;
+
+    private static PendingExportAttributeValueChange Change(
+        string name,
+        AttributeDataType type,
+        string? text = null,
+        int? number = null,
+        Guid? guid = null)
+    {
+        var attribute = new ConnectedSystemObjectTypeAttribute { Id = ++_attributeId, Name = name, Type = type };
+
+        return new PendingExportAttributeValueChange
+        {
+            Id = Guid.NewGuid(),
+            Attribute = attribute,
+            AttributeId = attribute.Id,
+            ChangeType = PendingExportAttributeChangeType.Update,
+            StringValue = text,
+            IntValue = number,
+            GuidValue = guid
+        };
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Connectors/SqlAnchorValueTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlAnchorValueTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Tetron Commercial License. See LICENSE file in the project root.
 
 using JIM.Connectors.Sql;
+using JIM.Connectors.Sql.Providers;
 using JIM.Models.Core;
 using JIM.Utilities;
 using NUnit.Framework;
@@ -9,19 +10,35 @@ using NUnit.Framework;
 namespace JIM.Worker.Tests.Connectors;
 
 /// <summary>
-/// Covers the conversion of a keyset-pagination anchor to and from the string form carried in a
-/// Connected System Pagination Token. A lossy conversion here silently skips or repeats rows between
-/// pages, which is the worst kind of import defect: it looks like a successful run.
+/// Covers the conversion of an anchor between what a database driver hands over and the string form JIM
+/// carries it as: an external ID, a Connected System Pagination Token, or a Delta Import watermark. A
+/// lossy conversion here silently skips or repeats rows between pages, and a conversion that differs by
+/// direction leaves an exported object that no import can find, which is the worst kind of defect: it
+/// looks like a successful run.
 /// </summary>
+/// <remarks>
+/// The real providers are used rather than a stand-in, because the one dialect-specific thing in here is
+/// GUID byte order and a stand-in that passed bytes through unchanged would prove nothing about it.
+/// </remarks>
 [TestFixture]
 public class SqlAnchorValueTests
 {
+    private SqlServerProvider _sqlServer = null!;
+    private OracleProvider _oracle = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sqlServer = new SqlServerProvider();
+        _oracle = new OracleProvider();
+    }
+
     #region Decimal
 
     [Test]
     public void ToTokenString_DecimalWithTrailingZeros_ProducesTheCanonicalForm()
     {
-        var token = SqlAnchorValue.ToTokenString(5.00m, AttributeDataType.Decimal);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, 5.00m, AttributeDataType.Decimal);
 
         Assert.That(token, Is.EqualTo(DecimalAttributeValue.ToCanonicalString(5.00m)),
             "Numerically equal decimals must produce identical tokens, or a resumed page compares against a different string for the same value.");
@@ -35,8 +52,8 @@ public class SqlAnchorValueTests
     {
         var original = decimal.Parse(literal, System.Globalization.CultureInfo.InvariantCulture);
 
-        var token = SqlAnchorValue.ToTokenString(original, AttributeDataType.Decimal);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.Decimal, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.Decimal);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.Decimal, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -50,7 +67,7 @@ public class SqlAnchorValueTests
     [SetCulture("de-DE")]
     public void ToTokenString_DecimalUnderACommaDecimalCulture_StillUsesTheInvariantForm()
     {
-        var token = SqlAnchorValue.ToTokenString(1.5m, AttributeDataType.Decimal);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, 1.5m, AttributeDataType.Decimal);
 
         Assert.That(token, Is.EqualTo("1.5"),
             "A culture-sensitive format would write '1,5' and make the persisted watermark unreadable on a differently configured host.");
@@ -60,7 +77,7 @@ public class SqlAnchorValueTests
     [SetCulture("de-DE")]
     public void TryFromTokenString_DecimalUnderACommaDecimalCulture_StillParsesTheInvariantForm()
     {
-        var parsed = SqlAnchorValue.TryFromTokenString("1.5", AttributeDataType.Decimal, out var value);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, "1.5", AttributeDataType.Decimal, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -72,7 +89,7 @@ public class SqlAnchorValueTests
     [Test]
     public void TryFromTokenString_DecimalOverflow_ReturnsFalseRatherThanRounding()
     {
-        var parsed = SqlAnchorValue.TryFromTokenString("792281625142643375935439503350", AttributeDataType.Decimal, out _);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, "792281625142643375935439503350", AttributeDataType.Decimal, out _);
 
         Assert.That(parsed, Is.False, "A value outside decimal's range must surface as an error, never as a silently rounded anchor.");
     }
@@ -84,8 +101,8 @@ public class SqlAnchorValueTests
     [Test]
     public void RoundTrip_Number_PreservesTheValue()
     {
-        var token = SqlAnchorValue.ToTokenString(4711, AttributeDataType.Number);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.Number, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, 4711, AttributeDataType.Number);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.Number, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -97,8 +114,8 @@ public class SqlAnchorValueTests
     [Test]
     public void RoundTrip_LongNumber_PreservesTheValue()
     {
-        var token = SqlAnchorValue.ToTokenString(long.MaxValue, AttributeDataType.LongNumber);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.LongNumber, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, long.MaxValue, AttributeDataType.LongNumber);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.LongNumber, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -110,8 +127,8 @@ public class SqlAnchorValueTests
     [Test]
     public void RoundTrip_Text_PreservesTheValue()
     {
-        var token = SqlAnchorValue.ToTokenString("EMP-0042", AttributeDataType.Text);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.Text, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, "EMP-0042", AttributeDataType.Text);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.Text, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -125,8 +142,8 @@ public class SqlAnchorValueTests
     {
         var original = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
 
-        var token = SqlAnchorValue.ToTokenString(original, AttributeDataType.Guid);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.Guid, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.Guid);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.Guid, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -141,8 +158,8 @@ public class SqlAnchorValueTests
     {
         var original = new DateTime(2026, 7, 14, 22, 0, 0, 123, DateTimeKind.Utc);
 
-        var token = SqlAnchorValue.ToTokenString(original, AttributeDataType.DateTime);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.DateTime, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.DateTime);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.DateTime, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -157,8 +174,8 @@ public class SqlAnchorValueTests
     {
         var original = new byte[] { 0x00, 0x0F, 0xA1, 0xFF };
 
-        var token = SqlAnchorValue.ToTokenString(original, AttributeDataType.Binary);
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.Binary, out var value);
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.Binary);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.Binary, out var value);
 
         using (Assert.EnterMultipleScope())
         {
@@ -169,19 +186,108 @@ public class SqlAnchorValueTests
 
     #endregion
 
+    #region GUID byte order
+
+    [Test]
+    public void ToTokenString_AnOracleRaw16Value_ReadsTheBytesInTheDialectsOwnOrder()
+    {
+        // What an Oracle RAW(16) primary key defaulted from SYS_GUID() hands back: bytes, never a Guid.
+        // Rendering them without the dialect's conversion is what made such a table unimportable.
+        var original = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+        var raw16 = IdentifierParser.ToRfc4122Bytes(original);
+
+        var token = SqlAnchorValue.ToTokenString(_oracle, raw16, AttributeDataType.Guid);
+
+        Assert.That(token, Is.EqualTo("550e8400-e29b-41d4-a716-446655440000"),
+            "Oracle stores a GUID big-endian; reading it any other way transposes the first three components without any error.");
+    }
+
+    [Test]
+    public void ToTokenString_TheSameGuidInEitherDialectsBytes_ComposesTheSameToken()
+    {
+        var original = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(SqlAnchorValue.ToTokenString(_oracle, IdentifierParser.ToRfc4122Bytes(original), AttributeDataType.Guid),
+                Is.EqualTo(SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.Guid)),
+                "An anchor token identifies the object, so the same identifier must produce the same string whichever dialect it came out of.");
+
+            Assert.That(SqlAnchorValue.ToTokenString(_sqlServer, IdentifierParser.ToMicrosoftBytes(original), AttributeDataType.Guid),
+                Is.EqualTo(SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.Guid)));
+        }
+    }
+
+    [Test]
+    public void ToTokenString_AGuidValueAgainstSqlServer_ComposesTheHyphenatedFormItAlwaysDid()
+    {
+        // The regression guard for the dialect this Connector already worked against: SqlClient hands
+        // back a Guid for a uniqueidentifier, and the token it composes must not have moved.
+        var original = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+        Assert.That(SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.Guid), Is.EqualTo("11111111-2222-3333-4444-555555555555"));
+    }
+
+    [Test]
+    public void RoundTrip_GuidThroughTheOracleDialect_ReturnsTheBytesThatDialectBinds()
+    {
+        var original = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+        var token = SqlAnchorValue.ToTokenString(_oracle, IdentifierParser.ToRfc4122Bytes(original), AttributeDataType.Guid);
+        var parsed = SqlAnchorValue.TryFromTokenString(_oracle, token, AttributeDataType.Guid, out var value);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(parsed, Is.True);
+            Assert.That(value, Is.EqualTo(IdentifierParser.ToRfc4122Bytes(original)),
+                "A token is read back to be bound, so it has to come back in the shape the driver takes, not the shape JIM holds.");
+        }
+    }
+
+    #endregion
+
+    #region Dates
+
+    [Test]
+    public void ToTokenString_AValueCarryingItsOwnOffset_NormalisesItToTheInstantItNames()
+    {
+        // What a driver returns for a datetimeoffset or a TIMESTAMP WITH TIME ZONE column. Convert.
+        // ToDateTime throws for it (DateTimeOffset does not implement IConvertible), which made such a
+        // column unusable as a watermark as well as as an anchor.
+        var original = new DateTimeOffset(2026, 7, 14, 23, 0, 0, TimeSpan.FromHours(1));
+
+        var token = SqlAnchorValue.ToTokenString(_sqlServer, original, AttributeDataType.DateTime);
+
+        Assert.That(token, Is.EqualTo(SqlAnchorValue.ToTokenString(_sqlServer, original.UtcDateTime, AttributeDataType.DateTime)),
+            "The same instant must produce the same string whether it arrived with an offset or without one.");
+    }
+
+    [Test]
+    public void ToTokenString_TheSameInstantWithDifferentOffsets_ComposesTheSameToken()
+    {
+        var here = new DateTimeOffset(2026, 7, 14, 23, 0, 0, TimeSpan.FromHours(1));
+        var there = here.ToOffset(TimeSpan.FromHours(-5));
+
+        Assert.That(SqlAnchorValue.ToTokenString(_sqlServer, there, AttributeDataType.DateTime),
+            Is.EqualTo(SqlAnchorValue.ToTokenString(_sqlServer, here, AttributeDataType.DateTime)),
+            "A server that reports the same instant in a different offset must not look like a different row.");
+    }
+
+    #endregion
+
     #region Rejections
 
     [Test]
     public void ToTokenString_BooleanAnchor_Throws()
     {
-        Assert.Throws<NotSupportedException>(() => SqlAnchorValue.ToTokenString(true, AttributeDataType.Boolean),
+        Assert.Throws<NotSupportedException>(() => SqlAnchorValue.ToTokenString(_sqlServer, true, AttributeDataType.Boolean),
             "A two-state column cannot order a keyset page, so accepting it would produce an import that never terminates.");
     }
 
     [Test]
     public void ToTokenString_NullValue_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => SqlAnchorValue.ToTokenString(null!, AttributeDataType.Text),
+        Assert.Throws<ArgumentNullException>(() => SqlAnchorValue.ToTokenString(_sqlServer, null!, AttributeDataType.Text),
             "A null anchor means the row cannot be positioned, which is a configuration error rather than a page boundary.");
     }
 
@@ -190,7 +296,7 @@ public class SqlAnchorValueTests
     [TestCase("not-a-number")]
     public void TryFromTokenString_UnusableToken_ReturnsFalse(string? token)
     {
-        var parsed = SqlAnchorValue.TryFromTokenString(token, AttributeDataType.Number, out var value);
+        var parsed = SqlAnchorValue.TryFromTokenString(_sqlServer, token, AttributeDataType.Number, out var value);
 
         using (Assert.EnterMultipleScope())
         {

--- a/test/JIM.Worker.Tests/Connectors/SqlAnchorValueTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlAnchorValueTests.cs
@@ -246,6 +246,48 @@ public class SqlAnchorValueTests
 
     #endregion
 
+    #region Agreement across the shapes a driver hands a value back in
+
+    /// <summary>
+    /// The same logical anchor, in each CLR shape it reaches this class as. An export binds the shape
+    /// JIM holds the value in; an import receives whatever the driver chose to return for the column,
+    /// and the two are routinely different (Oracle answers every NUMBER column with a decimal, whatever
+    /// its precision). Both have to compose the same string, or an exported object cannot be found by
+    /// the import that confirms it.
+    /// </summary>
+    private static IEnumerable<TestCaseData> EquivalentShapes()
+    {
+        yield return new TestCaseData(AttributeDataType.Number, 4711, 4711m).SetName("Number: an int and the decimal Oracle returns for a NUMBER(10)");
+        yield return new TestCaseData(AttributeDataType.Number, 4711, (short)4711).SetName("Number: an int and a smallint");
+        yield return new TestCaseData(AttributeDataType.LongNumber, 4711L, 4711m).SetName("LongNumber: a long and the decimal Oracle returns");
+        yield return new TestCaseData(AttributeDataType.Decimal, 5m, 5.00m).SetName("Decimal: the same number at two scales");
+        yield return new TestCaseData(AttributeDataType.Decimal, 4711m, 4711L).SetName("Decimal: a decimal and an exact integer of the same value");
+        yield return new TestCaseData(AttributeDataType.Text, "EMP-0042", "EMP-0042").SetName("Text: a string either way");
+        yield return new TestCaseData(AttributeDataType.Binary, new byte[] { 0xDE, 0xAD }, new byte[] { 0xDE, 0xAD }).SetName("Binary: bytes either way");
+    }
+
+    [TestCaseSource(nameof(EquivalentShapes))]
+    public void ToTokenString_TheSameValueInEitherShapeADriverReturnsIt_ComposesTheSameToken(AttributeDataType type, object exportShape, object importShape)
+    {
+        Assert.That(SqlAnchorValue.ToTokenString(_sqlServer, importShape, type),
+            Is.EqualTo(SqlAnchorValue.ToTokenString(_sqlServer, exportShape, type)));
+    }
+
+    [Test]
+    public void ToTokenString_AZonelessDateTime_ComposesTheSameTokenWhateverKindItArrivesWith()
+    {
+        // A zoneless column holds wall-clock time in the Connected System's declared Database Time Zone.
+        // An export binds it with an unspecified kind so that no driver converts it a second time, and an
+        // import reads it back the same way, so the two must agree without either applying an offset.
+        var wallClock = new DateTime(2026, 7, 14, 23, 0, 0, DateTimeKind.Unspecified);
+
+        Assert.That(SqlAnchorValue.ToTokenString(_sqlServer, wallClock, AttributeDataType.DateTime),
+            Is.EqualTo(SqlAnchorValue.ToTokenString(_sqlServer, DateTime.SpecifyKind(wallClock, DateTimeKind.Utc), AttributeDataType.DateTime)),
+            "An unspecified kind is taken to be UTC already; converting from the host's local time would move the anchor by whichever machine ran the run.");
+    }
+
+    #endregion
+
     #region Dates
 
     [Test]

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorDeltaImportTests.cs
@@ -1052,7 +1052,7 @@ public class SqlConnectorDeltaImportTests
     /// A date and time as a watermark carries it, so a test states the value it expects rather than its
     /// rendering.
     /// </summary>
-    private static string? TokenFor(DateTime value) => SqlConnectorWatermark.Describe(value)?.Value;
+    private static string? TokenFor(DateTime value) => SqlConnectorWatermark.Describe(new FakeSqlProvider(), value)?.Value;
 
     private static ConnectedSystem PersonSystem() => new()
     {

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
@@ -74,6 +74,19 @@ public class SqlConnectorExportTests
         """;
 
     /// <summary>
+    /// An object type identified by a GUID column, which is what an Oracle table keyed on
+    /// <c>RAW(16) DEFAULT SYS_GUID()</c> and a Microsoft SQL Server table keyed on a
+    /// <c>uniqueidentifier</c> both look like.
+    /// </summary>
+    private const string GuidAnchorDocument = """
+        {
+          "objectTypes": [
+            { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "STAFF_GUID" ] }
+          ]
+        }
+        """;
+
+    /// <summary>
     /// A composite anchor one of whose parts is a GUID column, which is the case a part bound as text
     /// cannot survive: no dialect implicitly converts a string to a uniqueidentifier or a RAW(16).
     /// </summary>
@@ -229,6 +242,81 @@ public class SqlConnectorExportTests
             Assert.That(insert.CommandText, Does.Contain("[COMPANY_ID]").And.Contain("[EMPLOYEE_ID]"),
                 "A natural key is written as part of the row, not asked of the database.");
             Assert.That(insert.Parameters.Values, Does.Contain(7).And.Contain(4711));
+        }
+    }
+
+    [Test]
+    public async Task ExportAsync_ACreateAgainstAnOracleRaw16GeneratedKey_ComposesTheExternalIdAnImportOfTheSameRowWouldCompose()
+    {
+        // RAW(16) DEFAULT SYS_GUID() is how an Oracle table generates a GUID key. The driver returns
+        // bytes, so an export that rendered what it was handed composed hex, while an import of the same
+        // row composed the hyphenated form: JIM would never find the object it had just created.
+        var identifier = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+        var provider = new FakeSqlProvider
+        {
+            DialectUnderTest = SqlDatabaseType.Oracle,
+            GeneratedKeyRetrievalMode = SqlGeneratedKeyRetrieval.OutputParameter,
+            GeneratedKey = IdentifierParser.ToRfc4122Bytes(identifier)
+        };
+
+        provider.Catalogue.AddTable("HR", "EMPLOYEES",
+            new FakeCatalogueColumn("STAFF_GUID", "RAW", MaxLength: 16, IsNullable: false),
+            new FakeCatalogueColumn("DISPLAY_NAME", "NVARCHAR2", MaxLength: 200));
+
+        var results = await ExportAsync(provider, GuidAnchorDocument,
+            [Create(Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))],
+            configureSettings: settingValues => SqlConnectorSettingValues.SetCheckbox(settingValues, SqlConnectorConstants.SettingTreatRaw16AsGuid, true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.True);
+            Assert.That(results[0].ExternalId, Is.EqualTo(identifier.ToString("D")),
+                "The external ID is what the confirming import has to match the row by, so it must be the same string that import composes.");
+        }
+    }
+
+    [Test]
+    public async Task ExportAsync_ACreateSupplyingAGuidAnchor_ComposesTheExternalIdInTheFormAnImportWould()
+    {
+        var identifier = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var provider = new FakeSqlProvider();
+
+        var results = await ExportAsync(provider, GuidAnchorDocument,
+            [Create(Change("STAFF_GUID", AttributeDataType.Guid, guid: identifier), Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.True);
+            Assert.That(results[0].ExternalId, Is.EqualTo(identifier.ToString("D")));
+            Assert.That(provider.ExecutedStatements.Single().Parameters.Values, Does.Contain(provider.ConvertFromGuid(identifier)),
+                "The value written to the column still crosses the seam through the provider, whatever the external ID reads as.");
+        }
+    }
+
+    [Test]
+    public async Task ExportAsync_ACreateSupplyingACompositeAnchorMixingAGuidAndANumber_ComposesBothPartsByTheirOwnType()
+    {
+        var identifier = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var provider = new FakeSqlProvider { DialectUnderTest = SqlDatabaseType.Oracle };
+        provider.Catalogue.AddTable("HR", "EMPLOYEES",
+            new FakeCatalogueColumn("COMPANY_ID", "NUMBER", Precision: 10, Scale: 0, IsNullable: false),
+            new FakeCatalogueColumn("STAFF_GUID", "RAW", MaxLength: 16, IsNullable: false),
+            new FakeCatalogueColumn("DISPLAY_NAME", "NVARCHAR2", MaxLength: 200));
+
+        var results = await ExportAsync(provider, CompositeGuidAnchorDocument,
+        [
+            Create(
+                Change("COMPANY_ID", AttributeDataType.Number, number: 7),
+                Change("STAFF_GUID", AttributeDataType.Guid, guid: identifier),
+                Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))
+        ],
+            configureSettings: settingValues => SqlConnectorSettingValues.SetCheckbox(settingValues, SqlConnectorConstants.SettingTreatRaw16AsGuid, true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.True);
+            Assert.That(results[0].ExternalId, Is.EqualTo($"7+{identifier:D}"),
+                "Each part of a composed external ID is rendered by its own column's type, exactly as an import of the same row renders it.");
         }
     }
 

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
@@ -321,6 +321,28 @@ public class SqlConnectorExportTests
     }
 
     [Test]
+    public async Task ExportAsync_ACreateAgainstAnAnchorColumnJimHasNoTypeFor_FailsThatObjectRatherThanGuessingItsExternalId()
+    {
+        // The external ID has to be composed by the anchor column's own type, so a column JIM cannot type
+        // fails the object naming it. Assuming an exact numeric because identities and sequences usually
+        // generate one is what let a GUID key be recorded as hex.
+        var provider = new FakeSqlProvider { GeneratedKey = 4711 };
+        provider.Catalogue.AddTable("HR", "EMPLOYEES",
+            new FakeCatalogueColumn("EMPLOYEE_ID", "geography", IsNullable: false),
+            new FakeCatalogueColumn("DISPLAY_NAME", "nvarchar", MaxLength: 200));
+
+        var results = await ExportAsync(provider, PersonDocument, [Create(Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.False);
+            Assert.That(results[0].ErrorMessage, Does.Contain("EMPLOYEE_ID").And.Contain("geography"),
+                "The administrator has to be told which column identifies the object type and what type it is.");
+            Assert.That(provider.ExecutedStatements, Is.Empty, "Nothing is written for an object JIM could never find again.");
+        }
+    }
+
+    [Test]
     public async Task ExportAsync_ACreateSupplyingOnlyPartOfACompositeAnchor_FailsThatObjectRatherThanHalfWritingIt()
     {
         var provider = new FakeSqlProvider();

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorImportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorImportTests.cs
@@ -141,6 +141,96 @@ public class SqlConnectorImportTests
             "A Connected System Object is identified by one value, so a composite anchor is projected as the composed attribute schema discovery declared.");
     }
 
+    [Test]
+    public async Task ImportAsync_AnOracleRaw16Anchor_ReadsEveryRowAndPagesOnTheGuidTheBytesMean()
+    {
+        // The shape that made this Connector unusable against Oracle: a primary key declared
+        // RAW(16) DEFAULT SYS_GUID(). The driver hands back bytes, never a Guid, and composing the
+        // anchor without the dialect's own byte order failed every row of the run.
+        const string document = """
+            {
+              "objectTypes": [
+                { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "STAFF_GUID" ] }
+              ]
+            }
+            """;
+
+        var identifiers = new[]
+        {
+            Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            Guid.Parse("550e8400-e29b-41d4-a716-446655440000"),
+            Guid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        };
+
+        var provider = new FakeSqlProvider { DialectUnderTest = SqlDatabaseType.Oracle };
+        provider.Catalogue.AddRows("HR", "EMPLOYEES", ["STAFF_GUID", "DISPLAY_NAME"],
+            [IdentifierParser.ToRfc4122Bytes(identifiers[0]), "Ada"],
+            [IdentifierParser.ToRfc4122Bytes(identifiers[1]), "Grace"],
+            [IdentifierParser.ToRfc4122Bytes(identifiers[2]), "Katherine"]);
+
+        var connectedSystem = new ConnectedSystem
+        {
+            Name = "HR Database",
+            ObjectTypes =
+            [
+                ObjectType("Person",
+                    Attribute("STAFF_GUID", AttributeDataType.Guid, isExternalId: true),
+                    Attribute("DISPLAY_NAME", AttributeDataType.Text))
+            ]
+        };
+
+        // Two rows a page, so the run also has to write an anchor into a pagination token and bind it
+        // back as the boundary of the next page.
+        var run = await RunImportAsync(provider, document, connectedSystem, pageSize: 2);
+
+        var imported = run.ImportObjects
+            .Select(importObject => Attribute(importObject, "STAFF_GUID").GuidValues.Single())
+            .ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(run.Pages, Has.Count.GreaterThan(1), "Three rows at two a page means the pagination token was replayed at least once.");
+            Assert.That(imported, Is.EquivalentTo(identifiers),
+                "Oracle stores a GUID big-endian; reading it as Microsoft byte order transposes the first three components with no error raised.");
+        }
+    }
+
+    [Test]
+    public async Task ImportAsync_ACompositeAnchorMixingAGuidAndANumber_ComposesTheExternalIdFromBothParts()
+    {
+        const string document = """
+            {
+              "objectTypes": [
+                { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "COMPANY_ID", "STAFF_GUID" ] }
+              ]
+            }
+            """;
+
+        var identifier = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+        var provider = new FakeSqlProvider { DialectUnderTest = SqlDatabaseType.Oracle };
+        provider.Catalogue.AddRows("HR", "EMPLOYEES", ["COMPANY_ID", "STAFF_GUID", "DISPLAY_NAME"],
+            [7, IdentifierParser.ToRfc4122Bytes(identifier), "Ada"]);
+
+        var connectedSystem = new ConnectedSystem
+        {
+            Name = "HR Database",
+            ObjectTypes =
+            [
+                ObjectType("Person",
+                    Attribute("COMPANY_ID", AttributeDataType.Number),
+                    Attribute("STAFF_GUID", AttributeDataType.Guid),
+                    Attribute("DISPLAY_NAME", AttributeDataType.Text),
+                    Attribute("COMPANY_ID+STAFF_GUID", AttributeDataType.Text, isExternalId: true))
+            ]
+        };
+
+        var run = await RunImportAsync(provider, document, connectedSystem, pageSize: 10);
+
+        Assert.That(Attribute(run.ImportObjects.Single(), "COMPANY_ID+STAFF_GUID").StringValues.Single(),
+            Is.EqualTo($"7+{identifier:D}"),
+            "Each part of a composed anchor is rendered by its own type, so a GUID part is the hyphenated form beside a plain integer.");
+    }
+
     #endregion
 
     #region Object shaping

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
@@ -250,18 +250,21 @@ internal sealed class FakeSqlProvider : SqlProviderBase
               $"RETURNING {QuoteIdentifier(command.GeneratedKeyColumn!)} INTO {GetParameterPlaceholder(command.GeneratedKeyParameterName!)}";
     }
 
-    public override Guid ConvertToGuid(object value)
-    {
-        return value switch
-        {
-            Guid guid => guid,
-            byte[] bytes => IdentifierParser.FromMicrosoftBytes(bytes),
-            string text => IdentifierParser.FromString(text),
-            _ => throw new ArgumentException($"Unexpected GUID value of type {value.GetType().Name}.", nameof(value))
-        };
-    }
+    /// <summary>
+    /// The byte order of the dialect this stand-in is speaking, delegated to that dialect's own
+    /// provider rather than reimplemented here. GUID byte order is the one value conversion a database
+    /// server genuinely differs on, and a stand-in that passed bytes through unchanged would let a test
+    /// assert a round trip that no real driver performs.
+    /// </summary>
+    private static readonly SqlServerProvider SqlServerByteOrder = new();
 
-    public override object ConvertFromGuid(Guid value) => value;
+    private static readonly OracleProvider OracleByteOrder = new();
+
+    private ISqlProvider ByteOrder => DialectUnderTest == SqlDatabaseType.Oracle ? OracleByteOrder : SqlServerByteOrder;
+
+    public override Guid ConvertToGuid(object value) => ByteOrder.ConvertToGuid(value);
+
+    public override object ConvertFromGuid(Guid value) => ByteOrder.ConvertFromGuid(value);
 
     // Catalogue queries are the real providers' own SQL, which no stand-in database could answer. These
     // stand in for them as recognisable tokens, so a test can still assert that discovery asked the

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
@@ -877,6 +877,11 @@ internal sealed class FakeDbCommand : DbCommand
         if (IsNumeric(left) && IsNumeric(right))
             return Convert.ToDecimal(left, CultureInfo.InvariantCulture).CompareTo(Convert.ToDecimal(right, CultureInfo.InvariantCulture));
 
+        // A binary anchor (an Oracle RAW(16) key is the one that matters) orders by its bytes, as both
+        // dialects do. No byte array implements IComparable, so the default comparer would throw.
+        if (left is byte[] leftBytes && right is byte[] rightBytes)
+            return leftBytes.AsSpan().SequenceCompareTo(rightBytes);
+
         return Comparer<object>.Default.Compare(left, right);
     }
 


### PR DESCRIPTION
## Description

Two faults in how the JIM SQL Connector turns a database value into the string form JIM carries an anchor as (an external ID, a Connected System Pagination Token, or a Delta Import watermark).

**1. Import threw on every row of an Oracle `RAW(16)` key.** `SqlAnchorValue.ToGuid` accepts a `Guid` or a `string` and throws for anything else; its own message says bytes must be converted through the provider first. Import called it with the raw driver value at seven sites, and a `RAW(16)` column comes back as `byte[]`, so with the `treatRaw16AsGuid` option on, every row failed. `ISqlProvider.ConvertToGuid` exists precisely for this and was never called on that path.

**2. Import and export composed different tokens for the same value.** Import rendered a GUID anchor as `"D"` form; export's generated-key path used an untyped renderer where a `byte[]` became hex. An Oracle table keyed `RAW(16) DEFAULT SYS_GUID()` would therefore compose one token on create and a different one on the confirming import, so the object could never be found again.

A third fault surfaced while auditing the rest: a `datetimeoffset` or `TIMESTAMP WITH TIME ZONE` column threw `InvalidCastException` on import, because `DateTimeOffset` does not implement `IConvertible` and `Convert.ToDateTime` refuses it. That routine also renders Delta Import watermarks, and a last-modified offset-carrying column is the commonest Watermark Column configuration there is, so this sat in the main delta path rather than on an exotic edge.

**Layer 4 (top) of a four-PR stack**, based on #1269. Land bottom-up.

Part of #170.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment

The test doubles now delegate GUID conversion to the real `SqlServerProvider` and `OracleProvider` rather than passing bytes through, so byte order is genuinely exercised rather than assumed away. What remains unproven without a live database is the driver's own shapes: that ODP.NET returns `byte[]` for `RAW(16)`, and `decimal` for `NUMBER`. Both were pre-existing assumptions, unchanged here, and Phase 7's Oracle matrix is where they get settled.

## Documentation

- [x] No documentation needed

<!-- Docs: n/a - the JIM SQL Connector is registered nowhere yet, so none of this is observable in a shipped build. Its documentation page and changelog entry land together at Phase 8. -->

## Additional context

**The structural fix matters more than either bug.** The untyped renderer is deleted, and the typed one now takes the provider as a parameter, so there is no longer any way to compose an anchor token without supplying a dialect: a future call site cannot forget a conversion it never had the option to omit. `TryFromTokenString` takes the provider for the same reason, which removed two call sites that separately remembered to convert afterwards. An asymmetric pair is exactly the invitation to drift that produced fault 2.

**Every anchor type was audited for import-versus-export agreement**, not just GUID: Text, Number, LongNumber, Decimal and Binary already agreed; Guid and DateTime did not and now do; Boolean and Reference are refused on both sides rather than one side silently rendering `"True"`.

**The DateTime anchor is handled rather than refused.** Refusing it was not available, because the same routine renders Delta Import watermarks and would have taken an ordinary feature down with a pathological one.

**Also replaced:** the generated-key type guess (`?? Decimal`), with the catalogue's own type. An Oracle `RAW(16)` key would otherwise have bound a decimal output parameter. Types now resolve before the `INSERT` runs, so an untypeable anchor fails while there is still nothing to undo.