### PR TITLE
fix: read and write Oracle local-time-zone columns consistently (#170)

### DIFF
--- a/src/JIM.Connectors/Sql/Providers/ISqlProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/ISqlProvider.cs
@@ -82,6 +82,21 @@ internal interface ISqlProvider
     void ConfigureConnection(DbConnection connection, SqlConnectionSettings settings);
 
     /// <summary>
+    /// Applies any configuration this dialect can only apply to a live session, immediately after the
+    /// connection has been opened and before anything is read or written through it.
+    /// <para>
+    /// Oracle Database's session time zone is the case this exists for. It decides what a
+    /// <c>TIMESTAMP WITH LOCAL TIME ZONE</c> column reads back as, ODP.NET defaults it to the client
+    /// host's zone, and the driver offers no way to set it before the connection is open, so
+    /// <see cref="ConfigureConnection"/> cannot reach it. Pinning it to
+    /// <see cref="SqlConnectionSettings.DatabaseTimeZone"/> is half of what keeps that column type
+    /// correct; <see cref="ColumnCarriesAnOffset"/> is the other half.
+    /// </para>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The session could not be configured as the Connected System asks, so the connection is unusable rather than quietly reading values in the wrong zone.</exception>
+    void ConfigureOpenedConnection(DbConnection connection, SqlConnectionSettings settings);
+
+    /// <summary>
     /// Creates a command on a connection, with any dialect-specific command configuration applied.
     /// </summary>
     DbCommand CreateCommand(DbConnection connection, string commandText);

--- a/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/OracleProvider.cs
@@ -188,6 +188,93 @@ internal class OracleProvider : SqlProviderBase
         oracleConnection.SqlNetCryptoChecksumTypesClient = "SHA512, SHA384, SHA256";
     }
 
+    /// <summary>
+    /// Pins the session's time zone to the Connected System's Database Time Zone, which is what makes a
+    /// <c>TIMESTAMP WITH LOCAL TIME ZONE</c> column mean the same thing on every Worker.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Oracle stores a local-time-zone value normalised to the database time zone and returns it
+    /// converted into the <i>session's</i> time zone. ODP.NET leaves the session at the client host's
+    /// zone, so without this the value JIM reads depends on which machine the run happened on: neither
+    /// UTC nor the zone the administrator declared. Verified against Oracle Database Free 23ai, where
+    /// one stored value read back as 13:45, 14:45 or 08:45 according to the session's zone alone.
+    /// </para>
+    /// <para>
+    /// <b>This is one half of a two-part fix, and neither half works alone.</b> The other half is that
+    /// <c>TIMESTAMP WITH LOCAL TIME ZONE</c> is not in
+    /// <see cref="SqlTypeMapper"/>'s offset-carrying set, so both directions treat it as the zoneless
+    /// wall-clock reading the driver actually hands over. That treatment is only true once the session
+    /// is pinned here: the wall clock has to be in the zone the administrator declared for the zoneless
+    /// path to convert it correctly, and for an export's inverse conversion to write the instant back
+    /// unchanged. Remove the pinning and the classification is wrong; remove the classification and the
+    /// pinning is pointless. Do not delete either as redundant.
+    /// </para>
+    /// <para>
+    /// Applied through the driver's own session API rather than by running an <c>ALTER SESSION</c>: it
+    /// takes the region as a value rather than as SQL text, so a time zone name can never become part of
+    /// a statement. It also leaves the rest of the session's globalisation alone, which was confirmed
+    /// against the live container (<c>NLS_DATE_FORMAT</c> unchanged either side of the call).
+    /// </para>
+    /// <para>
+    /// A zone the database does not recognise fails the connection rather than being quietly downgraded
+    /// to an offset: a fixed offset would be right for half the year and silently an hour out for the
+    /// other half, which is exactly the class of corruption this method exists to prevent.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The connection is not open, or Oracle does not recognise the configured time zone.</exception>
+    public override void ConfigureOpenedConnection(DbConnection connection, SqlConnectionSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        // Refused rather than skipped: a connection whose session was never pinned reads local-time-zone
+        // columns in the host's zone, and a silent skip is how that reaches production unnoticed.
+        if (connection.State != ConnectionState.Open)
+            throw new InvalidOperationException("An Oracle session's time zone can only be set once the connection is open.");
+
+        var oracleConnection = (OracleConnection)connection;
+        var region = ResolveSessionTimeZoneName(settings.DatabaseTimeZone);
+
+        // Read-modify-write is Oracle's own pattern for this API: the globalisation object carries the
+        // whole session state, so it is fetched rather than constructed, and only the time zone altered.
+        var globalization = oracleConnection.GetSessionInfo();
+        globalization.TimeZone = region;
+
+        try
+        {
+            oracleConnection.SetSessionInfo(globalization);
+        }
+        catch (OracleException ex)
+        {
+            throw new InvalidOperationException(
+                $"Oracle does not recognise the time zone region '{region}', so this Connected System's {SqlConnectorConstants.SettingDatabaseTimeZone} cannot be applied to the session. " +
+                "Date and time columns would otherwise be read in whichever zone the Worker's host uses, so the connection is refused instead. " +
+                "Choose a time zone the database's own time zone file knows, or have the database's time zone file updated.", ex);
+        }
+    }
+
+    /// <summary>
+    /// The Oracle time zone region name for a .NET time zone.
+    /// </summary>
+    /// <remarks>
+    /// Oracle names its regions exactly as IANA does, and the Database Time Zone setting asks an
+    /// administrator for an IANA name, so the two agree without translation on Linux, where a resolved
+    /// zone already carries its IANA identifier. A Worker on Windows resolves the same zone to a Windows
+    /// identifier Oracle has never heard of ("GMT Standard Time"), which is what the conversion is for.
+    /// Anything neither of those recognises is handed over as it stands: Oracle is the authority on what
+    /// region names it knows, and its refusal is a clearer answer than a guess made here.
+    /// </remarks>
+    internal static string ResolveSessionTimeZoneName(TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        if (timeZone.HasIanaId)
+            return timeZone.Id;
+
+        return TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZone.Id, out var ianaId) ? ianaId : timeZone.Id;
+    }
+
     public override DbConnection CreateConnection(string connectionString)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
