### PR TITLE
docs: record that a rebased stack layer loses its commit signatures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,15 @@ When feature work surfaces something that must be solved to deliver the feature 
   ```
 
   **Do NOT use `gh stack rebase` for this.** It rebases *every* branch in the chain, starting with the bottom layer onto `main`, which is precisely what the merge-don't-rebase rule exists to avoid: on a long-lived bottom layer it replays every commit over `main`'s drift and re-resolves the same conflicts per commit. On stack #1211 it hit conflicts in three files while replaying 53 commits and had to be aborted with `gh stack rebase --abort` (which restores cleanly). The `--onto` form above touches only the layer that actually needs moving. The `-c rebase.backend=apply` is for the same misleading "local changes would be overwritten by merge" on a clean tree noted in the next section; without it the rebase aborts on the first commit.
+- **A rebased layer loses its commit signatures; re-sign before wondering why it will not merge.** `main`'s ruleset carries a `required_signatures` rule, and a rebase performed by the stack tooling (or by GitHub retargeting a layer onto `main` when the layer below merges) rewrites the commit *without* re-signing it. The PR then sits at `mergeStateStatus: BLOCKED` with **every required check green and no failures**, which reads exactly like "checks still settling" and is not. Confirm with `gh api graphql -f query='{repository(owner:"TetronIO",name:"JIM"){pullRequest(number:<n>){commits(last:1){nodes{commit{oid signature{isValid state}}}}}}}'`; a `signature` of `null` is the answer. Fix by re-signing the identical tree and force-pushing:
+
+  ```bash
+  git commit --amend --no-edit -S   # commit.gpgsign is already true; the tree is unchanged
+  git push --force-with-lease
+  ```
+
+  Note that `git log --format='%G?'` reports `N` locally even for correctly signed commits, because `gpg.ssh.allowedSignersFile` is not configured; that is a local *verification* gap, not a signing failure. Check `git cat-file commit HEAD` for a `gpgsig` header, or ask GitHub as above. (Rule added after stack #1320's upper layer sat BLOCKED with nine green checks and no failures.)
+- **`failures: none` is not `mergeable`.** When polling a PR, key on `mergeStateStatus`, not on the absence of failed checks: a required check that never ran, and an unsigned commit, are both invisible to a rollup that only lists what exists. `CLEAN` is the only state that means ready.
 - Layers stay shallow and single-concern; nest further layers the same way. Layer branches belong to the same session and objective as their parent feature branch; the `-stack-` naming keeps the lineage visible across parallel sessions.
 - GitHub issues remain only for genuine observations that are NOT needed to deliver the current objective (link them with native blocked-by/sub-issue relationships per the rules above).
 


### PR DESCRIPTION
Cost most of an hour on stack #1320 and would have cost it again.

When the layer below a stacked PR merges, GitHub retargets the layer above onto `main` and rebases it — rewriting the commit **without re-signing it**. `main`'s ruleset carries a `required_signatures` rule, so the PR then sits at `mergeStateStatus: BLOCKED` with every required check green and no failures. That reads exactly like "checks still settling", and is not.

Observed on #1319: nine required checks `SUCCESS`, `mergeable: MERGEABLE`, no review threads, not behind `main`, still `BLOCKED`. Its head commit's `signature` was `null`; #1317's, which merged, was `VALID`.

Adds three things to the stacked-PR section:

1. The failure mode, how to confirm it in one GraphQL call, and the fix (`git commit --amend --no-edit -S` on the identical tree, then force-push).
2. The general form, because this is the second time the same shape has cost a session: **`failures: none` is not `mergeable`**. A required check that never ran (the CodeQL trigger, #1315) and an unsigned commit are both invisible to a rollup that only lists the checks which exist, so polling must key on `mergeStateStatus`.
3. The local verification gap: `git log --format='%G?'` reports `N` here even for correctly signed commits, because `gpg.ssh.allowedSignersFile` is not configured. That is a verification gap, not a signing failure — check `git cat-file commit HEAD` for a `gpgsig` header, or ask GitHub.

Docs: n/a - developer guidance in CLAUDE.md; no user-facing behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)