### PR TITLE
fix: show, search and sort every anchor type in the Connector Space (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- 🐛 The Connector Space list now shows, searches and sorts on the External Id of every Connected System Object, not only those whose anchor happens to be text. Active Directory and Samba AD type `objectGUID` as a GUID, and a GUID is stored in its own column, so the External Id column was blank for every one of their objects, pasting an `objectGUID` into the search box silently returned nothing, and sorting by External Id treated every row as empty. Integer, long and decimal anchors, which is what a SQL or Oracle table's primary key becomes, were affected identically; only OpenLDAP's text-typed `entryUUID` came through. The value shown, the value you can search for, and the order the rows come back in are now produced by one shared rule, so they cannot drift apart again. This affects the portal, `GET /connected-systems/{id}/connector-space` and `Get-JIMConnectedSystemObject` alike, and a not-yet-exported External Id on a Pending Export is now rendered the same way. (#1286)
-
-- 🐛 An export is no longer permitted into a Container narrowed to One Level, or anywhere beneath one. Container Scope narrows what an import returns, and the export scope guard still assumed a whole subtree, so JIM could write an object where its own next import would not find it: the change went unconfirmed, the Full Import treated the object as deleted, and the following synchronisation disconnected it. The same rule now answers the question for import search scope, export, and the partition and container preview. (#1251)
-
-- 🐛 Delta Imports from OpenLDAP and other changelog-based directories no longer bring in objects a Full Import would never have returned. Those directories publish one directory-wide change log rather than letting JIM search per Container, and JIM was filtering its entries by Partition alone, ignoring which Containers within it were actually selected. A Delta Import could therefore import an object from a Container nobody had selected, which the next Full Import would then mark obsolete. Both the changelog and accesslog paths now apply the same Container selection a Full Import uses, and report how many entries they skipped. Active Directory was unaffected, as its Delta Import searches each selected Container directly. (#351)
-
 ### Security
 
 - 🔒 Values imported from connected systems (Distinguished Names, identifiers, CSV fields) can no longer forge or corrupt service log entries via embedded line breaks; all such values are now sanitised before logging across the import, synchronisation, and export paths. Identity display names are no longer written to service logs at all.
@@ -112,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ Those filters combine, so "which of last week's scheduled Full Imports against Contoso AD recorded errors?" is now one call rather than a sift through pages of Activities. The portal, REST API and PowerShell run the same query, so all three answer identically.
 
 ### Fixed
+
+- 🐛 The Connector Space now shows, searches and sorts on the External Id of every Connected System Object, not just those with a text anchor. Active Directory and Samba AD objects, anchored on `objectGUID`, previously showed a blank External Id and could not be searched for. (#1286)
 
 - 🐛 Containers discovered from a directory that publishes no name of its own are now named after themselves rather than after their whole address. Only Active Directory supplies the `name` attribute JIM asked for; against OpenLDAP and other directories it was absent and JIM fell back to the entire Distinguished Name, so every row of the Container tree read `ou=Sales,ou=Corp,dc=example,dc=com` instead of `Sales`, restating in text the ancestry the tree already draws and burying the one component that tells two Containers apart. Containers now take the value of their leaf component, which is how Containers created during an export have always been named, so the two can no longer disagree about what the same Container is called. Distinguished Names are unchanged and still identify Containers everywhere JIM records them; a directory that does publish its own name still wins. Refresh the hierarchy on an existing Connected System to rename Containers already discovered.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 The Connector Space list now shows, searches and sorts on the External Id of every Connected System Object, not only those whose anchor happens to be text. Active Directory and Samba AD type `objectGUID` as a GUID, and a GUID is stored in its own column, so the External Id column was blank for every one of their objects, pasting an `objectGUID` into the search box silently returned nothing, and sorting by External Id treated every row as empty. Integer, long and decimal anchors, which is what a SQL or Oracle table's primary key becomes, were affected identically; only OpenLDAP's text-typed `entryUUID` came through. The value shown, the value you can search for, and the order the rows come back in are now produced by one shared rule, so they cannot drift apart again. This affects the portal, `GET /connected-systems/{id}/connector-space` and `Get-JIMConnectedSystemObject` alike, and a not-yet-exported External Id on a Pending Export is now rendered the same way. (#1286)
+
+- 🐛 An export is no longer permitted into a Container narrowed to One Level, or anywhere beneath one. Container Scope narrows what an import returns, and the export scope guard still assumed a whole subtree, so JIM could write an object where its own next import would not find it: the change went unconfirmed, the Full Import treated the object as deleted, and the following synchronisation disconnected it. The same rule now answers the question for import search scope, export, and the partition and container preview. (#1251)
+
+- 🐛 Delta Imports from OpenLDAP and other changelog-based directories no longer bring in objects a Full Import would never have returned. Those directories publish one directory-wide change log rather than letting JIM search per Container, and JIM was filtering its entries by Partition alone, ignoring which Containers within it were actually selected. A Delta Import could therefore import an object from a Container nobody had selected, which the next Full Import would then mark obsolete. Both the changelog and accesslog paths now apply the same Container selection a Full Import uses, and report how many entries they skipped. Active Directory was unaffected, as its Delta Import searches each selected Container directly. (#351)
+
 ### Security
 
 - 🔒 Values imported from connected systems (Distinguished Names, identifiers, CSV fields) can no longer forge or corrupt service log entries via embedded line breaks; all such values are now sanitised before logging across the import, synchronisation, and export paths. Identity display names are no longer written to service logs at all.

--- a/src/JIM.PostgresData/ExternalIdValueText.cs
+++ b/src/JIM.PostgresData/ExternalIdValueText.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Linq.Expressions;
+using JIM.Models.Staging;
+using JIM.Models.Transactional;
+
+namespace JIM.PostgresData;
+
+/// <summary>
+/// The single definition of how an external ID's stored value is rendered as text by a list-page query.
+/// <para>
+/// An external ID is stored in whichever typed column matches its attribute's declared
+/// <see cref="JIM.Models.Core.AttributeDataType"/>: an Active Directory or Samba AD <c>objectGUID</c> anchor
+/// lands in <c>GuidValue</c>, a SQL integer key in <c>IntValue</c>, an Oracle <c>NUMBER</c> key in
+/// <c>DecimalValue</c>, and only an OpenLDAP-style <c>entryUUID</c> in <c>StringValue</c>. Reading
+/// <c>StringValue</c> alone therefore blanks the External Id column for most Connected Systems, which is
+/// exactly what issue #1286 was: the Connector Space list projected, searched and sorted on that one column.
+/// </para>
+/// <para>
+/// These are EF Core expressions rather than an in-memory formatter so that one rule serves all three
+/// uses. Searching and sorting happen in the database, over the whole result set, and cannot be served by a
+/// coalesce applied after materialisation; projecting through the same expression is what guarantees that
+/// the value a user sees, the value they can search for, and the key the rows are ordered by are the same
+/// string. Npgsql translates each to a single correlated scalar subquery containing one <c>CASE</c>, so the
+/// cost matches the <c>StringValue</c>-only projection it replaces. Keep the projection single-column:
+/// selecting an anonymous type of the raw columns instead makes EF Core emit a <c>ROW_NUMBER()</c> window
+/// over the entire attribute-value table.
+/// </para>
+/// <para>
+/// The column priority mirrors <see cref="ConnectedSystemObjectAttributeValue.ToStringNoName"/>, which is
+/// what the Connected System Object detail page renders. The rendered text agrees with it exactly for
+/// string, integer, long, decimal, GUID and boolean values (PostgreSQL casts a <c>uuid</c> to the same
+/// lowercase hyphenated form as <see cref="Guid.ToString()"/>, a <c>numeric</c> to the same
+/// scale-preserving invariant form, and Npgsql renders a boolean as <c>'True'</c>/<c>'False'</c> to match
+/// .NET). A <c>DateTime</c> is the one exception: PostgreSQL renders it in the database session's form
+/// rather than the host's current culture. No connector declares a date and time anchor, and it is included
+/// only so that the column can never silently blank again for a type someone adds later. The byte and
+/// reference columns are deliberately absent; neither can identify an object.
+/// </para>
+/// </summary>
+public static class ExternalIdValueText
+{
+    /// <summary>
+    /// Renders a Connected System Object's external ID (primary or secondary) as the text a list page shows.
+    /// Yields null when no value column is populated, so a caller can fall back to a snapshot column.
+    /// </summary>
+    public static readonly Expression<Func<ConnectedSystemObjectAttributeValue, string?>> FromAttributeValue = av =>
+        !string.IsNullOrEmpty(av.StringValue) ? av.StringValue
+        : av.DateTimeValue != null ? av.DateTimeValue.Value.ToString()
+        : av.IntValue != null ? av.IntValue.Value.ToString()
+        : av.LongValue != null ? av.LongValue.Value.ToString()
+        : av.DecimalValue != null ? av.DecimalValue.Value.ToString()
+        : av.GuidValue != null ? av.GuidValue.Value.ToString()
+        : av.BoolValue != null ? av.BoolValue.Value.ToString()
+        : null;
+
+    /// <summary>
+    /// The same rule for a Pending Export's not-yet-exported external ID, which carries the identical set of
+    /// typed value columns.
+    /// </summary>
+    public static readonly Expression<Func<PendingExportAttributeValueChange, string?>> FromPendingExportAttributeValueChange = avc =>
+        !string.IsNullOrEmpty(avc.StringValue) ? avc.StringValue
+        : avc.DateTimeValue != null ? avc.DateTimeValue.Value.ToString()
+        : avc.IntValue != null ? avc.IntValue.Value.ToString()
+        : avc.LongValue != null ? avc.LongValue.Value.ToString()
+        : avc.DecimalValue != null ? avc.DecimalValue.Value.ToString()
+        : avc.GuidValue != null ? avc.GuidValue.Value.ToString()
+        : avc.BoolValue != null ? avc.BoolValue.Value.ToString()
+        : null;
+}

--- a/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
@@ -984,29 +984,16 @@ public class ActivityRepository : IActivityRepository
                     ?? i.ConnectedSystemObject!.AttributeValues.Where(av => av.Attribute.Name.ToLower() == nameCandidate2).Select(av => av.StringValue).FirstOrDefault()
                     ?? i.ConnectedSystemObject!.AttributeValues.Where(av => av.Attribute.Name.ToLower() == nameCandidate3).Select(av => av.StringValue).FirstOrDefault(),
                 TypeLive = i.ConnectedSystemObject!.Type!.Name,
-                // External id resolved as per-column scalar subqueries. A single multi-column
-                // projection here (`.Select(av => new {...}).FirstOrDefault()`) makes EF Core emit a
+                // External id rendered by ExternalIdValueText, the shared definition the Connector Space
+                // list uses too. Keep the projection single-column: selecting an anonymous type of the raw
+                // columns here (`.Select(av => new {...}).FirstOrDefault()`) makes EF Core emit a
                 // ROW_NUMBER() window over the WHOLE AttributeValues table instead of a correlated
-                // subquery, which is catastrophic at scale; separate single-column subqueries each
-                // translate to a cheap correlated scalar subquery run only for the page's rows.
-                ExtIdString = i.ConnectedSystemObject!.AttributeValues
+                // subquery, which is catastrophic at scale.
+                ExtIdText = i.ConnectedSystemObject!.AttributeValues
                     .Where(av => av.AttributeId == i.ConnectedSystemObject!.ExternalIdAttributeId)
-                    .Select(av => av.StringValue).FirstOrDefault(),
-                ExtIdDateTime = i.ConnectedSystemObject!.AttributeValues
-                    .Where(av => av.AttributeId == i.ConnectedSystemObject!.ExternalIdAttributeId)
-                    .Select(av => av.DateTimeValue).FirstOrDefault(),
-                ExtIdInt = i.ConnectedSystemObject!.AttributeValues
-                    .Where(av => av.AttributeId == i.ConnectedSystemObject!.ExternalIdAttributeId)
-                    .Select(av => av.IntValue).FirstOrDefault(),
-                ExtIdLong = i.ConnectedSystemObject!.AttributeValues
-                    .Where(av => av.AttributeId == i.ConnectedSystemObject!.ExternalIdAttributeId)
-                    .Select(av => av.LongValue).FirstOrDefault(),
-                ExtIdGuid = i.ConnectedSystemObject!.AttributeValues
-                    .Where(av => av.AttributeId == i.ConnectedSystemObject!.ExternalIdAttributeId)
-                    .Select(av => av.GuidValue).FirstOrDefault(),
-                ExtIdBool = i.ConnectedSystemObject!.AttributeValues
-                    .Where(av => av.AttributeId == i.ConnectedSystemObject!.ExternalIdAttributeId)
-                    .Select(av => av.BoolValue).FirstOrDefault()
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
+                    .FirstOrDefault()
             })
             .ToListAsync();
 
@@ -1015,9 +1002,7 @@ public class ActivityRepository : IActivityRepository
         var results = projected.Select(p => new ActivityRunProfileExecutionItemHeader
         {
             Id = p.Id,
-            ExternalIdValue = FormatExternalIdValue(
-                p.ExtIdString, p.ExtIdDateTime, p.ExtIdInt,
-                p.ExtIdLong, p.ExtIdGuid, p.ExtIdBool) ?? p.ExternalIdSnapshot,
+            ExternalIdValue = p.ExtIdText ?? p.ExternalIdSnapshot,
             DisplayName = p.DisplayNameLive ?? p.DisplayNameSnapshot,
             ConnectedSystemObjectType = p.TypeLive ?? p.ObjectTypeSnapshot,
             ErrorType = p.ErrorType,
@@ -1044,30 +1029,6 @@ public class ActivityRepository : IActivityRepository
         pagedResultSet.TotalResults = 0;
         pagedResultSet.Results.Clear();
         return pagedResultSet;
-    }
-
-    /// <summary>
-    /// Formats an external-id attribute value from its raw value columns, mirroring
-    /// <see cref="JIM.Models.Staging.ConnectedSystemObjectAttributeValue.ToStringNoName"/> for the
-    /// scalar column set an external id can use (string, date, int, long, guid, bool; reference and
-    /// binary do not apply to an external id). Returns null when no value column is populated, so the
-    /// caller can fall back to the RPEI external-id snapshot column.
-    /// </summary>
-    private static string? FormatExternalIdValue(string? stringValue, DateTime? dateTimeValue, int? intValue, long? longValue, Guid? guidValue, bool? boolValue)
-    {
-        if (!string.IsNullOrEmpty(stringValue))
-            return stringValue;
-        if (dateTimeValue != null)
-            return dateTimeValue.ToString();
-        if (intValue != null)
-            return intValue.ToString();
-        if (longValue != null)
-            return longValue.ToString();
-        if (guidValue != null)
-            return guidValue.ToString();
-        if (boolValue != null)
-            return boolValue.ToString();
-        return null;
     }
 
     /// <summary>

--- a/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ActivitiesRepository.cs
@@ -901,12 +901,14 @@ public class ActivityRepository : IActivityRepository
                 // Search display name (snapshot fallback)
                 (item.DisplayNameSnapshot != null &&
                  EF.Functions.ILike(item.DisplayNameSnapshot, searchPattern)) ||
-                // Search external ID (live CSO attribute)
+                // Search external ID (live CSO attribute), rendered by the same shared definition the
+                // projection below uses so a non-Text anchor is matchable as it is displayed (#1286)
                 (item.ConnectedSystemObject != null &&
-                 item.ConnectedSystemObject.AttributeValues.Any(av =>
-                    av.AttributeId == item.ConnectedSystemObject.ExternalIdAttributeId &&
-                    av.StringValue != null &&
-                    EF.Functions.ILike(av.StringValue, searchPattern))) ||
+                 item.ConnectedSystemObject.AttributeValues
+                    .Where(av => av.AttributeId == item.ConnectedSystemObject.ExternalIdAttributeId)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
+                    .Any(externalIdText => EF.Functions.ILike(externalIdText!, searchPattern))) ||
                 // Search external ID (snapshot fallback)
                 (item.ExternalIdSnapshot != null &&
                  EF.Functions.ILike(item.ExternalIdSnapshot, searchPattern)));
@@ -915,17 +917,21 @@ public class ActivityRepository : IActivityRepository
         // Apply sorting
         query = sortBy?.ToLower() switch
         {
+            // Sorts on the rendered external id, so the sort key matches what the External Id column
+            // shows for every anchor type rather than only for a Text one (#1286).
             "externalid" => sortDescending
                 ? query.OrderByDescending(item => item.ConnectedSystemObject != null
                     ? item.ConnectedSystemObject.AttributeValues
                         .Where(av => av.AttributeId == item.ConnectedSystemObject.ExternalIdAttributeId)
-                        .Select(av => av.StringValue)
+                        .AsQueryable()
+                        .Select(ExternalIdValueText.FromAttributeValue)
                         .FirstOrDefault() ?? item.ExternalIdSnapshot
                     : item.ExternalIdSnapshot)
                 : query.OrderBy(item => item.ConnectedSystemObject != null
                     ? item.ConnectedSystemObject.AttributeValues
                         .Where(av => av.AttributeId == item.ConnectedSystemObject.ExternalIdAttributeId)
-                        .Select(av => av.StringValue)
+                        .AsQueryable()
+                        .Select(ExternalIdValueText.FromAttributeValue)
                         .FirstOrDefault() ?? item.ExternalIdSnapshot
                     : item.ExternalIdSnapshot),
             // Sorts on the resolved live name, coalescing the naming tiers in preference order so the

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -993,7 +993,12 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
         }
 
         // Apply search filter - search on display name, external ID, or secondary external ID
-        // Search is case-insensitive for user convenience
+        // Search is case-insensitive for user convenience.
+        // The external ID clauses match against ExternalIdValueText, the same rendering the sort clauses
+        // and the projection below use, so typing an anchor exactly as the External Id column shows it
+        // finds the row whichever typed column that anchor is stored in (#1286). Matching StringValue
+        // alone silently returned nothing for every Active Directory and Samba AD object, whose objectGUID
+        // anchor lives in GuidValue.
         if (!string.IsNullOrWhiteSpace(searchQuery))
         {
             var searchPattern = $"%{searchQuery}%";
@@ -1004,38 +1009,46 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
                     av.StringValue != null &&
                     EF.Functions.ILike(av.StringValue, searchPattern)) ||
                 // Search external ID (primary)
-                cso.AttributeValues.Any(av =>
-                    av.AttributeId == cso.ExternalIdAttributeId &&
-                    av.StringValue != null &&
-                    EF.Functions.ILike(av.StringValue, searchPattern)) ||
+                cso.AttributeValues
+                    .Where(av => av.AttributeId == cso.ExternalIdAttributeId)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
+                    .Any(externalIdText => EF.Functions.ILike(externalIdText!, searchPattern)) ||
                 // Search secondary external ID
                 (cso.SecondaryExternalIdAttributeId != null &&
-                 cso.AttributeValues.Any(av =>
-                    av.AttributeId == cso.SecondaryExternalIdAttributeId &&
-                    av.StringValue != null &&
-                    EF.Functions.ILike(av.StringValue, searchPattern))));
+                 cso.AttributeValues
+                    .Where(av => av.AttributeId == cso.SecondaryExternalIdAttributeId)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
+                    .Any(externalIdText => EF.Functions.ILike(externalIdText!, searchPattern))));
         }
 
         // Apply sorting
         query = sortBy?.ToLower() switch
         {
+            // Sorts on the rendered external ID, so the ordering matches what the External Id column
+            // shows rather than treating every non-Text anchor as null (#1286).
             "externalid" => sortDescending
                 ? query.OrderByDescending(cso => cso.AttributeValues
                     .Where(av => av.AttributeId == cso.ExternalIdAttributeId)
-                    .Select(av => av.StringValue)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
                     .FirstOrDefault())
                 : query.OrderBy(cso => cso.AttributeValues
                     .Where(av => av.AttributeId == cso.ExternalIdAttributeId)
-                    .Select(av => av.StringValue)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
                     .FirstOrDefault()),
             "secondaryexternalid" => sortDescending
                 ? query.OrderByDescending(cso => cso.AttributeValues
                     .Where(av => av.AttributeId == cso.SecondaryExternalIdAttributeId)
-                    .Select(av => av.StringValue)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
                     .FirstOrDefault())
                 : query.OrderBy(cso => cso.AttributeValues
                     .Where(av => av.AttributeId == cso.SecondaryExternalIdAttributeId)
-                    .Select(av => av.StringValue)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
                     .FirstOrDefault()),
             // Sorts on the resolved name, coalescing the naming tiers in preference order so the sort
             // key matches what the Display Name column actually renders.
@@ -1098,9 +1111,12 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
                     cso.AttributeValues.Where(av => nameTier1.Contains(av.AttributeId)).Select(av => av.StringValue).FirstOrDefault()
                     ?? cso.AttributeValues.Where(av => nameTier2.Contains(av.AttributeId)).Select(av => av.StringValue).FirstOrDefault()
                     ?? cso.AttributeValues.Where(av => nameTier3.Contains(av.AttributeId)).Select(av => av.StringValue).FirstOrDefault(),
+                // Rendered from whichever typed column the anchor occupies, via the same expression the
+                // search and sort clauses above use (#1286).
                 ExternalIdValue = cso.AttributeValues
                     .Where(av => av.AttributeId == cso.ExternalIdAttributeId)
-                    .Select(av => av.StringValue)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
                     .FirstOrDefault(),
                 ExternalIdAttributeName = cso.AttributeValues
                     .Where(av => av.AttributeId == cso.ExternalIdAttributeId)
@@ -1110,7 +1126,8 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
                     ? null
                     : cso.AttributeValues
                         .Where(av => av.AttributeId == cso.SecondaryExternalIdAttributeId)
-                        .Select(av => av.StringValue)
+                        .AsQueryable()
+                        .Select(ExternalIdValueText.FromAttributeValue)
                         .FirstOrDefault(),
                 SecondaryExternalIdAttributeName = cso.SecondaryExternalIdAttributeId == null
                     ? null
@@ -1134,11 +1151,13 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
                         .Where(avc => allNameAttributeIds.Contains(avc.AttributeId))
                         .Select(avc => avc.StringValue)
                         .FirstOrDefault(),
+                // A Pending Export carries the same typed value columns as a Connected System Object
+                // Attribute Value, so it needs the same rendering (#1286).
                 PendingExternalId = Repository.Database.PendingExports
                     .Where(pe => pe.ConnectedSystemObjectId == cso.Id)
                     .SelectMany(pe => pe.AttributeValueChanges)
                     .Where(avc => avc.AttributeId == cso.ExternalIdAttributeId)
-                    .Select(avc => avc.StringValue)
+                    .Select(ExternalIdValueText.FromPendingExportAttributeValueChange)
                     .FirstOrDefault(),
                 PendingSecondaryExternalId = cso.SecondaryExternalIdAttributeId == null ||
                                               cso.AttributeValues.Any(av => av.AttributeId == cso.SecondaryExternalIdAttributeId)
@@ -1147,7 +1166,7 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
                         .Where(pe => pe.ConnectedSystemObjectId == cso.Id)
                         .SelectMany(pe => pe.AttributeValueChanges)
                         .Where(avc => avc.Attribute.IsSecondaryExternalId)
-                        .Select(avc => avc.StringValue)
+                        .Select(ExternalIdValueText.FromPendingExportAttributeValueChange)
                         .FirstOrDefault()
             });
         List<ConnectedSystemObjectHeader> results;

