### PR TITLE
Judge an integration scenario by its own verdict, not a stale exit code (#1382)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       shell: pwsh
       run: |
         $config = New-PesterConfiguration
-        $config.Run.Path = @("./src/JIM.PowerShell/Tests", "./scripts/Tests")
+        $config.Run.Path = @("./src/JIM.PowerShell/Tests", "./scripts/Tests", "./test/integration/utils")
         $config.Run.Exit = $true
         $config.Output.Verbosity = "Detailed"
         $config.TestResult.Enabled = $true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           Install-Module -Name Pester -MinimumVersion 5.0 -Force -Scope CurrentUser
           $config = New-PesterConfiguration
-          $config.Run.Path = @('./src/JIM.PowerShell/Tests', './scripts/Tests')
+          $config.Run.Path = @('./src/JIM.PowerShell/Tests', './scripts/Tests', './test/integration/utils')
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'
           Invoke-Pester -Configuration $config

--- a/test/integration/Run-IntegrationTests.ps1
+++ b/test/integration/Run-IntegrationTests.ps1
@@ -299,6 +299,7 @@ Assert-PrimaryCheckout -RepoRoot $repoRoot -Allow:$AllowWorktree -ScriptName "th
 # Import helpers early so Get-DirectoryConfig is available
 . "$scriptRoot/utils/Test-Helpers.ps1"
 . "$scriptRoot/utils/Initialize-WorkerLogDirectories.ps1"
+. "$scriptRoot/utils/Invoke-IntegrationScenario.ps1"
 
 # Hydrate JIM_BENCH_* from .env when not already set in the process environment.
 # .env is the canonical config surface for the project, but Docker Compose only
@@ -3288,8 +3289,12 @@ $errWatcher = Start-JimErrorWatcher -SentinelPath $errWatcherSentinel -Since $st
 $env:JIM_RUNPROFILE_ABORT_SENTINEL = $errWatcherSentinel
 
 try {
-    & $scenarioScript @scenarioParams
-    $scenarioExitCode = $LASTEXITCODE
+    # Not `& $scenarioScript; $scenarioExitCode = $LASTEXITCODE`. PowerShell does not set
+    # $LASTEXITCODE for a .ps1 that returns rather than exits, so that read picked up
+    # whatever the last native command inside the scenario had left behind and the
+    # scenario's own verdict was never consulted. See Invoke-IntegrationScenario and #1382.
+    $scenarioOutcome = Invoke-IntegrationScenario -Path $scenarioScript -Parameters $scenarioParams
+    $scenarioExitCode = $scenarioOutcome.ExitCode
 }
 catch {
     $scenarioExitCode = 1

--- a/test/integration/scenarios/Invoke-Scenario11-ScopingCriteriaMatrix.ps1
+++ b/test/integration/scenarios/Invoke-Scenario11-ScopingCriteriaMatrix.ps1
@@ -717,3 +717,14 @@ Write-Host "  Result: $(if ($overallPass) { 'PASS' } else { 'FAIL' })" -Foregrou
 if (-not $overallPass) {
     throw "Scenario 11 failed: $cellFail cell(s) and $roundTripFail round-trip case(s) did not match expected results."
 }
+
+# The runner reads this rather than $LASTEXITCODE, which a scenario that returns instead of
+# exiting cannot set; without it the verdict would be whatever the last native command left
+# behind. See utils/Invoke-IntegrationScenario.ps1 and #1382.
+return @{
+    Scenario  = "Scoping Criteria Matrix"
+    Tier      = $activeTier
+    Cells     = $cellPass
+    RoundTrip = $roundTripPass
+    Success   = $overallPass
+}

--- a/test/integration/scenarios/Invoke-Scenario6-SchedulerService.ps1
+++ b/test/integration/scenarios/Invoke-Scenario6-SchedulerService.ps1
@@ -988,4 +988,10 @@ $testSchedules = Get-JIMSchedule -Name "Integration Test*"
 foreach ($schedule in $testSchedules) {
     Disable-JIMSchedule -Id $schedule.id -ErrorAction SilentlyContinue
 }
+
+# The runner reads this rather than $LASTEXITCODE, which a scenario that returns instead of
+# exiting cannot set; without it the verdict would be whatever the last native command left
+# behind. It matters most under -ContinueOnError, where a failed run reaches here rather than
+# exiting above. See utils/Invoke-IntegrationScenario.ps1 and #1382.
+return $testResults
 Write-Host "Test schedules disabled (not deleted)." -ForegroundColor DarkGray

--- a/test/integration/utils/Initialize-WorkerLogDirectories.Tests.ps1
+++ b/test/integration/utils/Initialize-WorkerLogDirectories.Tests.ps1
@@ -55,7 +55,10 @@ Describe 'Initialize-WorkerLogDirectories' {
         (& stat -c '%a' $script:workerDir).Trim() | Should -Be '777'
     }
 
-    It 'throws an actionable error when a directory cannot be made writable' -Skip:(-not ($IsLinux -or $IsMacOS)) {
+    # Skipped for root as well as for Windows: uid 0 writes through the 0500 parent this test
+    # relies on, so the probe never fails and no exception is thrown. See the sibling
+    # Test-PathWritable test for the same guard.
+    It 'throws an actionable error when a directory cannot be made writable' -Skip:(-not ($IsLinux -or $IsMacOS) -or ((& id -u) -eq '0')) {
         # Mirror the real failure: the directories already exist (as they would after a
         # non-runner stack-up) but the parent is not writable by the current user. We cannot
         # reproduce true root-ownership without sudo, so a 0500 parent stands in; it exercises
@@ -84,7 +87,10 @@ Describe 'Test-PathWritable' {
         Test-PathWritable -Path $script:tempDir | Should -BeTrue
     }
 
-    It 'returns false for a non-writable directory' -Skip:(-not ($IsLinux -or $IsMacOS)) {
+    # Also skipped for root, which bypasses the permission bits entirely: chmod 0500 does not
+    # stop uid 0 writing, so the assertion is not merely untestable there but actively wrong.
+    # The cloud sandbox runs as root; CI and the devcontainer do not.
+    It 'returns false for a non-writable directory' -Skip:(-not ($IsLinux -or $IsMacOS) -or ((& id -u) -eq '0')) {
         & chmod 0500 $script:tempDir 2>$null
         Test-PathWritable -Path $script:tempDir | Should -BeFalse
     }

--- a/test/integration/utils/Invoke-IntegrationScenario.Tests.ps1
+++ b/test/integration/utils/Invoke-IntegrationScenario.Tests.ps1
@@ -1,0 +1,200 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for Invoke-IntegrationScenario, which decides whether an integration
+    scenario passed.
+
+.DESCRIPTION
+    Guards the verdict the integration test runner reports. Before #1382 the runner read
+    $LASTEXITCODE straight after calling the scenario with the call operator, which
+    PowerShell does not set for a .ps1 that returns rather than exits. The value that
+    survived was whatever the last native command inside the scenario had left, so
+    Scenario 16 printed "Result: PASS" and the run exited 1 because SQL*Plus had exited 1.
+
+    The reverse is the costlier direction and is covered here too: a scenario that fails
+    without throwing must not be reported as a pass just because its last native call
+    happened to return 0.
+
+    Each test writes a real scenario script to disk and runs it, rather than mocking the
+    invocation, because the defect lives in how PowerShell propagates exit codes across
+    the call operator and a mock would not reproduce it.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot/Invoke-IntegrationScenario.ps1"
+
+    $script:scenarioRoot = Join-Path ([System.IO.Path]::GetTempPath()) "jim-scenario-outcome-$([System.Guid]::NewGuid())"
+    New-Item -ItemType Directory -Path $script:scenarioRoot -Force | Out-Null
+
+    # Writes a scenario script and hands back its path. Every scenario body here starts by
+    # running a native command that exits non-zero, which is what a real scenario does when
+    # it shells out to sqlplus, docker or psql on its way to a perfectly good result.
+    function New-TestScenario {
+        param(
+            [Parameter(Mandatory = $true)][string]$Name,
+            [Parameter(Mandatory = $true)][string]$Body,
+            [switch]$NoDirtyExitCode
+        )
+
+        $preamble = if ($NoDirtyExitCode) { '' } else {
+            '& pwsh -NoProfile -Command "exit 1" | Out-Null' + [Environment]::NewLine
+        }
+
+        $path = Join-Path $script:scenarioRoot "$Name.ps1"
+        Set-Content -LiteralPath $path -Value ($preamble + $Body) -Encoding utf8
+        return $path
+    }
+}
+
+AfterAll {
+    if (Test-Path $script:scenarioRoot) {
+        Remove-Item -LiteralPath $script:scenarioRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Invoke-IntegrationScenario' {
+
+    Context 'when the scenario returns a result object' {
+
+        It 'reports success even though an internal native command exited non-zero' {
+            # This is #1382 exactly: Scenario 16 against Oracle.
+            $path = New-TestScenario -Name 'ReturnsSuccess' -Body @'
+Write-Host "  Result: PASS"
+return @{ Scenario = "Fake"; Success = $true }
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 0
+        }
+
+        It 'reports failure when the object says so, whatever the exit code holds' {
+            # The costlier direction: a scenario that fails without throwing must not pass
+            # just because its last native call returned 0.
+            $path = New-TestScenario -Name 'ReturnsFailure' -NoDirtyExitCode -Body @'
+& pwsh -NoProfile -Command "exit 0" | Out-Null
+Write-Host "  Result: FAIL"
+return @{ Scenario = "Fake"; Success = $false }
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 1
+        }
+
+        It 'hands the result object back to the caller' {
+            $path = New-TestScenario -Name 'ReturnsDetail' -Body @'
+return @{ Scenario = "Fake"; Cells = @("a", "b"); Success = $true }
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.Result.Scenario | Should -Be 'Fake'
+            $outcome.Result.Cells.Count | Should -Be 2
+        }
+
+        It 'accepts a PSCustomObject result as readily as a hashtable' {
+            $path = New-TestScenario -Name 'ReturnsPsCustomObject' -Body @'
+return [PSCustomObject]@{ Scenario = "Fake"; Success = $false }
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 1
+        }
+    }
+
+    Context 'when the scenario exits' {
+
+        It 'reports the code the scenario exited with' {
+            $path = New-TestScenario -Name 'ExitsThree' -NoDirtyExitCode -Body @'
+Write-Host "  giving up"
+exit 3
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 3
+        }
+
+        It 'reports success when the scenario exits zero after a dirty native call' {
+            $path = New-TestScenario -Name 'ExitsZero' -Body @'
+exit 0
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 0
+        }
+    }
+
+    Context 'when the scenario neither returns a result object nor exits' {
+
+        It 'is not coloured by an exit code left over from before the scenario started' {
+            $path = New-TestScenario -Name 'ReturnsNothingCleanly' -NoDirtyExitCode -Body @'
+Write-Host "  Result: PASS"
+'@
+            $global:LASTEXITCODE = 1
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 0
+        }
+
+        It 'falls back to the exit code, which is why a returning scenario must return a result object' {
+            # Pinning the one case the function cannot get right, so that the next person to
+            # read it knows it is a known limit rather than an oversight. A scenario that
+            # returns normally leaves $LASTEXITCODE holding whatever its last native call
+            # set, and PowerShell offers no way to tell that apart from a genuine exit 1.
+            # The remedy is the contract, not a cleverer heuristic: Scenario 6 and Scenario
+            # 11 were given result objects so that nothing relies on this path.
+            $path = New-TestScenario -Name 'ReturnsNothingAfterDirtyCall' -Body @'
+Write-Host "  Result: PASS"
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path
+
+            $outcome.ExitCode | Should -Be 1
+        }
+    }
+
+    Context 'when the scenario throws' {
+
+        It 'lets the exception reach the caller so the runner can report it' {
+            $path = New-TestScenario -Name 'Throws' -Body @'
+throw "Scenario 11 failed: 2 cell(s) did not match expected results."
+'@
+
+            { Invoke-IntegrationScenario -Path $path } | Should -Throw '*did not match expected results*'
+        }
+    }
+
+    Context 'output' {
+
+        It 'passes the scenario parameters through' {
+            $path = New-TestScenario -Name 'TakesParameters' -NoDirtyExitCode -Body @'
+param([string]$Template, [string]$Provider)
+return @{ Success = ($Template -eq "Nano" -and $Provider -eq "Oracle") }
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path -Parameters @{ Template = 'Nano'; Provider = 'Oracle' }
+
+            $outcome.ExitCode | Should -Be 0
+        }
+
+        It 'still emits the scenario output that is not the result object' {
+            $path = New-TestScenario -Name 'WritesOutput' -NoDirtyExitCode -Body @'
+Write-Output "a line the operator needs to see"
+return @{ Success = $true }
+'@
+
+            $emitted = Invoke-IntegrationScenario -Path $path 6>&1 | Out-String
+
+            $emitted | Should -BeLike '*a line the operator needs to see*'
+        }
+    }
+}

--- a/test/integration/utils/Invoke-IntegrationScenario.ps1
+++ b/test/integration/utils/Invoke-IntegrationScenario.ps1
@@ -1,0 +1,98 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Runs an integration scenario script and works out whether it passed.
+
+.DESCRIPTION
+    The runner used to read $LASTEXITCODE straight after calling the scenario with the call
+    operator. PowerShell does not set $LASTEXITCODE for a .ps1 that returns rather than
+    exits, so the value that survived was whatever the last native command inside the
+    scenario had left behind. Scenario 16 against Oracle printed "Result: PASS" and the run
+    exited 1, because it reaches Oracle through docker exec ... sqlplus and SQL*Plus had
+    exited 1. The same scenario against SQL Server exited 0, which made it look like an
+    Oracle quirk rather than the general defect it is (#1382).
+
+    The costlier direction is the reverse: a scenario that fails without throwing and
+    without exiting would be reported as a pass whenever its last native call returned 0.
+
+    A scenario therefore signals its outcome in exactly one of three ways, and this
+    function reads them in that order of authority:
+
+      1. It throws. The exception is left to propagate so the runner reports it.
+      2. It returns a result object carrying a Success property. That is the scenario's own
+         verdict and beats anything $LASTEXITCODE holds.
+      3. It calls exit. PowerShell does set $LASTEXITCODE for that, reliably, and it
+         overwrites any stray code from within the scenario.
+
+    A scenario that returns normally without a result object is left with case 3's answer,
+    which is the one case that can still inherit a stray code. That is why every scenario
+    which returns rather than exits must return a result object; Scenario 6 and Scenario 11
+    were changed alongside this function so that none currently relies on it.
+#>
+
+function Invoke-IntegrationScenario {
+    [CmdletBinding()]
+    param(
+        # The scenario script to run.
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        # Splatted to the scenario script.
+        [Parameter(Mandatory = $false)]
+        [hashtable]$Parameters = @{}
+    )
+
+    # Nothing the runner did during setup should be able to colour the scenario's verdict.
+    $global:LASTEXITCODE = 0
+
+    # Collected through a list rather than a variable assignment because the ForEach-Object
+    # block runs in its own scope; a method call on an object resolved from this scope works
+    # regardless. Everything that is not the result object is passed straight back out, so
+    # the scenario's output still streams to the operator as it is produced.
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    & $Path @Parameters | ForEach-Object {
+        if (Test-ScenarioResultObject -Candidate $_) { $results.Add($_) } else { $_ }
+    }
+
+    $exitCode = $LASTEXITCODE
+    $result = if ($results.Count -gt 0) { $results[$results.Count - 1] } else { $null }
+
+    if ($null -ne $result) {
+        $exitCode = if ($result.Success) { 0 } else { 1 }
+    }
+
+    return @{
+        ExitCode = $exitCode
+        Result   = $result
+    }
+}
+
+<#
+.SYNOPSIS
+    Tells a scenario's result object apart from its ordinary output.
+
+.DESCRIPTION
+    Scenarios return either a hashtable (Scenario 16) or a PSCustomObject, so both shapes
+    are recognised. The Success property is what makes an object a verdict rather than a
+    piece of output that happens to be a dictionary.
+#>
+function Test-ScenarioResultObject {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Candidate
+    )
+
+    if ($null -eq $Candidate) { return $false }
+
+    if ($Candidate -is [System.Collections.IDictionary]) {
+        return $Candidate.Contains('Success')
+    }
+
+    return $null -ne $Candidate.PSObject.Properties['Success']
+}


### PR DESCRIPTION
## Description

Closes #1382.

Stack layer 2 of 2. Base is `claude/jim-password-sync-qn16qb` (#1383), which fixes the `-Provider` splat defect found in the same session. Both came out of running the Scenario 16 matrix against #1344; they are separate defects and get a diff each.

`Run-IntegrationTests.ps1` read `$LASTEXITCODE` straight after invoking the scenario with the call operator:

```powershell
& $scenarioScript @scenarioParams
$scenarioExitCode = $LASTEXITCODE
```

PowerShell does not set `$LASTEXITCODE` for a `.ps1` that returns rather than exits. The value that survived was whatever the last **native command inside the scenario** had left behind, and the `Success` property the scenario returned was never read at all.

Scenario 16 against Oracle printed `Result: PASS`, 10 cells passed and 0 failed, and the run exited 1, because the scenario reaches Oracle through `docker exec ... sqlplus` and SQL\*Plus had exited 1. The same scenario against SQL Server exits 0, which made it look like an Oracle quirk rather than the general defect it is.

**The costlier direction was equally available.** A scenario that fails without throwing and without exiting reads as a pass whenever its last native call returned 0, so CI goes green on a red run. That direction is covered by a test here.

## The fix

`Invoke-IntegrationScenario` resolves the outcome from the scenario's own signals, in order of authority:

1. It throws. The exception propagates so the runner reports it.
2. It returns a result object carrying `Success`. That is the scenario's verdict and beats anything `$LASTEXITCODE` holds.
3. Otherwise `$LASTEXITCODE` decides, which PowerShell **does** set reliably for `exit`, overwriting any stray code from within.

It also resets `$LASTEXITCODE` before invoking, so nothing from the runner's own setup can colour the verdict, and streams the scenario's output through untouched apart from the result object itself.

### The limit, stated rather than hidden

A scenario that returns normally **without** a result object is the one case this cannot get right: a stray code is indistinguishable from a genuine `exit 1`, and PowerShell offers no way to tell them apart. The remedy is the contract, not a cleverer heuristic. Scenario 6 and Scenario 11 were the only two that reached that path, and both now return their result objects (Scenario 6 already computed `$testResults.Success` and simply never returned it). A test pins the limit so the next reader knows it is deliberate.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [ ] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

No .NET code is touched, so no build or unit-test run applies (per the build/test exceptions for scripts in `CLAUDE.md`).

**Red first.** Against the previous logic, 6 of the 11 Pester cases fail, including both directions of the defect:

```
[-] reports success even though an internal native command exited non-zero
    Expected 0, but got 1.
[-] reports failure when the object says so, whatever the exit code holds
    Expected 1, but got 0.
```

The 5 that passed are the `exit` and `throw` paths, which were already correct, so the suite is not trivially green. After the fix: 11 passed, 0 failed.

Each test writes a real scenario script to disk and runs it rather than mocking the invocation, because the defect lives in how PowerShell propagates exit codes across the call operator and a mock would not reproduce it.

End-to-end verification against the live stack is in progress and will be posted as a comment: Scenario 16 against Oracle, which must now print `Result: PASS` **and** exit 0.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

<!-- Docs: n/a - test tooling fix with no user-facing behaviour -->

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

**This also brings `test/integration/utils` into the CI and release Pester paths.** Two suites were already sitting there with nothing running them, so a new suite that CI ignores would have been decoration. Both of their permission-probe tests are now skipped for root as well as for Windows, since uid 0 writes straight through the `0500` directory they rely on; that is why they had never been noticed as unrun.

**The stack is not natively linked.** The Claude Code sandbox reaches GitHub through a relay that does not expose the operations needed to link a chain, so please either accept GitHub's banner on the chain or land the layers bottom-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_011asUjp5FYJeSF2YMvjhFfq)_