@@ -297,6 +384,15 @@ internal class OracleProvider : SqlProviderBase
     /// <para>
     /// A wrapper this Connector never binds a value as is refused rather than passed on, because passing
     /// it on is exactly the defect this method exists to fix.
+    /// </para>
+    /// <para>
+    /// <b>This is about bound parameters and nothing else.</b> Values that come back as query results do
+    /// not need it: measured against Oracle Database Free 23ai, both
+    /// <see cref="DbDataReader.GetValue"/> and <see cref="DbCommand.ExecuteScalar"/> answer with CLR
+    /// types (<c>Decimal</c> for a <c>NUMBER</c> and for <c>COUNT(*)</c>, <c>String</c>, <c>Byte[]</c>,
+    /// <c>DateTime</c>, <c>DateTimeOffset</c>, and <see cref="DBNull"/> for an empty result), never with
+    /// an ODP.NET wrapper. The Delta Import watermark read is the call site that would have suffered
+    /// otherwise, and it is correct as it stands.
     /// </para>
     /// </remarks>
     /// <exception cref="NotSupportedException">The driver answered with an ODP.NET type no value this Connector binds is ever returned as.</exception>

--- a/src/JIM.Connectors/Sql/Providers/SqlConnectionSettings.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlConnectionSettings.cs
@@ -57,6 +57,22 @@ internal sealed record SqlConnectionSettings
     internal int? ConnectionTimeoutSeconds { get; init; }
 
     /// <summary>
+    /// The time zone a zoneless date and time column records its values in, as the administrator
+    /// declared it in the Database Time Zone setting.
+    /// <para>
+    /// A connection setting rather than only an interpretation rule applied afterwards, because one
+    /// dialect converts before JIM ever sees a value: Oracle returns a <c>TIMESTAMP WITH LOCAL TIME
+    /// ZONE</c> column in the <i>session's</i> time zone, so the session has to be pinned to this zone
+    /// as the connection opens or the reading depends on which host the Worker ran on. See
+    /// <see cref="OracleProvider.ConfigureOpenedConnection"/>.
+    /// </para>
+    /// <para>
+    /// UTC by default, matching the setting's own default and the one zone that needs no interpreting.
+    /// </para>
+    /// </summary>
+    internal TimeZoneInfo DatabaseTimeZone { get; init; } = TimeZoneInfo.Utc;
+
+    /// <summary>
     /// A file holding the one server certificate this connection may accept in addition to whatever the
     /// operating system's bundle already vouches for. Null on every ordinary connection.
     /// <para>
@@ -70,6 +86,6 @@ internal sealed record SqlConnectionSettings
 
     public override string ToString()
     {
-        return $"{nameof(SqlConnectionSettings)} {{ Host = {Host}, Port = {Port?.ToString() ?? "(default)"}, DatabaseName = {DatabaseName}, ServiceName = {ServiceName}, Sid = {Sid}, Username = {Username}, Password = (redacted), Encryption = {Encryption}, ConnectionTimeoutSeconds = {ConnectionTimeoutSeconds}, PinnedServerCertificatePath = {PinnedServerCertificatePath} }}";
+        return $"{nameof(SqlConnectionSettings)} {{ Host = {Host}, Port = {Port?.ToString() ?? "(default)"}, DatabaseName = {DatabaseName}, ServiceName = {ServiceName}, Sid = {Sid}, Username = {Username}, Password = (redacted), Encryption = {Encryption}, ConnectionTimeoutSeconds = {ConnectionTimeoutSeconds}, DatabaseTimeZone = {DatabaseTimeZone.Id}, PinnedServerCertificatePath = {PinnedServerCertificatePath} }}";
     }
 }

