### PR TITLE
Close the coverage gaps around Container Scope as text

### DIFF
--- a/test/JIM.Models.Tests/Staging/ContainerScopeTextImportScopeTests.cs
+++ b/test/JIM.Models.Tests/Staging/ContainerScopeTextImportScopeTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Collections.Generic;
+using System.Linq;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+using JIM.Utilities;
+using NUnit.Framework;
+
+namespace JIM.Models.Tests.Staging;
+
+/// <summary>
+/// What an import actually asks after a Container Scope has been stated as text (#1255 Advanced Mode).
+/// </summary>
+/// <remarks>
+/// The Advanced Mode tests in <c>JIM.Utilities.Tests</c> assert on the flags the text sets, which leaves a seam: an
+/// administrator does not care what <see cref="ConnectedSystemContainer.Selected"/> reads, they care which objects
+/// the next Full Import returns. These join the two halves by putting the text through
+/// <see cref="ContainerScopeText.Apply"/> and then asking <see cref="ConnectedSystemScope"/> the one membership
+/// question import, export and preview all ask, so the chain from authored text to import scope is covered in one
+/// place rather than inferred from two.
+/// </remarks>
+[TestFixture]
+public class ContainerScopeTextImportScopeTests
+{
+    private const string Alice = "CN=Alice,OU=Corp,DC=example,DC=local";
+    private const string SalesBob = "CN=Bob,OU=Sales,OU=Corp,DC=example,DC=local";
+    private const string ServiceAccount = "CN=svc-backup,OU=Service Accounts,OU=Corp,DC=example,DC=local";
+    private const string App1Account = "CN=svc-app1,OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local";
+    private const string Partner = "CN=Pat,OU=Partners,DC=example,DC=local";
+
+    [Test]
+    public void AnIncludeStatedAsText_PutsThatBranchInImportScope()
+    {
+        var connectedSystem = SystemWithContainers();
+
+        var errors = ContainerScopeText.Apply("include OU=Corp,DC=example,DC=local", Partitions(connectedSystem));
+        var scope = ScopeFromCurrentSelection(connectedSystem);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(errors, Is.Empty);
+            Assert.That(scope.Contains(1, Alice), Is.True);
+            Assert.That(scope.Contains(1, SalesBob), Is.True, "a Subtree statement reaches everything beneath it");
+            Assert.That(scope.Contains(1, Partner), Is.False, "the text names OU=Corp and nothing else");
+        }
+    }
+
+    [Test]
+    public void AnExcludeStatedAsText_TakesThatBranchOutOfImportScope()
+    {
+        var connectedSystem = SystemWithContainers();
+
+        ContainerScopeText.Apply(
+            """
+            include OU=Corp,DC=example,DC=local
+            exclude OU=Service Accounts,OU=Corp,DC=example,DC=local
+            """,
+            Partitions(connectedSystem));
+        var scope = ScopeFromCurrentSelection(connectedSystem);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scope.Contains(1, Alice), Is.True);
+            Assert.That(scope.Contains(1, ServiceAccount), Is.False);
+            Assert.That(scope.Contains(1, App1Account), Is.False, "an exclusion reaches every Container beneath it too");
+        }
+    }
+
+    [Test]
+    public void AReInclusionStatedAsText_BringsItsBranchBackIntoImportScope()
+    {
+        // The case the tree expresses by ticking a Container inside a carve-out: whichever statement is nearest to
+        // an object decides its fate, and the text has to reach the same answer.
+        var connectedSystem = SystemWithContainers();
+
+        ContainerScopeText.Apply(
+            """
+            include OU=Corp,DC=example,DC=local
+            exclude OU=Service Accounts,OU=Corp,DC=example,DC=local
+            include OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local
+            """,
+            Partitions(connectedSystem));
+        var scope = ScopeFromCurrentSelection(connectedSystem);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scope.Contains(1, ServiceAccount), Is.False, "the carve-out still stands where nothing overrides it");
+            Assert.That(scope.Contains(1, App1Account), Is.True);
+        }
+    }
+
+    [Test]
+    public void OneLevelStatedAsText_LeavesTheContainersBeneathItOutOfImportScope()
+    {
+        var connectedSystem = SystemWithContainers();
+
+        ContainerScopeText.Apply("include one-level OU=Corp,DC=example,DC=local", Partitions(connectedSystem));
+        var scope = ScopeFromCurrentSelection(connectedSystem);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scope.Contains(1, Alice), Is.True, "objects held directly in OU=Corp are in scope");
+            Assert.That(scope.Contains(1, SalesBob), Is.False, "One Level reaches no Container beneath it");
+        }
+    }
+
+    [Test]
+    public void TextThatNamesNothing_LeavesNothingInImportScope()
+    {
+        // Clearing the text is how a Connected System is taken out of management entirely, and it has to be a
+        // determined "no" rather than an undetermined answer, because that is what a preview counts.
+        var connectedSystem = SystemWithContainers();
+        ContainerScopeText.Apply("include OU=Corp,DC=example,DC=local", Partitions(connectedSystem));
+
+        ContainerScopeText.Apply(string.Empty, Partitions(connectedSystem));
+        var scope = ScopeFromCurrentSelection(connectedSystem);
+
+        Assert.That(scope.Contains(1, Alice), Is.False);
+    }
+
+    [Test]
+    public void TextRefused_LeavesImportScopeExactlyAsItWas()
+    {
+        // The point of applying all-or-nothing: a refused text must not have moved a single object in or out of
+        // scope, since a scope applied halfway obsoletes objects nobody asked to obsolete.
+        var connectedSystem = SystemWithContainers();
+        ContainerScopeText.Apply("include OU=Corp,DC=example,DC=local", Partitions(connectedSystem));
+
+        var errors = ContainerScopeText.Apply(
+            """
+            include OU=Partners,DC=example,DC=local
+            exclude OU=Contractors,DC=example,DC=local
+            """,
+            Partitions(connectedSystem));
+        var scope = ScopeFromCurrentSelection(connectedSystem);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(errors, Has.Count.EqualTo(1));
+            Assert.That(scope.Contains(1, Alice), Is.True, "the selection the refused text would have replaced still stands");
+            Assert.That(scope.Contains(1, Partner), Is.False, "and the refused text's own first line was not applied either");
+        }
+    }
+
+    #region Helpers
+
+    private static IReadOnlyList<ConnectedSystemPartition> Partitions(ConnectedSystem connectedSystem) =>
+        [.. connectedSystem.Partitions!];
+
+    /// <summary>
+    /// The scope as the import would build it: from the Connected System's own flags, which is what the text has
+    /// just written, rather than from a proposal built by the test.
+    /// </summary>
+    private static ConnectedSystemScope ScopeFromCurrentSelection(ConnectedSystem connectedSystem)
+    {
+        var containers = (connectedSystem.Partitions ?? [])
+            .SelectMany(ContainerSelectionEditor.Flatten)
+            .ToList();
+
+        return ConnectedSystemScope.From(
+            connectedSystem,
+            new ConnectedSystemScopeSelectionProposal(
+                (connectedSystem.Partitions ?? []).Where(p => p.Selected).Select(p => p.Id).ToList(),
+                containers.Where(c => c.Selected).Select(c => c.Id).ToList(),
+                containers.Where(c => c.Excluded).Select(c => c.Id).ToList()),
+            DistinguishedNameContainment.Instance);
+    }
+
+    /// <summary>
+    /// DC=example,DC=local holding OU=Corp (with OU=Sales, and OU=Service Accounts holding OU=App1) and a sibling
+    /// OU=Partners: enough to express a carve-out, a re-inclusion inside it, and something outside the selection.
+    /// </summary>
+    private static ConnectedSystem SystemWithContainers()
+    {
+        var app1 = Container(13, "OU=App1,OU=Service Accounts,OU=Corp,DC=example,DC=local");
+        var serviceAccounts = Container(14, "OU=Service Accounts,OU=Corp,DC=example,DC=local");
+        serviceAccounts.AddChildContainer(app1);
+
+        var sales = Container(11, "OU=Sales,OU=Corp,DC=example,DC=local");
+        var corp = Container(10, "OU=Corp,DC=example,DC=local");
+        corp.AddChildContainer(sales);
+        corp.AddChildContainer(serviceAccounts);
+
+        var partners = Container(12, "OU=Partners,DC=example,DC=local");
+
+        var partition = new ConnectedSystemPartition
+        {
+            Id = 1,
+            Name = "example.local",
+            ExternalId = "DC=example,DC=local",
+            Selected = true,
+            Containers = [corp, partners]
+        };
+        corp.Partition = partition;
+        partners.Partition = partition;
+
+        return new ConnectedSystem
+        {
+            Name = "Test Directory",
+            ConnectorDefinition = new ConnectorDefinition { Name = "Test Connector", SupportsPartitionContainers = true },
+            Partitions = [partition]
+        };
+    }
+
+    private static ConnectedSystemContainer Container(int id, string externalId) =>
+        new() { Id = id, Name = externalId.Split(',')[0][3..], ExternalId = externalId };
+
+    #endregion
+}

