### PR TITLE
Settings validity is about the settings, not about the target system being up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔒 Attributes holding credential material, such as `unicodePwd` and `userPassword`, can no longer be imported, selected for management, or used in an Attribute Flow. Any that a deployment had already selected are deselected and locked rather than deleted, leaving Synchronisation Rules intact.
 - 🔒 JIM no longer depends on the third-party DNParser library for LDAP Distinguished Name parsing; DN handling is now performed by a small, self-contained parser built into the LDAP Connector. This removes a Code Project Open License (CPOL) dependency, which software composition scanners commonly flag and which is not OSI-approved, along with an unmaintained package from the supply chain, in keeping with JIM's self-contained, air-gap-deployable design.
 
+### Changed
+
+- 🔄 A Connected System whose external system is temporarily unreachable no longer loses its Schema, Partitions & Containers and Matching tabs. Those tabs are gated on the settings being complete, which is a fact about the configuration; saving any change during an outage previously recorded the settings as invalid and locked them until someone re-saved the Settings tab. Saving settings still tests the connection and reports what it finds.
+
 ### Added
 
 - ✨ A Container can now be **excluded** from a selection made above it: select `OU=Corp` and carve `OU=Service Accounts` out of it, rather than ticking eleven sibling OUs and hoping nobody adds a twelfth. Exclusions nest, and survive a rename. (#1255)

--- a/docs/configuration/connected-systems.md
+++ b/docs/configuration/connected-systems.md
@@ -11,6 +11,8 @@ Every Connected System is associated with a [connector](../connectors/index.md) 
 ## What a Connected System contains
 
 - **Connection details**<br /> How to reach the external system: server address, credentials, file path, and other connector-specific settings. The Settings tab groups these into a collapsible accordion by category (Connectivity, General, Export, and so on) so dense connector configuration stays easy to scan.
+
+    The Schema, Partitions &amp; Containers and Matching tabs stay unavailable until the required settings are filled in, because none of them can do anything useful without them. That gate is about the settings themselves, not about the external system being reachable: saving the Settings tab also tests the connection and tells you what it found, but a system that is down for maintenance does not take those tabs away, and you can keep working on the configuration while it is.
 - **Discovered schema**<br /> The object types and attributes available in the external system, populated on first contact.
 - **Connector space**<br /> A staging area that holds JIM's local copy of the external system's data.
 - **Run Profiles**<br /> Configured operations (import, sync, export) that can be executed against the system.

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -529,8 +529,7 @@ public class ConnectedSystemServer
 
         Log.Verbose($"UpdateConnectedSystemAsync() called for {connectedSystem}");
 
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
 
         AuditHelper.SetUpdated(connectedSystem, initiatedBy);
 
@@ -565,8 +564,7 @@ public class ConnectedSystemServer
 
         Log.Verbose($"UpdateConnectedSystemAsync() called for {connectedSystem} (API key initiated)");
 
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
 
         AuditHelper.SetUpdated(connectedSystem, initiatedByApiKey);
 
@@ -608,8 +606,7 @@ public class ConnectedSystemServer
         // caller sent, which closes any route that sets Selected outside the validated per-attribute endpoints.
         QuarantineCredentialAttributes(connectedSystem);
 
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
 
         AuditHelper.SetUpdated(connectedSystem, initiatedBy);
 
@@ -638,8 +635,7 @@ public class ConnectedSystemServer
     /// </summary>
     private async Task PersistConnectedSystemUpdateAsync(ConnectedSystem connectedSystem, MetaverseObject? initiatedBy)
     {
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
         AuditHelper.SetUpdated(connectedSystem, initiatedBy);
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem);
@@ -652,8 +648,7 @@ public class ConnectedSystemServer
     /// </summary>
     private async Task PersistConnectedSystemUpdateAsync(ConnectedSystem connectedSystem, ApiKey initiatedByApiKey)
     {
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
         AuditHelper.SetUpdated(connectedSystem, initiatedByApiKey);
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem);
@@ -666,8 +661,7 @@ public class ConnectedSystemServer
     /// </summary>
     private async Task PersistConnectedSystemUpdateAsync(ConnectedSystem connectedSystem, ActivityInitiatorType initiatorType, Guid? initiatorId, string? initiatorName)
     {
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
         AuditHelper.SetUpdated(connectedSystem, initiatorType, initiatorId, initiatorName);
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem);
@@ -679,8 +673,7 @@ public class ConnectedSystemServer
     /// </summary>
     private async Task PersistConnectedSystemSchemaUpdateAsync(ConnectedSystem connectedSystem, MetaverseObject? initiatedBy)
     {
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
         AuditHelper.SetUpdated(connectedSystem, initiatedBy);
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemSchemaAsync(connectedSystem);
@@ -692,8 +685,7 @@ public class ConnectedSystemServer
     /// </summary>
     private async Task PersistConnectedSystemSchemaUpdateAsync(ConnectedSystem connectedSystem, ApiKey initiatedByApiKey)
     {
-        var validationResults = ValidateConnectedSystemSettings(connectedSystem);
-        connectedSystem.SettingValuesValid = validationResults.All(q => q.IsValid);
+        connectedSystem.SettingValuesValid = AreSettingValuesComplete(connectedSystem);
         AuditHelper.SetUpdated(connectedSystem, initiatedByApiKey);
         SanitiseConnectedSystemUserInput(connectedSystem);
         await Application.Repository.ConnectedSystems.UpdateConnectedSystemSchemaAsync(connectedSystem);
@@ -1343,6 +1335,30 @@ public class ConnectedSystemServer
     /// Checks that all setting values are valid, according to business rules.
     /// </summary>
     /// <remarks>Do not make static, it needs to be available on the instance</remarks>
+    /// <summary>
+    /// Whether a Connected System's settings are complete and well-formed: every required setting has a value, and
+    /// every required-group and required-when constraint declared in the setting metadata is satisfied. Asked of the
+    /// values alone, and never of the target system.
+    /// </summary>
+    /// <remarks>
+    /// This is what <see cref="ConnectedSystem.SettingValuesValid"/> carries, and it is deliberately narrower than
+    /// <see cref="ValidateConnectedSystemSettings"/>. That method also asks the Connector, whose own validation is a
+    /// live probe: the LDAP Connector binds to the directory, the File Connector looks for the file. Persisting the
+    /// answer to a live probe as a property of the configuration means an unreachable target marks stored settings
+    /// invalid, and the portal gates the Schema, Partitions &amp; Containers and Matching tabs on this flag, so saving
+    /// anything at all during a directory outage locked an administrator out of three tabs until somebody re-saved
+    /// the Settings tab. It also put a network round trip on the path of every unrelated save.
+    ///
+    /// Whether the target answers is still reported, where it is actionable: the Settings tab and the settings-writing
+    /// REST endpoint both call <see cref="ValidateConnectedSystemSettings"/> and surface what it finds.
+    /// </remarks>
+    public static bool AreSettingValuesComplete(ConnectedSystem connectedSystem)
+    {
+        ValidateConnectedSystemParameter(connectedSystem);
+
+        return ConnectorSettingValidator.Validate(connectedSystem.SettingValues).All(r => r.IsValid);
+    }
+
     public IList<ConnectorSettingValueValidationResult> ValidateConnectedSystemSettings(ConnectedSystem connectedSystem)
     {
         ValidateConnectedSystemParameter(connectedSystem);

--- a/test/JIM.Worker.Tests/Servers/ConnectedSystemSettingValidityTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ConnectedSystemSettingValidityTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Connectors;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// What <see cref="ConnectedSystem.SettingValuesValid"/> is allowed to mean.
+/// </summary>
+/// <remarks>
+/// The flag is persisted, and the portal gates the Schema, Partitions &amp; Containers and Matching tabs on it, so it
+/// has to answer a question about the configuration: are the setting values complete and well-formed? It used to be
+/// recomputed on every save from the Connector's own validation, which opens a real connection to the target system.
+/// Saving anything at all while that system was unreachable, a container selection included, therefore persisted
+/// "settings invalid" and locked the administrator out of three tabs until somebody re-saved the Settings tab, and it
+/// put a network round trip on the path of every unrelated save.
+///
+/// Whether the target answers is a live fact that belongs on the Settings tab, where an administrator is configuring
+/// connectivity and can act on it. It is never a reason to declare the stored configuration invalid.
+/// </remarks>
+[TestFixture]
+public class ConnectedSystemSettingValidityTests
+{
+    private Mock<IRepository> _repo = null!;
+    private Mock<IActivityRepository> _activityRepo = null!;
+    private Mock<IServiceSettingsRepository> _settingsRepo = null!;
+    private Mock<IConnectedSystemRepository> _csRepo = null!;
+    private JimApplication _jim = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _repo = new Mock<IRepository>();
+        _activityRepo = new Mock<IActivityRepository>();
+        _settingsRepo = new Mock<IServiceSettingsRepository>();
+        _csRepo = new Mock<IConnectedSystemRepository>();
+        _repo.Setup(r => r.Activity).Returns(_activityRepo.Object);
+        _repo.Setup(r => r.ServiceSettings).Returns(_settingsRepo.Object);
+        _repo.Setup(r => r.ConnectedSystems).Returns(_csRepo.Object);
+
+        _activityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<Activity>())).Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<Activity>())).Returns(Task.CompletedTask);
+        _csRepo.Setup(r => r.UpdateConnectedSystemAsync(It.IsAny<ConnectedSystem>())).Returns(Task.CompletedTask);
+
+        // Configuration change capture is off: this fixture is about the validity flag, and a snapshot reload would
+        // need a graph these mocks do not serve.
+        _settingsRepo.Setup(r => r.GetSettingAsync(Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled))
+            .ReturnsAsync(new ServiceSetting
+            {
+                Key = Constants.SettingKeys.ChangeTrackingConfigurationChangesEnabled,
+                ValueType = ServiceSettingValueType.Boolean,
+                Value = "false"
+            });
+
+        _jim = new JimApplication(_repo.Object);
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    [Test]
+    public async Task UpdateConnectedSystemAsync_WithTheTargetSystemUnreachable_LeavesTheSettingsValidAsync()
+    {
+        // The File Connector stands in for any Connector whose own validation is a live probe: it reports a missing
+        // file exactly as the LDAP Connector reports a directory it cannot bind to. Neither says anything about
+        // whether the administrator's settings are complete.
+        var connectedSystem = BuildFileConnectedSystem("/nowhere/never-created.csv");
+        connectedSystem.SettingValuesValid = true;
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem, Administrator());
+
+        Assert.That(connectedSystem.SettingValuesValid, Is.True,
+            "an unreachable target must not persist the configuration as invalid, which is what gates the portal's tabs");
+    }
+
+    [Test]
+    public async Task UpdateConnectedSystemAsync_WithARequiredSettingMissing_MarksTheSettingsInvalidAsync()
+    {
+        // The other half of the split: completeness is a fact about the configuration, and the flag still carries it.
+        var connectedSystem = BuildFileConnectedSystem(filePath: null);
+        connectedSystem.SettingValuesValid = true;
+
+        await _jim.ConnectedSystems.UpdateConnectedSystemAsync(connectedSystem, Administrator());
+
+        Assert.That(connectedSystem.SettingValuesValid, Is.False);
+    }
+
+    [Test]
+    public void ValidateConnectedSystemSettings_StillReportsWhatTheConnectorItselfFinds()
+    {
+        // Unchanged, and the reason the split is safe: the Settings tab and the settings-writing REST endpoint both
+        // call this, so an administrator configuring connectivity is still told the target cannot be reached.
+        var connectedSystem = BuildFileConnectedSystem("/nowhere/never-created.csv");
+
+        var results = _jim.ConnectedSystems.ValidateConnectedSystemSettings(connectedSystem);
+
+        Assert.That(results.Any(r => !r.IsValid), Is.True);
+    }
+
+    private static MetaverseObject Administrator() => new() { Id = Guid.NewGuid(), CachedDisplayName = "Test Admin" };
+
+    private static ConnectedSystem BuildFileConnectedSystem(string? filePath) => new()
+    {
+        Id = 1,
+        Name = "HR Extract",
+        ConnectorDefinition = new ConnectorDefinition { Name = ConnectorConstants.FileConnectorName },
+        SettingValues =
+        [
+            new ConnectedSystemSettingValue
+            {
+                Id = 10,
+                Setting = new ConnectorDefinitionSetting { Id = 100, Name = "File Path", Required = true, Type = ConnectedSystemSettingType.File },
+                StringValue = filePath
+            },
+            new ConnectedSystemSettingValue
+            {
+                Id = 11,
+                Setting = new ConnectorDefinitionSetting { Id = 101, Name = "Mode", Required = true, Type = ConnectedSystemSettingType.DropDown },
+                StringValue = "Import Only"
+            }
+        ]
+    };
+}