--- a/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlProviderBase.cs
@@ -110,6 +110,14 @@ internal abstract class SqlProviderBase : ISqlProvider
     {
     }
 
+    /// <summary>
+    /// Nothing by default: a dialect whose values do not depend on session state has nothing to pin, and
+    /// only Oracle Database currently does.
+    /// </summary>
+    public virtual void ConfigureOpenedConnection(DbConnection connection, SqlConnectionSettings settings)
+    {
+    }
+
     public virtual DbCommand CreateCommand(DbConnection connection, string commandText)
     {
         ArgumentNullException.ThrowIfNull(connection);

--- a/src/JIM.Connectors/Sql/Providers/SqlServerProvider.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlServerProvider.cs
@@ -130,6 +130,15 @@ internal class SqlServerProvider : SqlProviderBase
         return new SqlConnection(connectionString);
     }
 
+    // ConfigureOpenedConnection is deliberately not overridden, and that is a finding rather than an
+    // omission. Microsoft SQL Server has no session time zone to pin, and no column type that would need
+    // one: 'datetime2', 'datetime' and 'date' are returned exactly as stored, so the Connected System's
+    // Database Time Zone interprets them after the fact and nothing about the client's own zone reaches
+    // the value, while 'datetimeoffset' carries its own offset and needs no interpreting at all. The
+    // Oracle case that hook exists for, TIMESTAMP WITH LOCAL TIME ZONE, has no analogue here; SQL
+    // Server's AT TIME ZONE is a per-expression operator rather than session state, and JIM never
+    // writes it.
+
     #endregion
 
     #region Import

--- a/src/JIM.Connectors/Sql/Providers/SqlTypeMapper.cs
+++ b/src/JIM.Connectors/Sql/Providers/SqlTypeMapper.cs
@@ -105,16 +105,33 @@ internal static class SqlTypeMapper
     /// the value conversions either side of it.
     /// <para>
     /// The spellings are the ones each catalogue reports, normalised: SQL Server's
-    /// <c>datetimeoffset</c>, and Oracle's <c>TIMESTAMP(n) WITH TIME ZONE</c> and
-    /// <c>TIMESTAMP(n) WITH LOCAL TIME ZONE</c>. PostgreSQL's <c>timestamptz</c> is present on the same
-    /// reasoning as the priority 2 spellings above: adding that provider stays additive.
+    /// <c>datetimeoffset</c> and Oracle's <c>TIMESTAMP(n) WITH TIME ZONE</c>. PostgreSQL's
+    /// <c>timestamptz</c> is present on the same reasoning as the priority 2 spellings above: adding
+    /// that provider stays additive.
+    /// </para>
+    /// <para>
+    /// <b>Oracle's <c>TIMESTAMP(n) WITH LOCAL TIME ZONE</c> is deliberately absent, and its absence is
+    /// the one worth explaining.</b> The catalogue names it as though it carried an offset, but the wire
+    /// says otherwise: ODP.NET hands the column back as a bare <see cref="DateTime"/> with
+    /// <see cref="DateTimeKind.Unspecified"/>, the same shape a zoneless <c>TIMESTAMP</c> arrives in,
+    /// because Oracle has already converted the stored value into the session's time zone. Listing it
+    /// here is what made import and export disagree about one column: import decides from the CLR type
+    /// the driver returned (zoneless, so the Database Time Zone applies), while export decides from this
+    /// set (offset-carrying, so it did not). Treating it as zoneless is what makes the two agree.
+    /// </para>
+    /// <para>
+    /// <b>That agreement is only correct because
+    /// <see cref="OracleProvider.ConfigureOpenedConnection"/> pins the session time zone to the
+    /// Connected System's Database Time Zone.</b> The two changes are one fix. Left unpinned, Oracle
+    /// converts the value into whichever zone the Worker's host happens to run in, and the zoneless path
+    /// then reads that wall clock as though it were the administrator's declared zone, silently out by
+    /// the difference. Neither half is redundant: removing either one reintroduces the defect.
     /// </para>
     /// </summary>
     private static readonly HashSet<string> OffsetCarryingTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "DATETIMEOFFSET",
         "TIMESTAMP WITH TIME ZONE",
-        "TIMESTAMP WITH LOCAL TIME ZONE",
         "TIMESTAMPTZ"
     };
 