--- a/test/JIM.Utilities.Tests/ContainerScopeTextTests.cs
+++ b/test/JIM.Utilities.Tests/ContainerScopeTextTests.cs
@@ -362,6 +362,99 @@ public class ContainerScopeTextTests
     }
 
     [Test]
+    public void Apply_APathWithAnEscapedSeparator_ResolvesDespiteTheOptionalWhitespace()
+    {
+        // The paste-from-elsewhere case where the Container's own name contains a comma: the whitespace after the
+        // real separator is dropped, and the whitespace inside the name is kept.
+        var partition = HierarchyWithAnEscapedSeparator();
+
+        var errors = ContainerScopeText.Apply(@"include OU=Sales\, EMEA, OU=Corp", [partition]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(errors, Is.Empty);
+            Assert.That(Find(partition, "Sales EMEA").Selected, Is.True);
+        }
+    }
+
+    [Test]
+    public void Apply_APathDifferingOnlyInsideAnEscapedName_ResolvesToNoContainer()
+    {
+        // The space after an escaped comma is part of the Container's name, so "OU=Sales\,EMEA" and
+        // "OU=Sales\, EMEA" are two different Containers and neither may stand in for the other. This is the only
+        // shape that can prove it: the authored path and the stored one go through the same normalisation, so an
+        // error applied to both cancels out everywhere except where the two names genuinely differ.
+        var partition = HierarchyWithAnEscapedSeparator();
+
+        var errors = ContainerScopeText.Apply(@"include OU=Sales\,EMEA,OU=Corp", [partition]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(errors, Has.Count.EqualTo(1), "a Container that is not there is an error, not a near-enough match");
+            Assert.That(Find(partition, "Sales EMEA").Selected, Is.False);
+        }
+    }
+
+    [Test]
+    public void Project_AContainerWithAnEscapedSeparator_WritesAPathThatResolvesBack()
+    {
+        var partition = HierarchyWithAnEscapedSeparator();
+        Find(partition, "Sales EMEA").Selected = true;
+
+        var text = ContainerScopeText.Project([partition]);
+        var reapplied = HierarchyWithAnEscapedSeparator();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ContainerScopeText.Apply(text, [reapplied]), Is.Empty);
+            Assert.That(Find(reapplied, "Sales EMEA").Selected, Is.True);
+        }
+    }
+
+    [Test]
+    public void Apply_ContainersInDifferentPartitions_StatesBothInOneText()
+    {
+        // The text covers a Connected System, not a partition, so a path is resolved against every partition's
+        // hierarchy and each one it names is selected along with the Containers in it.
+        var first = HierarchyWithServiceAccounts();
+        var second = PartitionWithArchive();
+        second.Selected = false;
+
+        var errors = ContainerScopeText.Apply(
+            """
+            include OU=Corp
+            include OU=Archive
+            """,
+            [first, second]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(errors, Is.Empty);
+            Assert.That(Find(first, "Corp").Selected, Is.True);
+            Assert.That(Find(second, "Archive").Selected, Is.True);
+            Assert.That(second.Selected, Is.True, "naming a Container selects the partition holding it, in either partition");
+        }
+    }
+
+    [Test]
+    public void Apply_TextNamingOnlyTheOtherPartition_ClearsTheFirstOne()
+    {
+        // The whole-scope rule has to hold across partitions too: a Container omitted from the text states nothing,
+        // wherever it lives, or an administrator restating one partition would silently keep another's selection.
+        var first = HierarchyWithServiceAccounts();
+        var second = PartitionWithArchive();
+        Find(first, "Corp").Selected = true;
+
+        ContainerScopeText.Apply("include OU=Archive", [first, second]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Find(first, "Corp").Selected, Is.False);
+            Assert.That(Find(second, "Archive").Selected, Is.True);
+        }
+    }
+
+    [Test]
     public void Apply_EmptyText_ClearsEveryStatement()
     {
         var partition = HierarchyWithServiceAccounts();
@@ -456,6 +549,46 @@ public class ContainerScopeTextTests
         var serviceAccounts = Container("Service Accounts", "OU=Service Accounts,OU=Corp", [app1]);
         var sales = Container("Sales", "OU=Sales,OU=Corp");
         var corp = Container("Corp", "OU=Corp", [sales, serviceAccounts]);
+
+        var partition = new ConnectedSystemPartition
+        {
+            Id = _nextId++,
+            Name = "DC=example,DC=com",
+            Selected = true,
+            Containers = [corp]
+        };
+
+        corp.Partition = partition;
+        return partition;
+    }
+
+    /// <summary>
+    /// A second partition, holding OU=Archive: enough to show that the text states a Connected System's scope
+    /// rather than one partition's.
+    /// </summary>
+    private ConnectedSystemPartition PartitionWithArchive()
+    {
+        var archive = Container("Archive", "OU=Archive");
+
+        var partition = new ConnectedSystemPartition
+        {
+            Id = _nextId++,
+            Name = "DC=archive,DC=example,DC=com",
+            Selected = true,
+            Containers = [archive]
+        };
+
+        archive.Partition = partition;
+        return partition;
+    }
+
+    /// <summary>
+    /// A hierarchy holding a Container whose own name contains a comma, escaped as RFC 4514 requires.
+    /// </summary>
+    private ConnectedSystemPartition HierarchyWithAnEscapedSeparator()
+    {
+        var salesEmea = Container("Sales EMEA", @"OU=Sales\, EMEA,OU=Corp");
+        var corp = Container("Corp", "OU=Corp", [salesEmea]);
 
         var partition = new ConnectedSystemPartition
         {

--- a/test/JIM.Worker.Tests/Servers/ContainerScopeTextUpdateDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ContainerScopeTextUpdateDatabaseTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Models.Core;
+using JIM.Models.Staging;
+using JIM.PostgresData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Real-PostgreSQL verification that Container Scope stated as text (#1255 Advanced Mode) actually reaches the
+/// database, from a host configured the way the portal and the REST API are.
+/// </summary>
+/// <remarks>
+/// The REST tests around this endpoint mock the repository, so they prove the controller calls the server and not
+/// that a row changes. That gap matters here more than most: three of JIM's four hosts run the DbContext
+/// <c>NoTracking</c> (JIM.Web, JIM.Scheduler, and <c>JimDbContext</c>'s own default), and a mutating path that
+/// assumes it was handed a tracked entity does nothing at all from those hosts while reporting success. Applying a
+/// scope writes a flag per Container across a loaded graph, which is exactly the shape that fails that way, and the
+/// in-memory provider tracks by default so the whole unit suite passes regardless.
+///
+/// Opt-in via the same <c>JIM_TEST_RESET_*</c> environment variables as the other real-database fixtures; ignored
+/// when <c>JIM_TEST_RESET_DB</c> is absent.
+/// </remarks>
+[TestFixture]
+[Category("RequiresPostgres")]
+public class ContainerScopeTextUpdateDatabaseTests
+{
+    private string _connectionString = null!;
+
+    // NoTracking, matching JIM.Web (JIM.Web/Program.cs) and JimDbContext's own default. A tracking context hides
+    // the whole class of fault this fixture exists to guard.
+    private JimDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseNpgsql(_connectionString)
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new JimDbContext(options);
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var dbName = Environment.GetEnvironmentVariable("JIM_TEST_RESET_DB");
+        if (string.IsNullOrEmpty(dbName))
+            Assert.Ignore("JIM_TEST_RESET_DB not set; skipping real-PostgreSQL Container Scope text tests.");
+
+        var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
+        var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
+        var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
+
+        using var ctx = NewContext();
+        ctx.Database.Migrate();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(@"
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+                FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '__EFMigrationsHistory') LOOP
+                    EXECUTE 'TRUNCATE TABLE ""' || r.tablename || '"" RESTART IDENTITY CASCADE';
+                END LOOP;
+            END $$;");
+    }
+
+    [Test]
+    public async Task ApplyContainerScopeTextAsync_PersistsTheSelectionAndTheExclusionAsync()
+    {
+        var (connectedSystemId, initiatorId) = await SeedConnectedSystemAsync();
+
+        await using (var applyContext = NewContext())
+        {
+            var jim = new JimApplication(new PostgresDataRepository(applyContext));
+            var result = await jim.ConnectedSystems.ApplyContainerScopeTextAsync(
+                connectedSystemId,
+                """
+                include OU=Corp,DC=example,DC=local
+                exclude OU=Service Accounts,OU=Corp,DC=example,DC=local
+                """,
+                await InitiatorAsync(applyContext, initiatorId));
+
+            Assert.That(result?.Applied, Is.True, "the text is valid, so it must have been applied");
+        }
+
+        await using var verify = NewContext();
+        var corp = await verify.ConnectedSystemContainers.SingleAsync(c => c.ExternalId == "OU=Corp,DC=example,DC=local");
+        var serviceAccounts = await verify.ConnectedSystemContainers.SingleAsync(c => c.ExternalId == "OU=Service Accounts,OU=Corp,DC=example,DC=local");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(corp.Selected, Is.True, "a scope that reports success and writes no row is the silent no-op this fixture guards");
+            Assert.That(corp.Excluded, Is.False);
+            Assert.That(serviceAccounts.Excluded, Is.True);
+            Assert.That(serviceAccounts.Selected, Is.False);
+        }
+    }
+
+    [Test]
+    public async Task ApplyContainerScopeTextAsync_OmittingAContainer_ClearsItsStoredSelectionAsync()
+    {
+        // The whole-scope rule has to survive the round trip to the database: a Container the text no longer names
+        // must come back deselected, not left set from the previous text.
+        var (connectedSystemId, initiatorId) = await SeedConnectedSystemAsync();
+
+        await using (var first = NewContext())
+        {
+            var jim = new JimApplication(new PostgresDataRepository(first));
+            await jim.ConnectedSystems.ApplyContainerScopeTextAsync(
+                connectedSystemId, "include OU=Sales,OU=Corp,DC=example,DC=local", await InitiatorAsync(first, initiatorId));
+        }
+
+        await using (var second = NewContext())
+        {
+            var jim = new JimApplication(new PostgresDataRepository(second));
+            await jim.ConnectedSystems.ApplyContainerScopeTextAsync(
+                connectedSystemId, "include OU=Corp,DC=example,DC=local", await InitiatorAsync(second, initiatorId));
+        }
+
+        await using var verify = NewContext();
+        var sales = await verify.ConnectedSystemContainers.SingleAsync(c => c.ExternalId == "OU=Sales,OU=Corp,DC=example,DC=local");
+        var corp = await verify.ConnectedSystemContainers.SingleAsync(c => c.ExternalId == "OU=Corp,DC=example,DC=local");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sales.Selected, Is.False, "the second text does not name OU=Sales, so it states nothing about it");
+            Assert.That(corp.Selected, Is.True);
+        }
+    }
+
+    [Test]
+    public async Task ApplyContainerScopeTextAsync_ARefusedText_LeavesTheStoredScopeUntouchedAsync()
+    {
+        var (connectedSystemId, initiatorId) = await SeedConnectedSystemAsync();
+
+        await using (var first = NewContext())
+        {
+            var jim = new JimApplication(new PostgresDataRepository(first));
+            await jim.ConnectedSystems.ApplyContainerScopeTextAsync(
+                connectedSystemId, "include OU=Corp,DC=example,DC=local", await InitiatorAsync(first, initiatorId));
+        }
+
+        await using (var refused = NewContext())
+        {
+            var jim = new JimApplication(new PostgresDataRepository(refused));
+            var result = await jim.ConnectedSystems.ApplyContainerScopeTextAsync(
+                connectedSystemId,
+                """
+                include OU=Sales,OU=Corp,DC=example,DC=local
+                exclude OU=Contractors,DC=example,DC=local
+                """,
+                await InitiatorAsync(refused, initiatorId));
+
+            Assert.That(result?.Applied, Is.False, "line 2 names no Container");
+        }
+
+        await using var verify = NewContext();
+        var corp = await verify.ConnectedSystemContainers.SingleAsync(c => c.ExternalId == "OU=Corp,DC=example,DC=local");
+        var sales = await verify.ConnectedSystemContainers.SingleAsync(c => c.ExternalId == "OU=Sales,OU=Corp,DC=example,DC=local");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(corp.Selected, Is.True, "the stored scope the refused text would have replaced still stands");
+            Assert.That(sales.Selected, Is.False, "and the refused text's own first line reached no row");
+        }
+    }
+
+    [Test]
+    public async Task GetContainerScopeTextAsync_ReadsBackWhatWasAppliedAsync()
+    {
+        // The round trip that makes the text safe to edit and re-send: what a read returns has to be what the
+        // previous write left behind, resolved from rows rather than from anything the write kept in memory.
+        var (connectedSystemId, initiatorId) = await SeedConnectedSystemAsync();
+
+        await using (var apply = NewContext())
+        {
+            var jim = new JimApplication(new PostgresDataRepository(apply));
+            await jim.ConnectedSystems.ApplyContainerScopeTextAsync(
+                connectedSystemId,
+                """
+                include one-level OU=Corp,DC=example,DC=local
+                include OU=Sales,OU=Corp,DC=example,DC=local
+                """,
+                await InitiatorAsync(apply, initiatorId));
+        }
+
+        await using var read = NewContext();
+        var readJim = new JimApplication(new PostgresDataRepository(read));
+        var text = await readJim.ConnectedSystems.GetContainerScopeTextAsync(connectedSystemId);
+
+        Assert.That(text, Is.EqualTo(
+            """
+            include one-level OU=Corp,DC=example,DC=local
+            include OU=Sales,OU=Corp,DC=example,DC=local
+            """));
+    }
+
+    /// <summary>
+    /// The administrator the change is attributed to, read on the context that will perform the save.
+    /// </summary>
+    private static async Task<MetaverseObject> InitiatorAsync(JimDbContext context, Guid initiatorId) =>
+        await context.MetaverseObjects.SingleAsync(o => o.Id == initiatorId);
+
+    /// <summary>
+    /// A Connected System with one partition holding OU=Corp, and OU=Sales plus OU=Service Accounts beneath it.
+    /// </summary>
+    private async Task<(int ConnectedSystemId, Guid InitiatorId)> SeedConnectedSystemAsync()
+    {
+        await using var seed = NewContext();
+
+        var connectorDefinition = new ConnectorDefinition
+        {
+            Name = "Test LDAP Connector",
+            SupportsPartitions = true,
+            SupportsPartitionContainers = true
+        };
+
+        var setting = new ConnectorDefinitionSetting { Name = "Host", Type = ConnectedSystemSettingType.String };
+        connectorDefinition.Settings.Add(setting);
+
+        var connectedSystem = new ConnectedSystem
+        {
+            Name = "Test Directory",
+            ConnectorDefinition = connectorDefinition,
+            SettingValues = [new ConnectedSystemSettingValue { Setting = setting, StringValue = "directory.example.local" }]
+        };
+
+        var sales = new ConnectedSystemContainer { Name = "Sales", ExternalId = "OU=Sales,OU=Corp,DC=example,DC=local" };
+        var serviceAccounts = new ConnectedSystemContainer { Name = "Service Accounts", ExternalId = "OU=Service Accounts,OU=Corp,DC=example,DC=local" };
+        var corp = new ConnectedSystemContainer { Name = "Corp", ExternalId = "OU=Corp,DC=example,DC=local" };
+        corp.AddChildContainer(sales);
+        corp.AddChildContainer(serviceAccounts);
+
+        var partition = new ConnectedSystemPartition
+        {
+            Name = "example.local",
+            ExternalId = "DC=example,DC=local",
+            Selected = true,
+            ConnectedSystem = connectedSystem,
+            Containers = [corp]
+        };
+        corp.Partition = partition;
+
+        // Applying a scope is a configuration change, and JIM records one against a security principal or not at
+        // all, so the fixture has to carry an administrator for the Activity to be attributed to.
+        var userType = new MetaverseObjectType { Name = "User", PluralName = "Users", BuiltIn = true };
+        var initiator = new MetaverseObject { Type = userType, CachedDisplayName = "Test Administrator" };
+
+        seed.ConnectedSystems.Add(connectedSystem);
+        seed.ConnectedSystemPartitions.Add(partition);
+        seed.MetaverseObjectTypes.Add(userType);
+        seed.MetaverseObjects.Add(initiator);
+        await seed.SaveChangesAsync();
+
+        return (connectedSystem.Id, initiator.Id);
+    }
+}


