### PR TITLE
Resolve Container scope by most specific match, not by any match (#1255 Phase 1)

### DIFF
--- a/engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md
+++ b/engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md
@@ -1,10 +1,10 @@
 # Container Scope: Exclusions and Advanced Mode
 
-- **Status:** Planned
+- **Status:** Doing (Phase 1 complete; model and persistence next)
 - **Issue**: [#1255](https://github.com/TetronIO/JIM/issues/1255)
 - **Related Issues**: [#351](https://github.com/TetronIO/JIM/issues/351) (Phase 1, OneLevel scope, landed), [#827](https://github.com/TetronIO/JIM/issues/827) (Configuration Change Preview), [#1250](https://github.com/TetronIO/JIM/issues/1250) (export managed scope), [#266](https://github.com/TetronIO/JIM/issues/266) (closed duplicate)
-- **Related Plans**: [`doing/CONFIGURATION_CHANGE_PREVIEW.md`](doing/CONFIGURATION_CHANGE_PREVIEW.md)
-- **Last Updated**: 2026-08-09
+- **Related Plans**: [`CONFIGURATION_CHANGE_PREVIEW.md`](CONFIGURATION_CHANGE_PREVIEW.md)
+- **Last Updated**: 2026-08-10
 
 ## Overview
 
@@ -46,11 +46,13 @@ Service Account, mailbox-archive and staging OUs sitting inside an otherwise who
 
 Add `bool Excluded` to `ConnectedSystemContainer`, mutually exclusive with `Selected`. Containers are already rows in the hierarchy, and they already carry `StableId` (objectGUID / entryUUID), which is what lets a selection survive a rename or a move. An exclusion list keyed on Distinguished Name text would reintroduce exactly the bug `StableId` was added to fix: rename the excluded OU and the exclusion silently evaporates, exposing every object in it to import on the next run.
 
-**2. Membership resolves by nearest ancestor, with specificity measured in JIM's own Container tree.**
+**2. Membership resolves by nearest ancestor, with specificity asked in the Connector's own terms.**
 
-For a given object identifier, collect every Container whose containment test admits it, then let the **deepest** one decide, where depth is the length of the `ParentContainer` chain in JIM's model. `Excluded` wins where it is deepest; `Selected` wins where it is deepest. Most-specific-match is the rule administrators already hold from file-system ACLs and firewall rules, and it composes without further machinery: exclude `OU=Service Accounts`, then re-include `OU=App1` beneath it, to any depth.
+For a given object identifier, collect every Container whose containment test admits it, then let the **most specific** one decide. `Excluded` wins where it is most specific; `Selected` wins where it is most specific. Most-specific-match is the rule administrators already hold from file-system ACLs and firewall rules, and it composes without further machinery: exclude `OU=Service Accounts`, then re-include `OU=App1` beneath it, to any depth.
 
-Measuring specificity in JIM's tree rather than in the Connector's naming means **`IConnectorContainment` does not change**. The Connector keeps answering the one question it is qualified to answer ("is this identifier within this Container?"); JIM ranks the answers using the hierarchy it already stores. Undiscovered Containers simply do not participate in ranking, which is correct: the deepest *known* Container containing the object is the most specific opinion anyone has expressed.
+Specificity is decided by asking the *same* containment question with a Container's own identifier as the subject: a Container that holds another matching Container is, by definition, the more general of the two. So **`IConnectorContainment` does not change** and no Container hierarchy has to be loaded or walked. That second property is load-bearing rather than incidental: the import and export scope checks receive a flat `IReadOnlyCollection<ConnectedSystemContainer>` with no parent chain populated, so any rule needing `ParentContainer` would work in the preview and silently mis-rank everywhere else.
+
+*(Implemented in `ContainerSpecificity` (JIM.Models). An earlier draft of this plan ranked by depth in JIM's own Container tree; that was wrong for the reason just given, and is superseded.)*
 
 **3. Exclusion filters entries; it does not decompose searches.**
 
@@ -92,8 +94,10 @@ An exclusion beneath a `OneLevel` parent is inert, and falls out of the design f
 
 ## Implementation Phases
 
-**Phase 1: Nearest-ancestor resolution (no behaviour change).**
-Replace the `Any(...)` OR in `ConnectedSystemScope.Contains` and in `LdapConnectorUtilities.IsDnWithinAnyContainerScope` with a deepest-match walk. With no exclusions in the model the deepest match is still a match, so results are identical; tests pin that equivalence explicitly, including the undetermined (`null`) cases, before anything else moves.
+**Phase 1: Nearest-ancestor resolution (no behaviour change).** ✅
+Replace the `Any(...)` OR in `ConnectedSystemScope.Contains` and in `LdapConnectorUtilities.IsDnWithinAnyContainerScope` with a most-specific-match resolution. With no exclusions in the model the most specific match is still a match, so results are identical; tests pin that equivalence explicitly, including the undetermined (`null`) cases, before anything else moves.
+
+*Landed as `ContainerSpecificity` (JIM.Models), with `ConnectedSystemScope.Contains` and `LdapConnectorUtilities.ResolveMostSpecificContainerScope` resolving through it. `ContainerSpecificityTests` pins the ranking rule, `ConnectedSystemScopeTests` the membership answers including the undetermined ones, and `LdapConnectorUtilitiesTests` the ranking running on this Connector's own predicate.*
 
 **Phase 2: Model and persistence.**
 `Excluded` on `ConnectedSystemContainer` + migration; mutual exclusivity with `Selected` enforced in `ContainerSelectionEditor` and rejected at the API boundary; `ApplyContainerInclusion` extended so coverage recalculation understands an excluded branch; hierarchy refresh merge keyed on `StableId` carries exclusions through renames and moves, with a `RequiresPostgres` round-trip test.
@@ -139,7 +143,8 @@ Parser and canonical text projection, wildcard support, resolution against the h
 - **Decompose subtree searches to avoid excluded branches.** Makes import scope depend on how recently the hierarchy was refreshed; a new OU under a selected parent would be silently skipped and its objects obsoleted. Rejected on synchronisation integrity.
 - **An exclusion list of Distinguished Names, separate from the Container rows.** Breaks on rename and move, which is the defect `StableId` exists to prevent.
 - **An `Excluded` member on `ConnectedSystemContainerScope`.** Conflates two orthogonal facts (how far a selection reaches; whether a branch is carved out) into one enum, and leaves "excluded" needing a scope of its own.
-- **Widening `IConnectorContainment` to report containment depth.** Unnecessary: specificity is measurable in JIM's own Container tree, and asking every Connector to rank its own containment is work with no second beneficiary.
+- **Widening `IConnectorContainment` to report containment depth.** Unnecessary: the existing predicate already ranks two Containers when one of them is made the subject, so every Connector gets ranking for free from the method it has already implemented.
+- **Ranking by depth in JIM's own Container tree.** Needs `ParentContainer` populated, which the import and export scope checks cannot rely on; it would rank correctly in the preview and silently mis-rank in the two paths that actually move data.
 
 ## Dependencies
 

--- a/src/JIM.Connectors/LDAP/LdapConnectorUtilities.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorUtilities.cs
@@ -568,8 +568,23 @@ internal static class LdapConnectorUtilities
         if (connectedSystemContainers.Count == 0)
             return true;
 
-        return connectedSystemContainers.Any(c => IsDnWithinContainerScope(distinguishedName, c));
+        return ResolveMostSpecificContainerScope(distinguishedName, connectedSystemContainers) is not null;
     }
+
+    /// <summary>
+    /// Which of the supplied Containers has the final say over a distinguished name, or null where none covers it.
+    /// </summary>
+    /// <remarks>
+    /// The Containers handed to the import and export scope checks are a flat collection with no hierarchy to walk,
+    /// so specificity is asked in the only terms available here and the only ones that are the Connector's own: a
+    /// Container holding another matching Container is the more general of the two. Deciding this way rather than by
+    /// taking the first match is what will let a Container beneath a selected one overrule it (#1255); until then
+    /// the two agree on every selection, because every Container in a selection says the same thing.
+    /// </remarks>
+    internal static ConnectedSystemContainer? ResolveMostSpecificContainerScope(
+        string? distinguishedName,
+        IReadOnlyCollection<ConnectedSystemContainer> connectedSystemContainers) =>
+        ContainerSpecificity.ResolveMostSpecific(distinguishedName, connectedSystemContainers, IsDnWithinContainerScope);
 
     /// <summary>
     /// Removes the optional whitespace some directories emit after each DN separator, leaving a form that can

--- a/src/JIM.Models/Staging/ConnectedSystemScope.cs
+++ b/src/JIM.Models/Staging/ConnectedSystemScope.cs
@@ -124,7 +124,10 @@ public sealed class ConnectedSystemScope
         if (_containment is null || string.IsNullOrEmpty(containerIdentifier))
             return null;
 
-        return SelectedContainers.Any(container => _containment.IsWithinContainer(containerIdentifier, container));
+        // The most specific selected container decides, rather than any of them being enough
+        // (<see cref="ContainerSpecificity"/>). While every container says the same thing the two are the same
+        // answer; they part company once a container can contradict the branch it sits in (#1255).
+        return ContainerSpecificity.ResolveMostSpecific(containerIdentifier, SelectedContainers, _containment.IsWithinContainer) is not null;
     }
 
     private static void CollectSelectedContainers(

--- a/src/JIM.Models/Staging/ContainerSpecificity.cs
+++ b/src/JIM.Models/Staging/ContainerSpecificity.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Staging;
+
+/// <summary>
+/// Which of several Containers has the final say over an object.
+/// </summary>
+/// <remarks>
+/// Membership across a set of Containers was an OR: any Container admitting the object put it in scope. That answers
+/// "is this object in scope?" and nothing else, and it is why the model cannot currently express "manage this branch
+/// except that part of it" (#1255): the including ancestor admits every object beneath it, so it wins an OR
+/// unconditionally and no Container deeper down can overrule it.
+///
+/// Ranking replaces the OR. The Container that decides is the most specific one admitting the object, and
+/// specificity is asked in the Connector's own terms, by asking whether one Container's identifier falls within
+/// another's: a Container that holds another matching Container is, by definition, the less specific of the two.
+/// Nothing here knows what containment means, which is <see cref="Interfaces.IConnectorContainment"/>'s whole point,
+/// and no Container hierarchy has to be loaded or navigated for the question to be answerable, which is what lets
+/// the Connector paths use this over a flat collection.
+/// </remarks>
+public static class ContainerSpecificity
+{
+    /// <summary>
+    /// The Container that decides whether <paramref name="objectIdentifier"/> is in scope, or <c>null</c> where no
+    /// Container admits it at all.
+    /// </summary>
+    /// <param name="objectIdentifier">The object's identifier in the Connected System's own terms.</param>
+    /// <param name="containers">The Containers to choose between, in any order.</param>
+    /// <param name="isWithinContainer">
+    /// The containment rule, which must be the Connector's own: <see cref="Interfaces.IConnectorContainment"/> for
+    /// callers holding a Connector, and the Connector's internal predicate for callers inside one.
+    /// </param>
+    /// <remarks>
+    /// Every Container is tested, where the OR this replaced stopped at the first match. That is the cost of being
+    /// able to rank at all, and it is bounded by the number of selected Containers rather than by directory size.
+    /// The ranking pass beyond that runs only where more than one Container matched, which for a hierarchy means
+    /// nested selections and for one object is typically none.
+    ///
+    /// Two Containers that admit the same object while neither contains the other cannot arise from a hierarchy,
+    /// where every Container admitting an object lies on one path down to it. A Connector whose containment is not a
+    /// tree could produce it, and the first such Container in <paramref name="containers"/> is returned. Any caller
+    /// that comes to attach *opposing* meanings to Containers (an exclusion, #1255) must resolve that tie
+    /// deliberately rather than inherit this one, because "whichever we saw first" is not a defensible answer to
+    /// "is this object managed?".
+    /// </remarks>
+    public static ConnectedSystemContainer? ResolveMostSpecific(
+        string? objectIdentifier,
+        IReadOnlyCollection<ConnectedSystemContainer> containers,
+        Func<string?, ConnectedSystemContainer, bool> isWithinContainer)
+    {
+        ArgumentNullException.ThrowIfNull(containers);
+        ArgumentNullException.ThrowIfNull(isWithinContainer);
+
+        if (containers.Count == 0 || string.IsNullOrEmpty(objectIdentifier))
+            return null;
+
+        var matches = containers.Where(container => isWithinContainer(objectIdentifier, container)).ToList();
+        if (matches.Count <= 1)
+            return matches.FirstOrDefault();
+
+        // The most specific match is the one holding no other match: anything holding another match is an ancestor
+        // of it, and an ancestor is the more general statement of the two.
+        return matches.FirstOrDefault(candidate => !matches.Any(other =>
+                   !ReferenceEquals(other, candidate) && isWithinContainer(other.ExternalId, candidate)))
+               ?? matches[0];
+    }
+}

--- a/test/JIM.Models.Tests/Staging/ConnectedSystemScopeTests.cs
+++ b/test/JIM.Models.Tests/Staging/ConnectedSystemScopeTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using System.Collections.Generic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+using NUnit.Framework;
+
+namespace JIM.Models.Tests.Staging;
+
+/// <summary>
+/// The one membership question import, export and preview all ask.
+/// </summary>
+/// <remarks>
+/// Written as the baseline for #1255: the resolution beneath <see cref="ConnectedSystemScope.Contains"/> changes
+/// from an OR across the selected Containers to the most specific Container having the final say, and these pin
+/// every answer it gives, including the undetermined (<c>null</c>) ones, so that change is provably behaviour-
+/// preserving. The <c>null</c> cases matter most: a preview that resolved undetermined to "out of scope" would
+/// count objects as leaving that may not be.
+/// </remarks>
+[TestFixture]
+public class ConnectedSystemScopeTests
+{
+    [Test]
+    public void Contains_NoPartitionOnTheObject_ReturnsUndetermined()
+    {
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10]);
+
+        Assert.That(scope.Contains(null, "CN=Alice,OU=Corp,DC=example,DC=local"), Is.Null);
+    }
+
+    [Test]
+    public void Contains_PartitionNotSelected_ReturnsFalse()
+    {
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [], selectedContainerIds: [10]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Corp,DC=example,DC=local"), Is.False);
+    }
+
+    [Test]
+    public void Contains_ContainersDoNotDecideScope_ReturnsTrueForASelectedPartition()
+    {
+        // A Connector with partitions but no Containers: the selected partition is the whole answer.
+        var connectedSystem = SystemWithContainers();
+        connectedSystem.ConnectorDefinition!.SupportsPartitionContainers = false;
+
+        var scope = ScopeOver(connectedSystem, selectedPartitionIds: [1], selectedContainerIds: []);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Anywhere,DC=example,DC=local"), Is.True);
+    }
+
+    [Test]
+    public void Contains_SelectedPartitionWithNoSelectedContainers_ReturnsFalse()
+    {
+        // Determined, not undetermined: an administrator who has just cleared every Container needs that counted.
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: []);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Corp,DC=example,DC=local"), Is.False);
+    }
+
+    [Test]
+    public void Contains_ConnectorCannotExpressContainment_ReturnsUndetermined()
+    {
+        var scope = ConnectedSystemScope.From(
+            SystemWithContainers(),
+            new ConnectedSystemScopeSelectionProposal([1], [10]),
+            containment: null);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Corp,DC=example,DC=local"), Is.Null);
+    }
+
+    [Test]
+    public void Contains_ObjectCarriesNoIdentifier_ReturnsUndetermined()
+    {
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scope.Contains(1, null), Is.Null);
+            Assert.That(scope.Contains(1, string.Empty), Is.Null);
+        }
+    }
+
+    [Test]
+    public void Contains_ObjectInASelectedContainer_ReturnsTrue()
+    {
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Corp,DC=example,DC=local"), Is.True);
+    }
+
+    [Test]
+    public void Contains_ObjectOutsideEverySelectedContainer_ReturnsFalse()
+    {
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Partners,DC=example,DC=local"), Is.False);
+    }
+
+    [Test]
+    public void Contains_ObjectInANestedSelectedContainer_ReturnsTrue()
+    {
+        // Both Corp and Sales admit this object. Under the OR this passed because Corp matched; under most-specific
+        // resolution it passes because Sales does. The answer must not move.
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10, 11]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.True);
+    }
+
+    [Test]
+    public void Contains_ObjectBeneathAOneLevelContainerOnly_ReturnsFalse()
+    {
+        var connectedSystem = SystemWithContainers(corpScope: ConnectedSystemContainerScope.OneLevel);
+        var scope = ScopeOver(connectedSystem, selectedPartitionIds: [1], selectedContainerIds: [10]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.False);
+    }
+
+    [Test]
+    public void Contains_ObjectFromAnUnselectedPartitionsContainer_ReturnsFalse()
+    {
+        // Containers are collected from selected partitions only, so a Container id from elsewhere contributes nothing.
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10, 20]);
+
+        Assert.That(scope.Contains(2, "CN=Alice,OU=Archive,DC=example,DC=local"), Is.False);
+    }
+
+    #region Helper Methods
+
+    private static ConnectedSystemScope ScopeOver(
+        ConnectedSystem connectedSystem,
+        IReadOnlyList<int> selectedPartitionIds,
+        IReadOnlyList<int> selectedContainerIds) =>
+        ConnectedSystemScope.From(
+            connectedSystem,
+            new ConnectedSystemScopeSelectionProposal(selectedPartitionIds, selectedContainerIds),
+            DistinguishedNameContainment.Instance);
+
+    /// <summary>
+    /// Two partitions: the first holding OU=Corp (id 10) with OU=Sales beneath it (id 11) and a sibling OU=Partners
+    /// (id 12), the second holding OU=Archive (id 20).
+    /// </summary>
+    private static ConnectedSystem SystemWithContainers(
+        ConnectedSystemContainerScope corpScope = ConnectedSystemContainerScope.Subtree)
+    {
+        var corp = Container(10, "OU=Corp,DC=example,DC=local", corpScope);
+        var sales = Container(11, "OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        corp.AddChildContainer(sales);
+
+        return new ConnectedSystem
+        {
+            Name = "Test Directory",
+            ConnectorDefinition = new ConnectorDefinition { Name = "Test Connector", SupportsPartitionContainers = true },
+            Partitions =
+            [
+                new ConnectedSystemPartition
+                {
+                    Id = 1,
+                    Name = "example.local",
+                    ExternalId = "DC=example,DC=local",
+                    Selected = true,
+                    Containers = [corp, Container(12, "OU=Partners,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)]
+                },
+                new ConnectedSystemPartition
+                {
+                    Id = 2,
+                    Name = "archive.local",
+                    ExternalId = "DC=archive,DC=local",
+                    Selected = false,
+                    Containers = [Container(20, "OU=Archive,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)]
+                }
+            ]
+        };
+    }
+
+    private static ConnectedSystemContainer Container(int id, string externalId, ConnectedSystemContainerScope scope) =>
+        new() { Id = id, Name = externalId, ExternalId = externalId, Selected = true, Scope = scope };
+
+    #endregion
+}

--- a/test/JIM.Models.Tests/Staging/ContainerSpecificityTests.cs
+++ b/test/JIM.Models.Tests/Staging/ContainerSpecificityTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Staging;
+using NUnit.Framework;
+
+namespace JIM.Models.Tests.Staging;
+
+/// <summary>
+/// Which of several Containers has the final say over an object.
+/// </summary>
+/// <remarks>
+/// Membership used to be an OR across the selected Containers, which answers "is this object in scope?" and nothing
+/// else. An exclusion (#1255) needs the Container that is *most specific* about the object, because the including
+/// ancestor always matches and would always win an OR. These tests pin the ranking rule on its own, before anything
+/// depends on it.
+/// </remarks>
+[TestFixture]
+public class ContainerSpecificityTests
+{
+    [Test]
+    public void ResolveMostSpecific_NoContainers_ReturnsNull()
+    {
+        Assert.That(ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Corp,DC=example,DC=local", [], IsWithin), Is.Null);
+    }
+
+    [Test]
+    public void ResolveMostSpecific_TheOnlyContainerMatches_ReturnsIt()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Corp,DC=example,DC=local", [corp], IsWithin);
+
+        Assert.That(result, Is.SameAs(corp));
+    }
+
+    [Test]
+    public void ResolveMostSpecific_TheOnlyContainerDoesNotMatch_ReturnsNull()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Partners,DC=example,DC=local", [corp], IsWithin);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ResolveMostSpecific_NestedSubtreeContainers_ReturnsTheDeeperOne()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var sales = Container("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", [corp, sales], IsWithin);
+
+        Assert.That(result, Is.SameAs(sales));
+    }
+
+    [Test]
+    public void ResolveMostSpecific_NestedSubtreeContainersSuppliedDeepestFirst_ReturnsTheSameOne()
+    {
+        // The answer is a property of the Containers, not of the order a caller happened to collect them in.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var sales = Container("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", [sales, corp], IsWithin);
+
+        Assert.That(result, Is.SameAs(sales));
+    }
+
+    [Test]
+    public void ResolveMostSpecific_ThreeLevelsOfNesting_ReturnsTheDeepestOne()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var sales = Container("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var emea = Container("OU=EMEA,OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=EMEA,OU=Sales,OU=Corp,DC=example,DC=local", [corp, sales, emea], IsWithin);
+
+        Assert.That(result, Is.SameAs(emea));
+    }
+
+    [Test]
+    public void ResolveMostSpecific_ObjectAboveTheDeeperContainer_ReturnsTheAncestor()
+    {
+        // Only Corp admits an object held directly in Corp, so Corp is both the only match and the most specific.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var sales = Container("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Corp,DC=example,DC=local", [corp, sales], IsWithin);
+
+        Assert.That(result, Is.SameAs(corp));
+    }
+
+    [Test]
+    public void ResolveMostSpecific_OneLevelAncestorAndSubtreeDescendant_ReturnsTheOneMatchingContainer()
+    {
+        // A OneLevel Container and a Container beneath it never admit the same object, so no ranking is needed;
+        // this pins that the OneLevel ancestor does not steal an object that belongs to the descendant.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.OneLevel);
+        var sales = Container("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", [corp, sales], IsWithin), Is.SameAs(sales));
+            Assert.That(ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Corp,DC=example,DC=local", [corp, sales], IsWithin), Is.SameAs(corp));
+        }
+    }
+
+    [Test]
+    public void ResolveMostSpecific_ContainersInDisjointBranches_ReturnsTheMatchingOne()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var partners = Container("OU=Partners,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=External,OU=Partners,DC=example,DC=local", [corp, partners], IsWithin);
+
+        Assert.That(result, Is.SameAs(partners));
+    }
+
+    [Test]
+    public void ResolveMostSpecific_ObjectOutsideEveryContainer_ReturnsNull()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var partners = Container("OU=Partners,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = ContainerSpecificity.ResolveMostSpecific("CN=Alice,OU=Contractors,DC=example,DC=local", [corp, partners], IsWithin);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ResolveMostSpecific_NullIdentifier_ReturnsNull()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        Assert.That(ContainerSpecificity.ResolveMostSpecific(null, [corp], IsWithin), Is.Null);
+    }
+
+    #region Helper Methods
+
+    private static ConnectedSystemContainer Container(string externalId, ConnectedSystemContainerScope scope) =>
+        new() { Name = externalId, ExternalId = externalId, Selected = true, Scope = scope };
+
+    private static bool IsWithin(string? objectIdentifier, ConnectedSystemContainer container) =>
+        DistinguishedNameContainment.Instance.IsWithinContainer(objectIdentifier, container);
+
+    #endregion
+}

--- a/test/JIM.Models.Tests/Staging/DistinguishedNameContainment.cs
+++ b/test/JIM.Models.Tests/Staging/DistinguishedNameContainment.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System;
+using JIM.Models.Interfaces;
+using JIM.Models.Staging;
+
+namespace JIM.Models.Tests.Staging;
+
+/// <summary>
+/// A Distinguished Name containment rule standing in for a Connector's own, so that tests of scope resolution
+/// exercise the resolution rather than any Connector.
+/// </summary>
+/// <remarks>
+/// Deliberately simpler than the LDAP Connector's rule: no escaped separators, no normalisation of the spacing some
+/// directories emit after each separator. Those belong to <c>LdapConnectorUtilitiesTests</c>, which tests the real
+/// predicate; a second implementation of them here would be a second thing to keep correct with no second
+/// beneficiary.
+/// </remarks>
+internal sealed class DistinguishedNameContainment : IConnectorContainment
+{
+    internal static DistinguishedNameContainment Instance { get; } = new();
+
+    public bool IsWithinContainer(string? objectIdentifier, ConnectedSystemContainer container)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+
+        if (string.IsNullOrWhiteSpace(objectIdentifier) || string.IsNullOrWhiteSpace(container.ExternalId))
+            return false;
+
+        if (objectIdentifier.Equals(container.ExternalId, StringComparison.OrdinalIgnoreCase))
+        {
+            // A subtree search returns its base entry; a one-level search does not.
+            return container.Scope != ConnectedSystemContainerScope.OneLevel;
+        }
+
+        // Compare on the ",<base>" boundary so that OU=NotCorp,DC=x is not mistaken for a descendant of OU=Corp,DC=x.
+        var suffix = "," + container.ExternalId;
+        if (!objectIdentifier.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // One level: what remains once the base is removed must be a single RDN.
+        return container.Scope != ConnectedSystemContainerScope.OneLevel ||
+               !objectIdentifier[..^suffix.Length].Contains(',', StringComparison.Ordinal);
+    }
+}

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorUtilitiesTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorUtilitiesTests.cs
@@ -731,6 +731,85 @@ public class LdapConnectorUtilitiesTests
         Assert.That(LdapConnectorUtilities.IsDnWithinAnyContainerScope("CN=Alice,OU=Corp,DC=example,DC=local", []), Is.True);
     }
 