--- a/src/JIM.PostgresData/Repositories/SyncRepository.CsOperations.cs
+++ b/src/JIM.PostgresData/Repositories/SyncRepository.CsOperations.cs
@@ -1552,22 +1552,22 @@ public partial class SyncRepository
 
         var idList = csoIds as IList<Guid> ?? csoIds.ToList();
 
-        // Correlated single-column scalar subqueries keyed on the CSO's external-ID attribute; a
-        // single-column projection emits a clean correlated subquery rather than the whole-table
-        // ROW_NUMBER() a multi-column projection would produce, and filtering by ExternalIdAttributeId
-        // rides the (ConnectedSystemObjectId, AttributeId) index instead of scanning member values.
+        // A correlated single-column scalar subquery keyed on the CSO's external-ID attribute, rendering
+        // the anchor via the shared ExternalIdValueText definition; a single-column projection emits a
+        // clean correlated subquery rather than the whole-table ROW_NUMBER() a multi-column projection
+        // would produce, and filtering by ExternalIdAttributeId rides the
+        // (ConnectedSystemObjectId, AttributeId) index instead of scanning member values.
         var rows = await _context.ConnectedSystemObjects
             .AsNoTracking()
             .Where(cso => idList.Contains(cso.Id))
             .Select(cso => new
             {
                 cso.Id,
-                ExtIdString = cso.AttributeValues.Where(av => av.AttributeId == cso.ExternalIdAttributeId).Select(av => av.StringValue).FirstOrDefault(),
-                ExtIdDateTime = cso.AttributeValues.Where(av => av.AttributeId == cso.ExternalIdAttributeId).Select(av => av.DateTimeValue).FirstOrDefault(),
-                ExtIdInt = cso.AttributeValues.Where(av => av.AttributeId == cso.ExternalIdAttributeId).Select(av => av.IntValue).FirstOrDefault(),
-                ExtIdLong = cso.AttributeValues.Where(av => av.AttributeId == cso.ExternalIdAttributeId).Select(av => av.LongValue).FirstOrDefault(),
-                ExtIdGuid = cso.AttributeValues.Where(av => av.AttributeId == cso.ExternalIdAttributeId).Select(av => av.GuidValue).FirstOrDefault(),
-                ExtIdBool = cso.AttributeValues.Where(av => av.AttributeId == cso.ExternalIdAttributeId).Select(av => av.BoolValue).FirstOrDefault(),
+                ExtIdText = cso.AttributeValues
+                    .Where(av => av.AttributeId == cso.ExternalIdAttributeId)
+                    .AsQueryable()
+                    .Select(ExternalIdValueText.FromAttributeValue)
+                    .FirstOrDefault(),
                 TypeName = cso.Type!.Name
             })
             .ToListAsync();
