### PR TITLE
fix: unwrap ODP.NET driver values behind the SQL provider seam (#170)

### DIFF
--- a/src/JIM.Connectors/Sql/Providers/ISqlProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/ISqlProvider.cs
@@ -194,6 +194,31 @@ internal interface ISqlProvider
     #region Values
 
     /// <summary>
+    /// Materialises a value a driver handed back through a bound parameter as the CLR type the rest of
+    /// the Connector works in, so that no provider-specific type crosses this seam.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It exists because a driver is not obliged to answer <see cref="DbParameter.Value"/> with a CLR
+    /// primitive, and ODP.NET does not: a generated key comes back as an
+    /// <c>Oracle.ManagedDataAccess.Types</c> wrapper struct whose type depends on how the parameter was
+    /// bound. Read unwrapped, a sequence-backed <c>NUMBER</c> key fails every create with a cast error
+    /// naming a type an administrator has no way to act on.
+    /// </para>
+    /// <para>
+    /// The data reader path needs none of this: every driver JIM speaks to materialises a column as a
+    /// CLR value already. This is the parameter path only.
+    /// </para>
+    /// <para>
+    /// Null, <see cref="DBNull"/> and a driver's own per-type null sentinel all answer null, so a caller
+    /// has exactly one thing to test for. That matters: a driver's null sentinel need not be
+    /// <see cref="DBNull"/>, and a caller checking only for <see cref="DBNull"/> would read "the database
+    /// returned nothing" as a value.
+    /// </para>
+    /// </remarks>
+    object? ConvertFromDriverValue(object? value);
+
+    /// <summary>
     /// Materialises a GUID from whatever the reader returned for a GUID-typed column. The byte order
     /// is dialect-specific and getting it wrong transposes the first three components silently, so it
     /// belongs behind the seam rather than at the call site.

--- a/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
@@ -4,6 +4,7 @@
 using JIM.Models.Core;
 using JIM.Utilities;
 using Oracle.ManagedDataAccess.Client;
+using Oracle.ManagedDataAccess.Types;
 using System.Data;
 using System.Data.Common;
 
@@ -271,6 +272,55 @@ internal class OracleProvider : SqlProviderBase
     #endregion
 
     #region Values
+
+    /// <summary>
+    /// Unwraps ODP.NET's own value types, which is what a bound parameter answers with.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ODP.NET never answers <see cref="DbParameter.Value"/> with a CLR primitive: a
+    /// <c>RETURNING ... INTO</c> parameter comes back as an <see cref="OracleDecimal"/>, an
+    /// <see cref="OracleBinary"/> or an <see cref="OracleString"/> according to how it was bound. Only
+    /// the last of those survived being read straight through, and only because
+    /// <see cref="Convert.ToString(object?, IFormatProvider?)"/> falls back to a type's own
+    /// <c>ToString</c>; a sequence-backed <c>NUMBER</c> key, which is the ordinary Oracle case, failed
+    /// every create.
+    /// </para>
+    /// <para>
+    /// <b>The null sentinel is the part that has to be right.</b> Each wrapper states "no value" as a
+    /// null instance of itself rather than as <see cref="DBNull"/>, so an
+    /// <see cref="OracleDecimal"/>.<see cref="OracleDecimal.Null"/> read without this is an ordinary
+    /// boxed struct that passes every emptiness test the Connector makes. Answering null instead is what
+    /// keeps "the database returned no key" the clear failure it already was, rather than a wrong
+    /// external ID composed from a wrapper's <c>ToString</c>.
+    /// </para>
+    /// <para>
+    /// A wrapper this Connector never binds a value as is refused rather than passed on, because passing
+    /// it on is exactly the defect this method exists to fix.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="NotSupportedException">The driver answered with an ODP.NET type no value this Connector binds is ever returned as.</exception>
+    public override object? ConvertFromDriverValue(object? value)
+    {
+        if (value == null || value == DBNull.Value)
+            return null;
+
+        // Ahead of the type switch, so that every wrapper's null sentinel is answered the same way
+        // whichever type it is an instance of.
+        if (value is INullable { IsNull: true })
+            return null;
+
+        return value switch
+        {
+            OracleDecimal number => number.Value,
+            OracleString text => text.Value,
+            OracleBinary bytes => bytes.Value,
+            INullable => throw new NotSupportedException(
+                $"The Oracle driver returned a generated key as an {value.GetType().Name}, which JIM has no CLR value for. " +
+                "A generated key is bound as an exact numeric, a character string or a RAW, so this is a defect in the JIM SQL Connector rather than anything to correct in the database; report it with the Object Type's anchor column and its type."),
+            _ => value
+        };
+    }
 
     public override Guid ConvertToGuid(object value)
     {

--- a/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
@@ -316,8 +316,8 @@ internal class OracleProvider : SqlProviderBase
             OracleString text => text.Value,
             OracleBinary bytes => bytes.Value,
             INullable => throw new NotSupportedException(
-                $"The Oracle driver returned a generated key as an {value.GetType().Name}, which JIM has no CLR value for. " +
-                "A generated key is bound as an exact numeric, a character string or a RAW, so this is a defect in the JIM SQL Connector rather than anything to correct in the database; report it with the Object Type's anchor column and its type."),
+                $"The Oracle driver returned an {value.GetType().Name}, which the JIM SQL Connector has no CLR value for, so it is refused rather than passed on as a driver type. " +
+                "The Connector binds only exact numerics, character strings and RAW values through a parameter, so this is a defect in JIM rather than anything to correct in the database; report it with the Object Type and the column involved."),
             _ => value
         };
     }

