### PR TITLE
feat: honour Container exclusions on import and export (#1255 Phase 3)

### DIFF
--- a/engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md
+++ b/engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md
@@ -1,10 +1,10 @@
 # Container Scope: Exclusions and Advanced Mode
 
-- **Status:** Doing (Phases 1-2 complete; Connector honouring next)
+- **Status:** Doing (Phases 1-3 complete; portal next)
 - **Issue**: [#1255](https://github.com/TetronIO/JIM/issues/1255)
 - **Related Issues**: [#351](https://github.com/TetronIO/JIM/issues/351) (Phase 1, OneLevel scope, landed), [#827](https://github.com/TetronIO/JIM/issues/827) (Configuration Change Preview), [#1250](https://github.com/TetronIO/JIM/issues/1250) (export managed scope), [#266](https://github.com/TetronIO/JIM/issues/266) (closed duplicate)
 - **Related Plans**: [`CONFIGURATION_CHANGE_PREVIEW.md`](CONFIGURATION_CHANGE_PREVIEW.md)
-- **Last Updated**: 2026-08-10
+- **Last Updated**: 2026-08-11
 
 ## Overview
 
@@ -31,7 +31,7 @@ Service Account, mailbox-archive and staging OUs sitting inside an otherwise who
 | Per-Container scope (`Subtree` / `OneLevel`) | `ConnectedSystemContainer.Scope`, `ConnectedSystemEnums.cs` |
 | The one membership question | `ConnectedSystemScope.Contains(partitionId, containerIdentifier)` |
 | What containment *means* | `IConnectorContainment.IsWithinContainer`, implemented by the Connector |
-| LDAP's answer | `LdapConnectorUtilities.IsDnWithinContainerScope` / `IsDnWithinAnyContainerScope` |
+| LDAP's answer | `LdapConnectorUtilities.IsDnWithinContainerScope` / `IsDnInScope` (renamed from `IsDnWithinAnyContainerScope` in Phase 3, where "within any" stopped being what it answers) |
 | Import search roots and row coverage | `ConnectedSystemUtilities.ApplyContainerInclusion` |
 | Selection editing rules | `ContainerSelectionEditor` (JIM.Utilities) |
 | Portal control | `ScopedHierarchyPicker.razor` |
@@ -109,8 +109,22 @@ Replace the `Any(...)` OR in `ConnectedSystemScope.Contains` and in `LdapConnect
 
 *Two rules fell out of the work rather than the design. Roll-up must refuse to select an excluded parent, or completing the selection of every re-inclusion inside a carved-out branch silently undoes the exclusion. And an exclusion must not change the import's search roots: `GetTopLevelSelectedContainersTests` pins that, because the alternative is the search decomposition rejected below.*
 
-**Phase 3: Import, export, and the discard count.**
+**Phase 3: Import, export, and the discard count.** ✅
 Connector-side honouring via the shared predicate (full import, delta paths, export write guard); per-exclusion discarded-entry counts in the import summary statistics and on the Activity.
+
+*Landed. The phase turned on a distinction the code did not previously draw: the **selected** Containers say where JIM may search and write, and they do not say which Container decides an object's fate. `ConnectedSystemExtensions.GetScopeDecidingContainers` collects the selections and the exclusions together, and `ContainerSpecificity.IsInScope` ranks them so the most specific statement wins. Four paths ask it and all reach the same answer: the full import and the AD USN delta (filtering the entries their searches return, in `ConvertLdapResults`, since a Subtree search cannot exclude a branch server-side), the changelog and accesslog deltas, the export write guard, and `ConnectedSystemScope` so the preview cannot state a count the next import contradicts.*
+
+*Three decisions taken during the work:*
+
+- *Where containment is not a hierarchy, two Containers can admit an object without either holding the other, which `ContainerSpecificity` explicitly refused to resolve for opposing meanings. **Excluded wins** such a tie: importing an object an administrator excluded is the worse of the two failures.*
+- *`ConnectedSystemScope` reads which Containers carve out from the **proposal**, not from the Containers' stored `Excluded` flags, for the same reason the selection is a parameter at all. A preview that read the stored flags would evaluate the configuration the administrator is trying to move away from.*
+- *A Container the Connector creates mid-run is in scope because JIM selects it as the run ends, but not when an exclusion carves out the branch it was created in.*
+
+*The per-exclusion counts are reported as import summary statistics in the log. **Putting them on the Activity is deferred to Phase 6**: the Activity has no informational channel, only `WarningMessage`, and an exclusion doing exactly what it was configured to do is not a warning; flagging every exclusion-configured import as warned would train administrators to ignore the field. Phase 6 already opens the Activity and preview surfaces for this feature.*
+
+*No changelog entry or public documentation: nothing an administrator can reach has changed, because no surface can set `Excluded` until Phases 4 and 5. The user-facing entry belongs with the phase that makes exclusions settable.*
+
+*Runtime-verified against OpenLDAP on the sandbox light stack, not by unit tests alone. `ou=Corp` selected as a subtree imported 4 objects; excluding `ou=Service Accounts` beneath it imported 2 and logged "Discarded 2 entries read from excluded Containers across 1 exclusion(s)" attributed to that Container; selecting `ou=App1` beneath the exclusion brought its service account back, importing 3 and discarding 1.*
 
 **Phase 4: Portal.**
 The four row states above in `ScopedHierarchyPicker`, with the selection rules themselves in `ContainerSelectionEditor` where they stay unit-testable without rendering, plus bUnit coverage of the state transitions.

--- a/src/JIM.Connectors/LDAP/LdapConnector.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnector.cs
@@ -788,10 +788,10 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorDetec
         {
             case ConnectedSystemRunType.FullImport:
                 logger.Debug("ImportAsync: Full Import requested");
-                return WithPinValidationWarningAsync(import, import.GetFullImportObjectsAsync());
+                return FinaliseImportResultAsync(import, import.GetFullImportObjectsAsync());
             case ConnectedSystemRunType.DeltaImport:
                 logger.Debug("ImportAsync: Delta Import requested");
-                return WithPinValidationWarningAsync(import, import.GetDeltaImportObjectsAsync());
+                return FinaliseImportResultAsync(import, import.GetDeltaImportObjectsAsync());
             case ConnectedSystemRunType.FullSynchronisation:
             case ConnectedSystemRunType.DeltaSynchronisation:
             case ConnectedSystemRunType.Export:
@@ -801,15 +801,20 @@ public class LdapConnector : IConnector, IConnectorCapabilities, IConnectorDetec
     }
 
     /// <summary>
-    /// Carries a rejected-domain-controller warning from the import session onto its result, which is how it
-    /// reaches the Activity (issue #230 Phase 2). A warning the import raised about itself always wins: it
-    /// describes how the import was performed, which matters more than a note about domain controller pinning.
+    /// Everything an import session has to say once its work is done, applied to the result it is about to hand
+    /// back: the entries excluded Containers caused it to discard, and any rejected-domain-controller warning.
     /// </summary>
-    private static async Task<ConnectedSystemImportResult> WithPinValidationWarningAsync(
+    /// <remarks>
+    /// A warning the import raised about itself always wins over the domain controller pinning note (issue #230
+    /// Phase 2): it describes how the import was performed, which matters more than a note about plumbing.
+    /// </remarks>
+    private static async Task<ConnectedSystemImportResult> FinaliseImportResultAsync(
         LdapConnectorImport import,
         Task<ConnectedSystemImportResult> resultTask)
     {
         var result = await resultTask;
+
+        import.LogEntriesDiscardedByExclusion();
 
         if (result.WarningMessage == null && import.PinValidationWarning != null)
             result.WarningMessage = import.PinValidationWarning;

--- a/src/JIM.Connectors/LDAP/LdapConnectorExport.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorExport.cs
@@ -147,9 +147,10 @@ internal class LdapConnectorExport
         return results;
     }
 
-    // The containers the administrator has selected on this Connected System, or empty when JIM has not stated a
-    // scope (a Connected System with no container selections, or a caller that does not supply one). Each carries
-    // its own Container Scope, so a One Level container permits writes directly within it and nowhere beneath it.
+    // Every container stating where the administrator manages on this Connected System, selections and exclusions
+    // alike, or empty when JIM has not stated a scope (a Connected System with no container selections, or a
+    // caller that does not supply one). Each carries its own Container Scope, so a One Level container speaks for
+    // writes directly within it and for nothing beneath it.
     private IReadOnlyList<ConnectedSystemContainer> _managedScope = [];
 
     /// <summary>
@@ -159,9 +160,9 @@ internal class LdapConnectorExport
     /// An empty or unset scope means "not stated" and permits everything, so a Connected System with no container
     /// selections behaves exactly as it always has.
     /// </remarks>
-    internal void SetManagedScope(IReadOnlyList<ConnectedSystemContainer> selectedContainers)
+    internal void SetManagedScope(IReadOnlyList<ConnectedSystemContainer> scopeDecidingContainers)
     {
-        _managedScope = selectedContainers;
+        _managedScope = scopeDecidingContainers;
     }
 
     /// <summary>
@@ -198,15 +199,27 @@ internal class LdapConnectorExport
 
     private bool IsWithinManagedScope(string targetDn)
     {
-        if (LdapConnectorUtilities.IsDnWithinAnyContainerScope(targetDn, _managedScope))
+        if (LdapConnectorUtilities.IsDnInScope(targetDn, _managedScope))
             return true;
 
         // A container created during this run is selected by JIM the moment the run finishes, so an object being
         // provisioned into one it has just created is in scope even though the stored selection has yet to catch
         // up. It is selected as a subtree, which is what JIM's own auto-selection records.
-        return _createdContainerExternalIds.Any(createdDn =>
+        var withinAContainerCreatedThisRun = _createdContainerExternalIds.Any(createdDn =>
             LdapConnectorUtilities.IsDnWithinContainerScope(targetDn, new ConnectedSystemContainer { ExternalId = createdDn }));
+
+        // ...unless an exclusion carves that branch out, in which case the container JIM created sits inside a
+        // part of the directory the administrator has said it does not manage, and the selection about to catch up
+        // will not cover it either (#1255).
+        return withinAContainerCreatedThisRun && !IsCarvedOutByAnExclusion(targetDn);
     }
+
+    /// <summary>
+    /// Whether an excluded Container is the one with the final say over a Distinguished Name. Distinct from
+    /// "not in scope": a name nothing covers is merely unmanaged, where this one has been deliberately carved out.
+    /// </summary>
+    private bool IsCarvedOutByAnExclusion(string targetDn) =>
+        LdapConnectorUtilities.ResolveMostSpecificContainerScope(targetDn, _managedScope) is { Excluded: true };
 
     private ConnectedSystemExportResult ProcessPendingExport(PendingExport pendingExport)
     {

--- a/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorImport.cs
@@ -58,6 +58,20 @@ internal class LdapConnectorImport
     private LdapConnectorRootDse? _previousRootDse;
     private LdapConnectorRootDse? _currentRootDse;
 
+    /// <summary>
+    /// Every Container stating something about scope for this run, held once because every entry the searches
+    /// return is tested against it. Lazy because it depends on the Run Profile's target partitions, and
+    /// thread-safe because the parallel combos convert their entries concurrently.
+    /// </summary>
+    private readonly Lazy<List<ConnectedSystemContainer>> _scopeDecidingContainers;
+
+    /// <summary>
+    /// How many entries each excluded Container caused to be discarded on the way in, keyed by the Container's
+    /// external id. Client-side filtering means these entries were read from the directory and thrown away, and
+    /// the design accepted that cost on condition it is reported rather than hidden (#1255).
+    /// </summary>
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> _entriesDiscardedByExclusion = new();
+
     internal LdapConnectorImport(
         ConnectedSystem connectedSystem,
         ConnectedSystemRunProfile runProfile,
@@ -86,6 +100,7 @@ internal class LdapConnectorImport
         _logger = logger;
         _cancellationToken = cancellationToken;
         _progress = progress;
+        _scopeDecidingContainers = new Lazy<List<ConnectedSystemContainer>>(() => GetScopeDecidingContainers(GetTargetPartitions()));
 
         // Get search timeout from settings, defaulting to 5 minutes
         var searchTimeoutSetting = connectedSystem.SettingValues
@@ -396,7 +411,7 @@ internal class LdapConnectorImport
                 previousChangeNumber);
 
             await _progress.EnterPhaseAsync(LdapConnectorPhases.QueryChanges, $"Querying changelog since change number {previousChangeNumber:N0}...");
-            var changelogTargetContainers = GetTargetContainers(GetTargetPartitions());
+            var changelogTargetContainers = GetScopeDecidingContainers(GetTargetPartitions());
             await ReportObjectsReadByAsync(result,
                 () => GetDeltaResultsUsingChangelog(result, previousChangeNumber, changelogTargetContainers));
         }
@@ -432,18 +447,80 @@ internal class LdapConnectorImport
     }
 
     /// <summary>
-    /// Returns the Containers a full import would search, across the partitions this run targets, each carrying
-    /// its own scope.
+    /// Returns every Container stating something about scope across the partitions this run targets: the
+    /// selections and the exclusions alike.
     /// </summary>
     /// <remarks>
-    /// The full import and the AD USN delta search from each of these as a base, so the directory applies the
-    /// selection server-side. The changelog and accesslog delta paths cannot: they read one directory-wide log
-    /// and have to decide per entry whether the changed object is one this Connected System imports. This list
-    /// is what they decide against, so that a delta import sees the same objects a full import would.
+    /// This is what decides an object's fate, and it is deliberately a different list from the search roots
+    /// (<see cref="ConnectedSystemUtilities.GetTopLevelSelectedContainers"/>), which say only where to search
+    /// from. A Subtree search of a selected Container returns everything beneath it, including any branch the
+    /// administrator has excluded (#1255), so an exclusion adds no search root of its own and the entries a
+    /// search returns are filtered against this list on the way through. Decomposing the searches to avoid
+    /// excluded branches server-side was rejected in the design: it would make import scope depend on how
+    /// recently the hierarchy was refreshed, so a new Container beneath a selected parent would be silently
+    /// skipped and its objects obsoleted.
+    ///
+    /// Four paths ask this question and all must reach the same answer, or a delta import sees objects a full
+    /// import would not: the full import and the AD USN delta, filtering the entries their searches return; and
+    /// the changelog and accesslog deltas, which read one directory-wide log and have to decide per entry whether
+    /// the changed object is one this Connected System imports.
     /// </remarks>
-    private List<ConnectedSystemContainer> GetTargetContainers(IEnumerable<ConnectedSystemPartition> targetPartitions)
+    private List<ConnectedSystemContainer> GetScopeDecidingContainers(IEnumerable<ConnectedSystemPartition> targetPartitions)
     {
-        return targetPartitions.SelectMany(ConnectedSystemUtilities.GetTopLevelSelectedContainers).ToList();
+        return targetPartitions.SelectMany(partition => partition.GetScopeDecidingContainers()).ToList();
+    }
+
+    /// <summary>
+    /// Reports how many entries each excluded Container caused this import call to read and discard.
+    /// </summary>
+    /// <remarks>
+    /// Client-side filtering is the deliberate choice (#1255): a directory cannot express "this subtree except
+    /// that branch" in one search, and decomposing the searches instead would make import scope depend on how
+    /// recently the hierarchy was refreshed. The cost is entries transferred only to be thrown away, and the
+    /// design accepted that cost on condition it is visible: these counts are the evidence for revisiting the
+    /// decision if an exclusion turns out to sit in front of a large branch.
+    /// </remarks>
+    internal void LogEntriesDiscardedByExclusion()
+    {
+        if (_entriesDiscardedByExclusion.IsEmpty)
+            return;
+
+        var total = _entriesDiscardedByExclusion.Values.Sum();
+        _logger.Information("LdapConnectorImport: Discarded {DiscardedCount} entries read from excluded Containers across {ContainerCount} exclusion(s)",
+            total, _entriesDiscardedByExclusion.Count);
+
+        foreach (var (containerExternalId, discarded) in _entriesDiscardedByExclusion.OrderByDescending(entry => entry.Value))
+            _logger.Information("LdapConnectorImport: Excluded Container '{Container}' discarded {DiscardedCount} entries",
+                LogSanitiser.Sanitise(containerExternalId), discarded);
+    }
+
+    /// <summary>
+    /// Whether an entry a search returned is one this Connected System imports, counting it against the excluded
+    /// Container that carved it out where it is not.
+    /// </summary>
+    /// <remarks>
+    /// Applied to every entry converted, on the full import and both delta paths alike, because a directory
+    /// cannot express "this subtree except that branch" in a single search. Where no Container has been excluded
+    /// this is the same answer the search itself gave, at the cost of one containment test per entry against a
+    /// list bounded by the number of selected Containers.
+    /// </remarks>
+    private bool IsWithinImportScope(string? distinguishedName)
+    {
+        var scopeDecidingContainers = _scopeDecidingContainers.Value;
+
+        // No Container-level opinion to apply: the partition selection alone governs, as it did before Containers
+        // could be excluded.
+        if (scopeDecidingContainers.Count == 0)
+            return true;
+
+        if (LdapConnectorUtilities.IsDnInScope(distinguishedName, scopeDecidingContainers))
+            return true;
+
+        var excludedBy = LdapConnectorUtilities.ResolveMostSpecificContainerScope(distinguishedName, scopeDecidingContainers);
+        if (excludedBy is { Excluded: true })
+            _entriesDiscardedByExclusion.AddOrUpdate(excludedBy.ExternalId, 1, (_, count) => count + 1);
+
+        return false;
     }
 
     /// <summary>
@@ -1395,7 +1472,7 @@ internal class LdapConnectorImport
                 // Filter by Container scope — the changelog is directory-wide, so it reports changes to objects
                 // this Connected System does not import. A full import only reads the selected Containers, each
                 // to its own scope; without this, a delta import would bring in objects a full import never would.
-                if (!LdapConnectorUtilities.IsDnWithinAnyContainerScope(targetDn, targetContainers))
+                if (!LdapConnectorUtilities.IsDnInScope(targetDn, targetContainers))
                 {
                     skippedOutOfScope++;
                     continue;
@@ -1480,7 +1557,7 @@ internal class LdapConnectorImport
         // Partition filtering alone is not the same selection a full import makes: within a partition, only the
         // selected Containers are imported from, and each carries its own scope. Applying that here keeps a delta
         // import to the objects a full import would have returned.
-        var targetContainers = GetTargetContainers(targetPartitions);
+        var targetContainers = GetScopeDecidingContainers(targetPartitions);
 
         while (iterations < maxIterations)
         {
@@ -1565,7 +1642,7 @@ internal class LdapConnectorImport
 
                 // Filter by Container scope — the entry is within a selected partition, but the administrator
                 // selects Containers within it, and a OneLevel Container excludes everything below its own level.
-                if (!LdapConnectorUtilities.IsDnWithinAnyContainerScope(reqDn, targetContainers))
+                if (!LdapConnectorUtilities.IsDnInScope(reqDn, targetContainers))
                 {
                     skippedOutOfScope++;
                     continue;
@@ -1801,6 +1878,13 @@ internal class LdapConnectorImport
                 _logger.Information("ConvertLdapResults: Cancellation requested. Stopping.");
                 return importObjects;
             }
+
+            // Discard entries an excluded Container carves out. A Subtree search returns everything beneath its
+            // base, so the directory cannot apply an exclusion for us and every path that converts entries has to
+            // apply it here instead (#1255). Nothing beyond this point knows about Containers, so a discarded
+            // entry never becomes an import object, is never staged, and cannot be exported to.
+            if (!IsWithinImportScope(searchResult.DistinguishedName))
+                continue;
 
             // start to build the object that will represent the object in the Connected System. we will pass this back to JIM
             var importObject = new ConnectedSystemImportObject

--- a/src/JIM.Connectors/LDAP/LdapConnectorUtilities.cs
+++ b/src/JIM.Connectors/LDAP/LdapConnectorUtilities.cs
@@ -560,15 +560,22 @@ internal static class LdapConnectorUtilities
     }
 
     /// <summary>
-    /// Whether a distinguished name falls within the scope of any of the supplied Containers. An empty
-    /// collection means the caller has no Container-level opinion to apply, and every name is admitted.
+    /// Whether a distinguished name is within the scope the supplied Containers describe: the Container with the
+    /// final say over it admits it rather than carving it out. An empty collection means the caller has no
+    /// Container-level opinion to apply, and every name is admitted.
     /// </summary>
-    internal static bool IsDnWithinAnyContainerScope(string? distinguishedName, IReadOnlyCollection<ConnectedSystemContainer> connectedSystemContainers)
+    /// <remarks>
+    /// Callers must supply every Container stating something about scope, exclusions included; the selections alone
+    /// answer a different question (see <c>ConnectedSystemExtensions.GetScopeDecidingContainers</c>). Supplying only
+    /// the selections is not a partial answer but a wrong one: an exclusion that is not present cannot carve
+    /// anything out.
+    /// </remarks>
+    internal static bool IsDnInScope(string? distinguishedName, IReadOnlyCollection<ConnectedSystemContainer> connectedSystemContainers)
     {
         if (connectedSystemContainers.Count == 0)
             return true;
 
-        return ResolveMostSpecificContainerScope(distinguishedName, connectedSystemContainers) is not null;
+        return ContainerSpecificity.IsInScope(distinguishedName, connectedSystemContainers, IsDnWithinContainerScope);
     }
 
     /// <summary>

--- a/src/JIM.Models/Interfaces/IConnectorManagedScope.cs
+++ b/src/JIM.Models/Interfaces/IConnectorManagedScope.cs
@@ -25,17 +25,24 @@ namespace JIM.Models.Interfaces;
 public interface IConnectorManagedScope
 {
     /// <summary>
-    /// Supplies the containers the administrator has selected, which are the only places the Connector may write.
+    /// Supplies the containers stating where the administrator manages, which decide where the Connector may
+    /// write.
     /// </summary>
-    /// <param name="selectedContainers">
-    /// The selected containers, carrying their identifiers and their
-    /// <see cref="ConnectedSystemContainer.Scope"/>. Never null; an empty list means no scope has been stated and
-    /// everything is permitted.
+    /// <param name="scopeDecidingContainers">
+    /// Every container making a statement about scope, carrying its identifier, its
+    /// <see cref="ConnectedSystemContainer.Scope"/> and whether it is selected or
+    /// <see cref="ConnectedSystemContainer.Excluded"/>. Never null; an empty list means no scope has been stated
+    /// and everything is permitted.
     ///
     /// The whole container is supplied rather than its identifier alone because scope decides what "inside" means:
     /// a <see cref="ConnectedSystemContainerScope.OneLevel"/> container is not a licence to write anywhere beneath
     /// it, only directly within it, and an implementation that assumed a subtree would permit exactly the writes
     /// the next import cannot read back.
+    ///
+    /// Exclusions are part of this list for the same reason (#1255), and an implementation must honour them: the
+    /// most specific container covering a target decides, so an object written into an excluded branch of an
+    /// otherwise selected one is refused. Treating the list as selections alone would permit writes the next
+    /// import discards, which is the very failure this interface exists to prevent.
     /// </param>
-    public void SetManagedScope(IReadOnlyList<ConnectedSystemContainer> selectedContainers);
+    public void SetManagedScope(IReadOnlyList<ConnectedSystemContainer> scopeDecidingContainers);
 }

--- a/src/JIM.Models/Preview/ConnectedSystemScopeSelectionProposal.cs
+++ b/src/JIM.Models/Preview/ConnectedSystemScopeSelectionProposal.cs
@@ -23,9 +23,16 @@ namespace JIM.Models.Preview;
 /// appear here to be in scope; this is the set of containers explicitly ticked, exactly as
 /// <see cref="ConnectedSystemContainer.Selected"/> records it.
 /// </param>
+/// <param name="ExcludedContainerIds">
+/// The containers that would be carved out of the selection around them (#1255), exactly as
+/// <see cref="ConnectedSystemContainer.Excluded"/> records it. Null and empty mean the same thing: nothing carved
+/// out. A proposal that omits an exclusion the Connected System currently carries is proposing to remove it, so
+/// callers building a partial proposal must carry the current exclusions forward rather than leaving this unset.
+/// </param>
 public record ConnectedSystemScopeSelectionProposal(
     IReadOnlyList<int> SelectedPartitionIds,
-    IReadOnlyList<int> SelectedContainerIds)
+    IReadOnlyList<int> SelectedContainerIds,
+    IReadOnlyList<int>? ExcludedContainerIds = null)
 {
     /// <summary>
     /// The selection currently in force on <paramref name="connectedSystem"/>, as a proposal. What "no change"
@@ -40,7 +47,10 @@ public record ConnectedSystemScopeSelectionProposal(
             [.. partitions.Where(p => p.Selected).Select(p => p.Id)],
             [.. partitions
                 .Where(p => p.Containers != null)
-                .SelectMany(p => CollectSelectedContainerIds(p.Containers!))]);
+                .SelectMany(p => CollectContainerIds(p.Containers!, container => container.Selected))],
+            [.. partitions
+                .Where(p => p.Containers != null)
+                .SelectMany(p => CollectContainerIds(p.Containers!, container => container.Excluded))]);
     }
 
     /// <summary>
@@ -58,17 +68,20 @@ public record ConnectedSystemScopeSelectionProposal(
             return false;
 
         return SelectedPartitionIds.Order().SequenceEqual(other.SelectedPartitionIds.Order()) &&
-               SelectedContainerIds.Order().SequenceEqual(other.SelectedContainerIds.Order());
+               SelectedContainerIds.Order().SequenceEqual(other.SelectedContainerIds.Order()) &&
+               (ExcludedContainerIds ?? []).Order().SequenceEqual((other.ExcludedContainerIds ?? []).Order());
     }
 
-    private static IEnumerable<int> CollectSelectedContainerIds(IEnumerable<ConnectedSystemContainer> containers)
+    private static IEnumerable<int> CollectContainerIds(
+        IEnumerable<ConnectedSystemContainer> containers,
+        Func<ConnectedSystemContainer, bool> statesSomething)
     {
         foreach (var container in containers)
         {
-            if (container.Selected)
+            if (statesSomething(container))
                 yield return container.Id;
 
-            foreach (var descendantId in CollectSelectedContainerIds(container.ChildContainers))
+            foreach (var descendantId in CollectContainerIds(container.ChildContainers, statesSomething))
                 yield return descendantId;
         }
     }

--- a/src/JIM.Models/Staging/ConnectedSystemExtensions.cs
+++ b/src/JIM.Models/Staging/ConnectedSystemExtensions.cs
@@ -272,6 +272,52 @@ public static class ConnectedSystemExtensions
             .Where(c => !string.IsNullOrEmpty(c.ExternalId))
             .Select(c => c.ExternalId)];
 
+    /// <summary>
+    /// Every container stating something about scope beneath every selected partition: the selections and the
+    /// exclusions alike.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="GetSelectedContainers"/>, and the distinction matters (#1255).
+    /// <see cref="GetSelectedContainers"/> answers "where may JIM search, and where may it write?", which only a
+    /// selection can license. This answers "which container decides an object's fate?", which an exclusion decides
+    /// as much as a selection does. Handing the selections alone to a scope decision silently drops every
+    /// exclusion, and an exclusion that decides nothing carves nothing out: every object in the excluded branch
+    /// comes back in scope, imported and exported exactly as though the administrator had never excluded it.
+    ///
+    /// The whole hierarchy is walked rather than stopping at the outermost statement, because an exclusion always
+    /// sits beneath the selection it carves into, and a re-inclusion beneath that.
+    /// </remarks>
+    public static List<ConnectedSystemContainer> GetScopeDecidingContainers(this ConnectedSystem connectedSystem)
+    {
+        ArgumentNullException.ThrowIfNull(connectedSystem);
+
+        var deciding = new List<ConnectedSystemContainer>();
+        if (connectedSystem.Partitions == null)
+            return deciding;
+
+        foreach (var container in connectedSystem.Partitions
+                     .Where(p => p.Selected && p.Containers != null)
+                     .SelectMany(p => p.Containers!))
+            CollectScopeDecidingContainers(container, deciding);
+
+        return deciding;
+    }
+
+    /// <summary>
+    /// Every container stating something about scope within one partition, for callers working a partition at a
+    /// time (an import run targeting one). <see cref="GetScopeDecidingContainers(ConnectedSystem)"/> for the rest.
+    /// </summary>
+    public static List<ConnectedSystemContainer> GetScopeDecidingContainers(this ConnectedSystemPartition connectedSystemPartition)
+    {
+        ArgumentNullException.ThrowIfNull(connectedSystemPartition);
+
+        var deciding = new List<ConnectedSystemContainer>();
+        foreach (var container in connectedSystemPartition.Containers ?? [])
+            CollectScopeDecidingContainers(container, deciding);
+
+        return deciding;
+    }
+
     private static void CollectSelectedContainers(ConnectedSystemContainer container, List<ConnectedSystemContainer> selected)
     {
         if (container.Selected)
@@ -279,6 +325,15 @@ public static class ConnectedSystemExtensions
 
         foreach (var child in container.ChildContainers)
             CollectSelectedContainers(child, selected);
+    }
+
+    private static void CollectScopeDecidingContainers(ConnectedSystemContainer container, List<ConnectedSystemContainer> deciding)
+    {
+        if (container.Selected || container.Excluded)
+            deciding.Add(container);
+
+        foreach (var child in container.ChildContainers)
+            CollectScopeDecidingContainers(child, deciding);
     }
 
     /// <summary>

--- a/src/JIM.Models/Staging/ConnectedSystemScope.cs
+++ b/src/JIM.Models/Staging/ConnectedSystemScope.cs
@@ -39,6 +39,20 @@ public sealed class ConnectedSystemScope
     public IReadOnlyList<ConnectedSystemContainer> SelectedContainers { get; }
 
     /// <summary>
+    /// The containers this selection carves out of the branches around them (#1255), from partitions in this
+    /// selection only. Each carries its own <see cref="ConnectedSystemContainer.Scope"/>, which decides how far
+    /// its exclusion reaches, exactly as a selection's does.
+    /// </summary>
+    public IReadOnlyList<ConnectedSystemContainer> ExcludedContainers { get; }
+
+    /// <summary>
+    /// Every container with something to say about membership, which is what <see cref="Contains"/> ranks. Held
+    /// rather than composed per call: it is asked once per object, and the two lists never change after
+    /// construction.
+    /// </summary>
+    private readonly IReadOnlyList<ConnectedSystemContainer> _scopeDecidingContainers;
+
+    /// <summary>
     /// Whether container membership is part of scope for this Connected System. False for a Connector with
     /// partitions but no containers, where a selected partition is the whole answer.
     /// </summary>
@@ -47,13 +61,16 @@ public sealed class ConnectedSystemScope
     private ConnectedSystemScope(
         IReadOnlySet<int> selectedPartitionIds,
         IReadOnlyList<ConnectedSystemContainer> selectedContainers,
+        IReadOnlyList<ConnectedSystemContainer> excludedContainers,
         bool containersDecideScope,
         IConnectorContainment? containment)
     {
         SelectedPartitionIds = selectedPartitionIds;
         SelectedContainers = selectedContainers;
+        ExcludedContainers = excludedContainers;
         ContainersDecideScope = containersDecideScope;
         _containment = containment;
+        _scopeDecidingContainers = [.. selectedContainers, .. excludedContainers];
     }
 
     /// <summary>
@@ -78,15 +95,18 @@ public sealed class ConnectedSystemScope
         ArgumentNullException.ThrowIfNull(selection);
 
         var partitionIds = selection.SelectedPartitionIds.ToHashSet();
-        var containerIds = selection.SelectedContainerIds.ToHashSet();
-        var containers = new List<ConnectedSystemContainer>();
+        var selectedIds = selection.SelectedContainerIds.ToHashSet();
+        var excludedIds = (selection.ExcludedContainerIds ?? []).ToHashSet();
+        var selectedContainers = new List<ConnectedSystemContainer>();
+        var excludedContainers = new List<ConnectedSystemContainer>();
 
         foreach (var partition in (connectedSystem.Partitions ?? []).Where(p => partitionIds.Contains(p.Id) && p.Containers != null))
-            CollectSelectedContainers(partition.Containers!, containerIds, containers);
+            CollectContainers(partition.Containers!, selectedIds, excludedIds, selectedContainers, excludedContainers);
 
         return new ConnectedSystemScope(
             partitionIds,
-            containers,
+            selectedContainers,
+            excludedContainers,
             connectedSystem.ConnectorDefinition?.SupportsPartitionContainers ?? false,
             containment);
     }
@@ -124,23 +144,37 @@ public sealed class ConnectedSystemScope
         if (_containment is null || string.IsNullOrEmpty(containerIdentifier))
             return null;
 
-        // The most specific selected container decides, rather than any of them being enough
+        // The most specific container decides, rather than any selected one being enough
         // (<see cref="ContainerSpecificity"/>). While every container says the same thing the two are the same
-        // answer; they part company once a container can contradict the branch it sits in (#1255).
-        return ContainerSpecificity.ResolveMostSpecific(containerIdentifier, SelectedContainers, _containment.IsWithinContainer) is not null;
+        // answer; they part company once a container can contradict the branch it sits in (#1255), which is why
+        // the exclusions are ranked alongside the selections rather than subtracted afterwards.
+        //
+        // Which containers carve out is answered from this selection rather than from the containers' own flags,
+        // for the same reason the selection is a parameter at all: a proposal exists to differ from what is
+        // stored, and reading the stored flags would evaluate the configuration the administrator is trying to
+        // change instead of the one they are proposing.
+        return ContainerSpecificity.IsInScope(
+            containerIdentifier,
+            _scopeDecidingContainers,
+            _containment.IsWithinContainer,
+            ExcludedContainers.Contains);
     }
 
-    private static void CollectSelectedContainers(
+    private static void CollectContainers(
         IEnumerable<ConnectedSystemContainer> containers,
         IReadOnlySet<int> selectedContainerIds,
-        List<ConnectedSystemContainer> collected)
+        IReadOnlySet<int> excludedContainerIds,
+        List<ConnectedSystemContainer> selected,
+        List<ConnectedSystemContainer> excluded)
     {
         foreach (var container in containers)
         {
             if (selectedContainerIds.Contains(container.Id))
-                collected.Add(container);
+                selected.Add(container);
+            else if (excludedContainerIds.Contains(container.Id))
+                excluded.Add(container);
 
-            CollectSelectedContainers(container.ChildContainers, selectedContainerIds, collected);
+            CollectContainers(container.ChildContainers, selectedContainerIds, excludedContainerIds, selected, excluded);
         }
     }
 }

--- a/src/JIM.Models/Staging/ContainerSpecificity.cs
+++ b/src/JIM.Models/Staging/ContainerSpecificity.cs
@@ -47,22 +47,78 @@ public static class ContainerSpecificity
     public static ConnectedSystemContainer? ResolveMostSpecific(
         string? objectIdentifier,
         IReadOnlyCollection<ConnectedSystemContainer> containers,
+        Func<string?, ConnectedSystemContainer, bool> isWithinContainer) =>
+        ResolveMostSpecificMatches(objectIdentifier, containers, isWithinContainer).FirstOrDefault();
+
+    /// <summary>
+    /// Whether <paramref name="objectIdentifier"/> is in the scope these Containers describe: the Container with the
+    /// final say over it admits it rather than carving it out.
+    /// </summary>
+    /// <param name="objectIdentifier">The object's identifier in the Connected System's own terms.</param>
+    /// <param name="containers">
+    /// Every Container making a statement about scope, selections and exclusions alike. Supplying only the
+    /// selections answers a different and wrong question: an exclusion the caller left out cannot carve anything
+    /// out, so the object comes back in scope.
+    /// </param>
+    /// <param name="isWithinContainer">The containment rule, which must be the Connector's own.</param>
+    /// <param name="isExcluded">
+    /// Whether a Container carves its scope out rather than admitting it. Defaults to the Container's own
+    /// <see cref="ConnectedSystemContainer.Excluded"/> flag, which is what a caller working from the stored
+    /// configuration wants. A caller evaluating a *proposed* selection must supply its own, because the stored
+    /// flags are precisely what the proposal is asking to change; taking them at face value would answer the
+    /// question the administrator is trying to move away from.
+    /// </param>
+    /// <returns>
+    /// <c>false</c> where no Container admits the object at all. An empty collection is therefore out of scope
+    /// rather than unconstrained; a caller holding no Container-level opinion has no scope to narrow and does not
+    /// ask this question.
+    /// </returns>
+    /// <remarks>
+    /// Where two Containers admit the object and neither holds the other, ranking has nothing to separate them, and
+    /// <see cref="ResolveMostSpecific"/> is explicit that a caller attaching opposing meanings must resolve that tie
+    /// deliberately. This one resolves it to <b>excluded wins</b>: importing an object an administrator excluded is
+    /// the worse of the two failures, and it is the direction every other synchronisation-integrity decision in JIM
+    /// already leans. Such a tie cannot arise from a hierarchy, where every Container admitting an object lies on
+    /// one path down to it.
+    /// </remarks>
+    public static bool IsInScope(
+        string? objectIdentifier,
+        IReadOnlyCollection<ConnectedSystemContainer> containers,
+        Func<string?, ConnectedSystemContainer, bool> isWithinContainer,
+        Func<ConnectedSystemContainer, bool>? isExcluded = null)
+    {
+        var carvesOut = isExcluded ?? (static container => container.Excluded);
+        var deciding = ResolveMostSpecificMatches(objectIdentifier, containers, isWithinContainer);
+
+        return deciding.Count > 0 && !deciding.Any(carvesOut);
+    }
+
+    /// <summary>
+    /// The Containers with the final say over an object: those admitting it that no other admitting Container is
+    /// more specific than. One of them in a hierarchy; more only where containment is not one.
+    /// </summary>
+    private static List<ConnectedSystemContainer> ResolveMostSpecificMatches(
+        string? objectIdentifier,
+        IReadOnlyCollection<ConnectedSystemContainer> containers,
         Func<string?, ConnectedSystemContainer, bool> isWithinContainer)
     {
         ArgumentNullException.ThrowIfNull(containers);
         ArgumentNullException.ThrowIfNull(isWithinContainer);
 
         if (containers.Count == 0 || string.IsNullOrEmpty(objectIdentifier))
-            return null;
+            return [];
 
         var matches = containers.Where(container => isWithinContainer(objectIdentifier, container)).ToList();
         if (matches.Count <= 1)
-            return matches.FirstOrDefault();
+            return matches;
 
         // The most specific match is the one holding no other match: anything holding another match is an ancestor
         // of it, and an ancestor is the more general statement of the two.
-        return matches.FirstOrDefault(candidate => !matches.Any(other =>
-                   !ReferenceEquals(other, candidate) && isWithinContainer(other.ExternalId, candidate)))
-               ?? matches[0];
+        var mostSpecific = matches.Where(candidate => !matches.Any(other =>
+            !ReferenceEquals(other, candidate) && isWithinContainer(other.ExternalId, candidate))).ToList();
+
+        // Containment that admits every match into every other leaves nothing to rank, so every match still has a
+        // say. Ranking cannot narrow the field, and silently picking one would hide that.
+        return mostSpecific.Count > 0 ? mostSpecific : matches;
     }
 }

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -1157,9 +1157,15 @@ public class SynchronisationController(
             return NotFound(ApiErrorResponse.NotFound($"Connected System with ID {connectedSystemId} not found."));
 
         var currentSelection = ConnectedSystemScopeSelectionProposal.FromCurrentSelection(connectedSystem);
+
+        // Exclusions are carried forward from the current selection rather than proposed: this endpoint cannot
+        // express them yet (#1255 Phase 5 adds them to the request alongside the write surfaces). Omitting them
+        // would preview the removal of every exclusion the Connected System carries, which is a change the caller
+        // did not ask for and would be counted as objects coming back into scope.
         var proposal = new ConnectedSystemScopeSelectionProposal(
             request.SelectedPartitionIds ?? currentSelection.SelectedPartitionIds,
-            request.SelectedContainerIds ?? currentSelection.SelectedContainerIds);
+            request.SelectedContainerIds ?? currentSelection.SelectedContainerIds,
+            currentSelection.ExcludedContainerIds);
 
         // An id naming nothing in this hierarchy is different in kind from a selection the preview disagrees with:
         // there is no coherent proposal to evaluate, and silently ignoring it would produce a confident answer to a

--- a/src/JIM.Worker/Processors/SyncExportTaskProcessor.cs
+++ b/src/JIM.Worker/Processors/SyncExportTaskProcessor.cs
@@ -158,13 +158,15 @@ public class SyncExportTaskProcessor
         // Full Import treated the object as deleted, and synchronisation then disconnected and re-provisioned it.
         // Stated only when there is a selection to state; a Connected System with none permits everything, exactly
         // as before.
+        // Selections and exclusions both, because both decide where JIM may write: an export into an excluded
+        // branch is as unreadable on the way back as one into a container that was never selected (#1255).
         if (_connector is IConnectorManagedScope scopedConnector)
         {
-            var managedContainers = _connectedSystem.GetSelectedContainers();
+            var managedContainers = _connectedSystem.GetScopeDecidingContainers();
             if (managedContainers.Count > 0)
             {
                 scopedConnector.SetManagedScope(managedContainers);
-                Log.Debug("PerformExportAsync: Stated a managed scope of {ContainerCount} selected container(s) to the {Connector} connector",
+                Log.Debug("PerformExportAsync: Stated a managed scope of {ContainerCount} container(s) to the {Connector} connector",
                     managedContainers.Count, _connector.Name);
             }
         }

--- a/test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs
+++ b/test/JIM.Models.Tests/Staging/ConnectedSystemExtensionsTests.cs
@@ -710,7 +710,116 @@ public class ConnectedSystemExtensionsTests
 
     #endregion
 
+    #region GetScopeDecidingContainers Tests
+
+    // Every Container stating something about scope, selections and exclusions alike (#1255). Distinct from
+    // GetSelectedContainers, which answers "where may we search and write?"; this answers "which Container decides
+    // an object's fate?", and an exclusion left out of that set cannot carve anything out.
+
+    [Test]
+    public void GetScopeDecidingContainers_SelectionsAndExclusions_ReturnsBoth()
+    {
+        // Arrange
+        var serviceAccounts = ExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local");
+        var corp = SelectedContainer("OU=Corp,DC=example,DC=local", serviceAccounts);
+        var connectedSystem = SystemWithContainers(partitionSelected: true, corp);
+
+        // Act
+        var result = connectedSystem.GetScopeDecidingContainers();
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(new[] { corp, serviceAccounts }));
+    }
+
+    [Test]
+    public void GetScopeDecidingContainers_ContainerStatingNothing_IsNotReturned()
+    {
+        // A Container nobody has ticked or excluded has no say; including it would make it a match that decides
+        // nothing, and the most specific match would stop being the one that states something.
+        // Arrange
+        var sales = new ConnectedSystemContainer { Name = "Sales", ExternalId = "OU=Sales,OU=Corp,DC=example,DC=local" };
+        var corp = SelectedContainer("OU=Corp,DC=example,DC=local", sales);
+        var connectedSystem = SystemWithContainers(partitionSelected: true, corp);
+
+        // Act
+        var result = connectedSystem.GetScopeDecidingContainers();
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(new[] { corp }));
+    }
+
+    [Test]
+    public void GetScopeDecidingContainers_ExclusionNestedSeveralLevelsDown_IsReturned()
+    {
+        // Arrange
+        var app1 = SelectedContainer("OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local");
+        var serviceAccounts = ExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", app1);
+        var corp = SelectedContainer("OU=Corp,DC=example,DC=local", serviceAccounts);
+        var connectedSystem = SystemWithContainers(partitionSelected: true, corp);
+
+        // Act
+        var result = connectedSystem.GetScopeDecidingContainers();
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(new[] { corp, serviceAccounts, app1 }));
+    }
+
+    [Test]
+    public void GetScopeDecidingContainers_DeselectedPartition_ReturnsNothingFromIt()
+    {
+        // A deselected partition is not imported at all, so its Containers decide nothing.
+        // Arrange
+        var corp = SelectedContainer("OU=Corp,DC=example,DC=local");
+        var connectedSystem = SystemWithContainers(partitionSelected: false, corp);
+
+        // Act
+        var result = connectedSystem.GetScopeDecidingContainers();
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetScopeDecidingContainers_NoPartitions_ReturnsEmpty()
+    {
+        Assert.That(new ConnectedSystem { Name = "Test System" }.GetScopeDecidingContainers(), Is.Empty);
+    }
+
+    #endregion
+
     #region Helper Methods
+
+    private static ConnectedSystemContainer SelectedContainer(string externalId, params ConnectedSystemContainer[] children) =>
+        WithChildren(new ConnectedSystemContainer { Name = externalId, ExternalId = externalId, Selected = true }, children);
+
+    private static ConnectedSystemContainer ExcludedContainer(string externalId, params ConnectedSystemContainer[] children) =>
+        WithChildren(new ConnectedSystemContainer { Name = externalId, ExternalId = externalId, Excluded = true }, children);
+
+    private static ConnectedSystemContainer WithChildren(ConnectedSystemContainer container, params ConnectedSystemContainer[] children)
+    {
+        foreach (var child in children)
+        {
+            child.ParentContainer = container;
+            container.ChildContainers.Add(child);
+        }
+
+        return container;
+    }
+
+    private static ConnectedSystem SystemWithContainers(bool partitionSelected, params ConnectedSystemContainer[] rootContainers) =>
+        new()
+        {
+            Name = "Test System",
+            Partitions =
+            [
+                new ConnectedSystemPartition
+                {
+                    Name = "example.local",
+                    Selected = partitionSelected,
+                    Containers = [.. rootContainers]
+                }
+            ]
+        };
 
     private static ConnectedSystem CreateConnectedSystemWithMode(string mode)
     {

--- a/test/JIM.Models.Tests/Staging/ConnectedSystemScopeTests.cs
+++ b/test/JIM.Models.Tests/Staging/ConnectedSystemScopeTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JIM.Models.Preview;
 using JIM.Models.Staging;
 using NUnit.Framework;
@@ -126,15 +127,117 @@ public class ConnectedSystemScopeTests
         Assert.That(scope.Contains(2, "CN=Alice,OU=Archive,DC=example,DC=local"), Is.False);
     }
 
+    #region Exclusions (#1255)
+
+    // The preview and the import must answer alike, which is the whole reason this type exists. An exclusion the
+    // import honours and the preview does not is a preview stating a count the next import contradicts.
+
+    [Test]
+    public void Contains_ObjectWithinAnExcludedBranchOfASelectedContainer_ReturnsFalse()
+    {
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10], excludedContainerIds: [11]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.False);
+            Assert.That(scope.Contains(1, "CN=Bob,OU=Corp,DC=example,DC=local"), Is.True);
+        }
+    }
+
+    [Test]
+    public void Contains_ExclusionProposedOnAContainerNotYetExcluded_HonoursTheProposal()
+    {
+        // The proposal is the parameter, not the Connected System's stored flags: every Container in
+        // SystemWithContainers is stored as Selected, and proposing to exclude one has to take effect here or the
+        // preview would report on the configuration the administrator is trying to move away from.
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10], excludedContainerIds: [11]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.False);
+    }
+
+    [Test]
+    public void Contains_ContainerExcludedOnTheConnectedSystemButSelectedInTheProposal_HonoursTheProposal()
+    {
+        // The mirror image: an administrator proposing to lift an existing exclusion.
+        var connectedSystem = SystemWithContainers();
+        var sales = connectedSystem.Partitions![0].Containers!.Single(c => c.Id == 10).ChildContainers.Single();
+        sales.Selected = false;
+        sales.Excluded = true;
+
+        var scope = ScopeOver(connectedSystem, selectedPartitionIds: [1], selectedContainerIds: [10, 11]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.True);
+    }
+
+    [Test]
+    public void Contains_OnlyAnExclusionSelected_ReturnsFalse()
+    {
+        // An exclusion with nothing selected around it manages nothing, which is a determined answer.
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [], excludedContainerIds: [11]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.False);
+    }
+
+    [Test]
+    public void Contains_ExcludedContainerInADeselectedPartition_IsNotConsulted()
+    {
+        // Containers are collected from selected partitions only, and an exclusion is no different: a partition
+        // nobody imports from decides nothing about the partition they do.
+        var scope = ScopeOver(SystemWithContainers(), selectedPartitionIds: [1], selectedContainerIds: [10], excludedContainerIds: [20]);
+
+        Assert.That(scope.Contains(1, "CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local"), Is.True);
+    }
+
+    [Test]
+    public void FromCurrentSelection_ContainerExcludedOnTheConnectedSystem_CarriesTheExclusion()
+    {
+        // What "no change" looks like, and the baseline every preview is evaluated against. An exclusion missing
+        // from the baseline reads as an exclusion the proposal is adding.
+        var connectedSystem = SystemWithContainers();
+        var sales = connectedSystem.Partitions![0].Containers!.Single(c => c.Id == 10).ChildContainers.Single();
+        sales.Selected = false;
+        sales.Excluded = true;
+
+        var current = ConnectedSystemScopeSelectionProposal.FromCurrentSelection(connectedSystem);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(current.ExcludedContainerIds, Is.EquivalentTo(new[] { 11 }));
+
+            // Every partition's Containers, not just the selected partitions': the baseline records the
+            // configuration as it stands, and ConnectedSystemScope.From is what narrows it to the partitions in
+            // play. Container 20 sits in the deselected partition and is still recorded here.
+            Assert.That(current.SelectedContainerIds, Is.EquivalentTo(new[] { 10, 12, 20 }));
+        }
+    }
+
+    [Test]
+    public void DescribesSameSelectionAs_SameSelectionButDifferentExclusions_ReturnsFalse()
+    {
+        // A preview an administrator is looking at stops answering their question when they change an exclusion,
+        // exactly as when they change a selection.
+        var withExclusion = new ConnectedSystemScopeSelectionProposal([1], [10], [11]);
+        var withoutExclusion = new ConnectedSystemScopeSelectionProposal([1], [10]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(withExclusion.DescribesSameSelectionAs(withoutExclusion), Is.False);
+            Assert.That(withExclusion.DescribesSameSelectionAs(new ConnectedSystemScopeSelectionProposal([1], [10], [11])), Is.True);
+        }
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static ConnectedSystemScope ScopeOver(
         ConnectedSystem connectedSystem,
         IReadOnlyList<int> selectedPartitionIds,
-        IReadOnlyList<int> selectedContainerIds) =>
+        IReadOnlyList<int> selectedContainerIds,
+        IReadOnlyList<int>? excludedContainerIds = null) =>
         ConnectedSystemScope.From(
             connectedSystem,
-            new ConnectedSystemScopeSelectionProposal(selectedPartitionIds, selectedContainerIds),
+            new ConnectedSystemScopeSelectionProposal(selectedPartitionIds, selectedContainerIds, excludedContainerIds),
             DistinguishedNameContainment.Instance);
 
     /// <summary>

--- a/test/JIM.Models.Tests/Staging/ContainerSpecificityTests.cs
+++ b/test/JIM.Models.Tests/Staging/ContainerSpecificityTests.cs
@@ -136,13 +136,133 @@ public class ContainerSpecificityTests
         Assert.That(ContainerSpecificity.ResolveMostSpecific(null, [corp], IsWithin), Is.Null);
     }
 
+    #region IsInScope tests
+
+    // The decision the ranking exists to serve (#1255). Ranking on its own says which Container decides; this says
+    // what that Container's decision is, which is the question every import, export and preview actually asks.
+
+    [Test]
+    public void IsInScope_NoContainers_ReturnsFalse()
+    {
+        // No Container admits the object, so nothing puts it in scope. A caller with no Container-level opinion to
+        // apply at all does not ask this question; it never narrows scope in the first place.
+        Assert.That(ContainerSpecificity.IsInScope("CN=Alice,OU=Corp,DC=example,DC=local", [], IsWithin), Is.False);
+    }
+
+    [Test]
+    public void IsInScope_ObjectOutsideEveryContainer_ReturnsFalse()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        Assert.That(ContainerSpecificity.IsInScope("CN=Alice,OU=Partners,DC=example,DC=local", [corp], IsWithin), Is.False);
+    }
+
+    [Test]
+    public void IsInScope_TheDecidingContainerIsSelected_ReturnsTrue()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        Assert.That(ContainerSpecificity.IsInScope("CN=Alice,OU=Corp,DC=example,DC=local", [corp], IsWithin), Is.True);
+    }
+
+    [Test]
+    public void IsInScope_ObjectWithinAnExcludedBranchOfASelectedParent_ReturnsFalse()
+    {
+        // The case the whole of #1255 exists for: manage Corp, except its Service Accounts.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var serviceAccounts = ExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ContainerSpecificity.IsInScope("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local", [corp, serviceAccounts], IsWithin), Is.False);
+            Assert.That(ContainerSpecificity.IsInScope("CN=Alice,OU=Corp,DC=example,DC=local", [corp, serviceAccounts], IsWithin), Is.True);
+        }
+    }
+
+    [Test]
+    public void IsInScope_ExclusionSuppliedBeforeTheSelectionItSitsWithin_ReturnsTheSameAnswer()
+    {
+        // The answer is a property of the Containers, not of the order a caller happened to collect them in.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var serviceAccounts = ExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        Assert.That(ContainerSpecificity.IsInScope("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local", [serviceAccounts, corp], IsWithin), Is.False);
+    }
+
+    [Test]
+    public void IsInScope_SelectionBeneathAnExclusion_ReturnsTrue()
+    {
+        // Re-inclusion to arbitrary depth is what most-specific-match buys, with no further machinery.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var serviceAccounts = ExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var app1 = Container("OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ContainerSpecificity.IsInScope("CN=svc-app1,OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local", [corp, serviceAccounts, app1], IsWithin), Is.True);
+            Assert.That(ContainerSpecificity.IsInScope("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local", [corp, serviceAccounts, app1], IsWithin), Is.False);
+        }
+    }
+
+    [Test]
+    public void IsInScope_ExcludedOneLevelContainer_CarvesOutOnlyItsOwnLevel()
+    {
+        // A Container's Scope says how far its statement reaches, whether that statement is a selection or an
+        // exclusion. A One Level exclusion says nothing about what sits beneath it, so the selected ancestor still
+        // governs there.
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+        var staging = ExcludedContainer("OU=Staging,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.OneLevel);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ContainerSpecificity.IsInScope("CN=Temp,OU=Staging,OU=Corp,DC=example,DC=local", [corp, staging], IsWithin), Is.False);
+            Assert.That(ContainerSpecificity.IsInScope("CN=Temp,OU=Batch,OU=Staging,OU=Corp,DC=example,DC=local", [corp, staging], IsWithin), Is.True);
+        }
+    }
+
+    [Test]
+    public void IsInScope_TwoEquallySpecificContainersDisagree_ReturnsFalse()
+    {
+        // Containment that is not a tree can admit an object into two Containers neither of which holds the other,
+        // and ranking has no answer between them. Where they disagree the exclusion decides: importing an object an
+        // administrator excluded is the worse of the two failures, and "whichever we saw first" is not an answer to
+        // "is this object managed?" at all.
+        var selected = Container("first", ConnectedSystemContainerScope.Subtree);
+        var excluded = ExcludedContainer("second", ConnectedSystemContainerScope.Subtree);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ContainerSpecificity.IsInScope("object", [selected, excluded], AdmitsEverything), Is.False);
+            Assert.That(ContainerSpecificity.IsInScope("object", [excluded, selected], AdmitsEverything), Is.False);
+        }
+    }
+
+    [Test]
+    public void IsInScope_NullIdentifier_ReturnsFalse()
+    {
+        var corp = Container("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree);
+
+        Assert.That(ContainerSpecificity.IsInScope(null, [corp], IsWithin), Is.False);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static ConnectedSystemContainer Container(string externalId, ConnectedSystemContainerScope scope) =>
         new() { Name = externalId, ExternalId = externalId, Selected = true, Scope = scope };
 
+    private static ConnectedSystemContainer ExcludedContainer(string externalId, ConnectedSystemContainerScope scope) =>
+        new() { Name = externalId, ExternalId = externalId, Excluded = true, Scope = scope };
+
     private static bool IsWithin(string? objectIdentifier, ConnectedSystemContainer container) =>
         DistinguishedNameContainment.Instance.IsWithinContainer(objectIdentifier, container);
+
+    /// <summary>
+    /// Containment that is not a hierarchy: every Container admits everything, including the other Containers, so
+    /// no Container is more specific than any other.
+    /// </summary>
+    private static bool AdmitsEverything(string? objectIdentifier, ConnectedSystemContainer container) => true;
 
     #endregion
 }

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorExportScopeTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorExportScopeTests.cs
@@ -174,6 +174,64 @@ public class LdapConnectorExportScopeTests
         Assert.That(results[0].Success, Is.True);
     }
 
+    [Test]
+    public async Task ExecuteAsync_TargetWithinAnExcludedBranch_FailsThatObjectWithoutWritingAsync()
+    {
+        // An exclusion is as much a statement about where JIM may write as a selection is (#1255): an object
+        // written into an excluded branch is exactly as unreadable on the next import as one written outside the
+        // selection altogether, and produces the same churn.
+        var export = CreateExport();
+        export.SetManagedScope([Managed("OU=Corp,DC=test,DC=local"), Excluded("OU=Service Accounts,OU=Corp,DC=test,DC=local")]);
+
+        var results = await export.ExecuteAsync(
+            [CreateUpdatePendingExport("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=test,DC=local")],
+            CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results[0].Success, Is.False);
+            Assert.That(results[0].ErrorType, Is.EqualTo(ConnectedSystemExportErrorType.OutsideManagedScope));
+        }
+        _mockExecutor.Verify(e => e.SendRequest(It.IsAny<ModifyRequest>()), Times.Never);
+        _mockExecutor.Verify(e => e.SendRequestAsync(It.IsAny<ModifyRequest>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_TargetElsewhereInABranchWithAnExclusion_WritesAsUsualAsync()
+    {
+        // The exclusion carves out its own branch and nothing else; the selection around it still permits writes.
+        SetupModifyResponse(ResultCode.Success);
+        var export = CreateExport();
+        export.SetManagedScope([Managed("OU=Corp,DC=test,DC=local"), Excluded("OU=Service Accounts,OU=Corp,DC=test,DC=local")]);
+
+        var results = await export.ExecuteAsync(
+            [CreateUpdatePendingExport("CN=Bob,OU=Users,OU=Corp,DC=test,DC=local")],
+            CancellationToken.None);
+
+        Assert.That(results[0].Success, Is.True);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_TargetWithinASelectionBeneathAnExclusion_WritesAsUsualAsync()
+    {
+        // Re-inclusion: the most specific statement decides, so a selected container inside an excluded branch
+        // permits writes again.
+        SetupModifyResponse(ResultCode.Success);
+        var export = CreateExport();
+        export.SetManagedScope(
+        [
+            Managed("OU=Corp,DC=test,DC=local"),
+            Excluded("OU=Service Accounts,OU=Corp,DC=test,DC=local"),
+            Managed("OU=App1,OU=Service Accounts,OU=Corp,DC=test,DC=local")
+        ]);
+
+        var results = await export.ExecuteAsync(
+            [CreateUpdatePendingExport("CN=svc-app1,OU=App1,OU=Service Accounts,OU=Corp,DC=test,DC=local")],
+            CancellationToken.None);
+
+        Assert.That(results[0].Success, Is.True);
+    }
+
     #region Helper methods
 
     private LdapConnectorExport CreateExport()
@@ -254,4 +312,13 @@ public class LdapConnectorExportScopeTests
         string externalId,
         ConnectedSystemContainerScope scope = ConnectedSystemContainerScope.Subtree) =>
         new() { ExternalId = externalId, Scope = scope };
+
+    /// <summary>
+    /// A container the administrator has carved out of the selection around it (#1255), as JIM states it to the
+    /// Connector alongside the selections.
+    /// </summary>
+    private static ConnectedSystemContainer Excluded(
+        string externalId,
+        ConnectedSystemContainerScope scope = ConnectedSystemContainerScope.Subtree) =>
+        new() { ExternalId = externalId, Scope = scope, Excluded = true };
 }

--- a/test/JIM.Worker.Tests/Connectors/LdapConnectorUtilitiesTests.cs
+++ b/test/JIM.Worker.Tests/Connectors/LdapConnectorUtilitiesTests.cs
@@ -700,7 +700,7 @@ public class LdapConnectorUtilitiesTests
     }
 
     [Test]
-    public void IsDnWithinAnyContainerScope_DnInTheSecondContainer_ReturnsTrue()
+    public void IsDnInScope_DnInTheSecondContainer_ReturnsTrue()
     {
         var containers = new List<ConnectedSystemContainer>
         {
@@ -708,11 +708,11 @@ public class LdapConnectorUtilitiesTests
             CreateContainer("OU=Partners,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
         };
 
-        Assert.That(LdapConnectorUtilities.IsDnWithinAnyContainerScope("CN=Alice,OU=External,OU=Partners,DC=example,DC=local", containers), Is.True);
+        Assert.That(LdapConnectorUtilities.IsDnInScope("CN=Alice,OU=External,OU=Partners,DC=example,DC=local", containers), Is.True);
     }
 
     [Test]
-    public void IsDnWithinAnyContainerScope_DnBeneathAOneLevelContainerOnly_ReturnsFalse()
+    public void IsDnInScope_DnBeneathAOneLevelContainerOnly_ReturnsFalse()
     {
         var containers = new List<ConnectedSystemContainer>
         {
@@ -720,19 +720,19 @@ public class LdapConnectorUtilitiesTests
             CreateContainer("OU=Partners,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
         };
 
-        Assert.That(LdapConnectorUtilities.IsDnWithinAnyContainerScope("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", containers), Is.False);
+        Assert.That(LdapConnectorUtilities.IsDnInScope("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", containers), Is.False);
     }
 
     [Test]
-    public void IsDnWithinAnyContainerScope_NoContainers_ReturnsTrue()
+    public void IsDnInScope_NoContainers_ReturnsTrue()
     {
         // No selected Containers means no Container-level opinion to apply; the caller's partition filtering
         // still governs. Returning false here would silently empty every delta import.
-        Assert.That(LdapConnectorUtilities.IsDnWithinAnyContainerScope("CN=Alice,OU=Corp,DC=example,DC=local", []), Is.True);
+        Assert.That(LdapConnectorUtilities.IsDnInScope("CN=Alice,OU=Corp,DC=example,DC=local", []), Is.True);
     }
 
     [Test]
-    public void IsDnWithinAnyContainerScope_DnInsideNestedSelectedContainers_ReturnsTrue()
+    public void IsDnInScope_DnInsideNestedSelectedContainers_ReturnsTrue()
     {
         // Two Containers admit this object, one nested inside the other. The answer is the same either way; that it
         // stays the same is the point, because what decides it is now the deeper Container rather than whichever
@@ -743,7 +743,68 @@ public class LdapConnectorUtilitiesTests
             CreateContainer("OU=Sales,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
         };
 
-        Assert.That(LdapConnectorUtilities.IsDnWithinAnyContainerScope("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", containers), Is.True);
+        Assert.That(LdapConnectorUtilities.IsDnInScope("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", containers), Is.True);
+    }
+
+    [Test]
+    public void IsDnInScope_DnWithinAnExcludedBranchOfASelectedContainer_ReturnsFalse()
+    {
+        // "Manage Corp, except its Service Accounts" (#1255), asked of this Connector's own containment rule.
+        var containers = new List<ConnectedSystemContainer>
+        {
+            CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree),
+            CreateExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
+        };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(LdapConnectorUtilities.IsDnInScope("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local", containers), Is.False);
+            Assert.That(LdapConnectorUtilities.IsDnInScope("CN=Alice,OU=Sales,OU=Corp,DC=example,DC=local", containers), Is.True);
+        }
+    }
+
+    [Test]
+    public void IsDnInScope_ExcludedContainerItself_ReturnsFalse()
+    {
+        // The excluded Container is an object in the directory too, and a Subtree statement covers its own entry.
+        var containers = new List<ConnectedSystemContainer>
+        {
+            CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree),
+            CreateExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
+        };
+
+        Assert.That(LdapConnectorUtilities.IsDnInScope("OU=Service Accounts,OU=Corp,DC=example,DC=local", containers), Is.False);
+    }
+
+    [Test]
+    public void IsDnInScope_SelectedContainerBeneathAnExcludedOne_ReturnsTrue()
+    {
+        var containers = new List<ConnectedSystemContainer>
+        {
+            CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree),
+            CreateExcludedContainer("OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree),
+            CreateContainer("OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree)
+        };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(LdapConnectorUtilities.IsDnInScope("CN=svc-app1,OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local", containers), Is.True);
+            Assert.That(LdapConnectorUtilities.IsDnInScope("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local", containers), Is.False);
+        }
+    }
+
+    [Test]
+    public void IsDnInScope_ExclusionWrittenWithTheSpacingSomeDirectoriesEmit_StillCarvesItOut()
+    {
+        // The exclusion has to survive the same normalisation the selections do; a spacing difference silently
+        // reinstating an excluded branch is precisely the failure this Connector's own predicate exists to prevent.
+        var containers = new List<ConnectedSystemContainer>
+        {
+            CreateContainer("OU=Corp,DC=example,DC=local", ConnectedSystemContainerScope.Subtree),
+            CreateExcludedContainer("OU=Service Accounts, OU=Corp, DC=example, DC=local", ConnectedSystemContainerScope.Subtree)
+        };
+
+        Assert.That(LdapConnectorUtilities.IsDnInScope("CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local", containers), Is.False);
     }
 
     #endregion
@@ -805,7 +866,7 @@ public class LdapConnectorUtilitiesTests
     [Test]
     public void ResolveMostSpecificContainerScope_NoContainers_ReturnsNull()
     {
-        // No Containers is no opinion, which IsDnWithinAnyContainerScope reads as "admit everything". There is no
+        // No Containers is no opinion, which IsDnInScope reads as "admit everything". There is no
         // Container to name as the one that decided, so this says so rather than inventing one.
         Assert.That(LdapConnectorUtilities.ResolveMostSpecificContainerScope("CN=Alice,OU=Corp,DC=example,DC=local", []), Is.Null);
     }
@@ -821,6 +882,17 @@ public class LdapConnectorUtilitiesTests
             Name = externalId,
             ExternalId = externalId,
             Selected = true,
+            Scope = scope
+        };
+    }
+
+    private static ConnectedSystemContainer CreateExcludedContainer(string externalId, ConnectedSystemContainerScope scope)
+    {
+        return new ConnectedSystemContainer
+        {
+            Name = externalId,
+            ExternalId = externalId,
+            Excluded = true,
             Scope = scope
         };
     }


### PR DESCRIPTION
## Description

Phase 3 of [#1255](https://github.com/TetronIO/JIM/issues/1255) ([plan](engineering/plans/doing/CONTAINER_SCOPE_EXCLUSIONS.md)). Phase 2 gave a Container an `Excluded` flag and taught the editor its rules; nothing read it. This makes it change what an import returns and what an export is allowed to write.

The phase turns on a distinction the code did not previously draw. The **selected** Containers say where JIM may search and where it may write. They do not say *which Container decides an object's fate*, which an exclusion decides as much as a selection does. `ConnectedSystemExtensions.GetScopeDecidingContainers` collects both, and `ContainerSpecificity.IsInScope` ranks them so the most specific statement wins. Handing a scope decision the selections alone is not a partial answer but a wrong one: an exclusion that is not present carves nothing out.

Honoured in four places, all reaching the same answer:

- **The full import and the AD USN delta** filter the entries their searches return, in `ConvertLdapResults`. A directory cannot express "this subtree except that branch" in one search, and decomposing the searches instead was rejected in the design because it would make import scope depend on how recently the hierarchy was refreshed. Search roots are therefore unchanged, and an exclusion adds none of its own.
- **The changelog and accesslog deltas** already filtered a directory-wide log per entry; they now filter against the exclusions too.
- **The export write guard** refuses a write into an excluded branch, including into a Container the Connector created during the run: JIM would select that Container as the run ends, but not when an exclusion carves out the branch it sits in.
- **`ConnectedSystemScope`**, so the preview cannot state a count the next import contradicts.

Two smaller decisions taken during the work:

- Where containment is not a hierarchy, two Containers can admit an object without either holding the other, and `ContainerSpecificity` was explicit that a caller attaching opposing meanings must resolve that tie deliberately. **Excluded wins**: importing an object an administrator excluded is the worse of the two failures.
- `ConnectedSystemScope` reads which Containers carve out from the **proposal**, not from the Containers' stored `Excluded` flags, for the same reason the selection is a parameter at all. A preview that read the stored flags would evaluate the configuration the administrator is trying to move away from.

`LdapConnectorUtilities.IsDnWithinAnyContainerScope` is renamed `IsDnInScope`; "within any" stopped being what it answers.

### Deferred, deliberately

- **The per-exclusion discard count on the Activity moves to Phase 6.** Client-side filtering costs entries read only to be thrown away, and the design accepted that cost on condition it is visible, so each import logs how many entries each exclusion discarded. Putting the figure on the Activity needs a channel that does not exist: the Activity has only `WarningMessage`, and an exclusion doing exactly what it was configured to do is not a warning. Flagging every exclusion-configured import as warned would train administrators to ignore the field. Phase 6 already opens the Activity and preview surfaces for this feature.
- **No changelog entry and no public documentation.** Nothing an administrator can reach has changed, because no surface can set `Excluded` until Phases 4 (portal) and 5 (REST and PowerShell). The user-facing entry belongs with the phase that makes exclusions settable.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

Written red-first. New coverage: `ContainerSpecificityTests` for the scope decision including the non-hierarchy tie; `ConnectedSystemExtensionsTests` for collecting the scope-deciding Containers; `ConnectedSystemScopeTests` for exclusions, for a proposal that differs from the stored flags in both directions, and for the proposal baseline and comparison; `LdapConnectorUtilitiesTests` for the exclusion running on this Connector's own containment predicate, including the spacing normalisation; `LdapConnectorExportScopeTests` for the write guard. The export exclusion test was confirmed to fail against an implementation that ignores `Excluded`.

**Runtime-verified against OpenLDAP on the sandbox light stack**, since unit tests mock away the path where entries are actually filtered:

| Configuration | Objects imported | Entries discarded |
|---|---|---|
| `ou=Corp` selected (Subtree) | 4 | 0 |
| ...with `ou=Service Accounts` excluded beneath it | 2 | 2, attributed to that Container |
| ...with `ou=App1` re-included beneath the exclusion | 3 | 1 |

```
LdapConnectorImport: Discarded 2 entries read from excluded Containers across 1 exclusion(s)
LdapConnectorImport: Excluded Container 'ou=Service Accounts,ou=Corp,dc=yellowstone,dc=local' discarded 2 entries
```

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [ ] No documentation needed

The plan document records Phase 3 as landed, the decisions taken during the work, the Phase 6 deferral and the runtime verification.

Docs: n/a - no surface can set an exclusion until Phases 4 and 5, so nothing an administrator can reach has changed yet; the public documentation lands with the phase that makes exclusions settable

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

Phases 1 (#1290) and 2 (#1306) landed earlier, along with the moved-Container fix (#1321) this phase depends on: an exclusion has to survive a hierarchy refresh to be worth anything. Phase 4 (portal) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfeypW7jcRid2SyWLEDzdp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfeypW7jcRid2SyWLEDzdp)_