@@ -1575,30 +1575,9 @@ public partial class SyncRepository
         return rows.ToDictionary(r => r.Id, r => new ConnectedSystemObjectDisplaySnapshot
         {
             ConnectedSystemObjectId = r.Id,
-            ExternalId = FormatExternalIdSnapshotValue(r.ExtIdString, r.ExtIdDateTime, r.ExtIdInt, r.ExtIdLong, r.ExtIdGuid, r.ExtIdBool),
+            ExternalId = r.ExtIdText,
             TypeName = r.TypeName
         });
-    }
-
-    /// <summary>
-    /// Formats a Connected System Object external-ID attribute value from its typed columns, mirroring
-    /// the priority order in <see cref="ConnectedSystemObjectAttributeValue.ToStringNoName"/>.
-    /// </summary>
-    private static string? FormatExternalIdSnapshotValue(string? stringValue, DateTime? dateTimeValue, int? intValue, long? longValue, Guid? guidValue, bool? boolValue)
-    {
-        if (!string.IsNullOrEmpty(stringValue))
-            return stringValue;
-        if (dateTimeValue != null)
-            return dateTimeValue.ToString();
-        if (intValue != null)
-            return intValue.ToString();
-        if (longValue != null)
-            return longValue.ToString();
-        if (guidValue != null)
-            return guidValue.ToString();
-        if (boolValue != null)
-            return boolValue.ToString();
-        return null;
     }
 
     /// <summary>