--- a/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
@@ -449,6 +449,17 @@ internal abstract class SqlProviderBase : ISqlProvider
 
     #region Values
 
+    /// <summary>
+    /// A pass-through, beyond normalising the two ways ADO.NET states "nothing" into one. That is right
+    /// for any driver that materialises a parameter's value as a CLR type, which is every driver except
+    /// ODP.NET; a dialect whose driver hands back wrappers of its own overrides this and unwraps them
+    /// there, so those types are never named outside that provider.
+    /// </summary>
+    public virtual object? ConvertFromDriverValue(object? value)
+    {
+        return value == null || value == DBNull.Value ? null : value;
+    }
+
     public abstract Guid ConvertToGuid(object value);
 
     public abstract object ConvertFromGuid(Guid value);

--- a/src/JIM.Connectors/Sql/SqlConnectorExport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorExport.cs
@@ -298,7 +298,10 @@ internal sealed class SqlConnectorExport
             if (await command.ExecuteNonQueryAsync(cancellationToken) == 0)
                 throw new InvalidOperationException(InsertWroteNothingMessage(plan.QualifiedTableName));
 
-            generatedKey = keyParameter.Value;
+            // Through the seam, never read raw: a driver is free to answer a bound parameter with a
+            // value type of its own, and ODP.NET always does. The provider is also what decides whether
+            // the driver said "no value", because its way of saying so need not be DBNull.
+            generatedKey = _provider.ConvertFromDriverValue(keyParameter.Value);
         }
 
         if (generatedKey == null || generatedKey == DBNull.Value)

--- a/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
@@ -6,6 +6,7 @@ using JIM.Models.Core;
 using JIM.Utilities;
 using NUnit.Framework;
 using Oracle.ManagedDataAccess.Client;
+using Oracle.ManagedDataAccess.Types;
 using System.Data;
 
 namespace JIM.Worker.Tests.Connectors;
@@ -594,6 +595,102 @@ public class OracleProviderTests
 
         Assert.That(result, Is.EqualTo(Guid.Parse("550e8400-e29b-41d4-a716-446655440000")),
             "Some estates store identifiers as VARCHAR2 rather than RAW(16).");