@@ -127,6 +144,11 @@ internal static class SqlTypeMapper
     /// it (PRD requirement 9): import takes the instant the driver hands back, and export writes the
     /// instant JIM holds. A zoneless column states nothing, so its values are wall-clock time in the
     /// zone the administrator declared, and both directions convert through it.
+    /// <para>
+    /// "At the wire level" is the whole test, and it is why Oracle's <c>TIMESTAMP WITH LOCAL TIME
+    /// ZONE</c> answers false here despite a catalogue name that reads otherwise. See
+    /// <see cref="OffsetCarryingTypes"/>.
+    /// </para>
     /// </remarks>
     internal static bool CarriesAnOffset(SqlColumnType columnType)
     {

--- a/src/JIM.Connectors/Sql/SqlConnector.cs
+++ b/src/JIM.Connectors/Sql/SqlConnector.cs
@@ -722,6 +722,14 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
             provider.ConfigureConnection(connection, connectionSettings);
 
             connection.Open();
+
+            // And anything the dialect can only apply to a live session is applied here, before a single
+            // value crosses the connection. Oracle's session time zone is the case that needs it: the
+            // driver has no way to set it before the connection is open, and a local-time-zone column
+            // read on an unpinned session comes back in the Worker host's zone rather than the
+            // Connected System's.
+            provider.ConfigureOpenedConnection(connection, connectionSettings);
+
             return connection;
         }
         catch (Exception ex) when (ex is DbException or InvalidOperationException or ArgumentException or SocketException or IOException)
@@ -816,7 +824,13 @@ public class SqlConnector : IConnector, IConnectorCapabilities, IConnectorSettin
             Username = username,
             Password = decryptedPassword,
             Encryption = ResolveEncryption(settingValues),
-            ConnectionTimeoutSeconds = GetInt(settingValues, SqlConnectorConstants.SettingConnectionTimeout) ?? SqlConnectorConstants.DefaultConnectionTimeoutSeconds
+            ConnectionTimeoutSeconds = GetInt(settingValues, SqlConnectorConstants.SettingConnectionTimeout) ?? SqlConnectorConstants.DefaultConnectionTimeoutSeconds,
+
+            // Carried on the connection settings as well as held for the value conversions, because one
+            // dialect has to act on it while the connection is being established rather than afterwards:
+            // Oracle returns a TIMESTAMP WITH LOCAL TIME ZONE column in the session's time zone, so the
+            // session is pinned to this zone as it opens.
+            DatabaseTimeZone = ResolveDatabaseTimeZone(settingValues)
         };
     }
 

--- a/src/JIM.Connectors/Sql/SqlConnectorImport.cs
+++ b/src/JIM.Connectors/Sql/SqlConnectorImport.cs
@@ -703,6 +703,13 @@ internal sealed class SqlConnectorImport
     /// divergence to hide behind the provider seam: an aggregate over a source is the same statement in
     /// both, built from the same quoting the seam already provides.
     /// </summary>
+    /// <remarks>
+    /// The value is read straight rather than through
+    /// <see cref="Providers.ISqlProvider.ConvertFromDriverValue"/>, and deliberately so. That seam exists
+    /// because ODP.NET answers a <i>bound parameter</i> with a wrapper struct of its own; a query result
+    /// is a different matter, and measured against Oracle Database Free 23ai this call answers with
+    /// ordinary CLR types. Routing it through the seam anyway would suggest the two cases were the same.
+    /// </remarks>
     private async Task<object?> ReadHighestValueAsync(string source, string column)
     {
         using var command = _provider.CreateCommand(_connection, $"SELECT MAX({_provider.QuoteIdentifier(column)}) FROM {source}");

--- a/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/OracleProviderTests.cs
@@ -491,6 +491,46 @@ public class OracleProviderTests
     }
 
     [Test]