--- a/test/JIM.Worker.Tests/Repositories/ConnectedSystemObjectHeaderExternalIdDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Repositories/ConnectedSystemObjectHeaderExternalIdDatabaseTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Reflection;
+using JIM.Application.Servers;
+using JIM.Connectors.Mock;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Staging;
+using JIM.Models.Staging.DTOs;
+using JIM.PostgresData;
+using JIM.Worker.Processors;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Repositories;
+
+/// <summary>
+/// Real-PostgreSQL characterisation of the External Id column on the Connector Space list, i.e. the
+/// <c>ExternalIdValue</c> projection in <c>ConnectedSystemRepository.GetConnectedSystemObjectHeadersAsync</c>,
+/// across every anchor data type a Connected System can declare.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projection reads <c>ConnectedSystemObjectAttributeValue.StringValue</c> alone, but the import path
+/// stores each imported value in the typed column matching the attribute's declared
+/// <see cref="AttributeDataType"/>: a Guid anchor lands in <c>GuidValue</c>, an Int anchor in <c>IntValue</c>,
+/// and only a Text anchor in <c>StringValue</c>. These tests exist to settle, with evidence rather than
+/// reading, what the projection actually returns per anchor type. Issue #1286.
+/// </para>
+/// <para>
+/// Real PostgreSQL matters because the assertion is about which typed column a value physically occupies.
+/// EF Core's in-memory provider evaluates the projection over tracked CLR graphs, so a fixture that happened
+/// to set both <c>StringValue</c> and <c>GuidValue</c> would pass there regardless; and a Moq-based fixture
+/// (which is what the existing API-controller coverage uses) never executes the projection at all.
+/// </para>
+/// <para>
+/// The Connected System Objects under test are built by invoking the production import writer,
+/// <c>SyncImportTaskProcessor.CreateConnectedSystemObjectFromImportObject</c>, rather than by hand. Which
+/// typed column an imported anchor occupies is the entire question, so the fixture must not be free to
+/// answer it by construction. The method is private and the surrounding import loop needs an activity, a
+/// run profile and a live sync repository to drive end to end, so it is reached reflectively; the method
+/// itself touches only the Connected System and Run Profile fields, both of which are supplied for real.
+/// </para>
+/// <para>
+/// Opt-in via the same <c>JIM_TEST_RESET_*</c> environment variables as the other RequiresPostgres fixtures.
+/// </para>
+/// </remarks>
+[TestFixture]
+[Category("RequiresPostgres")]
+public class ConnectedSystemObjectHeaderExternalIdDatabaseTests
+{
+    private const string ExternalIdAttributeName = "anchor";
+    private const string DisplayNameAttributeName = "displayName";
+
+    private string _connectionString = null!;
+
+    private JimDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseNpgsql(_connectionString)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new JimDbContext(options);
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var dbName = Environment.GetEnvironmentVariable("JIM_TEST_RESET_DB");
+        if (string.IsNullOrEmpty(dbName))
+            Assert.Ignore("JIM_TEST_RESET_DB not set; skipping real-PostgreSQL Connected System Object header external id tests.");
+
+        var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
+        var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
+        var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
+
+        using var ctx = NewContext();
+        ctx.Database.Migrate();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(@"
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+                FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '__EFMigrationsHistory') LOOP
+                    EXECUTE 'TRUNCATE TABLE ""' || r.tablename || '"" RESTART IDENTITY CASCADE';
+                END LOOP;
+            END $$;");
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_GuidAnchor_ProjectsTheGuidAsTheExternalIdValueAsync()
+    {
+        // Arrange: an Active Directory-shaped anchor. LdapConnectorRootDse.ExternalIdDataType types
+        // objectGUID as AttributeDataType.Guid for ActiveDirectory and SambaAD.
+        var anchor = Guid.Parse("6f9619ff-8b86-d011-b42d-00c04fc964ff");
+        var systemId = await SeedImportedCsoAsync(
+            AttributeDataType.Guid,
+            attribute => attribute.GuidValues.Add(anchor),
+            displayName: "Ada Lovelace");
+
+        // Act
+        var header = await GetSingleHeaderAsync(systemId);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(header.DisplayName, Is.EqualTo("Ada Lovelace"),
+                "The rest of the row must project normally, so any external id failure is specific to the anchor.");
+            Assert.That(header.ExternalIdAttributeName, Is.EqualTo(ExternalIdAttributeName));
+            Assert.That(header.ExternalIdValue, Is.EqualTo(anchor.ToString()),
+                "A Guid-anchored Connected System Object must surface its anchor in the Connector Space list.");
+        }
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_IntAnchor_ProjectsTheNumberAsTheExternalIdValueAsync()
+    {
+        // Arrange: a SQL-shaped anchor, e.g. an integer primary key column.
+        const int anchor = 40711;
+        var systemId = await SeedImportedCsoAsync(
+            AttributeDataType.Number,
+            attribute => attribute.IntValues.Add(anchor),
+            displayName: "Grace Hopper");
+
+        // Act
+        var header = await GetSingleHeaderAsync(systemId);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(header.DisplayName, Is.EqualTo("Grace Hopper"));
+            Assert.That(header.ExternalIdAttributeName, Is.EqualTo(ExternalIdAttributeName));
+            Assert.That(header.ExternalIdValue, Is.EqualTo(anchor.ToString()),
+                "An Int-anchored Connected System Object must surface its anchor in the Connector Space list.");
+        }
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_TextAnchor_ProjectsTheStringAsTheExternalIdValueAsync()
+    {
+        // Arrange: an OpenLDAP-shaped anchor. Rfc4512SchemaParser types entryUUID as
+        // AttributeDataType.Text, so the same logical UUID is stored as a string here.
+        const string anchor = "b18b3e5c-1f2c-103a-9c1a-6f0f5f1c8f5b";
+        var systemId = await SeedImportedCsoAsync(
+            AttributeDataType.Text,
+            attribute => attribute.StringValues.Add(anchor),
+            displayName: "Alan Turing");
+
+        // Act
+        var header = await GetSingleHeaderAsync(systemId);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(header.DisplayName, Is.EqualTo("Alan Turing"));
+            Assert.That(header.ExternalIdAttributeName, Is.EqualTo(ExternalIdAttributeName));
+            Assert.That(header.ExternalIdValue, Is.EqualTo(anchor),
+                "A Text-anchored Connected System Object must surface its anchor in the Connector Space list.");
+        }
+    }
+
+    /// <summary>
+    /// Records which typed column the production import writer puts an anchor in, per declared data type.
+    /// This is the premise the three projection tests rest on; if the writer ever starts populating
+    /// <c>StringValue</c> alongside the typed column, this test says so directly rather than leaving the
+    /// projection tests to pass for a reason nobody stated.
+    /// </summary>
+    [Test]
+    public async Task ImportWriter_TypedAnchors_PopulateOnlyTheColumnMatchingTheDeclaredDataTypeAsync()
+    {
+        // Arrange
+        var guidAnchor = Guid.Parse("6f9619ff-8b86-d011-b42d-00c04fc964ff");
+        var guidSystemId = await SeedImportedCsoAsync(
+            AttributeDataType.Guid, attribute => attribute.GuidValues.Add(guidAnchor), "Ada Lovelace");
+
+        await SetUp();
+        var intSystemId = await SeedImportedCsoAsync(
+            AttributeDataType.Number, attribute => attribute.IntValues.Add(40711), "Grace Hopper");
+        var intAnchorValue = await GetPersistedAnchorAsync(intSystemId);
+
+        await SetUp();
+        var textSystemId = await SeedImportedCsoAsync(
+            AttributeDataType.Text, attribute => attribute.StringValues.Add("entry-uuid"), "Alan Turing");
+        var textAnchorValue = await GetPersistedAnchorAsync(textSystemId);
+
+        // The Guid seed was truncated away above, so re-seed it last and read it back.
+        await SetUp();
+        guidSystemId = await SeedImportedCsoAsync(
+            AttributeDataType.Guid, attribute => attribute.GuidValues.Add(guidAnchor), "Ada Lovelace");
+        var guidAnchorValue = await GetPersistedAnchorAsync(guidSystemId);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(guidAnchorValue.GuidValue, Is.EqualTo(guidAnchor));
+            Assert.That(guidAnchorValue.StringValue, Is.Null,
+                "The import writer stores a Guid anchor in GuidValue only.");
+            Assert.That(intAnchorValue.IntValue, Is.EqualTo(40711));
+            Assert.That(intAnchorValue.StringValue, Is.Null,
+                "The import writer stores an Int anchor in IntValue only.");
+            Assert.That(textAnchorValue.StringValue, Is.EqualTo("entry-uuid"));
+            Assert.That(textAnchorValue.GuidValue, Is.Null);
+        }
+    }
+
+    #region helpers
+
+    /// <summary>
+    /// Seeds a Connected System carrying one object type with an anchor attribute of the supplied data type,
+    /// and one Connected System Object built by the production import writer.
+    /// </summary>
+    /// <returns>The Connected System's id.</returns>
+    private async Task<int> SeedImportedCsoAsync(
+        AttributeDataType anchorDataType,
+        Action<ConnectedSystemImportObjectAttribute> populateAnchor,
+        string displayName)
+    {
+        await using var seed = NewContext();
+
+        var connectorDefinition = new ConnectorDefinition { Name = "Test Connector", BuiltIn = true };
+        var connectedSystem = new ConnectedSystem { Name = "Glitterband", ConnectorDefinition = connectorDefinition };
+        var objectType = new ConnectedSystemObjectType { Name = "user", ConnectedSystem = connectedSystem, Selected = true };
+        objectType.Attributes.Add(new ConnectedSystemObjectTypeAttribute
+        {
+            Name = ExternalIdAttributeName,
+            ConnectedSystemObjectType = objectType,
+            Type = anchorDataType,
+            AttributePlurality = AttributePlurality.SingleValued,
+            Selected = true,
+            IsExternalId = true
+        });
+        objectType.Attributes.Add(new ConnectedSystemObjectTypeAttribute
+        {
+            Name = DisplayNameAttributeName,
+            ConnectedSystemObjectType = objectType,
+            Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.SingleValued,
+            Selected = true
+        });
+        seed.AddRange(connectorDefinition, connectedSystem, objectType);
+        await seed.SaveChangesAsync();
+
+        var anchorAttribute = new ConnectedSystemImportObjectAttribute { Name = ExternalIdAttributeName };
+        populateAnchor(anchorAttribute);
+
+        var importObject = new ConnectedSystemImportObject
+        {
+            ChangeType = ObjectChangeType.NotSet,
+            ObjectType = objectType.Name,
+            Attributes =
+            [
+                anchorAttribute,
+                new ConnectedSystemImportObjectAttribute
+                {
+                    Name = DisplayNameAttributeName,
+                    StringValues = [displayName]
+                }
+            ]
+        };
+
+        var cso = CreateCsoViaProductionImportWriter(connectedSystem, objectType, importObject);
+        seed.Add(cso);
+        await seed.SaveChangesAsync();
+
+        return connectedSystem.Id;
+    }
+
+    /// <summary>
+    /// Builds a Connected System Object exactly as a Full Import does, by invoking
+    /// <c>SyncImportTaskProcessor.CreateConnectedSystemObjectFromImportObject</c>. See the fixture remarks
+    /// for why this is reached reflectively rather than mirrored by hand.
+    /// </summary>
+    private static ConnectedSystemObject CreateCsoViaProductionImportWriter(
+        ConnectedSystem connectedSystem,
+        ConnectedSystemObjectType objectType,
+        ConnectedSystemImportObject importObject)
+    {
+        var runProfile = new ConnectedSystemRunProfile
+        {
+            Name = "Full Import",
+            RunType = ConnectedSystemRunType.FullImport,
+            ConnectedSystemId = connectedSystem.Id
+        };
+        var workerTask = TestUtilities.CreateTestWorkerTask(new Activity(), initiatedBy: null);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // The writer under test reads only the Connected System and the Run Profile from the processor, both
+        // supplied for real below. The application, repository, sync server and sync engine are constructor
+        // dependencies of the wider import loop and are never dereferenced on this path.
+        var processor = new SyncImportTaskProcessor(
+            null!,
+            null!,
+            null!,
+            new SyncEngine(),
+            new MockFileConnector(),
+            connectedSystem,
+            runProfile,
+            workerTask,
+            cancellationTokenSource);
+
+        const string writerName = "CreateConnectedSystemObjectFromImportObject";
+        var writer = typeof(SyncImportTaskProcessor).GetMethod(writerName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                $"SyncImportTaskProcessor.{writerName} was not found. If it has been renamed or its signature has " +
+                "changed, update this fixture to invoke the current production import writer; do not replace it with " +
+                "a hand-built Connected System Object, because which typed column the anchor lands in is the " +
+                "behaviour under test.");
+
+        var executionItem = new ActivityRunProfileExecutionItem { Id = Guid.NewGuid() };
+        var cso = writer.Invoke(processor, [importObject, objectType, executionItem]) as ConnectedSystemObject;
+
+        Assert.That(cso, Is.Not.Null,
+            $"The import writer rejected the test import object: {executionItem.ErrorType} {executionItem.ErrorMessage}");
+
+        // The writer links the execution item to the object it built. Nothing in this fixture persists
+        // execution items, so break the link before EF sees the graph.
+        executionItem.ConnectedSystemObject = null;
+        return cso;
+    }
+
+    private async Task<ConnectedSystemObjectHeader> GetSingleHeaderAsync(int connectedSystemId)
+    {
+        await using var ctx = NewContext();
+        var repository = new PostgresDataRepository(ctx);
+
+        var page = await repository.ConnectedSystems.GetConnectedSystemObjectHeadersAsync(
+            connectedSystemId, page: 1, pageSize: 10);
+
+        Assert.That(page.Results, Has.Count.EqualTo(1), "Expected exactly one seeded Connected System Object.");
+        return page.Results[0];
+    }
+
+    private async Task<ConnectedSystemObjectAttributeValue> GetPersistedAnchorAsync(int connectedSystemId)
+    {
+        await using var ctx = NewContext();
+
+        var anchor = await ctx.ConnectedSystemObjectAttributeValues
+            .AsNoTracking()
+            .Where(av => av.ConnectedSystemObject.ConnectedSystemId == connectedSystemId &&
+                         av.Attribute.Name == ExternalIdAttributeName)
+            .SingleAsync();
+
+        return anchor;
+    }
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Repositories/ConnectedSystemObjectHeaderExternalIdDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Repositories/ConnectedSystemObjectHeaderExternalIdDatabaseTests.cs
@@ -18,17 +18,18 @@ using NUnit.Framework;
 namespace JIM.Worker.Tests.Repositories;
 
 /// <summary>