### PR DESCRIPTION
## Description

Advanced Mode (#1255, merged in #1367) shipped with 45 tests, every one of which asserts on the flags the text sets. Three things that matters for were not covered. Test-only; no production code changes.

- **The chain from authored text to import scope.** An administrator does not care what `Selected` reads, they care which objects the next Full Import returns, and nothing joined the two halves: the text's own tests stop at the flags, and the scope engine's tests start from a proposal built by hand. `ContainerScopeTextImportScopeTests` puts text through `ContainerScopeText.Apply` and then asks `ConnectedSystemScope` the one membership question import, export and preview all ask, covering include, exclude, re-inclusion beneath a carve-out, `one-level`, empty text, and that a refused text moves no object in or out of scope.
- **The save path, on a real database, from a host configured as the portal and the REST API are.** The REST tests mock the repository, so they prove the controller calls the server rather than that a row changes. Three of JIM's four hosts run the DbContext `NoTracking`, and a mutating path that assumes a tracked entity does nothing at all from those hosts while reporting success, which the in-memory provider structurally cannot catch. `ContainerScopeTextUpdateDatabaseTests` is `RequiresPostgres` on a `NoTracking` context, covering persistence, the whole-scope rule surviving a round trip, a refused text leaving stored rows untouched, and a read returning what the write left behind.
- **Two parser cases.** Container Scope across more than one partition, since the text states a Connected System's scope rather than a partition's; and a path whose Container name contains an escaped comma.

## Type of change

- [x] Other: test coverage for functionality already merged

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors (and zero warnings)
- [x] `dotnet test JIM.sln` passes (7,745 tests)
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] `RequiresPostgres` tests run green against a real PostgreSQL 17 database

**Every new test was checked against a deliberately broken implementation, because a test written after the code it covers can pass for the wrong reason.**

- The four database tests all fail with the `persistAsync` call removed from `ApplyContainerScopeTextAsync`, and all pass with it restored. That is the silent-no-op class the fixture exists for.
- The escaped-comma test was written twice. The first version passed with the branch it covers deliberately broken, because the authored path and the stored `ExternalId` go through the same normalisation, so an error applied to both cancels out. Only a path that differs from the stored one *where the escape matters* can discriminate: `OU=Sales\,EMEA` must not resolve to the Container named `OU=Sales\, EMEA`, since the space after an escaped comma is part of the name. That shape fails against the broken branch and is what shipped.

## Documentation

- [x] No documentation needed

<!-- Docs: n/a - test-only change; the feature's own documentation landed with #1367 -->

## Additional context

Deliberately not added: an integration-suite scenario driving a real import against a text-applied scope. The first bullet's tests cover the same seam through `ConnectedSystemScope`, which is the object the import actually asks, so the marginal value of a Docker-bound scenario is low against its cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfeypW7jcRid2SyWLEDzdp)_