+    }
+
+    #endregion
+
+    #region Driver values
+
+    [Test]
+    public void ConvertFromDriverValue_AnOracleDecimal_UnwrapsToTheDecimalItHolds()
+    {
+        // A sequence-backed NUMBER key. ODP.NET's wrapper implements none of the conversion interfaces
+        // the rest of the Connector reads a value through, so left wrapped it fails every create.
+        var result = _provider.ConvertFromDriverValue(new OracleDecimal(4711));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(4711m));
+            Assert.That(result, Is.TypeOf<decimal>(), "No provider-specific type may cross the dialect seam.");
+        }
+    }
+
+    [Test]
+    public void ConvertFromDriverValue_AnOracleBinary_UnwrapsToTheBytesItHolds()
+    {
+        var raw16 = IdentifierParser.ToRfc4122Bytes(Guid.Parse("550e8400-e29b-41d4-a716-446655440000"));
+
+        var result = _provider.ConvertFromDriverValue(new OracleBinary(raw16));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(raw16));
+            Assert.That(result, Is.TypeOf<byte[]>(),
+                "The bytes are what ConvertToGuid reads, and it is deliberately given no knowledge of ODP.NET's wrappers.");
+        }
+    }
+
+    [Test]
+    public void ConvertFromDriverValue_AnOracleString_UnwrapsToTheTextItHolds()
+    {
+        var result = _provider.ConvertFromDriverValue(new OracleString("EMP-4711"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo("EMP-4711"));
+            Assert.That(result, Is.TypeOf<string>());
+        }
+    }
+
+    /// <summary>
+    /// ODP.NET states "no value" with a null sentinel of the wrapper's own type. A null
+    /// <c>OracleDecimal</c> is an ordinary boxed struct rather than <see cref="DBNull"/>, so a caller
+    /// testing only for <see cref="DBNull"/> would read one as though it held a value.
+    /// </summary>
+    [TestCaseSource(nameof(NullSentinels))]
+    public void ConvertFromDriverValue_AWrappersOwnNullSentinel_IsNull(object nullSentinel)
+    {
+        Assert.That(_provider.ConvertFromDriverValue(nullSentinel), Is.Null);
+    }
+
+    private static IEnumerable<TestCaseData> NullSentinels()
+    {
+        yield return new TestCaseData(OracleDecimal.Null).SetArgDisplayNames("OracleDecimal.Null");
+        yield return new TestCaseData(OracleString.Null).SetArgDisplayNames("OracleString.Null");
+        yield return new TestCaseData(OracleBinary.Null).SetArgDisplayNames("OracleBinary.Null");
+    }
+
+    [Test]
+    public void ConvertFromDriverValue_NothingAtAll_IsNull()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_provider.ConvertFromDriverValue(null), Is.Null);
+            Assert.That(_provider.ConvertFromDriverValue(DBNull.Value), Is.Null);
+        }
+    }
+
+    [Test]
+    public void ConvertFromDriverValue_AValueThatIsAlreadyAClrType_IsHandedBackUnchanged()
+    {
+        // The data reader path already yields CLR types, and a provider that re-interpreted them would
+        // be a second conversion nobody asked for.
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_provider.ConvertFromDriverValue(4711m), Is.EqualTo(4711m));
+            Assert.That(_provider.ConvertFromDriverValue("EMP-4711"), Is.EqualTo("EMP-4711"));
+            Assert.That(_provider.ConvertFromDriverValue(new byte[] { 1, 2, 3 }), Is.EqualTo(new byte[] { 1, 2, 3 }));
+        }
+    }
+
+    [Test]
+    public void ConvertFromDriverValue_AnOdpNetWrapperNoGeneratedKeyIsEverBoundAs_ThrowsRatherThanPassingItThrough()
+    {
+        // Fast and hard, rather than handing a wrapper struct on to a conversion that would report a
+        // cast failure naming a type an administrator has no way to act on.
+        var exception = Assert.Throws<NotSupportedException>(() => _provider.ConvertFromDriverValue(new OracleDate(new DateTime(2026, 8, 8, 0, 0, 0, DateTimeKind.Utc))));
+
+        Assert.That(exception.Message, Does.Contain(nameof(OracleDate)));
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
@@ -690,7 +690,7 @@ public class OracleProviderTests
         // cast failure naming a type an administrator has no way to act on.
         var exception = Assert.Throws<NotSupportedException>(() => _provider.ConvertFromDriverValue(new OracleDate(new DateTime(2026, 8, 8, 0, 0, 0, DateTimeKind.Utc))));
 
-        Assert.That(exception.Message, Does.Contain(nameof(OracleDate)));
+        Assert.That(exception!.Message, Does.Contain(nameof(OracleDate)));
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
@@ -8,6 +8,7 @@ using JIM.Models.Staging;
 using JIM.Models.Transactional;
 using JIM.Utilities;
 using NUnit.Framework;
+using Oracle.ManagedDataAccess.Types;
 using Serilog;
 using Serilog.Core;
 
@@ -82,6 +83,18 @@ public class SqlConnectorExportTests
         {
           "objectTypes": [
             { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "STAFF_GUID" ] }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// An object type identified by a character column, which is what an Oracle table keyed on a
+    /// <c>VARCHAR2</c> filled by a trigger looks like.
+    /// </summary>
+    private const string TextAnchorDocument = """
+        {
+          "objectTypes": [
+            { "name": "Person", "schema": "HR", "table": "EMPLOYEES", "anchorColumns": [ "STAFF_CODE" ] }
           ]
         }
         """;
@@ -832,6 +845,127 @@ public class SqlConnectorExportTests
             Assert.That(results[0].Success, Is.False);
             Assert.That(provider.Transactions.Single().RolledBack, Is.True);
         }
+    }
+
+    #endregion
+
+    #region Oracle driver values
+
+    /// <summary>
+    /// A sequence-backed <c>NUMBER</c> primary key, which is the ordinary way an Oracle table generates
+    /// one. ODP.NET never hands a CLR primitive back through an output parameter, so every create
+    /// against one failed on a cast the driver's own wrapper struct could not satisfy.
+    /// </summary>
+    [Test]
+    public async Task ExportAsync_AnOracleNumberKeyReturnedAsAnOracleDecimal_ComposesTheExternalIdAnImportOfTheSameRowWouldCompose()
+    {
+        var provider = OracleGeneratedKeyProvider(new OracleDecimal(4711));
+
+        var results = await ExportAsync(provider, PersonDocument, [Create(Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.True, results[0].ErrorMessage);
+            Assert.That(results[0].ExternalId, Is.EqualTo("4711"),
+                "The driver's own numeric wrapper has to be unwrapped before the external ID is composed, or the object is never findable again.");
+            Assert.That(provider.Transactions.Single().Committed, Is.True);
+        }
+    }
+
+    /// <summary>
+    /// <c>RAW(16) DEFAULT SYS_GUID()</c>, whose key ODP.NET returns as an <c>OracleBinary</c> rather
+    /// than as the <c>byte[]</c> the same column reads back as through a data reader.
+    /// </summary>
+    [Test]
+    public async Task ExportAsync_AnOracleRaw16KeyReturnedAsAnOracleBinary_ComposesTheGuidInOraclesOwnByteOrder()
+    {
+        var identifier = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+        var provider = OracleGeneratedKeyProvider(new OracleBinary(IdentifierParser.ToRfc4122Bytes(identifier)));
+
+        var results = await ExportAsync(provider, GuidAnchorDocument,
+            [Create(Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))],
+            configureSettings: settingValues => SqlConnectorSettingValues.SetCheckbox(settingValues, SqlConnectorConstants.SettingTreatRaw16AsGuid, true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.True, results[0].ErrorMessage);
+            Assert.That(results[0].ExternalId, Is.EqualTo(identifier.ToString("D")),
+                "Oracle stores a GUID big-endian, so the unwrapped bytes still have to cross the dialect seam before they are rendered.");
+        }
+    }
+
+    /// <summary>
+    /// A text key, which happened to survive because <see cref="Convert.ToString(object?, IFormatProvider?)"/>
+    /// falls back to a wrapper's own <c>ToString</c>. It is covered so the unwrapping cannot regress it.
+    /// </summary>
+    [Test]
+    public async Task ExportAsync_AnOracleTextKeyReturnedAsAnOracleString_ComposesTheExternalIdFromTheTextItHolds()
+    {
+        var provider = OracleGeneratedKeyProvider(new OracleString("EMP-4711"));
+
+        var results = await ExportAsync(provider, TextAnchorDocument, [Create(Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.True, results[0].ErrorMessage);
+            Assert.That(results[0].ExternalId, Is.EqualTo("EMP-4711"));
+        }
+    }
+
+    /// <summary>
+    /// ODP.NET expresses "no value" with a null sentinel of the wrapper's own type, which is not
+    /// <see cref="DBNull"/>: a null <c>OracleDecimal</c> is a perfectly ordinary boxed struct. Read
+    /// without unwrapping, an <c>OracleString.Null</c> composes an external ID out of the wrapper's
+    /// <c>ToString</c>, which is worse than the failure it should have been.
+    /// </summary>
+    [TestCaseSource(nameof(OracleNullSentinels))]
+    public async Task ExportAsync_AnOracleKeyThatCameBackNull_FailsTheObjectAndRollsItBack(object nullSentinel, string objectTypesDocument, string anchorColumn)
+    {
+        var provider = OracleGeneratedKeyProvider(nullSentinel);
+
+        var results = await ExportAsync(provider, objectTypesDocument,
+            [Create(Change("DISPLAY_NAME", AttributeDataType.Text, text: "Ada"))],
+            configureSettings: settingValues => SqlConnectorSettingValues.SetCheckbox(settingValues, SqlConnectorConstants.SettingTreatRaw16AsGuid, true));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.False, "Nothing would identify the new object, so the create cannot be confirmed.");
+            Assert.That(results[0].ErrorMessage, Does.Contain($"returned no value for its anchor column '{anchorColumn}'"));
+            Assert.That(provider.Transactions.Single().RolledBack, Is.True);
+        }
+    }
+
+    /// <summary>
+    /// The null sentinel of every wrapper this Connector can bind a generated key as, each against the
+    /// kind of anchor column that wrapper actually comes back from.
+    /// </summary>
+    private static IEnumerable<TestCaseData> OracleNullSentinels()
+    {
+        yield return new TestCaseData(OracleDecimal.Null, PersonDocument, "EMPLOYEE_ID").SetArgDisplayNames("OracleDecimal.Null");
+        yield return new TestCaseData(OracleString.Null, TextAnchorDocument, "STAFF_CODE").SetArgDisplayNames("OracleString.Null");
+        yield return new TestCaseData(OracleBinary.Null, GuidAnchorDocument, "STAFF_GUID").SetArgDisplayNames("OracleBinary.Null");
+    }
+
+    /// <summary>
+    /// A stand-in Oracle Database that generates the given key and hands it back the way ODP.NET does:
+    /// through a bound output parameter, as the driver's own wrapper rather than as a CLR value.
+    /// </summary>
+    private static FakeSqlProvider OracleGeneratedKeyProvider(object? generatedKey)
+    {
+        var provider = new FakeSqlProvider
+        {
+            DialectUnderTest = SqlDatabaseType.Oracle,
+            GeneratedKeyRetrievalMode = SqlGeneratedKeyRetrieval.OutputParameter,
+            GeneratedKey = generatedKey
+        };
+
+        provider.Catalogue.AddTable("HR", "EMPLOYEES",
+            new FakeCatalogueColumn("EMPLOYEE_ID", "NUMBER", Precision: 10, Scale: 0, IsNullable: false),
+            new FakeCatalogueColumn("STAFF_CODE", "VARCHAR2", MaxLength: 30, IsNullable: false),
+            new FakeCatalogueColumn("STAFF_GUID", "RAW", MaxLength: 16, IsNullable: false),
+            new FakeCatalogueColumn("DISPLAY_NAME", "NVARCHAR2", MaxLength: 200));
+
+        return provider;
     }
 
     #endregion

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
@@ -251,20 +251,22 @@ internal sealed class FakeSqlProvider : SqlProviderBase
     }
 
     /// <summary>