-/// Real-PostgreSQL characterisation of the External Id column on the Connector Space list, i.e. the
-/// <c>ExternalIdValue</c> projection in <c>ConnectedSystemRepository.GetConnectedSystemObjectHeadersAsync</c>,
-/// across every anchor data type a Connected System can declare.
+/// Real-PostgreSQL regression coverage for the External Id column on the Connector Space list, i.e. the
+/// <c>ExternalIdValue</c> projection in <c>ConnectedSystemRepository.GetConnectedSystemObjectHeadersAsync</c>
+/// plus the search predicate and sort clauses that must render the anchor the same way, across every anchor
+/// data type a Connected System can declare.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The projection reads <c>ConnectedSystemObjectAttributeValue.StringValue</c> alone, but the import path
-/// stores each imported value in the typed column matching the attribute's declared
+/// The import path stores each imported value in the typed column matching the attribute's declared
 /// <see cref="AttributeDataType"/>: a Guid anchor lands in <c>GuidValue</c>, an Int anchor in <c>IntValue</c>,
-/// and only a Text anchor in <c>StringValue</c>. These tests exist to settle, with evidence rather than
-/// reading, what the projection actually returns per anchor type. Issue #1286.
+/// and only a Text anchor in <c>StringValue</c>. Issue #1286: all three read
+/// <c>ConnectedSystemObjectAttributeValue.StringValue</c> alone, so the column was blank, search returned
+/// nothing and sort saw null for every Active Directory and Samba AD object.
 /// </para>
 /// <para>
 /// Real PostgreSQL matters because the assertion is about which typed column a value physically occupies.