### PR DESCRIPTION
## Description

Top layer of a three-PR stack (base is the layer below, not `main`). Discovered while runtime-verifying #1255: an ordinary save locked the portal's tabs.

The portal gates the Schema, Partitions & Containers and Matching tabs on `ConnectedSystem.SettingValuesValid`, and that flag was recomputed on **every** save from the Connector's own validation, which is a live probe: the LDAP Connector binds to the directory, the File Connector looks for the file.

Two consequences. Saving anything at all while the target was unreachable, a Container selection included, persisted "settings invalid" and took three tabs away until somebody re-saved the Settings tab; a directory down for maintenance therefore locked an administrator out of configuration work that has nothing to do with reaching it. And every unrelated save carried a network round trip to the target system.

The flag now carries only what it is asked to mean: completeness and well-formedness of the values, via the same required, required-group and required-when validation as before.

**Nothing loses the connectivity feedback**, which is why the split is safe. Whether the target answers is still reported where it is actionable and where an administrator is in a position to act on it: the Settings tab runs the full validation before saving and blocks on it per setting (`ConnectedSystemSettingsTab.HandleValidSettingsSubmitAsync`), and the settings-writing REST endpoint rejects with structured per-setting errors. Both call `ValidateConnectedSystemSettings`, which is unchanged.

### Stack

1. `claude/gh-issue-351-review-rhww8b` — #1345, Container Scope exclusions
2. `claude/gh-issue-351-review-rhww8b-stack-sandbox-sdk` — #1346, sandbox SDK pin
3. **This PR** (base: the branch above)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

Red-first. `ConnectedSystemSettingValidityTests` uses the File Connector as the stand-in for any Connector whose own validation is a live probe: it reports a missing file exactly as the LDAP Connector reports a directory it cannot bind to, and neither says anything about whether the settings are complete. Before the change, exactly one of the three tests failed, and for the right reason. The fixture also pins the two halves that must not move: a missing required setting still marks the settings invalid, and `ValidateConnectedSystemSettings` still reports what the Connector itself finds.

The original symptom was reproduced in the running portal first: saving a Container selection with OpenLDAP stopped greyed out the Schema, Partitions & Containers and Matching tabs, and they only came back after the flag was restored.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `docs/configuration/connected-systems.md`
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [ ] No documentation needed

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

`AreSettingValuesComplete` is deliberately a separate public method rather than a flag on the existing one, so that a future caller has to choose between "is this configuration complete?" and "can we reach the target right now?" rather than getting whichever the parameter default happened to be.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfeypW7jcRid2SyWLEDzdp)_