+    public void ResolveSessionTimeZoneName_Utc_IsTheUtcRegion()
+    {
+        Assert.That(OracleProvider.ResolveSessionTimeZoneName(TimeZoneInfo.Utc), Is.EqualTo("UTC"),
+            "Verified against Oracle Database Free 23ai: 'UTC' is a region name ALTER SESSION accepts.");
+    }
+
+    [TestCase("Europe/London")]
+    [TestCase("America/New_York")]
+    [TestCase("Australia/Sydney")]
+    [TestCase("Asia/Kolkata")]
+    public void ResolveSessionTimeZoneName_AnIanaZone_IsPassedThroughUnchanged(string ianaId)
+    {
+        // Oracle names its time zone regions exactly as IANA does, and the Database Time Zone setting
+        // asks an administrator for an IANA name, so the two agree without translation. Every one of
+        // these was accepted by the live 23ai container.
+        Assert.That(OracleProvider.ResolveSessionTimeZoneName(TimeZoneInfo.FindSystemTimeZoneById(ianaId)), Is.EqualTo(ianaId));
+    }
+
+    [Test]
+    public void ResolveSessionTimeZoneName_AWindowsZone_IsConvertedToItsIanaName()
+    {
+        // A Worker running on Windows resolves a zone to a Windows identifier ("GMT Standard Time"),
+        // which Oracle has never heard of. On Linux the same lookup already yields the IANA name, so
+        // this holds on both.
+        Assert.That(OracleProvider.ResolveSessionTimeZoneName(TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")), Is.EqualTo("Europe/London"));
+    }
+
+    [Test]
+    public void ConfigureOpenedConnection_AClosedConnection_IsLeftAlone()
+    {
+        // Pinning the session time zone needs a session. The Connector only ever calls this on an open
+        // connection; a closed one is refused rather than silently skipped, because a connection that
+        // never had its session pinned would read local-time-zone columns in the host's zone.
+        var settings = new SqlConnectionSettings { Host = "oracle.example.local", ServiceName = "HRPDB", DatabaseTimeZone = TimeZoneInfo.Utc };
+        using var connection = _provider.CreateConnection(_provider.BuildConnectionString(settings));
+
+        Assert.Throws<InvalidOperationException>(() => _provider.ConfigureOpenedConnection(connection, settings));
+    }
+
+    [Test]
     public void BuildConnectionString_NeitherServiceNameNorSid_Throws()
     {
         var settings = new SqlConnectionSettings { Host = "oracle.example.local", Port = 1521 };

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorExportTests.cs
@@ -1179,6 +1179,55 @@ public class SqlConnectorExportTests
     }
 
     [Test]
+    public async Task ExportAsync_AnOracleLocalTimeZoneColumn_WritesLocalWallClockTimeInTheConfiguredZone()
+    {
+        // Oracle's catalogue calls this column offset-carrying, but ODP.NET hands it back as a bare
+        // DateTime that Oracle has already converted into the session's time zone, which the Connector
+        // pins to this same Database Time Zone. So it is written exactly as any other zoneless column is;
+        // treating it as offset-carrying wrote the UTC instant instead, an hour out under British Summer
+        // Time, with nothing to say so.
+        var provider = new FakeSqlProvider();
+        var pendingExport = Update(Anchor("EMPLOYEE_ID", AttributeDataType.Number, number: 4711),
+            Change("LOCAL_UPDATED", AttributeDataType.DateTime, dateTime: new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc), changeType: PendingExportAttributeChangeType.Update));
+
+        await ExportAsync(provider, PersonDocument, [pendingExport], databaseTimeZone: "Europe/London");
+
+        var bound = provider.ExecutedStatements.Single().Parameters[ParameterFor(provider.ExecutedStatements.Single(), "LOCAL_UPDATED")];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bound, Is.EqualTo(new DateTime(2026, 7, 1, 13, 0, 0)), "British Summer Time is one hour ahead of UTC on that date.");
+            Assert.That(((DateTime)bound!).Kind, Is.EqualTo(DateTimeKind.Unspecified),
+                "A kind of UTC would have the driver convert the value a second time on its way into the column.");
+        }
+    }
+
+    [Test]
+    public async Task ExportAsync_AnOracleLocalTimeZoneColumn_WritesTheSameWallClockAnImportWouldReadBackAsTheOriginalInstant()
+    {
+        // The round trip is the property that matters: what an export writes into a local-time-zone
+        // column is what a session pinned to the same zone reads back, and interpreting that reading in
+        // the Database Time Zone has to land on the instant JIM started with.
+        var provider = new FakeSqlProvider();
+        var instant = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var pendingExport = Update(Anchor("EMPLOYEE_ID", AttributeDataType.Number, number: 4711),
+            Change("LOCAL_UPDATED", AttributeDataType.DateTime, dateTime: instant, changeType: PendingExportAttributeChangeType.Update));
+
+        await ExportAsync(provider, PersonDocument, [pendingExport], databaseTimeZone: "Europe/London");
+
+        var written = (DateTime)provider.ExecutedStatements.Single().Parameters[ParameterFor(provider.ExecutedStatements.Single(), "LOCAL_UPDATED")]!;
+
+        // What an import does with the value a pinned session hands back: a zoneless reading interpreted
+        // in the Connected System's declared zone.
+        var readBack = DateTime.SpecifyKind(
+            TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(written, DateTimeKind.Unspecified), TimeZoneInfo.FindSystemTimeZoneById("Europe/London")),
+            DateTimeKind.Utc);
+
+        Assert.That(readBack, Is.EqualTo(instant),
+            "Export inverts exactly what import applies, so the instant survives the round trip through a local-time-zone column.");
+    }
+
+    [Test]
     public async Task ExportAsync_AResolvedReferenceToANumericColumn_WritesTheReferencedObjectsAnchorAsANumber()
     {
         var provider = new FakeSqlProvider();
@@ -1472,6 +1521,11 @@ public class SqlConnectorExportTests
             new FakeCatalogueColumn("STAFF_GUID", "uniqueidentifier"),
             new FakeCatalogueColumn("START_DATE", "datetime2"),
             new FakeCatalogueColumn("LAST_REVIEWED", "datetimeoffset"),
+
+            // Oracle's third date and time shape. It sits in an otherwise Microsoft SQL Server catalogue
+            // because the classification is the provider-independent part; what is being pinned down here
+            // is that the Connector writes wall-clock time into it, not the dialect that declared it.
+            new FakeCatalogueColumn("LOCAL_UPDATED", "TIMESTAMP(3) WITH LOCAL TIME ZONE"),
             new FakeCatalogueColumn("MANAGER_EMPLOYEE_ID", "int"),
             new FakeCatalogueColumn("MANAGER_STAFF_GUID", "uniqueidentifier"));
 

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTestDoubles.cs
@@ -151,6 +151,18 @@ internal sealed class FakeSqlProvider : SqlProviderBase
     internal List<SqlConnectionSettings> ConfiguredConnectionSettings { get; } = [];
 
     /// <summary>