@@ -146,6 +147,55 @@ public class ConnectedSystemObjectHeaderExternalIdDatabaseTests
     }
 
     [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_LongAnchor_ProjectsTheNumberAsTheExternalIdValueAsync()
+    {
+        // Arrange: a 64-bit key, e.g. a SQL bigint identity column. IConnectedSystemRepository's
+        // deletion-detection path treats LongNumber as a supported anchor type alongside Text, Number
+        // and Guid, but nothing exercised it through this projection.
+        const long anchor = 9_007_199_254_740_993L;
+        var systemId = await SeedImportedCsoAsync(
+            AttributeDataType.LongNumber,
+            attribute => attribute.LongValues.Add(anchor),
+            displayName: "Katherine Johnson");
+
+        // Act
+        var header = await GetSingleHeaderAsync(systemId);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(header.DisplayName, Is.EqualTo("Katherine Johnson"));
+            Assert.That(header.ExternalIdAttributeName, Is.EqualTo(ExternalIdAttributeName));
+            Assert.That(header.ExternalIdValue, Is.EqualTo(anchor.ToString()),
+                "A Long-anchored Connected System Object must surface its anchor in the Connector Space list.");
+        }
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_DecimalAnchor_ProjectsTheNumberAsTheExternalIdValueAsync()
+    {
+        // Arrange: an Oracle-shaped anchor. A NUMBER primary key maps to AttributeDataType.Decimal, which
+        // SqlAnchorValue calls out as the case that matters most in practice for a SQL Connector.
+        const decimal anchor = 40711.25m;
+        var systemId = await SeedImportedCsoAsync(
+            AttributeDataType.Decimal,
+            attribute => attribute.DecimalValues.Add(anchor),
+            displayName: "Dorothy Vaughan");
+
+        // Act
+        var header = await GetSingleHeaderAsync(systemId);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(header.DisplayName, Is.EqualTo("Dorothy Vaughan"));
+            Assert.That(header.ExternalIdAttributeName, Is.EqualTo(ExternalIdAttributeName));
+            Assert.That(header.ExternalIdValue, Is.EqualTo("40711.25"),
+                "A Decimal-anchored Connected System Object must surface its anchor in the Connector Space list.");
+        }
+    }
+
+    [Test]
     public async Task GetConnectedSystemObjectHeadersAsync_TextAnchor_ProjectsTheStringAsTheExternalIdValueAsync()
     {
         // Arrange: an OpenLDAP-shaped anchor. Rfc4512SchemaParser types entryUUID as
@@ -166,6 +216,69 @@ public class ConnectedSystemObjectHeaderExternalIdDatabaseTests
             Assert.That(header.ExternalIdAttributeName, Is.EqualTo(ExternalIdAttributeName));
             Assert.That(header.ExternalIdValue, Is.EqualTo(anchor),
                 "A Text-anchored Connected System Object must surface its anchor in the Connector Space list.");
+        }
+    }
+
+    /// <summary>
+    /// Searching and sorting run in the database, over the whole Connector Space rather than the page in
+    /// hand, so neither is served by anything the projection does after materialisation. These two tests
+    /// cover the halves a user notices most: typing an objectGUID into the search box, and clicking the
+    /// External Id column header.
+    /// </summary>
+    [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_SearchByGuidAnchor_FindsTheObjectAsync()
+    {
+        // Arrange
+        var anchor = Guid.Parse("6f9619ff-8b86-d011-b42d-00c04fc964ff");
+        var otherAnchor = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var systemId = await SeedImportedCsosAsync(
+            AttributeDataType.Guid,
+            (attribute => attribute.GuidValues.Add(anchor), "Ada Lovelace"),
+            (attribute => attribute.GuidValues.Add(otherAnchor), "Grace Hopper"));
+
+        // Act: the canonical hyphenated form is what the External Id column renders and what an
+        // administrator copies out of it, so it is what must match.
+        var exact = await GetHeadersAsync(systemId, searchQuery: anchor.ToString());
+        var upperCasePartial = await GetHeadersAsync(systemId, searchQuery: "6F9619FF-8B86");
+        var noMatch = await GetHeadersAsync(systemId, searchQuery: "00000000-0000-0000-0000-000000000000");
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exact.Select(h => h.DisplayName).ToArray(), Is.EqualTo(new[] { "Ada Lovelace" }),
+                "Searching the Connector Space by a Guid anchor's canonical string form must find the object.");
+            Assert.That(upperCasePartial.Select(h => h.DisplayName).ToArray(), Is.EqualTo(new[] { "Ada Lovelace" }),
+                "External Id search is case-insensitive and matches on a substring, as it does for a Text anchor.");
+            Assert.That(noMatch, Is.Empty,
+                "A Guid that no object carries must match nothing; the predicate must filter, not pass everything through.");
+        }
+    }
+
+    [Test]
+    public async Task GetConnectedSystemObjectHeadersAsync_SortByExternalId_OrdersByTheRenderedGuidAsync()
+    {
+        // Arrange: seeded out of order, so the ordering asserted below can only come from the sort clause.
+        var first = Guid.Parse("1a000000-0000-0000-0000-000000000000");
+        var second = Guid.Parse("5b000000-0000-0000-0000-000000000000");
+        var third = Guid.Parse("c3000000-0000-0000-0000-000000000000");
+        var systemId = await SeedImportedCsosAsync(
+            AttributeDataType.Guid,
+            (attribute => attribute.GuidValues.Add(third), "Third"),
+            (attribute => attribute.GuidValues.Add(first), "First"),
+            (attribute => attribute.GuidValues.Add(second), "Second"));
+
+        // Act
+        var ascending = await GetHeadersAsync(systemId, sortBy: "externalid", sortDescending: false);
+        var descending = await GetHeadersAsync(systemId, sortBy: "externalid", sortDescending: true);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ascending.Select(h => h.ExternalIdValue).ToArray(),
+                Is.EqualTo(new[] { first.ToString(), second.ToString(), third.ToString() }),
+                "Sorting by External Id must order Guid anchors by the value the column renders, not treat them all as null.");
+            Assert.That(descending.Select(h => h.ExternalIdValue).ToArray(),
+                Is.EqualTo(new[] { third.ToString(), second.ToString(), first.ToString() }));
         }
     }
 
