### PR TITLE
fix: stop the multi-account password progress test dropping an outcome

### DIFF
--- a/test/JIM.Worker.Tests/Servers/MultiAccountPasswordSetTests.cs
+++ b/test/JIM.Worker.Tests/Servers/MultiAccountPasswordSetTests.cs
@@ -3,6 +3,7 @@
 
 using JIM.Application;
 using JIM.Connectors;
+using System.Collections.Concurrent;
 using JIM.Data;
 using JIM.Data.Repositories;
 using JIM.Models.Activities;
@@ -197,8 +198,13 @@ public class MultiAccountPasswordSetTests
     [Test]
     public async Task SetPasswordOnAccountsAsync_ReportsEachOutcomeAsItLandsAsync()
     {
-        var reported = new List<AccountPasswordSetOutcome>();
-        await SetOnAsync(progress: new Progress<AccountPasswordSetOutcome>(reported.Add));
+        // A concurrent collection rather than a List, because the callbacks are not serialised: NUnit's
+        // SafeSynchronizationContext hands each Progress<T> callback to its own thread pool thread, so all three
+        // can run at once even though the product reports the accounts strictly one at a time. Two concurrent
+        // List<T>.Add calls can write the same index, and the outcome that loses is gone with no error anywhere;
+        // that is what failed this test on main, reproducibly at roughly one run in thirteen.
+        var reported = new ConcurrentQueue<AccountPasswordSetOutcome>();
+        await SetOnAsync(progress: new Progress<AccountPasswordSetOutcome>(reported.Enqueue));
 
         // Progress<T> posts to the captured context, so the reports may arrive after the call returns.
         var deadline = DateTime.UtcNow.AddSeconds(5);


### PR DESCRIPTION
## Why

`SetPasswordOnAccountsAsync_ReportsEachOutcomeAsItLandsAsync` **failed CI on `main`** ([run 31174587511](https://github.com/TetronIO/JIM/actions/runs/31174587511)), expecting three reported outcomes and seeing two:

```
Expected: equivalent to < "Contoso AD", "Fabrikam HR", "Research LDAP" >
But was:  < "Fabrikam HR", "Research LDAP" >
Missing (1): < "Contoso AD" >
```

Reproducible locally: **3 failures in 40 runs** of the fixture.

## Diagnosis

The product is not at fault. `SetPasswordOnAccountsAsync` reports the accounts strictly one at a time, in a `foreach`.

The test collected the reports in a `List<T>`, and the callbacks are **not serialised**. Probing NUnit shows `SafeSynchronizationContext` hands each `Progress<T>` callback to its own thread pool thread:

```
SynchronizationContext.Current = NUnit.Framework.Internal.SafeSynchronizationContext
test thread = 15
callbacks=3 threads=[5,7,16]
```

Two concurrent `List<T>.Add` calls can write the same index, and the outcome that loses is gone with no error anywhere. That is why the failure presented as a *missing account* rather than a timeout, and why it was the first account rather than the last.

## Fix

Collect into a `ConcurrentQueue<T>`. It is the only `Progress<T>` callback in the test suite, so there is no sibling to fix.

## Verification

| | Before | After |
|---|---|---|
| Fixture runs | 40 | 60 |
| Failures | 3 | **0** |

- `dotnet build JIM.sln`: 0 warnings, 0 errors
- `dotnet test JIM.sln`: 7,153 passed, 0 failed

Docs: n/a - test-only fix, no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)