+    /// The settings every connection was configured with once it was open, which is the only point a
+    /// session setting such as Oracle Database's session time zone can be applied at.
+    /// </summary>
+    internal List<SqlConnectionSettings> ConfiguredOpenConnectionSettings { get; } = [];
+
+    /// <summary>
+    /// What state each connection was actually in when the dialect was given its post-open chance, so a
+    /// test can prove the hook is not simply the pre-open one called a second time.
+    /// </summary>
+    internal List<ConnectionState> ConnectionStatesWhenConfiguredOpen { get; } = [];
+
+    /// <summary>
     /// Which dialect this stand-in speaks. Settable so a test can exercise the Oracle type-mapping
     /// opt-ins, which are the one place schema discovery's answer depends on the database server.
     /// </summary>
@@ -211,6 +223,15 @@ internal sealed class FakeSqlProvider : SqlProviderBase
     {
         ArgumentNullException.ThrowIfNull(settings);
         ConfiguredConnectionSettings.Add(settings);
+    }
+
+    public override void ConfigureOpenedConnection(DbConnection connection, SqlConnectionSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        ConfiguredOpenConnectionSettings.Add(settings);
+        ConnectionStatesWhenConfiguredOpen.Add(connection.State);
     }
 
     /// <summary>

--- a/test/JIM.Worker.Tests/Connectors/SqlConnectorTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlConnectorTests.cs
@@ -7,6 +7,7 @@ using JIM.Connectors.Sql.Providers;
 using JIM.Models.Staging;
 using NUnit.Framework;
 using Serilog;
+using System.Data;
 using ILogger = Serilog.ILogger;
 
 namespace JIM.Worker.Tests.Connectors;
@@ -629,6 +630,59 @@ public class SqlConnectorTests
 
         Assert.That(provider.ConfiguredConnectionSettings, Has.Count.EqualTo(1));
         Assert.That(provider.ConfiguredConnectionSettings[0], Is.SameAs(provider.BuiltConnectionSettings[0]));
+    }
+
+    [Test]
+    public void ValidateSettingValues_AnyConnection_LetsTheDialectConfigureTheSessionOnceItIsOpen()
+    {
+        // Oracle Database's session time zone is the case this exists for: it decides what a TIMESTAMP
+        // WITH LOCAL TIME ZONE column reads back as, and ODP.NET offers no way to set it before the
+        // connection is open, so a pre-open hook alone cannot reach it.
+        var provider = new FakeSqlProvider();
+        var connector = CreateConnectorWith(provider);
+
+        connector.ValidateSettingValues(CreateSqlServerSettingValues(encrypt: true), _logger);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.ConfiguredOpenConnectionSettings, Has.Count.EqualTo(1));
+            Assert.That(provider.ConfiguredOpenConnectionSettings[0], Is.SameAs(provider.BuiltConnectionSettings[0]));
+            Assert.That(provider.ConnectionStatesWhenConfiguredOpen, Is.EqualTo(new[] { ConnectionState.Open }),
+                "A session setting can only be applied to a session, so the connection has to be open by the time the dialect is asked.");
+        }
+    }
+
+    [Test]
+    public void ValidateSettingValues_ADatabaseTimeZone_ReachesTheProviderAsTheConfiguredZoneRatherThanTheHosts()
+    {
+        // The Database Time Zone is not only an interpretation rule applied after the fact: Oracle
+        // Database converts a local-time-zone column into the session's time zone before the driver
+        // ever sees it, so the provider needs the configured zone at connection time to pin the session
+        // to it. Left to itself the session takes the Worker host's zone, which makes what JIM reads
+        // depend on which machine the run happened on.
+        var provider = new FakeSqlProvider();
+        var connector = CreateConnectorWith(provider);
+        var settingValues = CreateSqlServerSettingValues(encrypt: true);
+        SetString(settingValues, SqlConnectorConstants.SettingDatabaseTimeZone, "Australia/Sydney");
+
+        connector.ValidateSettingValues(settingValues, _logger);
+
+        Assert.That(provider.BuiltConnectionSettings.Single().DatabaseTimeZone,
+            Is.EqualTo(TimeZoneInfo.FindSystemTimeZoneById("Australia/Sydney")));
+    }
+
+    [Test]
+    public void ValidateSettingValues_NoDatabaseTimeZone_ReachesTheProviderAsUtc()
+    {
+        var provider = new FakeSqlProvider();
+        var connector = CreateConnectorWith(provider);
+        var settingValues = CreateSqlServerSettingValues(encrypt: true);
+        SetString(settingValues, SqlConnectorConstants.SettingDatabaseTimeZone, null);
+
+        connector.ValidateSettingValues(settingValues, _logger);
+
+        Assert.That(provider.BuiltConnectionSettings.Single().DatabaseTimeZone, Is.EqualTo(TimeZoneInfo.Utc),
+            "UTC is the documented default, and the one zone that needs no interpretation.");
     }
 
     // The expected value crosses as an int because the encryption mode is internal to JIM.Connectors:

--- a/test/JIM.Worker.Tests/Connectors/SqlServerProviderTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlServerProviderTests.cs
@@ -397,6 +397,47 @@ public class SqlServerProviderTests
     }
 
     [Test]
+    public void ConfigureOpenedConnection_AnyConnection_ChangesNothingAboutTheSession()
+    {
+        // Microsoft SQL Server has no analogue of Oracle's session time zone, and no analogue of
+        // TIMESTAMP WITH LOCAL TIME ZONE for one to act on: 'datetime2' is returned exactly as stored
+        // and 'datetimeoffset' carries its own offset, so neither depends on the client's zone. There is
+        // therefore nothing to pin here, and this asserts the Oracle fix left this dialect alone.
+        var settings = new SqlConnectionSettings
+        {
+            Host = "sql.example.local",
+            DatabaseName = "HR",
+            DatabaseTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Australia/Sydney")
+        };
+
+        using var connection = _provider.CreateConnection(_provider.BuildConnectionString(settings));
+        var connectionStringBeforehand = connection.ConnectionString;
+
+        // A closed connection is accepted precisely because nothing is done to the session, which is the
+        // difference from Oracle worth pinning down.
+        _provider.ConfigureOpenedConnection(connection, settings);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(connection.State, Is.EqualTo(ConnectionState.Closed));
+            Assert.That(connection.ConnectionString, Is.EqualTo(connectionStringBeforehand));
+        }
+    }
+
+    [Test]
+    public void ColumnCarriesAnOffset_SqlServerDateAndTimeTypes_AreUnchangedByTheOracleLocalTimeZoneFix()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_provider.ColumnCarriesAnOffset(new SqlColumnType("datetimeoffset")), Is.True,
+                "'datetimeoffset' states the offset of every value it holds.");
+            Assert.That(_provider.ColumnCarriesAnOffset(new SqlColumnType("datetime2")), Is.False);
+            Assert.That(_provider.ColumnCarriesAnOffset(new SqlColumnType("datetime")), Is.False);
+            Assert.That(_provider.ColumnCarriesAnOffset(new SqlColumnType("date")), Is.False);
+        }
+    }
+
+    [Test]
     public void BuildConnectionString_DiscreteSettings_ProducesTheExpectedConnectionString()
     {
         var settings = new SqlConnectionSettings

--- a/test/JIM.Worker.Tests/Connectors/SqlTypeMapperTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/SqlTypeMapperTests.cs
@@ -182,6 +182,58 @@ public class SqlTypeMapperTests
 
     #endregion
 
+    #region Offset-carrying columns
+
+    [TestCase("datetimeoffset")]
+    [TestCase("datetimeoffset(3)")]
+    [TestCase("DATETIMEOFFSET")]
+    public void CarriesAnOffset_SqlServerDateTimeOffset_IsOffsetCarrying(string typeName)
+    {
+        Assert.That(SqlTypeMapper.CarriesAnOffset(new SqlColumnType(typeName)), Is.True,
+            "'datetimeoffset' states the offset of every value it holds, so the Database Time Zone must not be applied to it in either direction.");
+    }
+
+    [TestCase("TIMESTAMP WITH TIME ZONE")]
+    [TestCase("TIMESTAMP(3) WITH TIME ZONE")]
+    [TestCase("TIMESTAMP(6) WITH TIME ZONE")]
+    public void CarriesAnOffset_OracleTimeStampWithTimeZone_IsOffsetCarrying(string typeName)
+    {
+        // Verified against Oracle Database Free 23ai: ODP.NET returns a DateTimeOffset carrying the
+        // stored offset for this column, and the value it returns does not change with the session's
+        // time zone. It genuinely carries its own offset.
+        Assert.That(SqlTypeMapper.CarriesAnOffset(new SqlColumnType(typeName)), Is.True,
+            "Oracle's TIMESTAMP WITH TIME ZONE stores the offset alongside the value and the driver hands both back.");
+    }
+
+    [TestCase("TIMESTAMP WITH LOCAL TIME ZONE")]
+    [TestCase("TIMESTAMP(3) WITH LOCAL TIME ZONE")]
+    [TestCase("TIMESTAMP(6) WITH LOCAL TIME ZONE")]
+    [TestCase("timestamp(3) with local time zone")]
+    public void CarriesAnOffset_OracleTimeStampWithLocalTimeZone_IsNotOffsetCarrying(string typeName)
+    {
+        // The catalogue names this column as though it carried an offset, but the wire says otherwise:
+        // verified against Oracle Database Free 23ai, ODP.NET hands it back as a bare DateTime with
+        // Kind=Unspecified, already converted into the session's time zone. Import reads that CLR type
+        // and applies the Database Time Zone; classifying it as offset-carrying here made export skip
+        // the same conversion, so the two directions disagreed about one column.
+        Assert.That(SqlTypeMapper.CarriesAnOffset(new SqlColumnType(typeName)), Is.False,
+            "A TIMESTAMP WITH LOCAL TIME ZONE column reaches JIM as a zoneless wall-clock reading, so it is interpreted through the Connected System's Database Time Zone like any other zoneless column.");
+    }
+
+    [TestCase("datetime2")]
+    [TestCase("datetime")]
+    [TestCase("date")]
+    [TestCase("TIMESTAMP")]
+    [TestCase("TIMESTAMP(6)")]
+    [TestCase("DATE")]
+    public void CarriesAnOffset_ZonelessDateOrTimeType_IsNotOffsetCarrying(string typeName)
+    {
+        Assert.That(SqlTypeMapper.CarriesAnOffset(new SqlColumnType(typeName)), Is.False,
+            $"'{typeName}' states nothing about an offset, so its values are wall-clock time in the zone the administrator declared.");
+    }
+
+    #endregion
+
     #region Guid
 
     [Test]

--- a/test/integration/utils/Test-Helpers.ps1
+++ b/test/integration/utils/Test-Helpers.ps1
@@ -641,9 +641,12 @@ function Get-DatabaseConfig {
                 Binary          = "RAW(64)"
             }
 
-            # Oracle's third date/time shape, and the one the matrix exists to pin down: the catalogue
-            # calls it offset-carrying, but ODP.NET returns a zoneless DateTime for it, converted into
-            # the session's time zone rather than the Connected System's.
+            # Oracle's third date/time shape, and the one the matrix exists to pin down. Its catalogue
+            # name reads as though it carried an offset, but ODP.NET returns a zoneless DateTime for it,
+            # already converted into the session's time zone. The connector therefore classifies it as
+            # zoneless in both directions and pins the session to the Connected System's Database Time
+            # Zone as each connection opens; those two together are what make a value written here read
+            # back as the same instant, whichever host the Worker happens to run on.
             LocalZoneDateColumn = "TIMESTAMP(3) WITH LOCAL TIME ZONE"
             GeneratedKeyStyle   = "Sequence"
         }


### PR DESCRIPTION
Stack layer 3 of the Phase 7 stack for the JIM SQL Connector (#170). Base is #1309.

`TIMESTAMP WITH LOCAL TIME ZONE` was classified as offset-carrying, so the Connector left its values alone on the way in and on the way out. Oracle normalises such a column to the session time zone rather than storing an offset with the value, so the value JIM read back was not the value it wrote.

- Removes `TIMESTAMP WITH LOCAL TIME ZONE` from `OffsetCarryingTypes`; it is now treated as a naive column, interpreted in the declared Database Time Zone like every other one
- Sets the Oracle session time zone through `OracleGlobalization`/`SetSessionInfo` rather than by issuing SQL text, so there is no injection surface
- `CarriesAnOffset()` normalises the type name first, stripping a `(n)` precision and collapsing whitespace, so `TIMESTAMP(6) WITH TIME ZONE` classifies the same as `TIMESTAMP WITH TIME ZONE`

The classification change is empirical, from Scenario 16's date-and-time rows, not from reading the catalogue documentation.

Docs: n/a - fixes a defect in the unreleased SQL Connector; the feature's changelog entry is on the register layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)