+    [Test]
+    public void IsDnWithinAnyContainerScope_DnInsideNestedSelectedContainers_ReturnsTrue()
+    {
+        // Two Containers admit this object, one nested inside the other. The answer is the same either way; that it
+        // stays the same is the point, because what decides it is now the deeper Container rather than whichever
+        // matched first.
+        var containers = new List<ConnectedSystemContainer>
+        {
+            CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree),
+            CreateContainer("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
+        };
+
+        Assert.That(LdapConnectorUtilities.IsDnWithinAnyContainerScope("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", containers), Is.True);
+    }
+
+    #endregion
+
+    #region ResolveMostSpecificContainerScope tests
+
+    // Ranking one Container against another asks the same containment question with a Container's own Distinguished
+    // Name as the subject, so the normalisation and boundary rules above have to hold for it too. The ranking rule
+    // itself is pinned in ContainerSpecificityTests; these cover it running on this Connector's predicate.
+
+    [Test]
+    public void ResolveMostSpecificContainerScope_NestedSubtreeContainers_ReturnsTheDeeperOne()
+    {
+        var corp = CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var sales = CreateContainer("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = LdapConnectorUtilities.ResolveMostSpecificContainerScope(
+            "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", [corp, sales]);
+
+        Assert.That(result, Is.SameAs(sales));
+    }
+
+    [Test]
+    public void ResolveMostSpecificContainerScope_ContainersDifferingInCasingAndSpacing_ReturnsTheDeeperOne()
+    {
+        var corp = CreateContainer("ou=corp, dc=example, dc=local", ConnectedSystemContainerScope.Subtree);
+        var sales = CreateContainer("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = LdapConnectorUtilities.ResolveMostSpecificContainerScope(
+            "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", [corp, sales]);
+
+        Assert.That(result, Is.SameAs(sales));
+    }
+
+    [Test]
+    public void ResolveMostSpecificContainerScope_DnHeldDirectlyInTheAncestor_ReturnsTheAncestor()
+    {
+        var corp = CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var sales = CreateContainer("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = LdapConnectorUtilities.ResolveMostSpecificContainerScope(
+            "CN=Alice,OU=Corp,DC=example,DC=local", [corp, sales]);
+
+        Assert.That(result, Is.SameAs(corp));
+    }
+
+    [Test]
+    public void ResolveMostSpecificContainerScope_DnOutsideEveryContainer_ReturnsNull()
+    {
+        var corp = CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var partners = CreateContainer("OU=Partners,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        var result = LdapConnectorUtilities.ResolveMostSpecificContainerScope(
+            "CN=Alice,OU=Contractors,DC=example,DC=local", [corp, partners]);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ResolveMostSpecificContainerScope_NoContainers_ReturnsNull()
+    {
+        // No Containers is no opinion, which IsDnWithinAnyContainerScope reads as "admit everything". There is no
+        // Container to name as the one that decided, so this says so rather than inventing one.
+        Assert.That(LdapConnectorUtilities.ResolveMostSpecificContainerScope("CN=Alice,OU=Corp,DC=example,DC=local", []), Is.Null);
+    }
+
     #endregion
 
     #region Helper Methods


### PR DESCRIPTION
## Description

Phase 1 of Container Scope exclusions ([#1255](https://github.com/TetronIO/JIM/issues/1255)), per [`engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md`](https://github.com/TetronIO/JIM/blob/main/engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md). **No behaviour changes.**

Membership across a set of Containers was an OR: any Container admitting an object put it in scope (`ConnectedSystemScope.Contains` and `LdapConnectorUtilities.IsDnWithinAnyContainerScope` both did `.Any(...)`). That answers "is this object in scope?" and nothing else, and it is why the model cannot express "manage this branch except that part of it": the including ancestor admits everything beneath it, so it wins an OR unconditionally and no Container deeper down can ever overrule it. Exclusions are unimplementable until that changes, so it changes first, on its own, against a pinned baseline.

`ContainerSpecificity` (JIM.Models) replaces the OR with a ranking: the Container that decides is the most specific one admitting the object. Specificity is asked in the **Connector's own terms**, by putting a Container's identifier to the same containment question the Connector already answers: a Container holding another matching Container is, by definition, the more general of the two. So `IConnectorContainment` is unchanged, and no Container hierarchy has to be loaded or walked.

That second property is load-bearing rather than incidental, and it is a correction to the plan as merged. The plan ranked by depth in JIM's own Container tree via `ParentContainer`; the import and export scope checks receive a flat `IReadOnlyCollection<ConnectedSystemContainer>` with no parent chain populated, so that rule would have ranked correctly in the preview and silently mis-ranked in the two paths that actually move data. The plan document is corrected in this PR, and the superseded approach is recorded under Rejected Alternatives.

**Why this is safe:** while every Container in a selection says the same thing, "the most specific one admits it" and "any of them admits it" are the same answer. They part company only once a Container can contradict the branch it sits in, which is Phase 2.

**Two costs worth knowing**, both bounded by the number of selected Containers rather than by directory size: every Container is now tested where the OR stopped at the first match, and the ranking pass runs only where more than one Container matched (for one object under a hierarchy, that means nested selections and typically none).

`ConnectedSystemScope` had no test coverage at all before this. It now has a full characterisation suite including the undetermined (`null`) answers, which is what the later phases move against.

## Type of change

- [x] Refactor (no functional change)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment

Full solution build clean with **0 warnings**; full `dotnet test JIM.sln` green (7,372 passed, 247 skipped). 22 new tests, written red-first:

- `ContainerSpecificityTests` (JIM.Models.Tests): the ranking rule on its own, including that the answer does not depend on the order Containers were collected in, three levels of nesting, disjoint branches, and that a `OneLevel` ancestor does not steal an object belonging to a Container beneath it.
- `ConnectedSystemScopeTests` (JIM.Models.Tests): every answer `Contains` gives, including all three undetermined cases (no partition on the object, no containment rule from the Connector, no identifier to test).
- `LdapConnectorUtilitiesTests`: the ranking running on this Connector's own predicate, so the casing and spacing normalisation is exercised with a Container's Distinguished Name as the subject.

Not runtime-verified on the light stack: this phase is behaviour-preserving by construction and there is nothing observable to drive. Phase 2 is where behaviour changes and will be verified against a running stack.

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [ ] Public documentation updated (`docs/`); page(s):
- [ ] No documentation needed

Plan moved to `engineering/plans/doing/` with `Status: Doing`, Phase 1 marked complete, and the specificity rule corrected. No `docs/` change and no changelog entry: nothing an administrator can observe has changed.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

Does not close #1255. Next is Phase 2: the `Excluded` flag on `ConnectedSystemContainer`, its migration, the editor rules and coverage recalculation, and the hierarchy refresh merge carrying exclusions through renames and moves. Issue #1255's link to the plan needs repointing to `engineering/plans/doing/…` once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfeypW7jcRid2SyWLEDzdp)_