-    /// The byte order of the dialect this stand-in is speaking, delegated to that dialect's own
-    /// provider rather than reimplemented here. GUID byte order is the one value conversion a database
-    /// server genuinely differs on, and a stand-in that passed bytes through unchanged would let a test
-    /// assert a round trip that no real driver performs.
+    /// The value conversions of the dialect this stand-in is speaking, delegated to that dialect's own
+    /// provider rather than reimplemented here. GUID byte order and the driver's own value types are
+    /// the two things a database server genuinely differs on, and a stand-in that passed either through
+    /// unchanged would let a test assert a round trip that no real driver performs.
     /// </summary>
-    private static readonly SqlServerProvider SqlServerByteOrder = new();
+    private static readonly SqlServerProvider SqlServerValues = new();
 
-    private static readonly OracleProvider OracleByteOrder = new();
+    private static readonly OracleProvider OracleValues = new();
 
-    private ISqlProvider ByteOrder => DialectUnderTest == SqlDatabaseType.Oracle ? OracleByteOrder : SqlServerByteOrder;
+    private ISqlProvider Values => DialectUnderTest == SqlDatabaseType.Oracle ? OracleValues : SqlServerValues;
 
-    public override Guid ConvertToGuid(object value) => ByteOrder.ConvertToGuid(value);
+    public override object? ConvertFromDriverValue(object? value) => Values.ConvertFromDriverValue(value);
 
