### PR TITLE
test: implement Scenario 16's Synchronisation Rules and matrix rows (#170)

### DIFF
--- a/engineering/INTEGRATION_TESTING.md
+++ b/engineering/INTEGRATION_TESTING.md
@@ -1119,7 +1119,14 @@ The scenario seeds its own fixed test users positioned relative to "now" and ign
 
 #### Scenario 16: JIM SQL Connector Provider x Capability Matrix
 
-**Status**: implemented. This is the correctness gate for the JIM SQL Connector ([#170](https://github.com/TetronIO/JIM/issues/170)).
+**Status**: written, and **blocked from running** until the connector is registered. This is the correctness gate for the JIM SQL Connector ([#170](https://github.com/TetronIO/JIM/issues/170)).
+
+> **The scenario cannot execute a single matrix row today, and the blocker is not in the scenario.** The JIM SQL Connector is deliberately registered in neither `ConnectorFactory.CreateConnectorInstance` nor `SeedingServer.BuiltInConnectors()` until Phase 8 of the plan, so:
+>
+> - no `JIM SQL Connector` Connector Definition is ever seeded, and `Setup-Scenario16.ps1` stops at Step 4 with *"The 'JIM SQL Connector' Connector Definition was not found"*; and
+> - even with a definition in place, `ConnectorFactory` would throw `NotSupportedException` for the name, which is the single dispatch point for the save-time connectivity test, schema discovery, every import and every export.
+>
+> Both registrations are one line each. Until they land, treat every row below as authored but unproven, and do not read a green summary from this scenario as evidence of anything. Verified on this branch against a freshly built stack: `ConnectorDefinitions` holds only the LDAP, File and SCIM 2.0 Client definitions, and both `-Provider SqlServer -Quick` and `-Provider Oracle -Quick` abort at Step 4 in about four seconds.
 
 **Purpose**: drive one capability row per line of the PRD's Testing Requirements table against both priority 1 providers, **Microsoft SQL Server** and **Oracle Database**: full import from a table and from a view, multi-valued and reference import, delta import in both modes plus the fallback path, export (create, update, delete, natural-key and reference), the type-mapping round trip, configuration validation, the provider driver-shape rows the unit suite cannot reach, and the 500,000-row scale import. Databases are deliberately not retrofitted into Scenarios 1-14; this matrix plus the road-mapped Multi-Source Aggregation scenario are the two vehicles for database regression coverage.
 
@@ -1146,6 +1153,19 @@ With neither switch, the default tier runs every functional row against the chos
 - `sqlserver-hris-a` runs `mcr.microsoft.com/mssql/server:2022-latest`. The 2022 image ships **mssql-tools18 only**, so the healthcheck uses the fully qualified `/opt/mssql-tools18/bin/sqlcmd` path (nothing named `sqlcmd` is on `PATH`), with `-C` to trust the self-signed certificate SQL Server generates for itself; tools18 encrypts by default, where the older tools did not, so without `-C` the check fails on every interval no matter how healthy the server is. The SA password comes from `MSSQL_SA_PASSWORD` (the unprefixed `SA_PASSWORD` is deprecated and logs a warning on every start), overridable via `SQL_SA_PASSWORD`. Sized at 4 CPUs / 6GB for the 500,000-row scale run.
 - `oracle-hris-b` runs `container-registry.oracle.com/database/free:23.9.0.0` (**Oracle Database Free 23ai**, not the retired Express 21c image). It pulls **anonymously** from Oracle's own registry: no `docker login`, no licence click-through, and no third-party Docker Hub redistribution. The image is 13.6GB. The CDB service is `FREE`; the pluggable database JIM connects to is `FREEPDB1`, set explicitly via `ORACLE_PDB`. Connect to the PDB, never the CDB: application schemas live in the PDB and a CDB connection cannot see them. Sized at 4 CPUs / 8GB, with `shm_size: 2gb` because Oracle puts the SGA in System V shared memory and Docker's 64MB default `/dev/shm` is far too small (see [ORA-00845](#oracle-fails-to-start-with-ora-00845) below).
 - Oracle's healthcheck runs the image's own `/opt/oracle/checkDBStatus.sh`. It authenticates as SYSDBA through operating-system authentication (`sqlplus -s /`), so it carries **no credentials at all**, and it fails while the pluggable database is still MOUNTED rather than open READ WRITE, which is exactly the window in which a connection attempt would fail confusingly. Its `start_period` is 600s to cover a first start against an empty named volume, which creates the database from scratch. In practice the warm path is far quicker: on the development host used to validate this work, the container reported healthy about **40 seconds** after `docker compose up`, because the 23.9 image ships a pre-created database in its layers.
+
+**What the setup configures.** One Connected System per provider, with all five Object Types selected (`Person`, `PersonView`, `AppUser`, `NaturalKeyAccount`, and `GuidKeyedPerson` on Oracle only), five Run Profiles at page size 10, an Object Matching Rule on `EMPLOYEE_NUMBER`, one inbound Synchronisation Rule projecting `EMPLOYEES` into the Metaverse, and two outbound rules (three on Oracle) covering the three export shapes: a database-generated `IDENTITY` key, a natural key JIM authors, and Oracle's `RAW(16) DEFAULT SYS_GUID()`. It also contributes two Metaverse Attributes, `SQL Matrix FTE` (Decimal) and `SQL Matrix Headcount` (LongNumber), because no built-in attribute has those data types and mapping a `NUMBER(9,4)` onto an Integer attribute would round the value that the exact-numeric row exists to protect.
+
+**Database Time Zone is `Australia/Sydney`, and that is load-bearing.** At the UTC default every zone conversion is the identity, so a zone-inversion defect passes unnoticed; that much is a PRD requirement. What is less obvious is that **Europe/London does not work either for this seed**: the seeder derives `START_DATE` as 2020-01-06 plus n days, so a 50-row database never leaves January and February, where London is UTC+00:00 and the conversion is the identity again. Sydney is UTC+11:00 across the seeded range. The zoneless driver-shape row additionally writes a southern-winter date in (where Sydney is UTC+10:00), asserts against it, and restores the original, because a fixed-offset implementation passes a single-season test.
+
+**Seeder timings** (measured on the validation host, Docker Desktop, 16 CPUs / 64GB, warm containers). The seeder is set-based (`INSERT ... SELECT` over a generated series) rather than one statement per row, and it is not the expensive part of the scenario:
+
+| Provider | 50 rows | 500,000 rows |
+|----------|---------|--------------|
+| Microsoft SQL Server | ~1.2s | **6.8s** |
+| Oracle Database Free 23ai | ~2.0s | **7.9s** |
+
+Re-seeding is skipped when a content hash of the generated script matches what the `JIM_SEED_MANIFEST` table records, so an unchanged seed costs one round trip; pass `-Force` to rebuild regardless. Because the hash covers the script and not the data, rows that a matrix row mutated are **not** detected as drift: re-run with `-Force` when a previous run left the database dirty.
 
 **Image pinning**: both database images use mutable tags on purpose. `engineering/DEPENDENCY_PINNING.md` row 9 records integration test images as an accepted exception to digest pinning (test-only, never shipped, chosen for connector compatibility testing rather than supply chain assurance) and updates them manually as needed. Do not digest-pin them without changing that policy row first.
 
@@ -1768,6 +1788,23 @@ netstat -an | Select-String "389"
 ```
 
 ### Phase 2 Database Containers (Scenario 16)
+
+**"network jim-network was found but has incorrect label" when starting the JIM stack**: the phase2 database containers were brought up before the JIM stack, against a hand-created `jim-network`. The main compose file owns that network (it is not declared external there), so it refuses to reuse one it did not create, and the JIM stack will not start at all. The runner avoids this by starting the stack first; you only hit it when driving the containers by hand.
+
+Do not fix it by tearing the databases down: Oracle's first boot against an empty volume is the expensive part of the whole scenario. Either recreate the network with the containers still running:
+
+```powershell
+docker network disconnect jim-network oracle-hris-b
+docker network disconnect jim-network sqlserver-hris-a
+docker network rm jim-network
+# let the JIM stack create it, then put the databases back
+docker network connect jim-network oracle-hris-b
+docker network connect jim-network sqlserver-hris-a
+```
+
+or add a throwaway overlay that marks the network external for that one run (`networks: { jim-network: { name: jim-network, external: true } }`) and pass it as an extra `-f` after `docker-compose.override.yml`. Neither belongs in the repository.
+
+**Driving the scenario from a Windows host rather than the devcontainer**: the `jim-*` shell aliases do not exist there. The equivalents are `docker compose -f docker-compose.yml -f docker-compose.override.yml --profile with-db up -d --build` (set `OPENAPI_STAGE=publish` first to skip the five-minute OpenAPI stage) and `pwsh -NoProfile -File ./test/integration/Run-IntegrationTests.ps1 ...`. You will also need a `.env`: the worktree does not inherit the main clone's copy, and `JIM_INFRASTRUCTURE_API_KEY` must be present before `jim.web` first starts or the scenario's API calls all fail authentication. The Keycloak image comes from quay.io, which times out often enough to be worth a bare `docker pull quay.io/keycloak/keycloak:<tag>` retry before concluding anything is wrong.
 
 **Oracle takes a long time to start**:
 ```powershell

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -101,6 +101,8 @@ pwsh test/integration/Invoke-IntegrationTests.ps1 -ScenariosOnly
 
 ### Phase 2 Scenarios
 - **Scenario 16: JIM SQL Connector Matrix** - the connector's provider x capability matrix driven against Microsoft SQL Server and Oracle Database ([#170](https://github.com/TetronIO/JIM/issues/170)). Accepts `-Provider SqlServer|Oracle|Both` (default `Both`), `-Quick` for the representative subset, and `-FullMatrix` for the full matrix including the 500,000-row scale import. `-Template` is ignored; the scenario seeds its own rows.
+  - **Blocked from running.** The JIM SQL Connector is registered in neither `ConnectorFactory` nor `SeedingServer.BuiltInConnectors()` until Phase 8, so no Connector Definition is seeded and `Setup-Scenario16.ps1` stops at Step 4. Every row is written but unproven; a green summary from this scenario would not mean anything yet. See the Scenario 16 section of `engineering/INTEGRATION_TESTING.md` for the detail, the seeder timings, and the `jim-network` and Windows-host gotchas.
+  - Rows that cannot be exercised report **`skip` with a reason, never `pass`**. Preserve that: a matrix whose green cells include things nobody ran is worse than no matrix. Two rows are skipped by design today (`Delta.WatermarkColumn` and `Delta.Fallback`), because both need the Connected System's Delta Import Mode changed and its persisted watermark cleared mid-run.
 - Still road-mapped: multi-source aggregation across two database sources, and performance baselines. PostgreSQL and MySQL support are the connector's priority 2 providers and are not covered yet.
 
 ## Available Scripts

--- a/test/integration/Setup-Scenario16.ps1
+++ b/test/integration/Setup-Scenario16.ps1
@@ -21,9 +21,9 @@
 
     The Database Time Zone is deliberately NOT UTC. At the UTC default every zone conversion is the
     identity, so a zone-inversion defect (import and export applying the offset the same way round
-    rather than inverting each other) passes unnoticed. Europe/London in summer is one hour off UTC,
-    which makes the two directions distinguishable. This is a PRD acceptance requirement, not a
-    preference.
+    rather than inverting each other) passes unnoticed. Australia/Sydney is eleven hours off UTC over
+    the seeded date range, which makes the two directions distinguishable. This is a PRD acceptance
+    requirement, not a preference; see the parameter's own comment for why it is not Europe/London.
 
     Both Oracle opt-ins are turned on (NUMBER(1) as Boolean, RAW(16) as Guid), because the columns those
     settings reinterpret are exactly the ones the matrix exists to pin down.
@@ -50,8 +50,15 @@ param(
     [int]$RowCount = 50,
 
     # The zone zoneless columns are declared to be in. Not UTC by default, on purpose; see above.
+    #
+    # Australia/Sydney rather than Europe/London. Every seeded date sits in January or February (the
+    # generator derives START_DATE as 2020-01-06 plus n days, so a 50-row seed never leaves winter), and
+    # Europe/London is UTC+00:00 for all of them: the conversion would be the identity and the assertion
+    # would pass with a zone-inversion defect fully present, which is precisely the failure this setting
+    # exists to prevent. Sydney is UTC+11:00 over the seeded range and UTC+10:00 in the southern winter,
+    # so the offset is both non-zero and season-dependent.
     [Parameter(Mandatory=$false)]
-    [string]$DatabaseTimeZone = "Europe/London",
+    [string]$DatabaseTimeZone = "Australia/Sydney",
 
     [Parameter(Mandatory=$false)]
     [string]$Template = "Nano",

--- a/test/integration/Setup-Scenario16.ps1
+++ b/test/integration/Setup-Scenario16.ps1
@@ -7,8 +7,15 @@
 
 .DESCRIPTION
     Creates one Connected System per requested provider against the seeded HR schema, discovers its
-    schema, selects the Object Types and attributes the matrix asserts on, and creates the Run Profiles
-    each capability row drives.
+    schema, selects the Object Types and attributes the matrix asserts on, creates the Run Profiles each
+    capability row drives, and creates the inbound and outbound Synchronisation Rules the import-side and
+    export-side rows need.
+
+    NOT YET EXECUTED. The JIM SQL Connector is registered in neither ConnectorFactory nor
+    SeedingServer.BuiltInConnectors (deliberately, until Phase 8), so no 'JIM SQL Connector' Connector
+    Definition exists to create a Connected System against and this script stops at Step 4. Everything
+    from Step 4 onwards is therefore written but unproven; treat a failure here as a bug in this script
+    until it has had one clean run.
 
     Two configuration choices here are load-bearing rather than incidental:
 
@@ -311,18 +318,299 @@ foreach ($runProfile in $runProfiles) {
     Write-Host "  OK $($runProfile.Name) (page size $pageSize)" -ForegroundColor Green
 }
 
+# ─── Step 11: Metaverse plumbing ───────────────────────────────────────────────
+
+Write-TestStep "Step 11" "Resolving the Metaverse schema"
+
+$mvUserType = Get-JIMMetaverseObjectType | Where-Object { $_.name -eq "User" } | Select-Object -First 1
+if (-not $mvUserType) { throw "The built-in Metaverse Object Type 'User' was not found; JIM may not have seeded." }
+
+# Two column shapes the matrix cares about have no built-in Metaverse Attribute of the right data type:
+# a NUMBER(9,4)/decimal(9,4) needs Decimal (the built-in numeric attributes are Integer), and a
+# bigint/NUMBER(19) needs LongNumber. Mapping either onto an Integer attribute would either be refused
+# or would silently round, and a rounded value is exactly the defect the exact-numeric row exists to
+# catch, so the scenario contributes its own two attributes rather than borrowing an ill-fitting one.
+function Add-Scenario16MetaverseAttribute {
+    param(
+        [Parameter(Mandatory=$true)][string]$Name,
+        [Parameter(Mandatory=$true)][ValidateSet('Text','Integer','LongNumber','Decimal','DateTime','Boolean','Reference','Guid','Binary')][string]$Type
+    )
+
+    $attribute = Get-JIMMetaverseAttribute | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+    if (-not $attribute) {
+        $attribute = New-JIMMetaverseAttribute -Name $Name -Type $Type -Plurality SingleValued -PassThru
+        Write-Host "  Created Metaverse Attribute '$Name' ($Type)" -ForegroundColor Gray
+    }
+
+    # Binding is idempotent from the caller's point of view: a second bind of the same attribute to the
+    # same Object Type is a no-op the API accepts, and the setup runs once per provider.
+    Add-JIMMetaverseObjectTypeAttribute -AttributeId $attribute.id -ObjectTypeId $mvUserType.id -ErrorAction SilentlyContinue | Out-Null
+    return $attribute
+}
+
+$mvFteAttribute       = Add-Scenario16MetaverseAttribute -Name "SQL Matrix FTE"       -Type Decimal
+$mvHeadcountAttribute = Add-Scenario16MetaverseAttribute -Name "SQL Matrix Headcount" -Type LongNumber
+
+$mvAttributes = @(Get-JIMMetaverseAttribute)
+
+function Get-MvAttributeId {
+    param([string]$Name)
+    $attribute = $mvAttributes | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+    if (-not $attribute) { throw "Metaverse Attribute '$Name' was not found." }
+    return $attribute.id
+}
+
+function Get-CsAttributeId {
+    param([string]$ObjectTypeName, [string]$AttributeName)
+    if (-not $selectedTypes.ContainsKey($ObjectTypeName)) {
+        throw "Object Type '$ObjectTypeName' was not selected, so its attributes cannot be mapped."
+    }
+    $attribute = $selectedTypes[$ObjectTypeName].attributes | Where-Object { $_.name -eq $AttributeName } | Select-Object -First 1
+    if (-not $attribute) {
+        throw "Schema discovery did not return attribute '$AttributeName' on Object Type '$ObjectTypeName'. Discovered: $(($selectedTypes[$ObjectTypeName].attributes | ForEach-Object { $_.name }) -join ', ')"
+    }
+    return $attribute.id
+}
+
+# ─── Step 12: Object Matching Rule ─────────────────────────────────────────────
+
+Write-TestStep "Step 12" "Creating the Object Matching Rule for Person"
+
+# EMPLOYEE_NUMBER rather than EMPLOYEE_ID: the Metaverse's 'Employee ID' is a Text attribute and
+# EMPLOYEE_ID is an integer column, so the text-shaped EMPLOYEE_NUMBER is the one that joins without a
+# type coercion the mapping validator would have to invent.
+New-JIMMatchingRule `
+    -ConnectedSystemId $system.id `
+    -ObjectTypeId $selectedTypes['Person'].id `
+    -MetaverseObjectTypeId $mvUserType.id `
+    -SourceAttributeId (Get-CsAttributeId -ObjectTypeName 'Person' -AttributeName 'EMPLOYEE_NUMBER') `
+    -TargetMetaverseAttributeId (Get-MvAttributeId -Name 'Employee ID') | Out-Null
+Write-Host "  OK Person.EMPLOYEE_NUMBER matches on Metaverse 'Employee ID'" -ForegroundColor Green
+
+# ─── Step 13: Inbound Synchronisation Rule ─────────────────────────────────────
+
+Write-TestStep "Step 13" "Creating the inbound Synchronisation Rule (Person to Metaverse)"
+
+# The inbound rule is not decoration for the export rows: three driver-shape rows assert on the UTC
+# instant JIM derived from a source column, and the only place that instant is observable is the
+# Metaverse Object's attribute value. Without this rule those rows can only report the source wall
+# clock back to themselves, which proves nothing.
+$importRule = New-JIMSyncRule `
+    -Name "SQL Matrix Person Import ($($config.DisplayName))" `
+    -Description "Scenario 16 inbound rule: projects EMPLOYEES rows into the Metaverse so the driver-shape rows can read the values JIM derived." `
+    -ConnectedSystemId $system.id `
+    -ConnectedSystemObjectTypeId $selectedTypes['Person'].id `
+    -MetaverseObjectTypeId $mvUserType.id `
+    -Direction Import `
+    -ProjectToMetaverse `
+    -PassThru
+
+# Metaverse attribute names are borrowed for their data type, not their business meaning: this schema
+# has no 'hired at' concept, so the two extra date and time columns land on the closest-shaped built-ins.
+# The mapping table below is the authoritative statement of which column is which.
+$importMappings = @(
+    @{ Cs = 'EMPLOYEE_NUMBER';     Mv = 'Employee ID'         }
+    @{ Cs = 'EMPLOYEE_NUMBER';     Mv = 'Account Name'        }
+    @{ Cs = 'EMPLOYEE_ID';         Mv = 'Employee Number'     }
+    @{ Cs = 'FIRST_NAME';          Mv = 'First Name'          }
+    @{ Cs = 'LAST_NAME';           Mv = 'Last Name'           }
+    @{ Cs = 'EMAIL';               Mv = 'Email'               }
+    @{ Cs = 'DEPARTMENT';          Mv = 'Department'          }
+    @{ Cs = 'IS_ACTIVE';           Mv = 'Account Enabled'     }
+    @{ Cs = 'HEADCOUNT';           Mv = 'SQL Matrix Headcount'}
+    @{ Cs = 'FTE';                 Mv = 'SQL Matrix FTE'      }
+    # Zoneless: the Database Time Zone decides the instant. This is the DateTimeNonUtc row's subject.
+    @{ Cs = 'START_DATE';          Mv = 'Employee Start Date' }
+    # Offset-carrying (-05:00 in the seeded data): unambiguous on the wire, so no setting applies.
+    @{ Cs = 'HIRED_AT';            Mv = 'Employee End Date'   }
+    @{ Cs = 'EMPLOYEE_GUID';       Mv = 'objectGUID'          }
+    @{ Cs = 'PHOTO';               Mv = 'Photo'               }
+    @{ Cs = 'MANAGER_EMPLOYEE_ID'; Mv = 'Manager'             }
+    @{ Cs = 'PhoneNumbers';        Mv = 'Other Telephones'    }
+)
+
+# Oracle's third date and time shape. TIMESTAMP WITH LOCAL TIME ZONE exists on Oracle alone, and it is
+# the column where the connector's two oracles (catalogue type name on export, runtime CLR type on
+# import) can disagree, so it gets its own Metaverse attribute to be read back from.
+if ($Provider -eq "Oracle") {
+    $importMappings += @{ Cs = 'HIRED_AT_LOCAL'; Mv = 'Account Expires' }
+}
+
+foreach ($mapping in $importMappings) {
+    New-JIMSyncRuleMapping -SyncRuleId $importRule.id `
+        -TargetMetaverseAttributeId (Get-MvAttributeId -Name $mapping.Mv) `
+        -SourceConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'Person' -AttributeName $mapping.Cs) | Out-Null
+}
+Write-Host "  OK Inbound rule created with $($importMappings.Count) Attribute Flow(s)" -ForegroundColor Green
+
+# ─── Step 14: Outbound Synchronisation Rules ───────────────────────────────────
+
+Write-TestStep "Step 14" "Creating the outbound Synchronisation Rules"
+
+# ── AppUser: the database-generated key target ──
+#
+# APP_USERS.ID is an IDENTITY column on both providers, so JIM never writes it and must read it back
+# from the insert (OUTPUT INSERTED on SQL Server, RETURNING ... INTO on Oracle). That returned value
+# becomes the Connected System Object's external ID, and the confirming Full Import has to compose the
+# same token from the row it reads or the object is imported a second time as a stranger. That
+# agreement is what the Export.Create row checks, and it cannot be checked any other way.
+$appUserRule = New-JIMSyncRule `
+    -Name "SQL Matrix AppUser Export ($($config.DisplayName))" `
+    -Description "Scenario 16 outbound rule: provisions into APP_USERS, whose primary key the database generates." `
+    -ConnectedSystemId $system.id `
+    -ConnectedSystemObjectTypeId $selectedTypes['AppUser'].id `
+    -MetaverseObjectTypeId $mvUserType.id `
+    -Direction Export `
+    -ProvisionToConnectedSystem `
+    -OutboundDeprovisionAction Delete `
+    -PassThru
+
+$appUserMappings = @(
+    @{ Mv = 'Account Name';         Cs = 'USER_NAME'  }
+    @{ Mv = 'Email';                Cs = 'EMAIL'      }
+    @{ Mv = 'SQL Matrix FTE';       Cs = 'FTE'        }
+    @{ Mv = 'Account Enabled';      Cs = 'IS_ENABLED' }
+    @{ Mv = 'Employee Start Date';  Cs = 'STARTS_ON'  }
+    @{ Mv = 'Employee End Date';    Cs = 'STARTS_AT'  }
+    # The reference column. JIM writes the anchor of the manager's own object in THIS Connected System,
+    # which means the manager must have been provisioned first; the seeded population puts every manager
+    # in the first ten rows precisely so that ordering is exercised rather than avoided.
+    @{ Mv = 'Manager';              Cs = 'MANAGER_ID' }
+    # Related-table multi-valued maintenance: rows added to and removed from APP_USER_ROLES inside the
+    # same transaction as the parent row.
+    @{ Mv = 'Other Telephones';     Cs = 'Roles'      }
+)
+
+foreach ($mapping in $appUserMappings) {
+    New-JIMSyncRuleMapping -SyncRuleId $appUserRule.id `
+        -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'AppUser' -AttributeName $mapping.Cs) `
+        -SourceMetaverseAttributeId (Get-MvAttributeId -Name $mapping.Mv) | Out-Null
+}
+
+# An expression rather than a straight flow, so export-side expression evaluation is covered too.
+New-JIMSyncRuleMapping -SyncRuleId $appUserRule.id `
+    -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'AppUser' -AttributeName 'DISPLAY_NAME') `
+    -Expression 'mv["First Name"] + " " + mv["Last Name"]' | Out-Null
+
+# Scoped on Account Enabled, which is what gives the Export.Delete row something to drive: flipping a
+# source row's IS_ACTIVE takes its Metaverse Object out of scope, and OutboundDeprovisionAction Delete
+# turns that into a delete export rather than a disconnect. The seeded data disables every seventh
+# employee, so both sides of the scope are populated from the first import.
+$appUserScope = New-JIMScopingCriteriaGroup -SyncRuleId $appUserRule.id -Type All -PassThru
+New-JIMScopingCriterion `
+    -SyncRuleId $appUserRule.id `
+    -GroupId $appUserScope.id `
+    -MetaverseAttributeId (Get-MvAttributeId -Name 'Account Enabled') `
+    -ComparisonType Equals `
+    -BoolValue $true | Out-Null
+
+Write-Host "  OK AppUser export rule created ($($appUserMappings.Count + 1) Attribute Flows, scoped on Account Enabled)" -ForegroundColor Green
+
+# ── NaturalKeyAccount: the key JIM authors ──
+#
+# APP_ACCOUNTS_NATURAL.ACCOUNT_CODE is a natural primary key, so it is writable on create and JIM
+# supplies it. The external ID is then a value JIM chose rather than one the database handed back,
+# which is the opposite half of the anchor-agreement question the AppUser rule asks.
+$naturalRule = New-JIMSyncRule `
+    -Name "SQL Matrix NaturalKeyAccount Export ($($config.DisplayName))" `
+    -Description "Scenario 16 outbound rule: provisions into a table whose primary key JIM authors." `
+    -ConnectedSystemId $system.id `
+    -ConnectedSystemObjectTypeId $selectedTypes['NaturalKeyAccount'].id `
+    -MetaverseObjectTypeId $mvUserType.id `
+    -Direction Export `
+    -ProvisionToConnectedSystem `
+    -OutboundDeprovisionAction Delete `
+    -PassThru
+
+New-JIMSyncRuleMapping -SyncRuleId $naturalRule.id `
+    -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'NaturalKeyAccount' -AttributeName 'ACCOUNT_CODE') `
+    -SourceMetaverseAttributeId (Get-MvAttributeId -Name 'Account Name') | Out-Null
+
+New-JIMSyncRuleMapping -SyncRuleId $naturalRule.id `
+    -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'NaturalKeyAccount' -AttributeName 'IS_ENABLED') `
+    -SourceMetaverseAttributeId (Get-MvAttributeId -Name 'Account Enabled') | Out-Null
+
+New-JIMSyncRuleMapping -SyncRuleId $naturalRule.id `
+    -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'NaturalKeyAccount' -AttributeName 'DISPLAY_NAME') `
+    -Expression 'mv["First Name"] + " " + mv["Last Name"]' | Out-Null
+
+# A narrower scope than the AppUser rule's, so the two outbound rules provision different populations
+# and a row asserting on one cannot accidentally be satisfied by the other's work.
+$naturalScope = New-JIMScopingCriteriaGroup -SyncRuleId $naturalRule.id -Type All -PassThru
+New-JIMScopingCriterion `
+    -SyncRuleId $naturalRule.id `
+    -GroupId $naturalScope.id `
+    -MetaverseAttributeId (Get-MvAttributeId -Name 'Department') `
+    -ComparisonType Equals `
+    -StringValue "Research" | Out-Null
+
+Write-Host "  OK NaturalKeyAccount export rule created (3 Attribute Flows, scoped on Department = Research)" -ForegroundColor Green
+
+# ── GuidKeyedPerson (Oracle only): the RAW(16) DEFAULT SYS_GUID() key ──
+#
+# The single most load-bearing outbound rule in the scenario. The generated key comes back through a
+# bound output parameter as an ODP.NET wrapper struct rather than a plain byte[], and nothing in the
+# unit suite can see that shape. This is the first end-to-end proof that provisioning into Oracle works.
+$guidRule = $null
+if ($Provider -eq "Oracle") {
+    $guidRule = New-JIMSyncRule `
+        -Name "SQL Matrix GuidKeyedPerson Export (Oracle)" `
+        -Description "Scenario 16 outbound rule: provisions into a table keyed RAW(16) DEFAULT SYS_GUID()." `
+        -ConnectedSystemId $system.id `
+        -ConnectedSystemObjectTypeId $selectedTypes['GuidKeyedPerson'].id `
+        -MetaverseObjectTypeId $mvUserType.id `
+        -Direction Export `
+        -ProvisionToConnectedSystem `
+        -OutboundDeprovisionAction Delete `
+        -PassThru
+
+    New-JIMSyncRuleMapping -SyncRuleId $guidRule.id `
+        -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'GuidKeyedPerson' -AttributeName 'DEPARTMENT') `
+        -SourceMetaverseAttributeId (Get-MvAttributeId -Name 'Department') | Out-Null
+
+    New-JIMSyncRuleMapping -SyncRuleId $guidRule.id `
+        -TargetConnectedSystemAttributeId (Get-CsAttributeId -ObjectTypeName 'GuidKeyedPerson' -AttributeName 'FULL_NAME') `
+        -Expression 'mv["First Name"] + " " + mv["Last Name"]' | Out-Null
+
+    $guidScope = New-JIMScopingCriteriaGroup -SyncRuleId $guidRule.id -Type All -PassThru
+    New-JIMScopingCriterion `
+        -SyncRuleId $guidRule.id `
+        -GroupId $guidScope.id `
+        -MetaverseAttributeId (Get-MvAttributeId -Name 'Department') `
+        -ComparisonType Equals `
+        -StringValue "Finance" | Out-Null
+
+    Write-Host "  OK GuidKeyedPerson export rule created (2 Attribute Flows, scoped on Department = Finance)" -ForegroundColor Green
+}
+
 Write-TestSection "Scenario 16 Setup Complete: $($config.DisplayName)"
 Write-Host "  Connected System:   $systemName (ID: $($system.id))" -ForegroundColor Cyan
 Write-Host "  Object Types:       $(($expectedTypes) -join ', ')" -ForegroundColor Cyan
 Write-Host "  Database Time Zone: $DatabaseTimeZone (deliberately not UTC)" -ForegroundColor Cyan
 Write-Host "  Page size:          $pageSize" -ForegroundColor Cyan
+Write-Host "  Synchronisation Rules: 1 inbound, $(if ($Provider -eq 'Oracle') { 3 } else { 2 }) outbound" -ForegroundColor Cyan
 
 return @{
-    Provider          = $Provider
-    ConnectedSystemId = $system.id
-    SystemName        = $systemName
-    ObjectTypes       = $selectedTypes
-    RowCount          = $RowCount
-    DatabaseTimeZone  = $DatabaseTimeZone
-    PageSize          = $pageSize
+    Provider           = $Provider
+    ConnectedSystemId  = $system.id
+    SystemName         = $systemName
+    ObjectTypes        = $selectedTypes
+    RowCount           = $RowCount
+    DatabaseTimeZone   = $DatabaseTimeZone
+    PageSize           = $pageSize
+    MetaverseObjectTypeId = $mvUserType.id
+    ImportRuleId       = $importRule.id
+    AppUserRuleId      = $appUserRule.id
+    NaturalKeyRuleId   = $naturalRule.id
+    GuidKeyRuleId      = if ($guidRule) { $guidRule.id } else { $null }
+    # The Metaverse Attributes the driver-shape rows read their derived values back from, named here so
+    # a row does not have to re-derive which built-in was borrowed for which column.
+    MetaverseAttributes = @{
+        ZonelessDate    = 'Employee Start Date'
+        OffsetDate      = 'Employee End Date'
+        LocalZoneDate   = 'Account Expires'
+        Decimal         = $mvFteAttribute.name
+        LongNumber      = $mvHeadcountAttribute.name
+        MultiValued     = 'Other Telephones'
+    }
 }

--- a/test/integration/utils/Scenario16-Helpers.ps1
+++ b/test/integration/utils/Scenario16-Helpers.ps1
@@ -71,6 +71,51 @@ function Invoke-Scenario16Query {
     }
 }
 
+function Invoke-Scenario16NonQuery {
+    <#
+    .SYNOPSIS
+        Run a data-modifying statement against the source database.
+    .DESCRIPTION
+        The export rows need the source data to change between runs (a new email address, a disabled
+        employee, an extra phone number), and the scalar helper above cannot commit on Oracle. Same
+        interpolation rule applies: nothing that did not originate in this test suite goes into $Statement.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][hashtable]$Config,
+        [Parameter(Mandatory=$true)][string]$Statement
+    )
+
+    if ($Config.Provider -eq "SqlServer") {
+        $arguments = @("exec", $Config.ContainerName) + $Config.SqlCommand +
+                     @("-d", $Config.DatabaseName, "-Q", "SET NOCOUNT ON; $Statement")
+        $output = & docker @arguments 2>&1
+        if ($LASTEXITCODE -ne 0) { throw "Source statement failed on $($Config.DisplayName): $($output | Out-String)" }
+        return
+    }
+
+    # SQL*Plus does not commit implicitly, so an uncommitted change would be invisible to JIM's own
+    # session and the row would fail for a reason that has nothing to do with the connector.
+    $scriptName = "jim-s16-dml-$([Guid]::NewGuid().ToString('N')).sql"
+    $localPath = Join-Path ([System.IO.Path]::GetTempPath()) $scriptName
+    $script = "WHENEVER SQLERROR EXIT FAILURE`nSET DEFINE OFF`nSET FEEDBACK OFF`n$Statement`nCOMMIT;`nEXIT SUCCESS`n"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($localPath, $script, $utf8NoBom)
+
+    try {
+        docker cp $localPath "$($Config.ContainerName):/tmp/$scriptName" 2>&1 | Out-Null
+        $arguments = @("exec", $Config.ContainerName) + $Config.SqlCommand + @("@/tmp/$scriptName")
+        $output = & docker @arguments 2>&1
+        $text = ($output | Out-String)
+        if ($LASTEXITCODE -ne 0 -or $text -match 'ORA-\d{5}') {
+            throw "Source statement failed on $($Config.DisplayName): $text"
+        }
+    }
+    finally {
+        Remove-Item $localPath -ErrorAction SilentlyContinue
+        docker exec $Config.ContainerName rm -f "/tmp/$scriptName" 2>&1 | Out-Null
+    }
+}
+
 function Get-Scenario16ObjectTypeId {
     param(
         [Parameter(Mandatory=$true)][hashtable]$Context,
@@ -110,17 +155,19 @@ function Invoke-Scenario16Row {
         'ConfigurationValidation'          { return Test-S16ConfigurationValidation -Context $Context -Config $Config }
         'Scale.FullImport500k'             { return Test-S16ScaleImport -Context $Context -Config $Config }
 
-        # Rows whose implementation depends on outbound Synchronisation Rules, which Setup-Scenario16.ps1
-        # does not yet create. Reported as skipped with the reason rather than passed; see this file's
-        # header on why a green cell nobody ran is worse than an amber one.
+        'Export.Create'                    { return Test-S16ExportCreate -Context $Context -Config $Config }
+        'Export.Update'                    { return Test-S16ExportUpdate -Context $Context -Config $Config }
+        'Export.Delete'                    { return Test-S16ExportDelete -Context $Context -Config $Config }
+        'Export.NaturalKey'                { return Test-S16ExportNaturalKey -Context $Context -Config $Config }
+        'Reference.Export'                 { return Test-S16ReferenceExport -Context $Context -Config $Config }
+        'TypeMapping.RoundTrip'            { return Test-S16TypeMappingRoundTrip -Context $Context -Config $Config }
+
+        # Both delta rows remain unimplemented, and for a different reason from the export rows: they need
+        # the Connected System's Delta Import Mode changed and its persisted watermark cleared mid-run,
+        # neither of which the matrix has a mechanism for. Reported as skipped with the reason rather than
+        # passed; see this file's header on why a green cell nobody ran is worse than an amber one.
         'Delta.WatermarkColumn'  { return @{ Status = 'skip'; Detail = 'Not implemented: needs a second Connected System configured for Watermark Column delta mode.' } }
         'Delta.Fallback'         { return @{ Status = 'skip'; Detail = 'Not implemented: needs the persisted watermark to be cleared between runs.' } }
-        'Export.Create'          { return @{ Status = 'skip'; Detail = 'Not implemented: outbound Synchronisation Rules are not yet created by Setup-Scenario16.ps1.' } }
-        'Export.Update'          { return @{ Status = 'skip'; Detail = 'Not implemented: outbound Synchronisation Rules are not yet created by Setup-Scenario16.ps1.' } }
-        'Export.Delete'          { return @{ Status = 'skip'; Detail = 'Not implemented: outbound Synchronisation Rules are not yet created by Setup-Scenario16.ps1.' } }
-        'Export.NaturalKey'      { return @{ Status = 'skip'; Detail = 'Not implemented: outbound Synchronisation Rules are not yet created by Setup-Scenario16.ps1.' } }
-        'Reference.Export'       { return @{ Status = 'skip'; Detail = 'Not implemented: outbound Synchronisation Rules are not yet created by Setup-Scenario16.ps1.' } }
-        'TypeMapping.RoundTrip'  { return @{ Status = 'skip'; Detail = 'Partially covered by the driver-shape rows; the export half needs outbound Synchronisation Rules.' } }
 
         default { return @{ Status = 'skip'; Detail = "No implementation is registered for matrix row '$($Row.name)'." } }
     }
@@ -225,6 +272,329 @@ function Test-S16DeltaChangeLog {
     Assert-ActivitySuccess -ActivityId $result.activityId -Name "Scenario 16 Delta Import ($($Context.Provider))"
 
     return @{ Status = 'pass'; Detail = "Delta Import completed against the change-log table and persisted its watermark." }
+}
+
+# ─── Shared machinery for the synchronisation and export rows ──────────────────
+
+function Invoke-S16RunProfile {
+    param(
+        [Parameter(Mandatory=$true)][hashtable]$Context,
+        [Parameter(Mandatory=$true)][string]$Name
+    )
+
+    $result = Start-JIMRunProfile -ConnectedSystemId $Context.ConnectedSystemId -RunProfileName $Name -Wait -PassThru
+    Assert-ActivitySuccess -ActivityId $result.activityId -Name "Scenario 16 $Name ($($Context.Provider))"
+    return $result
+}
+
+function Invoke-S16Pipeline {
+    <#
+    .SYNOPSIS
+        Import, synchronise, export, then import again to confirm.
+    .DESCRIPTION
+        The trailing Full Import is not housekeeping. An object JIM exported carries an external ID the
+        connector composed from whatever the insert handed back; the confirming import composes one from
+        the row it reads. If the two disagree the import does not recognise its own work and creates a
+        second Connected System Object, so an object-count assertion after this sequence is what settles
+        anchor-token agreement. Nothing else in the suite can settle it.
+    #>
+    param([Parameter(Mandatory=$true)][hashtable]$Context)
+
+    Invoke-S16RunProfile -Context $Context -Name "Full Import"          | Out-Null
+    Invoke-S16RunProfile -Context $Context -Name "Full Synchronisation" | Out-Null
+    Invoke-S16RunProfile -Context $Context -Name "Export"               | Out-Null
+    Invoke-S16RunProfile -Context $Context -Name "Full Import"          | Out-Null
+}
+
+function Initialize-S16ExportBaseline {
+    <#
+    .SYNOPSIS
+        Ensure the export pipeline has run once for this provider, and only once.
+    .DESCRIPTION
+        Memoised on the context so each export row can be run on its own with -Step without every row
+        paying for a full pipeline when they run together.
+    #>
+    param([Parameter(Mandatory=$true)][hashtable]$Context)
+
+    if ($Context.ContainsKey('ExportBaselineDone') -and $Context.ExportBaselineDone) { return }
+
+    Invoke-S16Pipeline -Context $Context
+    $Context['ExportBaselineDone'] = $true
+}
+
+function Get-S16ExpectedCount {
+    <#
+    .SYNOPSIS
+        How many seeded employees satisfy one of the outbound rules' scopes.
+    .DESCRIPTION
+        Derived arithmetically from the row count rather than hard-coded, because the seeder's values are
+        derived arithmetically too and the matrix is meant to hold at 50 rows and at 500,000.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][int]$RowCount,
+        [Parameter(Mandatory=$true)][ValidateSet('Enabled', 'Research', 'Finance')][string]$Scope
+    )
+
+    switch ($Scope) {
+        # IS_ACTIVE is 0 for every seventh employee.
+        'Enabled'  { return $RowCount - [math]::Floor($RowCount / 7) }
+        # DEPARTMENT cycles Engineering, Finance, Operations, Research on n modulo 4.
+        'Research' { return @(1..$RowCount | Where-Object { ($_ % 4) -eq 3 }).Count }
+        'Finance'  { return @(1..$RowCount | Where-Object { ($_ % 4) -eq 1 }).Count }
+    }
+}
+
+function Get-S16EmployeeNumber {
+    param([Parameter(Mandatory=$true)][int]$EmployeeId)
+    return "E{0:D8}" -f $EmployeeId
+}
+
+function Get-S16MetaverseObject {
+    <#
+    .SYNOPSIS
+        The Metaverse Object the inbound rule projected for one seeded employee, with its values.
+    #>
+    param([Parameter(Mandatory=$true)][int]$EmployeeId)
+
+    $employeeNumber = Get-S16EmployeeNumber -EmployeeId $EmployeeId
+    $match = @(Get-JIMMetaverseObject -ObjectTypeName "User" -Search $employeeNumber -PageSize 10) | Select-Object -First 1
+    if (-not $match) { return $null }
+    return Get-JIMMetaverseObject -Id $match.id
+}
+
+function Get-S16MvoValue {
+    <#
+    .SYNOPSIS
+        One attribute value row off a Metaverse Object, or $null when the attribute carries no value.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]$Mvo,
+        [Parameter(Mandatory=$true)][string]$AttributeName
+    )
+
+    if (-not $Mvo -or -not $Mvo.attributeValues) { return $null }
+    return @($Mvo.attributeValues | Where-Object { $_.attributeName -ceq $AttributeName }) | Select-Object -First 1
+}
+
+# ─── Export rows ───────────────────────────────────────────────────────────────
+
+function Test-S16ExportCreate {
+    param([hashtable]$Context, [hashtable]$Config)
+
+    Initialize-S16ExportBaseline -Context $Context
+
+    $expected = Get-S16ExpectedCount -RowCount $Context.RowCount -Scope 'Enabled'
+    $actualRows = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USERS;")
+
+    if ($actualRows -ne $expected) {
+        return @{ Status = 'fail'; Detail = "The outbound rule is scoped to enabled employees, so $expected row(s) should have been inserted into APP_USERS; the table holds $actualRows." }
+    }
+
+    # Anchor-token agreement. The confirming Full Import in the pipeline re-read every row it had just
+    # written; if the external ID it composed from the row differed from the one the insert returned, the
+    # import would have created a second Connected System Object for each and the count would be doubled.
+    $appUserTypeId = Get-Scenario16ObjectTypeId -Context $Context -Name 'AppUser'
+    $csoCount = [int](Get-JIMConnectedSystemObject -ConnectedSystemId $Context.ConnectedSystemId -ObjectTypeId $appUserTypeId -Count)
+
+    if ($csoCount -ne $expected) {
+        return @{ Status = 'fail'; Detail = "APP_USERS holds $actualRows row(s) but JIM holds $csoCount Connected System Object(s) for the type. A mismatch here means the external ID composed on export does not equal the one composed on import, so the confirming import did not recognise the objects it had just created." }
+    }
+
+    # A generated key is only proof of anything if it actually came from the database: the seeded table is
+    # empty before this row runs, so every identifier present was returned by an insert.
+    $anchors = @(Get-JIMConnectedSystemObject -ConnectedSystemId $Context.ConnectedSystemId -ObjectTypeId $appUserTypeId -All -Force |
+                 ForEach-Object { $_.externalIdValue })
+    $unusable = @($anchors | Where-Object { [string]::IsNullOrWhiteSpace($_) -or $_ -notmatch '^\d+$' })
+    if ($unusable.Count -gt 0) {
+        return @{ Status = 'fail'; Detail = "$($unusable.Count) exported object(s) carry an external ID that is not the integer the IDENTITY column generates: '$(($unusable | Select-Object -First 5) -join "', '")'." }
+    }
+
+    return @{ Status = 'pass'; Detail = "$expected row(s) inserted with a database-generated key, and the confirming import composed the same anchor token for every one." }
+}
+
+function Test-S16ExportUpdate {
+    param([hashtable]$Context, [hashtable]$Config)
+
+    Initialize-S16ExportBaseline -Context $Context
+
+    # Employee 12 is enabled (12 is not a multiple of seven) and has two phone numbers (12 is a multiple
+    # of three), so both a scalar change and a multi-valued change have somewhere to land.
+    $employeeId = 12
+    $userName = Get-S16EmployeeNumber -EmployeeId $employeeId
+    $newEmail = "updated.employee$employeeId@panoply.local"
+    $newPhone = "+44 113 496 9999"
+
+    Invoke-Scenario16NonQuery -Config $Config -Statement "UPDATE $($Config.Schema).EMPLOYEES SET EMAIL = '$newEmail' WHERE EMPLOYEE_ID = $employeeId;"
+    Invoke-Scenario16NonQuery -Config $Config -Statement "INSERT INTO $($Config.Schema).EMPLOYEE_PHONES (EMPLOYEE_ID, PHONE_NUMBER, LAST_MODIFIED) SELECT $employeeId, '$newPhone', LAST_MODIFIED FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $employeeId;"
+
+    Invoke-S16Pipeline -Context $Context
+
+    $exportedEmail = (Invoke-Scenario16Query -Config $Config -Query "SELECT EMAIL FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';").Trim()
+    if ($exportedEmail -ne $newEmail) {
+        return @{ Status = 'fail'; Detail = "APP_USERS.EMAIL for $userName should be '$newEmail' after the update export; it is '$exportedEmail'." }
+    }
+
+    $roleCount = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USER_ROLES r JOIN $($Config.Schema).APP_USERS u ON u.ID = r.USER_ID WHERE u.USER_NAME = '$userName';")
+    if ($roleCount -ne 3) {
+        return @{ Status = 'fail'; Detail = "Employee $employeeId now has three phone numbers, so three related-table rows should exist for $userName; found $roleCount." }
+    }
+
+    # And the removal half. A related-table maintenance that only ever adds passes an add-only assertion.
+    Invoke-Scenario16NonQuery -Config $Config -Statement "DELETE FROM $($Config.Schema).EMPLOYEE_PHONES WHERE EMPLOYEE_ID = $employeeId AND PHONE_NUMBER = '$newPhone';"
+    Invoke-S16Pipeline -Context $Context
+
+    $roleCountAfter = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USER_ROLES r JOIN $($Config.Schema).APP_USERS u ON u.ID = r.USER_ID WHERE u.USER_NAME = '$userName';")
+    if ($roleCountAfter -ne 2) {
+        return @{ Status = 'fail'; Detail = "The third phone number was removed at source, so $userName should be back to two related-table rows; found $roleCountAfter." }
+    }
+
+    return @{ Status = 'pass'; Detail = "Scalar update applied, and the related table gained and then lost a row in step with the source." }
+}
+
+function Test-S16ExportDelete {
+    param([hashtable]$Context, [hashtable]$Config)
+
+    Initialize-S16ExportBaseline -Context $Context
+
+    # Employee 20 is enabled in the seeded data, so disabling it takes its Metaverse Object out of the
+    # outbound rule's scope; the rule's OutboundDeprovisionAction is Delete, so that becomes a delete
+    # export rather than a disconnect.
+    $employeeId = 20
+    $userName = Get-S16EmployeeNumber -EmployeeId $employeeId
+
+    $before = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';")
+    if ($before -ne 1) {
+        return @{ Status = 'fail'; Detail = "Employee $employeeId should have been provisioned by the baseline export before this row runs; APP_USERS holds $before row(s) for $userName." }
+    }
+
+    $disabledValue = if ($Config.Provider -eq "SqlServer") { "0" } else { "0" }
+    Invoke-Scenario16NonQuery -Config $Config -Statement "UPDATE $($Config.Schema).EMPLOYEES SET IS_ACTIVE = $disabledValue WHERE EMPLOYEE_ID = $employeeId;"
+
+    Invoke-S16Pipeline -Context $Context
+
+    $after = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';")
+    if ($after -ne 0) {
+        return @{ Status = 'fail'; Detail = "$userName left the outbound rule's scope, so its APP_USERS row should have been deleted; $after row(s) remain." }
+    }
+
+    # The related rows go with it. They are removed by the foreign key's cascade rather than by JIM, but a
+    # delete that left them behind would still be a defect worth catching here.
+    $orphanRoles = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USER_ROLES r WHERE NOT EXISTS (SELECT 1 FROM $($Config.Schema).APP_USERS u WHERE u.ID = r.USER_ID);")
+    if ($orphanRoles -ne 0) {
+        return @{ Status = 'fail'; Detail = "$orphanRoles related-table row(s) survived the parent's deletion." }
+    }
+
+    return @{ Status = 'pass'; Detail = "Deprovisioning removed the row and left no orphaned related-table rows." }
+}
+
+function Test-S16ExportNaturalKey {
+    param([hashtable]$Context, [hashtable]$Config)
+
+    Initialize-S16ExportBaseline -Context $Context
+
+    # The opposite half of the Export.Create question. Here the primary key is a natural identifier JIM
+    # authors and writes, so the external ID is a value JIM chose rather than one the database returned;
+    # the confirming import still has to compose the same token from the row.
+    $expected = Get-S16ExpectedCount -RowCount $Context.RowCount -Scope 'Research'
+    $actualRows = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_ACCOUNTS_NATURAL;")
+
+    if ($actualRows -ne $expected) {
+        return @{ Status = 'fail'; Detail = "The rule is scoped to Department = Research, so $expected row(s) should exist in APP_ACCOUNTS_NATURAL; the table holds $actualRows." }
+    }
+
+    $naturalTypeId = Get-Scenario16ObjectTypeId -Context $Context -Name 'NaturalKeyAccount'
+    $csoCount = [int](Get-JIMConnectedSystemObject -ConnectedSystemId $Context.ConnectedSystemId -ObjectTypeId $naturalTypeId -Count)
+    if ($csoCount -ne $expected) {
+        return @{ Status = 'fail'; Detail = "APP_ACCOUNTS_NATURAL holds $actualRows row(s) but JIM holds $csoCount Connected System Object(s), so the anchor JIM authored on export is not the one it composed on import." }
+    }
+
+    # The key JIM authored has to be the value the Attribute Flow supplied, not a surrogate of its own.
+    $malformed = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_ACCOUNTS_NATURAL WHERE ACCOUNT_CODE NOT LIKE 'E%';")
+    if ($malformed -ne 0) {
+        return @{ Status = 'fail'; Detail = "$malformed row(s) carry an ACCOUNT_CODE that did not come from the Metaverse 'Account Name' flow." }
+    }
+
+    return @{ Status = 'pass'; Detail = "$expected row(s) provisioned into a natural-key table, with JIM's authored key surviving the confirming import." }
+}
+
+function Test-S16ReferenceExport {
+    param([hashtable]$Context, [hashtable]$Config)
+
+    Initialize-S16ExportBaseline -Context $Context
+
+    # Employee 12's manager is employee 3 (the seeder gives every row past the tenth a manager of
+    # (n modulo 10) + 1), and employee 3 is itself enabled, so the manager has an exported row for the
+    # reference to point at. What is asserted is that JIM wrote the manager's OWN generated key rather
+    # than the source system's employee identifier.
+    $employeeId = 12
+    $managerEmployeeId = ($employeeId % 10) + 1
+    $userName = Get-S16EmployeeNumber -EmployeeId $employeeId
+    $managerUserName = Get-S16EmployeeNumber -EmployeeId $managerEmployeeId
+
+    $expectedManagerId = (Invoke-Scenario16Query -Config $Config -Query "SELECT ID FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$managerUserName';").Trim()
+    if ([string]::IsNullOrWhiteSpace($expectedManagerId)) {
+        return @{ Status = 'fail'; Detail = "The manager ($managerUserName) has no APP_USERS row, so the reference had nothing to resolve to." }
+    }
+
+    $writtenManagerId = (Invoke-Scenario16Query -Config $Config -Query "SELECT MANAGER_ID FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';").Trim()
+    if ($writtenManagerId -ne $expectedManagerId) {
+        return @{ Status = 'fail'; Detail = "APP_USERS.MANAGER_ID for $userName should be $expectedManagerId (the generated key of $managerUserName); it is '$writtenManagerId'." }
+    }
+
+    return @{ Status = 'pass'; Detail = "Reference exported as the target object's own anchor ($managerUserName resolved to $expectedManagerId)." }
+}
+
+function Test-S16TypeMappingRoundTrip {
+    param([hashtable]$Context, [hashtable]$Config)
+
+    Initialize-S16ExportBaseline -Context $Context
+
+    # One employee, every mapped shape, source value against exported value. Employee 12 is enabled so it
+    # has an exported row, and its FTE is 0.25, a value binary floating point cannot represent exactly.
+    $employeeId = 12
+    $userName = Get-S16EmployeeNumber -EmployeeId $employeeId
+    $failures = @()
+
+    $sourceFte = [decimal](Invoke-Scenario16Query -Config $Config -Query "SELECT TO_CHAR(FTE) FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $employeeId;" | ForEach-Object { $_ }).Trim()
+    if ($Config.Provider -eq "SqlServer") {
+        $sourceFte = [decimal]((Invoke-Scenario16Query -Config $Config -Query "SELECT CAST(FTE AS varchar(32)) FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $employeeId;").Trim())
+    }
+
+    $exportedFteText = (Invoke-Scenario16Query -Config $Config -Query $(
+        if ($Config.Provider -eq "SqlServer") { "SELECT CAST(FTE AS varchar(32)) FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';" }
+        else { "SELECT TO_CHAR(FTE) FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';" })).Trim()
+
+    if ([string]::IsNullOrWhiteSpace($exportedFteText)) {
+        $failures += "FTE was not written to APP_USERS at all."
+    }
+    elseif ([decimal]$exportedFteText -ne $sourceFte) {
+        $failures += "FTE round-tripped as $exportedFteText but the source holds $sourceFte; the exact-numeric value did not survive."
+    }
+
+    # The zoneless date and time column. Whatever the Database Time Zone does on the way in, the reverse
+    # conversion on the way out must land on the same wall clock, or the two directions are not inverses.
+    $sourceStart = (Invoke-Scenario16Query -Config $Config -Query $(
+        if ($Config.Provider -eq "SqlServer") { "SELECT CONVERT(varchar(19), START_DATE, 120) FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $employeeId;" }
+        else { "SELECT TO_CHAR(START_DATE,'YYYY-MM-DD HH24:MI:SS') FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $employeeId;" })).Trim()
+
+    $exportedStart = (Invoke-Scenario16Query -Config $Config -Query $(
+        if ($Config.Provider -eq "SqlServer") { "SELECT CONVERT(varchar(19), STARTS_ON, 120) FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';" }
+        else { "SELECT TO_CHAR(STARTS_ON,'YYYY-MM-DD HH24:MI:SS') FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName';" })).Trim()
+
+    if ($exportedStart -ne $sourceStart) {
+        $failures += "The zoneless date and time round-tripped as '$exportedStart' but the source wall clock is '$sourceStart'. Import and export are not inverting the Database Time Zone the same way."
+    }
+
+    $exportedEnabled = (Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).APP_USERS WHERE USER_NAME = '$userName' AND IS_ENABLED = 1;").Trim()
+    if ($exportedEnabled -ne '1') {
+        $failures += "The Boolean did not round-trip: IS_ENABLED is not set for an employee whose IS_ACTIVE is set."
+    }
+
+    if ($failures.Count -gt 0) {
+        return @{ Status = 'fail'; Detail = ($failures -join ' ') }
+    }
+
+    return @{ Status = 'pass'; Detail = "Exact-numeric Decimal, zoneless date and time, and Boolean all round-tripped for employee $employeeId." }
 }
 
 # ─── Driver-shape rows ─────────────────────────────────────────────────────────

--- a/test/integration/utils/Scenario16-Helpers.ps1
+++ b/test/integration/utils/Scenario16-Helpers.ps1
@@ -304,6 +304,28 @@ function Invoke-S16Pipeline {
     Invoke-S16RunProfile -Context $Context -Name "Full Synchronisation" | Out-Null
     Invoke-S16RunProfile -Context $Context -Name "Export"               | Out-Null
     Invoke-S16RunProfile -Context $Context -Name "Full Import"          | Out-Null
+
+    # A pipeline satisfies the lighter baseline too, so a driver-shape row running after an export row
+    # does not import and synchronise all over again for nothing.
+    $Context['SyncBaselineDone'] = $true
+}
+
+function Initialize-S16SyncBaseline {
+    <#
+    .SYNOPSIS
+        Ensure Metaverse Objects exist for the seeded population, and only import once to get them.
+    .DESCRIPTION
+        What the driver-shape rows need, and no more: they assert on the instant JIM derived from a
+        source column, which lives on the Metaverse Object, and none of them cares whether anything has
+        been exported.
+    #>
+    param([Parameter(Mandatory=$true)][hashtable]$Context)
+
+    if ($Context.ContainsKey('SyncBaselineDone') -and $Context.SyncBaselineDone) { return }
+
+    Invoke-S16RunProfile -Context $Context -Name "Full Import"          | Out-Null
+    Invoke-S16RunProfile -Context $Context -Name "Full Synchronisation" | Out-Null
+    $Context['SyncBaselineDone'] = $true
 }
 
 function Initialize-S16ExportBaseline {
@@ -599,6 +621,89 @@ function Test-S16TypeMappingRoundTrip {
 
 # ─── Driver-shape rows ─────────────────────────────────────────────────────────
 
+function ConvertTo-S16Utc {
+    <#
+    .SYNOPSIS
+        Normalise a Metaverse DateTime attribute value to a UTC DateTime.
+    .DESCRIPTION
+        JIM stores DateTime attribute values as UTC instants; how they arrive over the wire depends on
+        the JSON deserialiser, so both a DateTime and a string are accepted and both end up as Kind Utc.
+        Everything downstream compares instants, never wall clocks, because a wall-clock comparison is
+        the very confusion these rows exist to detect.
+    #>
+    param([Parameter(Mandatory=$true)]$Value)
+
+    if ($Value -is [datetime]) {
+        if ($Value.Kind -eq [System.DateTimeKind]::Utc) { return $Value }
+        return [System.DateTime]::SpecifyKind($Value, [System.DateTimeKind]::Utc)
+    }
+
+    return [System.DateTime]::Parse(
+        [string]$Value,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::AdjustToUniversal -bor [System.Globalization.DateTimeStyles]::AssumeUniversal)
+}
+
+function Get-S16SourceUtc {
+    <#
+    .SYNOPSIS
+        The UTC instant the database itself says an offset-carrying column holds.
+    .DESCRIPTION
+        The ground truth for the offset-carrying rows, computed by the server rather than by this script.
+        Deriving the expected instant here in PowerShell would mean reimplementing the very conversion
+        under test, and a test that reimplements its subject agrees with it by construction.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][hashtable]$Config,
+        [Parameter(Mandatory=$true)][string]$Column,
+        [Parameter(Mandatory=$true)][int]$EmployeeId
+    )
+
+    $query = if ($Config.Provider -eq "SqlServer") {
+        "SELECT CONVERT(varchar(19), SWITCHOFFSET($Column, 0), 120) FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $EmployeeId;"
+    }
+    else {
+        "SELECT TO_CHAR(SYS_EXTRACT_UTC($Column),'YYYY-MM-DD HH24:MI:SS') FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $EmployeeId;"
+    }
+
+    $text = (Invoke-Scenario16Query -Config $Config -Query $query).Trim()
+    return ConvertTo-S16Utc -Value $text
+}
+
+function Get-S16ZonelessWallClock {
+    param(
+        [Parameter(Mandatory=$true)][hashtable]$Config,
+        [Parameter(Mandatory=$true)][string]$Column,
+        [Parameter(Mandatory=$true)][int]$EmployeeId
+    )
+
+    $query = if ($Config.Provider -eq "SqlServer") {
+        "SELECT CONVERT(varchar(19), $Column, 120) FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $EmployeeId;"
+    }
+    else {
+        "SELECT TO_CHAR($Column,'YYYY-MM-DD HH24:MI:SS') FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = $EmployeeId;"
+    }
+
+    return (Invoke-Scenario16Query -Config $Config -Query $query).Trim()
+}
+
+function Get-S16ExpectedUtcForZoneless {
+    <#
+    .SYNOPSIS
+        The UTC instant a zoneless wall clock names when read in the Connected System's Database Time Zone.
+    #>
+    param(
+        [Parameter(Mandatory=$true)][string]$WallClock,
+        [Parameter(Mandatory=$true)][string]$TimeZoneId
+    )
+
+    $unspecified = [System.DateTime]::SpecifyKind(
+        [System.DateTime]::ParseExact($WallClock, 'yyyy-MM-dd HH:mm:ss', [System.Globalization.CultureInfo]::InvariantCulture),
+        [System.DateTimeKind]::Unspecified)
+    $zone = [System.TimeZoneInfo]::FindSystemTimeZoneById($TimeZoneId)
+    return [System.TimeZoneInfo]::ConvertTimeToUtc($unspecified, $zone)
+}
+
 function Test-S16DateTimeNonUtc {
     param([hashtable]$Context, [hashtable]$Config)
 
@@ -606,67 +711,202 @@ function Test-S16DateTimeNonUtc {
         return @{ Status = 'fail'; Detail = "The Connected System is configured for UTC, which makes every zone conversion the identity and the assertion meaningless. This row requires a non-UTC Database Time Zone." }
     }
 
-    # START_DATE is zoneless, so JIM must interpret it in the declared zone and store the corresponding
-    # UTC instant. Employee 7's START_DATE is 2020-01-13 00:00:00 local; Europe/London is UTC+0 in
-    # January, so the stored UTC instant is the same wall clock. Employee 200's is in July, where
-    # Europe/London is UTC+1 and the stored instant must be an hour earlier than the wall clock. Both
-    # are checked because a zone applied as a fixed offset passes the January case alone.
-    $januaryWallClock = (Invoke-Scenario16Query -Config $Config -Query "SELECT TO_CHAR(START_DATE,'YYYY-MM-DD HH24:MI:SS') FROM $($Config.Schema).EMPLOYEES WHERE EMPLOYEE_ID = 7;").Trim()
+    Initialize-S16SyncBaseline -Context $Context
 
-    return @{
-        Status = 'skip'
-        Detail = "Authored but not executed. Asserting the stored UTC instant requires reading the Metaverse Object's DateTime value back, which needs the inbound Synchronisation Rule Setup-Scenario16.ps1 does not yet create. Source wall clock for employee 7 is '$januaryWallClock' in $($Context.DatabaseTimeZone)."
+    # START_DATE is zoneless, so JIM must interpret it in the declared zone and store the corresponding
+    # UTC instant. Both sides of a daylight-saving transition are checked, because a zone applied as a
+    # fixed offset passes a single-season test: Australia/Sydney is UTC+11:00 over the seeded January
+    # dates and UTC+10:00 in the southern winter, so a fixed-offset implementation gets the second case
+    # an hour wrong and nothing else distinguishes the two.
+    $employeeId = 7
+    $failures = @()
+    $observed = @()
+
+    $originalWallClock = Get-S16ZonelessWallClock -Config $Config -Column 'START_DATE' -EmployeeId $employeeId
+
+    function Test-S16ZonelessInstant {
+        param([hashtable]$RowContext, [string]$Label, [string]$WallClock, [int]$Employee)
+
+        $attributeName = $RowContext.MetaverseAttributes.ZonelessDate
+        $mvo = Get-S16MetaverseObject -EmployeeId $Employee
+        if (-not $mvo) { return @{ Failure = "No Metaverse Object was projected for employee $Employee ($Label)."; Observation = $null } }
+
+        $value = Get-S16MvoValue -Mvo $mvo -AttributeName $attributeName
+        if (-not $value -or -not $value.dateTimeValue) {
+            return @{ Failure = "The Metaverse Object for employee $Employee carries no '$attributeName' value ($Label)."; Observation = $null }
+        }
+
+        $actual = ConvertTo-S16Utc -Value $value.dateTimeValue
+        $expected = Get-S16ExpectedUtcForZoneless -WallClock $WallClock -TimeZoneId $RowContext.DatabaseTimeZone
+        $observation = "$Label wall clock '$WallClock' in $($RowContext.DatabaseTimeZone) stored as $($actual.ToString('o'))"
+
+        if ($actual -ne $expected) {
+            return @{ Failure = "$Label : the source wall clock is '$WallClock' in $($RowContext.DatabaseTimeZone), so the stored instant should be $($expected.ToString('o')); JIM stored $($actual.ToString('o'))."; Observation = $observation }
+        }
+        return @{ Failure = $null; Observation = $observation }
     }
+
+    $summerOutcome = Test-S16ZonelessInstant -RowContext $Context -Label 'Southern summer (UTC+11:00)' -WallClock $originalWallClock -Employee $employeeId
+    if ($summerOutcome.Failure) { $failures += $summerOutcome.Failure } else { $observed += $summerOutcome.Observation }
+
+    # The seeded population never leaves January and February, so the other side of the transition has to
+    # be written in rather than found. Restored afterwards so later rows still see the deterministic seed.
+    $winterWallClock = '2020-07-15 09:30:00'
+    try {
+        Invoke-Scenario16NonQuery -Config $Config -Statement $(
+            if ($Config.Provider -eq "SqlServer") { "UPDATE $($Config.Schema).EMPLOYEES SET START_DATE = CAST('$winterWallClock' AS datetime2(3)) WHERE EMPLOYEE_ID = $employeeId;" }
+            else { "UPDATE $($Config.Schema).EMPLOYEES SET START_DATE = TIMESTAMP '$winterWallClock' WHERE EMPLOYEE_ID = $employeeId;" })
+
+        Invoke-S16RunProfile -Context $Context -Name "Full Import"          | Out-Null
+        Invoke-S16RunProfile -Context $Context -Name "Full Synchronisation" | Out-Null
+
+        $winterOutcome = Test-S16ZonelessInstant -RowContext $Context -Label 'Southern winter (UTC+10:00)' -WallClock $winterWallClock -Employee $employeeId
+        if ($winterOutcome.Failure) { $failures += $winterOutcome.Failure } else { $observed += $winterOutcome.Observation }
+    }
+    finally {
+        Invoke-Scenario16NonQuery -Config $Config -Statement $(
+            if ($Config.Provider -eq "SqlServer") { "UPDATE $($Config.Schema).EMPLOYEES SET START_DATE = CAST('$originalWallClock' AS datetime2(3)) WHERE EMPLOYEE_ID = $employeeId;" }
+            else { "UPDATE $($Config.Schema).EMPLOYEES SET START_DATE = TIMESTAMP '$originalWallClock' WHERE EMPLOYEE_ID = $employeeId;" })
+        Invoke-S16RunProfile -Context $Context -Name "Full Import"          | Out-Null
+        Invoke-S16RunProfile -Context $Context -Name "Full Synchronisation" | Out-Null
+    }
+
+    if ($failures.Count -gt 0) {
+        return @{ Status = 'fail'; Detail = ($failures -join ' ') }
+    }
+
+    return @{ Status = 'pass'; Detail = "Zoneless values interpreted in $($Context.DatabaseTimeZone) on both sides of the daylight-saving transition. $($observed -join '; ')." }
 }
 
 function Test-S16OffsetVersusZoneless {
     param([hashtable]$Context, [hashtable]$Config)
 
-    # LAST_MODIFIED (zoneless) and HIRED_AT (offset-carrying, -05:00) name the same wall clock in the
-    # seeded data but different instants. Import must treat them differently: the zoneless one through
-    # the Database Time Zone, the offset-carrying one at the instant it states.
-    return @{
-        Status = 'skip'
-        Detail = "Authored but not executed. Needs the inbound Synchronisation Rule to read both values back as Metaverse DateTime attributes."
+    Initialize-S16SyncBaseline -Context $Context
+
+    # START_DATE (zoneless) and HIRED_AT (offset-carrying, stated as -05:00) sit in the same table and are
+    # read by the same import. Import decides which is which from the runtime CLR type the driver returns,
+    # and the failure this row is built to catch is the Database Time Zone being applied to the
+    # offset-carrying column as well: the instant would then be wrong by the difference between the two
+    # offsets, and no single-column test would notice.
+    $employeeId = 7
+    $failures = @()
+
+    $mvo = Get-S16MetaverseObject -EmployeeId $employeeId
+    if (-not $mvo) {
+        return @{ Status = 'fail'; Detail = "No Metaverse Object was projected for employee $employeeId, so neither value can be read back." }
     }
+
+    $zonelessValue = Get-S16MvoValue -Mvo $mvo -AttributeName $Context.MetaverseAttributes.ZonelessDate
+    $offsetValue   = Get-S16MvoValue -Mvo $mvo -AttributeName $Context.MetaverseAttributes.OffsetDate
+
+    if (-not $zonelessValue -or -not $zonelessValue.dateTimeValue) { $failures += "The zoneless column produced no Metaverse value." }
+    if (-not $offsetValue   -or -not $offsetValue.dateTimeValue)   { $failures += "The offset-carrying column produced no Metaverse value." }
+
+    if ($failures.Count -gt 0) {
+        return @{ Status = 'fail'; Detail = ($failures -join ' ') }
+    }
+
+    $zonelessWallClock = Get-S16ZonelessWallClock -Config $Config -Column 'START_DATE' -EmployeeId $employeeId
+    $expectedZoneless = Get-S16ExpectedUtcForZoneless -WallClock $zonelessWallClock -TimeZoneId $Context.DatabaseTimeZone
+    $actualZoneless = ConvertTo-S16Utc -Value $zonelessValue.dateTimeValue
+    if ($actualZoneless -ne $expectedZoneless) {
+        $failures += "The zoneless column should have been read in $($Context.DatabaseTimeZone) as $($expectedZoneless.ToString('o')); JIM stored $($actualZoneless.ToString('o'))."
+    }
+
+    $expectedOffset = Get-S16SourceUtc -Config $Config -Column 'HIRED_AT' -EmployeeId $employeeId
+    $actualOffset = ConvertTo-S16Utc -Value $offsetValue.dateTimeValue
+    if ($actualOffset -ne $expectedOffset) {
+        $failures += "The offset-carrying column states its own offset, so the stored instant should be the $($expectedOffset.ToString('o')) the server itself reports; JIM stored $($actualOffset.ToString('o')). A difference matching the Database Time Zone's offset means the zone was applied to a column that did not need it."
+    }
+
+    if ($failures.Count -gt 0) {
+        return @{ Status = 'fail'; Detail = ($failures -join ' ') }
+    }
+
+    return @{ Status = 'pass'; Detail = "Both columns in one table read correctly and differently: zoneless through $($Context.DatabaseTimeZone), offset-carrying at the instant it states." }
 }
 
 function Test-S16LocalTimeZone {
     param([hashtable]$Context, [hashtable]$Config)
 
+    Initialize-S16SyncBaseline -Context $Context
+
     # Oracle's TIMESTAMP WITH LOCAL TIME ZONE is the case where the connector's two oracles can
     # disagree: SqlTypeMapper.CarriesAnOffset (which export consults, via the catalogue's type name)
     # lists it as offset-carrying, while import decides from the runtime CLR type the driver returns.
+    # SYS_EXTRACT_UTC is the arbiter, because it is the server's own answer for the absolute instant the
+    # column holds and it does not depend on either session's time zone.
+    $employeeId = 7
     $catalogueType = (Invoke-Scenario16Query -Config $Config -Query "SELECT DATA_TYPE FROM ALL_TAB_COLUMNS WHERE OWNER = '$($Config.Schema)' AND TABLE_NAME = 'EMPLOYEES' AND COLUMN_NAME = 'HIRED_AT_LOCAL';").Trim()
 
-    return @{
-        Status = 'skip'
-        Detail = "Authored but not executed. The catalogue reports '$catalogueType', which SqlTypeMapper treats as offset-carrying; a standalone driver probe established that ODP.NET returns a zoneless DateTime for this column, so import and export disagree. Confirming that end to end needs the inbound Synchronisation Rule."
+    $mvo = Get-S16MetaverseObject -EmployeeId $employeeId
+    if (-not $mvo) {
+        return @{ Status = 'fail'; Detail = "No Metaverse Object was projected for employee $employeeId." }
     }
+
+    $value = Get-S16MvoValue -Mvo $mvo -AttributeName $Context.MetaverseAttributes.LocalZoneDate
+    if (-not $value -or -not $value.dateTimeValue) {
+        return @{ Status = 'fail'; Detail = "The catalogue reports '$catalogueType' for HIRED_AT_LOCAL, but the column produced no Metaverse value at all." }
+    }
+
+    $expected = Get-S16SourceUtc -Config $Config -Column 'HIRED_AT_LOCAL' -EmployeeId $employeeId
+    $actual = ConvertTo-S16Utc -Value $value.dateTimeValue
+
+    if ($actual -ne $expected) {
+        return @{ Status = 'fail'; Detail = "HIRED_AT_LOCAL (catalogue type '$catalogueType') holds the instant $($expected.ToString('o')) according to Oracle's own SYS_EXTRACT_UTC; JIM imported $($actual.ToString('o')). The session time zone pinning is not holding through the import, or the column is being classified differently by import and export." }
+    }
+
+    # The two neighbouring shapes have to agree in the same import, or the classification is arbitrary.
+    $offsetValue = Get-S16MvoValue -Mvo $mvo -AttributeName $Context.MetaverseAttributes.OffsetDate
+    if ($offsetValue -and $offsetValue.dateTimeValue) {
+        $offsetExpected = Get-S16SourceUtc -Config $Config -Column 'HIRED_AT' -EmployeeId $employeeId
+        $offsetActual = ConvertTo-S16Utc -Value $offsetValue.dateTimeValue
+        if ($offsetActual -ne $offsetExpected) {
+            return @{ Status = 'fail'; Detail = "HIRED_AT_LOCAL imported correctly but its TIMESTAMP WITH TIME ZONE neighbour did not (expected $($offsetExpected.ToString('o')), got $($offsetActual.ToString('o'))), so the three date and time shapes in this table are not being told apart consistently." }
+        }
+    }
+
+    return @{ Status = 'pass'; Detail = "TIMESTAMP WITH LOCAL TIME ZONE imported at the instant Oracle's own SYS_EXTRACT_UTC reports, alongside a TIMESTAMP WITH TIME ZONE and a zoneless column in the same table." }
 }
 
 function Test-S16Raw16Anchor {
     param([hashtable]$Context, [hashtable]$Config)
+
+    # The export half is the reason this row exists at all: a key defaulted from SYS_GUID() comes back
+    # through a bound output parameter as an ODP.NET wrapper struct rather than a plain byte[], and
+    # nothing in the unit suite can see that shape. Running the baseline first means the table holds both
+    # the three pre-seeded rows (the import half) and the rows JIM provisioned (the export half).
+    Initialize-S16ExportBaseline -Context $Context
 
     $guidTypeId = Get-Scenario16ObjectTypeId -Context $Context -Name 'GuidKeyedPerson'
     $imported = Get-JIMConnectedSystemObject -ConnectedSystemId $Context.ConnectedSystemId -ObjectTypeId $guidTypeId -Count
     $expected = [int](Invoke-Scenario16Query -Config $Config -Query "SELECT COUNT(*) FROM $($Config.Schema).GUID_KEYED_PEOPLE;")
 
     if ([int]$imported -ne $expected) {
-        return @{ Status = 'fail'; Detail = "Expected $expected GuidKeyedPerson object(s) from the RAW(16)-anchored table, found $imported." }
+        return @{ Status = 'fail'; Detail = "GUID_KEYED_PEOPLE holds $expected row(s) but JIM holds $imported Connected System Object(s). If JIM holds more, the RAW(16) anchor it composed on export does not equal the one it composed on import and the confirming import did not recognise its own rows." }
     }
 
-    # The import half is what this proves: a RAW(16) anchor read back as bytes and rendered as a GUID.
-    # The export half (a generated key returned from RETURNING ... INTO) needs an outbound rule.
+    # The seeder writes three rows before anything runs; everything beyond that was provisioned by JIM
+    # and therefore had its key generated by the database and read back through the output parameter.
+    $provisioned = $expected - 3
+    $expectedProvisioned = Get-S16ExpectedCount -RowCount $Context.RowCount -Scope 'Finance'
+    if ($provisioned -ne $expectedProvisioned) {
+        return @{ Status = 'fail'; Detail = "The rule is scoped to Department = Finance, so $expectedProvisioned row(s) should have been provisioned on top of the three seeded ones; GUID_KEYED_PEOPLE holds $expected row(s) in total." }
+    }
+
     $objects = Get-JIMConnectedSystemObject -ConnectedSystemId $Context.ConnectedSystemId -ObjectTypeId $guidTypeId -All -Force
     $anchors = @($objects | ForEach-Object { $_.externalIdValue })
     $malformed = @($anchors | Where-Object { $_ -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$' })
 
     if ($malformed.Count -gt 0) {
-        return @{ Status = 'fail'; Detail = "RAW(16) anchors did not render as hyphenated GUIDs: $($malformed -join ', ')" }
+        return @{ Status = 'fail'; Detail = "RAW(16) anchors did not render as hyphenated GUIDs: $(($malformed | Select-Object -First 5) -join ', ')" }
     }
 
-    return @{ Status = 'pass'; Detail = "$imported RAW(16) anchor(s) imported and rendered as GUIDs (import half only; the generated-key export half needs an outbound Synchronisation Rule)." }
+    if (@($anchors | Select-Object -Unique).Count -ne $anchors.Count) {
+        return @{ Status = 'fail'; Detail = "The RAW(16) anchors are not distinct, which is what an output parameter read back as a default-initialised wrapper struct would look like." }
+    }
+
+    return @{ Status = 'pass'; Detail = "$expected RAW(16) anchor(s) round-tripped: three seeded rows imported, $provisioned provisioned with a SYS_GUID() key returned through the output parameter, and every one recognised again by the confirming import." }
 }
 
 function Test-S16NumberShapes {


### PR DESCRIPTION
Stack layer 5 of the Phase 7 stack for the JIM SQL Connector (#170). Base is #1311.

Fills in the Scenario 16 matrix that #1308 defined: the harness existed, the rows did not.

- Creates Scenario 16's inbound and outbound Synchronisation Rules
- Matrix row dispatch and the row bodies themselves
- Implements the export and date-and-time rows
- Records the scenario's current blocker, seeder timings and start-up gotchas

Docs: n/a - test implementation, no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)