@@ -220,10 +333,23 @@ public class ConnectedSystemObjectHeaderExternalIdDatabaseTests
     /// and one Connected System Object built by the production import writer.
     /// </summary>
     /// <returns>The Connected System's id.</returns>
-    private async Task<int> SeedImportedCsoAsync(
+    private Task<int> SeedImportedCsoAsync(
         AttributeDataType anchorDataType,
         Action<ConnectedSystemImportObjectAttribute> populateAnchor,
         string displayName)
+    {
+        return SeedImportedCsosAsync(anchorDataType, (populateAnchor, displayName));
+    }
+
+    /// <summary>
+    /// The multi-object form of <see cref="SeedImportedCsoAsync"/>, for the search and sort tests, which need
+    /// several Connected System Objects in one Connected System to have anything to filter or order.
+    /// Objects are persisted in the order supplied.
+    /// </summary>
+    /// <returns>The Connected System's id.</returns>
+    private async Task<int> SeedImportedCsosAsync(
+        AttributeDataType anchorDataType,
+        params (Action<ConnectedSystemImportObjectAttribute> PopulateAnchor, string DisplayName)[] objects)
     {
         await using var seed = NewContext();
 
@@ -250,27 +376,30 @@ public class ConnectedSystemObjectHeaderExternalIdDatabaseTests
         seed.AddRange(connectorDefinition, connectedSystem, objectType);
         await seed.SaveChangesAsync();
 
-        var anchorAttribute = new ConnectedSystemImportObjectAttribute { Name = ExternalIdAttributeName };
-        populateAnchor(anchorAttribute);
-
-        var importObject = new ConnectedSystemImportObject
+        foreach (var (populateAnchor, displayName) in objects)
         {
-            ChangeType = ObjectChangeType.NotSet,
-            ObjectType = objectType.Name,
-            Attributes =
-            [
-                anchorAttribute,
-                new ConnectedSystemImportObjectAttribute
-                {
-                    Name = DisplayNameAttributeName,
-                    StringValues = [displayName]
-                }
-            ]
-        };
+            var anchorAttribute = new ConnectedSystemImportObjectAttribute { Name = ExternalIdAttributeName };
+            populateAnchor(anchorAttribute);
 
-        var cso = CreateCsoViaProductionImportWriter(connectedSystem, objectType, importObject);
-        seed.Add(cso);
-        await seed.SaveChangesAsync();
+            var importObject = new ConnectedSystemImportObject
+            {
+                ChangeType = ObjectChangeType.NotSet,
+                ObjectType = objectType.Name,
+                Attributes =
+                [
+                    anchorAttribute,
+                    new ConnectedSystemImportObjectAttribute
+                    {
+                        Name = DisplayNameAttributeName,
+                        StringValues = [displayName]
+                    }
+                ]
+            };
+
+            var cso = CreateCsoViaProductionImportWriter(connectedSystem, objectType, importObject);
+            seed.Add(cso);
+            await seed.SaveChangesAsync();
+        }
 
         return connectedSystem.Id;
     }