-    public override object ConvertFromGuid(Guid value) => ByteOrder.ConvertFromGuid(value);
+    public override Guid ConvertToGuid(object value) => Values.ConvertToGuid(value);
+
+    public override object ConvertFromGuid(Guid value) => Values.ConvertFromGuid(value);
 
     // Catalogue queries are the real providers' own SQL, which no stand-in database could answer. These
     // stand in for them as recognisable tokens, so a test can still assert that discovery asked the

--- a/test/JIM.Worker.Tests/Connectors/SqlServerProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlServerProviderTests.cs
@@ -549,6 +549,39 @@ public class SqlServerProviderTests
 
     #endregion
 
+    #region Driver values
+
+    /// <summary>
+    /// SqlClient materialises an output parameter as a CLR value, so this dialect has nothing to unwrap
+    /// and must change nothing about what it was handed.
+    /// </summary>
+    [Test]
+    public void ConvertFromDriverValue_AValueSqlClientReturned_IsHandedBackUnchanged()
+    {
+        var identifier = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_provider.ConvertFromDriverValue(4711), Is.EqualTo(4711));
+            Assert.That(_provider.ConvertFromDriverValue(4711m), Is.EqualTo(4711m));
+            Assert.That(_provider.ConvertFromDriverValue("EMP-4711"), Is.EqualTo("EMP-4711"));
+            Assert.That(_provider.ConvertFromDriverValue(identifier), Is.EqualTo(identifier));
+        }
+    }
+
+    [Test]
+    public void ConvertFromDriverValue_NothingAtAll_IsNull()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_provider.ConvertFromDriverValue(null), Is.Null);
+            Assert.That(_provider.ConvertFromDriverValue(DBNull.Value), Is.Null,
+                "DBNull is how ADO.NET states SQL NULL, and it is not a value any anchor could be composed from.");
+        }
+    }
+
+    #endregion
+
     #region Schema catalogue queries
 
     [Test]


### PR DESCRIPTION
Stack layer 2 of the Phase 7 stack for the JIM SQL Connector (#170). Base is #1308.

ODP.NET returns its own wrapper structs (`OracleDecimal`, `OracleBinary`, `OracleString`) from `OracleParameter.Value`, though not from `ExecuteScalar` or `GetValue`. Those types were reaching code above the provider seam, which is the one thing `ISqlProvider` exists to prevent: no provider-specific type may cross it.

- `ISqlProvider` gains `ConvertFromDriverValue(object?)`, so each dialect unwraps its own driver types
- The Oracle provider implements it for the wrapper structs it can return
- The refusal is stated without assuming the value came from a generated key, since the same wrappers appear on any output parameter

Found while running Scenario 16's export rows against Oracle.

Docs: n/a - fixes a defect in the unreleased SQL Connector; the feature's changelog entry is on the register layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)