### PR TITLE
ci: run CodeQL on every pull request, not only those targeting main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,11 @@ name: CodeQL
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request:  # Runs on ALL pull requests regardless of target branch, matching ci.yml.
+                 # A stacked PR targets the layer below it rather than main, and every PR in a
+                 # stack is still evaluated against main's ruleset, so filtering to main here
+                 # left the required Analyze checks permanently unreported on every layer but
+                 # the bottom one, and the stack could never be merged.
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
 


### PR DESCRIPTION
## The problem

`codeql.yml` was the last required workflow still filtered to pull requests whose base is `main`:

```yaml
pull_request:
  branches: [ "main" ]
```

`ci.yml` deliberately carries no such filter (its comment says so in as many words), and `changelog-lint.yml` has none either.

A stacked pull request targets the layer below it rather than `main`, so the workflow never triggered on any layer but the bottom one, and its three required checks (`Analyze (actions)`, `Analyze (csharp)`, `Analyze (javascript-typescript)`) were never reported. Every PR in a stack is evaluated against `main`'s ruleset regardless of its direct base, so those layers sat permanently at "1 expected" and the stack could not be merged.

Observed on stack #1314: #1308 (base `main`) is ready to merge; #1309 through #1313 are all "Not ready".

Two of the three check names are incidentally satisfied today by the Code Quality bot, whose job names collide with them. `Analyze (actions)` has no such stand-in, which is why it alone showed as missing, and why the symptom read as one stray check rather than as CodeQL not running at all.

## Why waiting it out would not have worked

As each layer merged, the one above it retargets to `main`. But a base change does not fire `pull_request`'s default activity types (`opened`, `synchronize`, `reopened`), so the missing run would never have appeared on its own; each layer would have needed a manual re-run or an empty push.

## The change

Remove the `branches` filter from the `pull_request` trigger, matching `ci.yml`. The `push` trigger stays scoped to `main`, and the weekly schedule is untouched.

The cost is CodeQL running on feature-to-feature pull requests that previously skipped it. That is more scanning, not less, and is the same trade `ci.yml` already made.

Docs: n/a - CI configuration, no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)