@@ -330,14 +459,25 @@ public class ConnectedSystemObjectHeaderExternalIdDatabaseTests
 
     private async Task<ConnectedSystemObjectHeader> GetSingleHeaderAsync(int connectedSystemId)
     {
+        var results = await GetHeadersAsync(connectedSystemId);
+
+        Assert.That(results, Has.Count.EqualTo(1), "Expected exactly one seeded Connected System Object.");
+        return results[0];
+    }
+
+    private async Task<List<ConnectedSystemObjectHeader>> GetHeadersAsync(
+        int connectedSystemId,
+        string? searchQuery = null,
+        string? sortBy = null,
+        bool sortDescending = true)
+    {
         await using var ctx = NewContext();
         var repository = new PostgresDataRepository(ctx);
 
         var page = await repository.ConnectedSystems.GetConnectedSystemObjectHeadersAsync(
-            connectedSystemId, page: 1, pageSize: 10);
+            connectedSystemId, page: 1, pageSize: 10, searchQuery: searchQuery, sortBy: sortBy, sortDescending: sortDescending);
 
-        Assert.That(page.Results, Has.Count.EqualTo(1), "Expected exactly one seeded Connected System Object.");
-        return page.Results[0];
+        return page.Results;
     }
 
     private async Task<ConnectedSystemObjectAttributeValue> GetPersistedAnchorAsync(int connectedSystemId)


### PR DESCRIPTION
## Description

The Connector Space list showed a **blank External Id** for every Connected System Object whose anchor is not Text, could not **search** by such an anchor, and **sorted** every one of them as null. Active Directory and Samba AD anchor on `objectGUID`, so this affects them on `main` today; OpenLDAP escaped it because `entryUUID` maps to Text.

A regression from #705, which replaced an `ExternalIdAttributeValue` entity projection (rendered via `ToStringNoName()`, which handles every typed column) with a scalar `StringValue`-only projection for performance. The performance motivation was sound and is preserved here; only the lost type coverage is restored.

Closes #1286.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

Test-first: the fixture proving the defect was committed **before** the fix (`db66a75b`) and is deliberately red on that commit. The objects are built by invoking the production writer (`SyncImportTaskProcessor.CreateConnectedSystemObjectFromImportObject`) rather than constructed by hand, so the fixture cannot beg the question, and a companion test asserts at database level that a Guid anchor persists with `GuidValue` set and `StringValue` NULL.

`RequiresPostgres` suite executed (not skipped) against a throwaway `postgres:18.4`: 226 passed, 0 failed. Each new test confirmed red before the fix by reverting only `ConnectedSystemRepository.cs`.

Runtime validation against the running dev stack, read-only through the real repository: 50 Int-anchored objects rendered blank and sorted last before, and render `1`, `10`, `11` and search correctly after.

## Documentation

- [x] No documentation needed

<!-- Docs: n/a - bug fix restoring documented behaviour; no docs/ page describes the External Id column. -->

## Additional context

**One shared definition, replacing three copies.** `ActivitiesRepository.FormatExternalIdValue` (added by #1094) had already solved this correctly for the Activity execution-item list, and `SyncRepository.CsOperations.FormatExternalIdSnapshotValue` was a third copy. All three are now `JIM.PostgresData/ExternalIdValueText.cs`; the two existing copies each dropped from six correlated subqueries to one, and gained Decimal coverage neither had.

**It is an EF Core expression, not an in-memory formatter, and that is the load-bearing decision.** Coalescing after materialisation would fix the displayed column and leave search and sort broken, because both run in the database. As an expression it translates to a single correlated scalar subquery, and the projection, the `EXISTS (... ILIKE ...)` search predicate and the `ORDER BY` all reference the same expression, so they agree by construction rather than by convention. Emitted SQL was checked: no window function introduced, projection subqueries still outside the `LIMIT` derived table, subquery count per row unchanged.

`PendingExternalId` / `PendingSecondaryExternalId` had the same defect and are fixed. `ActivitiesRepository`'s own search and sort had it too, masked by its RPEI `ExternalIdSnapshot` fallback, and are aligned so its sort key matches what it renders.

**Two pre-existing disagreements between JIM's three external-ID string forms, neither introduced here**: `Decimal` (display preserves scale, `SqlAnchorValue` canonicalises, which `DecimalAttributeValue`'s documentation states is deliberate) and `DateTime` (three different forms; no Connector declares a date and time anchor today, and the column is covered only so it cannot silently blank later).

**Follow-up, not fixed here:** `GetExternalIdValueString` (the import-matching cache key) and the `GetAllExternalIdAttributeValuesOfType{String,Int,Long,Guid}Async` deletion-detection quartet have no Decimal path, so a Decimal-anchored Object Type would get a null cache key and be invisible to deletion detection. That is the repository-layer half of #1283 and is recorded there.