### PR TITLE
Stop the pin bot closing its own bump PR, and report an unbuildable pin loudly (#1374)

### DIFF
--- a/.github/scripts/Tests/CheckToolingPins.Tests.ps1
+++ b/.github/scripts/Tests/CheckToolingPins.Tests.ps1
@@ -1,0 +1,209 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for .github/scripts/check-tooling-pins.ps1.
+
+.DESCRIPTION
+    The apt pin check learnt from #1374 that asking "is a NEWER version
+    available?" leaves the more serious question unasked: is the version we
+    already pin still obtainable? A withdrawn pin means the environment can no
+    longer be built, and nothing else notices, because the drift comes from the
+    registry rather than from any commit. npm unpublishes and NuGet hard-deletes
+    are rarer than an Ubuntu archive rotation, but the failure mode is identical
+    and the check costs nothing: both registries already return the full version
+    list the script queries for "latest".
+
+    The registry is faked by shadowing Invoke-RestMethod with a function, which
+    beats a cmdlet in PowerShell's command resolution and is inherited by the
+    scope the script under test runs in. State lives in $global: because a
+    function's $script: scope resolves against the script running it, not the one
+    that defined it.
+#>
+
+BeforeAll {
+    $script:ScriptPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'check-tooling-pins.ps1')).Path
+
+    # The two registry documents the script reads, in the shape each registry
+    # actually returns: npm a packument keyed by version, NuGet a flat-container
+    # index listing versions ascending.
+    function New-FakeRegistry {
+        param(
+            [string]$NpmLatest = '0.0.80',
+            [string[]]$NpmVersions = @('0.0.78', '0.0.79', '0.0.80'),
+            [string[]]$NuGetVersions = @('10.0.9', '10.0.10', '10.0.11')
+        )
+
+        $global:FakeRegistry = @{
+            NpmLatest     = $NpmLatest
+            NpmVersions   = $NpmVersions
+            NuGetVersions = $NuGetVersions
+            Failing       = $false
+            Uris          = [System.Collections.ArrayList]::new()
+        }
+    }
+
+    function global:Invoke-RestMethod {
+        param([string]$Uri, [int]$TimeoutSec)
+
+        $global:FakeRegistry.Uris.Add($Uri) | Out-Null
+        if ($global:FakeRegistry.Failing) { throw "the fake registry is refusing connections" }
+
+        if ($Uri -match 'registry\.npmjs\.org') {
+            $versions = [ordered]@{}
+            foreach ($v in $global:FakeRegistry.NpmVersions) { $versions[$v] = @{ name = '@playwright/mcp'; version = $v } }
+            return [pscustomobject]@{
+                'dist-tags' = [pscustomobject]@{ latest = $global:FakeRegistry.NpmLatest }
+                versions    = [pscustomobject]$versions
+            }
+        }
+
+        if ($Uri -match 'api\.nuget\.org') {
+            return [pscustomobject]@{ versions = @($global:FakeRegistry.NuGetVersions) }
+        }
+
+        throw "the fake registry does not know $Uri"
+    }
+
+    # A working tree holding the real pin files, so the script's own regexes are
+    # what is under test rather than a simplified stand-in.
+    function New-PinTree {
+        param([string]$PlaywrightVersion = '0.0.79', [string]$DotnetEfVersion = '10.0.10')
+
+        $root = Join-Path $TestDrive ("Pins_" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $root '.devcontainer') -Force | Out-Null
+
+        Set-Content -Path (Join-Path $root '.devcontainer/setup.sh') -Value @"
+#!/usr/bin/env bash
+if dotnet tool install --global dotnet-ef --version $DotnetEfVersion; then
+    print_success "dotnet-ef $DotnetEfVersion installed globally"
+fi
+PLAYWRIGHT_MCP_VERSION="$PlaywrightVersion"
+npm install -g "@playwright/mcp@`${PLAYWRIGHT_MCP_VERSION}" --silent
+"@
+
+        Set-Content -Path (Join-Path $root '.mcp.json') -Value @"
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@$PlaywrightVersion"]
+    }
+  }
+}
+"@
+
+        return $root
+    }
+
+    function Invoke-CheckToolingPins {
+        param([string]$Tree, [switch]$Apply, [string]$OutputFile)
+
+        Push-Location $Tree
+        try {
+            $env:GITHUB_OUTPUT = $OutputFile
+            $script:Output = & $script:ScriptPath -Apply:$Apply *>&1 | Out-String
+            $script:ExitCode = $LASTEXITCODE
+        } finally {
+            $env:GITHUB_OUTPUT = $null
+            Pop-Location
+        }
+    }
+}
+
+Describe 'check-tooling-pins.ps1' {
+
+    BeforeEach {
+        New-FakeRegistry
+    }
+
+    Context 'when every pin is current and still published' {
+
+        It 'reports nothing to evaluate' {
+            New-FakeRegistry -NpmLatest '0.0.79' -NpmVersions @('0.0.78', '0.0.79') -NuGetVersions @('10.0.9', '10.0.10')
+
+            Invoke-CheckToolingPins -Tree (New-PinTree)
+
+            $script:ExitCode | Should -Be 0
+        }
+    }
+
+    Context 'when a newer version is available' {
+
+        It 'proposes the bump' {
+            $tree = New-PinTree
+            Invoke-CheckToolingPins -Tree $tree
+
+            $script:ExitCode | Should -Be 2
+            Get-Content (Join-Path $tree 'tooling-pin-pr-body.md') -Raw | Should -Match '0\.0\.80'
+        }
+    }
+
+    Context 'when the pinned version has been withdrawn from the registry' {
+
+        It 'fails loudly rather than reporting the pin as current' {
+            # 0.0.79 is pinned, unpublished upstream, and 0.0.78 is the latest
+            # left: nothing is "behind", so the newer-version check alone sees a
+            # perfectly healthy pin.
+            New-FakeRegistry -NpmLatest '0.0.78' -NpmVersions @('0.0.77', '0.0.78') -NuGetVersions @('10.0.9', '10.0.10')
+
+            Invoke-CheckToolingPins -Tree (New-PinTree)
+
+            $script:ExitCode | Should -Be 3
+            $script:Output | Should -Match 'WITHDRAWN'
+            $script:Output | Should -Match '@playwright/mcp'
+        }
+
+        It 'catches a withdrawn NuGet pin as well as an npm one' {
+            New-FakeRegistry -NuGetVersions @('10.0.9', '10.0.11')
+
+            Invoke-CheckToolingPins -Tree (New-PinTree)
+
+            $script:ExitCode | Should -Be 3
+            $script:Output | Should -Match 'dotnet-ef'
+        }
+
+        It 'still proposes and applies the bump that clears it' {
+            # Reporting the problem must not suppress the fix: the pinned 0.0.79
+            # is gone AND 0.0.80 is available, so the run has to do both.
+            New-FakeRegistry -NpmLatest '0.0.80' -NpmVersions @('0.0.78', '0.0.80') -NuGetVersions @('10.0.9', '10.0.10')
+            $tree = New-PinTree
+
+            Invoke-CheckToolingPins -Tree $tree -Apply
+
+            $script:ExitCode | Should -Be 3
+            Get-Content (Join-Path $tree 'tooling-pin-pr-body.md') -Raw | Should -Match '0\.0\.80'
+            Get-Content (Join-Path $tree '.mcp.json') -Raw | Should -Match '@playwright/mcp@0\.0\.80'
+            Get-Content (Join-Path $tree '.devcontainer/setup.sh') -Raw | Should -Match 'PLAYWRIGHT_MCP_VERSION="0\.0\.80"'
+        }
+
+        It 'tells the workflow, so the run can be failed after the PR is raised' {
+            New-FakeRegistry -NpmLatest '0.0.78' -NpmVersions @('0.0.77', '0.0.78') -NuGetVersions @('10.0.9', '10.0.10')
+            $outputFile = Join-Path $TestDrive ("out_" + [guid]::NewGuid().ToString('N') + '.txt')
+
+            Invoke-CheckToolingPins -Tree (New-PinTree) -OutputFile $outputFile
+
+            $written = Get-Content $outputFile -Raw
+            $written | Should -Match 'unavailable=true'
+            $written | Should -Match 'unavailable_tools=.*playwright'
+        }
+    }
+
+    Context 'when a registry cannot be reached' {
+
+        It 'refuses to report a result' {
+            New-FakeRegistry
+            $global:FakeRegistry.Failing = $true
+
+            Invoke-CheckToolingPins -Tree (New-PinTree)
+
+            # A silent false negative would leave the pin unmonitored while
+            # looking healthy, which is the failure mode this whole family of
+            # checks exists to avoid.
+            $script:ExitCode | Should -Be 1
+        }
+    }
+}

--- a/.github/scripts/Tests/OpenPinPr.Tests.ps1
+++ b/.github/scripts/Tests/OpenPinPr.Tests.ps1
@@ -63,6 +63,7 @@ BeforeAll {
             CommitSeq  = 0
             RefWrites  = [System.Collections.ArrayList]::new()
             Calls      = [System.Collections.ArrayList]::new()
+            RefuseCreate = $false
         }
 
         foreach ($name in $Branches.Keys) { $hub.Refs[$name] = $Branches[$name] }
@@ -285,7 +286,8 @@ BeforeAll {
             }
             'create' {
                 $head = $GhArgs[[array]::IndexOf($GhArgs, '--head') + 1]
-                if (@($global:FakeHub.Prs | Where-Object { $_.head -eq $head -and $_.state -eq 'OPEN' }).Count -gt 0) {
+                if ($global:FakeHub.RefuseCreate -or
+                    @($global:FakeHub.Prs | Where-Object { $_.head -eq $head -and $_.state -eq 'OPEN' }).Count -gt 0) {
                     $global:LASTEXITCODE = 1
                     return "gh: a pull request for branch $head already exists"
                 }
@@ -336,6 +338,10 @@ BeforeAll {
             # *>&1, not 2>&1: the script reports through Write-Host (the
             # information stream), which 2>&1 does not capture.
             $script:Output = & $script:ScriptPath @arguments *>&1 | Out-String
+            $script:Failed = $false
+        } catch {
+            $script:Output = "$_"
+            $script:Failed = $true
         } finally {
             Pop-Location
         }
@@ -467,6 +473,21 @@ Describe 'open-pin-pr.ps1' {
             $global:FakeHub.Refs.ContainsKey($script:BotBranch) | Should -BeTrue
             $global:FakeHub.Parents[$global:FakeHub.Refs[$script:BotBranch]] | Should -Be 'basesha001'
             (Get-FakePr -Number 1).state | Should -Be 'OPEN'
+        }
+
+        It 'fails the run when the pull request cannot be opened' {
+            # The tooling bot did exactly this in production, weekly, from 21
+            # July: it created the branch, pushed the bump commit, logged
+            # "Opening new PR ...", had `gh pr create` refused, and reported
+            # success because nothing checked the exit code. A bot that raises
+            # nothing must not report a green run.
+            $global:FakeHub.RefuseCreate = $true
+
+            $output = Invoke-OpenPinPr -WorkingTree (New-WorkingTree)
+
+            $script:Failed | Should -BeTrue
+            $output | Should -Match 'Failed to open a PR'
+            $global:FakeHub.Prs.Count | Should -Be 0
         }
 
         It 'opens a fresh pull request when the previous one was merged' {

--- a/.github/scripts/Tests/OpenPinPr.Tests.ps1
+++ b/.github/scripts/Tests/OpenPinPr.Tests.ps1
@@ -1,0 +1,484 @@
+# Copyright (c) Tetron Limited. All rights reserved.
+# Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Pester tests for .github/scripts/open-pin-pr.ps1.
+
+.DESCRIPTION
+    The motivating defect (#1374): the apt-pin-check run of 2026-08-15 closed the
+    very bump pull request it was updating (#1364), leaving a security pin
+    unlandable while `main` could not build the Worker image at all. The script
+    reset its bot branch to the tip of the base branch and then committed on top,
+    so between those two calls the head branch carried no commits ahead of base.
+    GitHub closes a pull request whose head branch is updated into that state, and
+    the close landed in that window.
+
+    These tests run the real script against a fake `gh` that models the small part
+    of GitHub the script touches: refs, commits and pull requests, INCLUDING the
+    auto-close rule above. That rule is what makes the tests meaningful; without
+    it the sequence of API calls looks perfectly healthy.
+
+    `gh` and `git` are replaced by PowerShell functions rather than shims on PATH:
+    a function beats an external command in PowerShell's command resolution, and
+    child scopes inherit it, so the script under test needs no seam of its own.
+    The fakes report failure the way a native command does (a non-zero
+    $LASTEXITCODE and a message on stdout), never as a PowerShell error record,
+    because the script's $ErrorActionPreference = 'Stop' would turn the latter
+    into a terminating error that `gh` itself would never raise.
+
+    The fakes' state lives in $global: rather than $script:. A function's
+    $script: scope resolves against the script that is *running* it, so a fake
+    called from inside open-pin-pr.ps1 would read that script's scope and find
+    nothing. $global: is the only scope both sides genuinely share.
+#>
+
+BeforeAll {
+    $script:ScriptPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'open-pin-pr.ps1')).Path
+
+    $global:FakeRepository = 'TetronIO/JIM'
+    $script:BotBranch = 'automation/apt-pin-updates'
+
+    # --- the fake GitHub -----------------------------------------------------
+
+    # Refs are keyed by branch name (no refs/heads/ prefix). Parents lets a test
+    # assert what the bump commit was actually built on. RefWrites records every
+    # ref update in order, which is how "the branch never sat at the base tip" is
+    # asserted directly rather than inferred from the outcome.
+    function New-FakeHub {
+        param(
+            [string]$BaseSha = 'basesha001',
+            [hashtable]$Branches = @{},
+            [array]$Prs = @()
+        )
+
+        $hub = [ordered]@{
+            BaseSha    = $BaseSha
+            Refs       = @{ 'main' = $BaseSha }
+            Parents    = @{}
+            Prs        = [System.Collections.ArrayList]::new()
+            NextPr     = 1
+            CommitSeq  = 0
+            RefWrites  = [System.Collections.ArrayList]::new()
+            Calls      = [System.Collections.ArrayList]::new()
+        }
+
+        foreach ($name in $Branches.Keys) { $hub.Refs[$name] = $Branches[$name] }
+        foreach ($pr in $Prs) {
+            $hub.Prs.Add([ordered]@{
+                number   = $hub.NextPr
+                head     = $pr.head
+                base     = if ($pr.base) { $pr.base } else { 'main' }
+                state    = $pr.state
+                body     = if ($pr.body) { $pr.body } else { 'original body' }
+                comments = [System.Collections.ArrayList]::new()
+                closedBy = $null
+            }) | Out-Null
+            $hub.NextPr++
+        }
+
+        return $hub
+    }
+
+    # Every ref update goes through here so the auto-close rule is applied
+    # uniformly, exactly as GitHub applies it however the ref was moved.
+    function Set-FakeRef {
+        param([string]$Branch, [string]$Sha)
+
+        $global:FakeHub.Refs[$Branch] = $Sha
+        $global:FakeHub.RefWrites.Add([ordered]@{ branch = $Branch; sha = $Sha }) | Out-Null
+
+        foreach ($pr in $global:FakeHub.Prs) {
+            if ($pr.state -ne 'OPEN' -or $pr.head -ne $Branch) { continue }
+            # A head branch carrying no commits ahead of its base is an empty
+            # pull request, and GitHub closes it. This is #1374.
+            if ($global:FakeHub.Refs.ContainsKey($pr.base) -and $Sha -eq $global:FakeHub.Refs[$pr.base]) {
+                $pr.state = 'CLOSED'
+                $pr.closedBy = 'github-empty-range'
+            }
+        }
+    }
+
+    function script:git {
+        $global:FakeHub.Calls.Add(@('git') + @($args)) | Out-Null
+        $global:LASTEXITCODE = 0
+        if (($args -join ' ') -eq 'diff --name-only') { return $global:FakeChangedFiles }
+        return @()
+    }
+
+    function script:gh {
+        $ghArgs = @($args)
+        $global:FakeHub.Calls.Add(@('gh') + $ghArgs) | Out-Null
+        $global:LASTEXITCODE = 0
+        $stdin = $input
+
+        switch ($ghArgs[0]) {
+            'api' { return Invoke-FakeGhApi -GhArgs $ghArgs -Stdin $stdin }
+            'pr'  { return Invoke-FakeGhPr  -GhArgs $ghArgs }
+            default {
+                $global:LASTEXITCODE = 1
+                return "unknown gh command: $($ghArgs -join ' ')"
+            }
+        }
+    }
+
+    # Only the filters the pin scripts actually use. Anything else fails loudly:
+    # a fake that quietly returned the whole document for an unrecognised filter
+    # would let a script pass its tests and misread the real gh's output.
+    function Invoke-FakeJq {
+        param([string]$Filter, [string]$Json)
+
+        if (-not $Filter) { return $Json }
+
+        switch ($Filter) {
+            '.object.sha'  { return (ConvertFrom-Json $Json).object.sha }
+            '.[0].number'  {
+                $first = @(ConvertFrom-Json $Json)[0]
+                return $(if ($first) { "$($first.number)" } else { '' })
+            }
+            default { throw "The fake gh does not implement --jq '$Filter'." }
+        }
+    }
+
+    function Invoke-FakeGhApi {
+        param([string[]]$GhArgs, $Stdin)
+
+        $method = 'GET'
+        if ($GhArgs -contains '-X') { $method = $GhArgs[[array]::IndexOf($GhArgs, '-X') + 1] }
+
+        # The endpoint is the first bare argument after 'api' (or after -X VERB).
+        $endpoint = @($GhArgs | Select-Object -Skip 1 | Where-Object { $_ -notmatch '^-' -and $_ -ne $method })[0]
+
+        # Field arguments (-f name=value / -F name=value).
+        $fields = @{}
+        for ($i = 0; $i -lt $GhArgs.Count; $i++) {
+            if ($GhArgs[$i] -in @('-f', '-F') -and $GhArgs[$i + 1] -match '^([^=]+)=(.*)$') {
+                $fields[$matches[1]] = $matches[2]
+            }
+        }
+
+        $jq = if ($GhArgs -contains '--jq') { $GhArgs[[array]::IndexOf($GhArgs, '--jq') + 1] } else { $null }
+
+        if ($endpoint -eq 'graphql') {
+            $payload = ($Stdin | Out-String) | ConvertFrom-Json
+            $mutationInput = $payload.variables.input
+            $branch = $mutationInput.branch.branchName
+            $expected = $mutationInput.expectedHeadOid
+
+            if ($global:FakeHub.Refs[$branch] -ne $expected) {
+                return '{"data":{"createCommitOnBranch":null},"errors":[{"message":"expectedHeadOid does not match the branch head"}]}'
+            }
+
+            $global:FakeHub.CommitSeq++
+            $oid = "commit{0:d3}" -f $global:FakeHub.CommitSeq
+            $global:FakeHub.Parents[$oid] = $expected
+            Set-FakeRef -Branch $branch -Sha $oid
+            return "{`"data`":{`"createCommitOnBranch`":{`"commit`":{`"oid`":`"$oid`",`"url`":`"https://example.invalid/$oid`"}}}}"
+        }
+
+        # repos/<owner>/<repo>/git/ref(s)/heads/<branch>, or .../git/refs for creates.
+        if ($endpoint -match "^repos/$([regex]::Escape($global:FakeRepository))/git/refs?(?:/heads/(?<branch>.+))?$") {
+            $branch = $matches['branch']
+
+            switch ($method) {
+                'GET' {
+                    if (-not $global:FakeHub.Refs.ContainsKey($branch)) {
+                        $global:LASTEXITCODE = 1
+                        return 'gh: Not Found (HTTP 404)'
+                    }
+                    $sha = $global:FakeHub.Refs[$branch]
+                    return (Invoke-FakeJq -Filter $jq -Json "{`"object`":{`"sha`":`"$sha`"}}")
+                }
+                'PATCH' {
+                    if (-not $global:FakeHub.Refs.ContainsKey($branch)) {
+                        $global:LASTEXITCODE = 1
+                        return 'gh: Reference does not exist (HTTP 422)'
+                    }
+                    Set-FakeRef -Branch $branch -Sha $fields['sha']
+                    return '{}'
+                }
+                'POST' {
+                    $new = $fields['ref'] -replace '^refs/heads/', ''
+                    if ($global:FakeHub.Refs.ContainsKey($new)) {
+                        $global:LASTEXITCODE = 1
+                        return 'gh: Reference already exists (HTTP 422)'
+                    }
+                    Set-FakeRef -Branch $new -Sha $fields['sha']
+                    return '{}'
+                }
+                'DELETE' {
+                    $global:FakeHub.Refs.Remove($branch)
+                    return '{}'
+                }
+            }
+        }
+
+        $global:LASTEXITCODE = 1
+        return "unknown gh api endpoint: $endpoint"
+    }
+
+    function Invoke-FakeGhPr {
+        param([string[]]$GhArgs)
+
+        $verb = $GhArgs[1]
+
+        switch ($verb) {
+            'list' {
+                $head = $GhArgs[[array]::IndexOf($GhArgs, '--head') + 1]
+                $wanted = @($global:FakeHub.Prs | Where-Object { $_.head -eq $head })
+                if ($GhArgs -contains '--state') {
+                    $state = $GhArgs[[array]::IndexOf($GhArgs, '--state') + 1]
+                    if ($state -eq 'open') { $wanted = @($wanted | Where-Object { $_.state -eq 'OPEN' }) }
+                }
+                # gh emits the newest pull request first. Objects rather than
+                # dictionaries so Sort-Object sees the property, and piped into
+                # ConvertTo-Json rather than passed as -InputObject: the latter
+                # treats the array as one value, which -AsArray then wraps again.
+                $projected = @($wanted | ForEach-Object { [pscustomobject]@{ number = $_.number; state = $_.state } } |
+                    Sort-Object number -Descending)
+                $json = $projected | ConvertTo-Json -Depth 5 -AsArray
+                $jq = if ($GhArgs -contains '--jq') { $GhArgs[[array]::IndexOf($GhArgs, '--jq') + 1] } else { $null }
+                return (Invoke-FakeJq -Filter $jq -Json $json)
+            }
+            { $_ -in @('edit', 'reopen', 'close') } {
+                $number = [int]$GhArgs[2]
+                $pr = @($global:FakeHub.Prs | Where-Object { $_.number -eq $number })[0]
+                if (-not $pr) { $global:LASTEXITCODE = 1; return "gh: no pull request #$number" }
+
+                if ($verb -eq 'edit' -and $GhArgs -contains '--body') {
+                    $pr.body = $GhArgs[[array]::IndexOf($GhArgs, '--body') + 1]
+                }
+                if ($verb -eq 'reopen') {
+                    if ($pr.state -eq 'MERGED') { $global:LASTEXITCODE = 1; return 'gh: cannot reopen a merged pull request' }
+                    $pr.state = 'OPEN'
+                    $pr.closedBy = $null
+                }
+                if ($verb -eq 'close') {
+                    $pr.state = 'CLOSED'
+                    $pr.closedBy = 'script'
+                    if ($GhArgs -contains '--comment') {
+                        $pr.comments.Add($GhArgs[[array]::IndexOf($GhArgs, '--comment') + 1]) | Out-Null
+                    }
+                }
+                return '{}'
+            }
+            'create' {
+                $head = $GhArgs[[array]::IndexOf($GhArgs, '--head') + 1]
+                if (@($global:FakeHub.Prs | Where-Object { $_.head -eq $head -and $_.state -eq 'OPEN' }).Count -gt 0) {
+                    $global:LASTEXITCODE = 1
+                    return "gh: a pull request for branch $head already exists"
+                }
+                $global:FakeHub.Prs.Add([ordered]@{
+                    number   = $global:FakeHub.NextPr
+                    head     = $head
+                    base     = $GhArgs[[array]::IndexOf($GhArgs, '--base') + 1]
+                    state    = 'OPEN'
+                    body     = $GhArgs[[array]::IndexOf($GhArgs, '--body') + 1]
+                    comments = [System.Collections.ArrayList]::new()
+                    closedBy = $null
+                }) | Out-Null
+                $global:FakeHub.NextPr++
+                return "https://example.invalid/pr/$($global:FakeHub.NextPr - 1)"
+            }
+        }
+
+        $global:LASTEXITCODE = 1
+        return "unknown gh pr verb: $verb"
+    }
+
+    # --- fixture + invocation ------------------------------------------------
+
+    # A working tree holding the file the -Apply step would have rewritten. The
+    # script reads the file's bytes to build the commit, so it has to exist.
+    function New-WorkingTree {
+        param([string[]]$Files = @('src/JIM.Worker/Dockerfile'))
+
+        $root = Join-Path $TestDrive ("Tree_" + [guid]::NewGuid().ToString('N'))
+        foreach ($rel in $Files) {
+            $full = Join-Path $root $rel
+            New-Item -ItemType Directory -Path (Split-Path $full -Parent) -Force | Out-Null
+            Set-Content -Path $full -Value "libgssapi-krb5-2=1.20.1-6ubuntu2.8" -NoNewline
+        }
+        return $root
+    }
+
+    function Invoke-OpenPinPr {
+        param([string]$WorkingTree, [hashtable]$ScriptArgs = @{})
+
+        $arguments = @{
+            Repository = $global:FakeRepository
+            Branch     = $script:BotBranch
+        } + $ScriptArgs
+
+        Push-Location $WorkingTree
+        try {
+            # *>&1, not 2>&1: the script reports through Write-Host (the
+            # information stream), which 2>&1 does not capture.
+            $script:Output = & $script:ScriptPath @arguments *>&1 | Out-String
+        } finally {
+            Pop-Location
+        }
+        return $script:Output
+    }
+
+    function Get-FakePr {
+        param([int]$Number)
+        return @($global:FakeHub.Prs | Where-Object { $_.number -eq $Number })[0]
+    }
+
+    function Get-BotRefWrites {
+        return @($global:FakeHub.RefWrites | Where-Object { $_.branch -eq $script:BotBranch } | ForEach-Object { $_.sha })
+    }
+}
+
+Describe 'open-pin-pr.ps1' {
+
+    BeforeEach {
+        $global:FakeChangedFiles = @('src/JIM.Worker/Dockerfile')
+        $global:FakeHub = $null
+    }
+
+    Context 'when a bump pull request is already open (#1374)' {
+
+        BeforeEach {
+            # The state the 2026-08-15 run found: an open PR raised two days
+            # earlier, its branch carrying the previous bump commit.
+            $global:FakeHub = New-FakeHub -BaseSha 'basesha001' `
+                -Branches @{ $script:BotBranch = 'oldbump01' } `
+                -Prs @(@{ head = $script:BotBranch; state = 'OPEN' })
+            $global:FakeHub.Parents['oldbump01'] = 'basesha000'
+        }
+
+        It 'leaves the pull request open' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            (Get-FakePr -Number 1).state | Should -Be 'OPEN'
+            (Get-FakePr -Number 1).closedBy | Should -BeNullOrEmpty
+        }
+
+        It 'never points the bump branch at the base branch tip' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            # The empty-commit-range window is the defect itself; asserting on it
+            # directly pins the mechanism, not just the symptom.
+            Get-BotRefWrites | Should -Not -Contain 'basesha001'
+        }
+
+        It 'survives consecutive runs' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            (Get-FakePr -Number 1).state | Should -Be 'OPEN'
+            $global:FakeHub.Prs.Count | Should -Be 1
+        }
+
+        It 'leaves the branch carrying exactly one commit on top of the base tip' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            # The branch is a single fresh commit off the current base, never a
+            # pile of superseded bumps, which is what the reset bought before.
+            $head = $global:FakeHub.Refs[$script:BotBranch]
+            $global:FakeHub.Parents[$head] | Should -Be 'basesha001'
+        }
+
+        It 'updates the pull request body with the new bump table' {
+            $bodyFile = Join-Path $TestDrive 'pr-body.md'
+            Set-Content -Path $bodyFile -Value '| libgssapi-krb5-2 | 2.7 | 2.8 |'
+
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) -ScriptArgs @{ BodyFile = $bodyFile } | Out-Null
+
+            (Get-FakePr -Number 1).body | Should -Match 'libgssapi-krb5-2'
+        }
+
+        It 'leaves no staging branch behind' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            @($global:FakeHub.Refs.Keys | Where-Object { $_ -ne 'main' -and $_ -ne $script:BotBranch }) | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'when the bump pull request was closed by an earlier run' {
+
+        BeforeEach {
+            $global:FakeHub = New-FakeHub -BaseSha 'basesha001' `
+                -Branches @{ $script:BotBranch = 'oldbump01' } `
+                -Prs @(@{ head = $script:BotBranch; state = 'CLOSED' })
+        }
+
+        It 'reopens it rather than leaving the bump unlandable' {
+            $output = Invoke-OpenPinPr -WorkingTree (New-WorkingTree)
+
+            (Get-FakePr -Number 1).state | Should -Be 'OPEN'
+            $output | Should -Match 'reopen'
+        }
+
+        It 'does not raise a second pull request for the same branch' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            $global:FakeHub.Prs.Count | Should -Be 1
+        }
+    }
+
+    Context 'when no bump pull request exists' {
+
+        BeforeEach {
+            $global:FakeHub = New-FakeHub -BaseSha 'basesha001'
+        }
+
+        It 'creates the branch and opens a pull request' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            $global:FakeHub.Prs.Count | Should -Be 1
+            (Get-FakePr -Number 1).state | Should -Be 'OPEN'
+            $global:FakeHub.Parents[$global:FakeHub.Refs[$script:BotBranch]] | Should -Be 'basesha001'
+        }
+
+        It 'opens a fresh pull request when the previous one was merged' {
+            $global:FakeHub.Prs.Add([ordered]@{
+                number = 1; head = $script:BotBranch; base = 'main'; state = 'MERGED'
+                body = 'landed'; comments = [System.Collections.ArrayList]::new(); closedBy = $null
+            }) | Out-Null
+            $global:FakeHub.NextPr = 2
+            $global:FakeHub.Refs[$script:BotBranch] = 'oldbump01'
+
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            $global:FakeHub.Prs.Count | Should -Be 2
+            (Get-FakePr -Number 2).state | Should -Be 'OPEN'
+        }
+    }
+
+    Context 'when there is nothing left to propose' {
+
+        BeforeEach {
+            $global:FakeChangedFiles = @()
+            $global:FakeHub = New-FakeHub -BaseSha 'basesha001' `
+                -Branches @{ $script:BotBranch = 'oldbump01' } `
+                -Prs @(@{ head = $script:BotBranch; state = 'OPEN' })
+        }
+
+        It 'closes the stale pull request deliberately, stating why' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) -ScriptArgs @{ CloseStalePr = $true } | Out-Null
+
+            $pr = Get-FakePr -Number 1
+            $pr.state | Should -Be 'CLOSED'
+            $pr.closedBy | Should -Be 'script'
+            $pr.comments.Count | Should -Be 1
+            $pr.comments[0] | Should -Match 'no longer'
+        }
+
+        It 'leaves the pull request alone unless the caller asked for the close' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            (Get-FakePr -Number 1).state | Should -Be 'OPEN'
+        }
+
+        It 'never touches the branch' {
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) -ScriptArgs @{ CloseStalePr = $true } | Out-Null
+
+            Get-BotRefWrites | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/.github/scripts/Tests/OpenPinPr.Tests.ps1
+++ b/.github/scripts/Tests/OpenPinPr.Tests.ps1
@@ -178,18 +178,37 @@ BeforeAll {
             return "{`"data`":{`"createCommitOnBranch`":{`"commit`":{`"oid`":`"$oid`",`"url`":`"https://example.invalid/$oid`"}}}}"
         }
 
-        # repos/<owner>/<repo>/git/ref(s)/heads/<branch>, or .../git/refs for creates.
-        if ($endpoint -match "^repos/$([regex]::Escape($global:FakeRepository))/git/refs?(?:/heads/(?<branch>.+))?$") {
+        # The singular endpoint, repos/<owner>/<repo>/git/ref/heads/<branch>, is
+        # an exact lookup and 404s when the ref does not exist.
+        if ($endpoint -match "^repos/$([regex]::Escape($global:FakeRepository))/git/ref/heads/(?<branch>.+)$") {
+            $branch = $matches['branch']
+            if (-not $global:FakeHub.Refs.ContainsKey($branch)) {
+                $global:LASTEXITCODE = 1
+                return 'gh: Not Found (HTTP 404)'
+            }
+            $sha = $global:FakeHub.Refs[$branch]
+            return (Invoke-FakeJq -Filter $jq -Json "{`"object`":{`"sha`":`"$sha`"}}")
+        }
+
+        # repos/<owner>/<repo>/git/refs/heads/<branch>, or .../git/refs for creates.
+        if ($endpoint -match "^repos/$([regex]::Escape($global:FakeRepository))/git/refs(?:/heads/(?<branch>.+))?$") {
             $branch = $matches['branch']
 
             switch ($method) {
                 'GET' {
-                    if (-not $global:FakeHub.Refs.ContainsKey($branch)) {
+                    # The PLURAL endpoint matches by PREFIX and returns every ref
+                    # under it. This is the sharp edge that broke the first live
+                    # run: probing "automation/x" found "automation/x-staging"
+                    # and reported a branch that did not exist as existing.
+                    $matched = @($global:FakeHub.Refs.Keys | Where-Object { $_ -eq $branch -or $_.StartsWith($branch) })
+                    if ($matched.Count -eq 0) {
                         $global:LASTEXITCODE = 1
                         return 'gh: Not Found (HTTP 404)'
                     }
-                    $sha = $global:FakeHub.Refs[$branch]
-                    return (Invoke-FakeJq -Filter $jq -Json "{`"object`":{`"sha`":`"$sha`"}}")
+                    $refs = @($matched | ForEach-Object {
+                        [pscustomobject]@{ ref = "refs/heads/$_"; object = [pscustomobject]@{ sha = $global:FakeHub.Refs[$_] } }
+                    })
+                    return ($refs | ConvertTo-Json -Depth 5 -AsArray)
                 }
                 'PATCH' {
                     if (-not $global:FakeHub.Refs.ContainsKey($branch)) {
@@ -433,6 +452,21 @@ Describe 'open-pin-pr.ps1' {
             $global:FakeHub.Prs.Count | Should -Be 1
             (Get-FakePr -Number 1).state | Should -Be 'OPEN'
             $global:FakeHub.Parents[$global:FakeHub.Refs[$script:BotBranch]] | Should -Be 'basesha001'
+        }
+
+        It 'creates the bump branch even though the staging ref shares its name as a prefix' {
+            # The first live run died here. The bot branch did not exist, the
+            # staging ref did, and the existence probe used GitHub's plural refs
+            # endpoint, which matches by prefix: it saw "<branch>-staging",
+            # reported the branch as existing, and the update of a ref that was
+            # never created failed with a 422.
+            $global:FakeHub.Refs["$($script:BotBranch)-staging"] = 'leftover01'
+
+            Invoke-OpenPinPr -WorkingTree (New-WorkingTree) | Out-Null
+
+            $global:FakeHub.Refs.ContainsKey($script:BotBranch) | Should -BeTrue
+            $global:FakeHub.Parents[$global:FakeHub.Refs[$script:BotBranch]] | Should -Be 'basesha001'
+            (Get-FakePr -Number 1).state | Should -Be 'OPEN'
         }
 
         It 'opens a fresh pull request when the previous one was merged' {

--- a/.github/scripts/check-apt-pins.ps1
+++ b/.github/scripts/check-apt-pins.ps1
@@ -30,6 +30,14 @@
          (`apt-get install --dry-run`), so a proposed bump is one we have proven
          resolvable, not just a version string. This matters because CI does not
          build the JIM images on a PR; the bot must not propose an unbuildable pin.
+      5. Validates that each Dockerfile's pins, AS A SET, still resolve in its
+         base image, which is the ground truth for "can this image still be
+         built at all". Nothing else in CI answers that: build-and-test compiles
+         and runs tests rather than building the production images, and the
+         drift comes from the archive rather than from any commit. When Ubuntu
+         published libgssapi-krb5-2 1.20.1-6ubuntu2.8 it withdrew 2.7, and
+         `main` could not build jim-worker for two days with every required
+         check green (#1374).
 
     Default mode reports findings as a table. `-Apply` additionally rewrites the
     validated bumps into the Dockerfiles in place (used by the apt-pin-check
@@ -47,11 +55,15 @@
     only reports.
 
 .NOTES
-    Exit codes:
+    Exit codes (the highest applicable one wins):
       0  success; no updates available (or -Apply applied them cleanly)
       1  an error occurred (Docker unavailable, parse failure, etc.)
       2  updates are available (reporting mode only; lets a scheduled check or
          workflow branch on "is there anything to evaluate")
+      3  at least one Dockerfile's pinned set can no longer be installed in its
+         base image, so that image cannot be built. Reported after any bumps have
+         been applied and written out, so the workflow can still raise the PR
+         that fixes it and then fail the run.
 #>
 
 [CmdletBinding()]
@@ -139,14 +151,22 @@ Test-DockerAvailable
 
 # --- Query each base image's archive for candidate versions -----------------
 
-# In-container script: for each "pkg|pinned" spec, emit one
-# "RESULT|pkg|pinned|candidate|newer|installable|security" line. Runs as root
-# (the .NET base images default to a non-root user, which cannot run apt).
+# In-container script: for each "pkg|pinned|dockerfile" spec, emit one
+# "RESULT|pkg|pinned|candidate|newer|installable|security" line, then one
+# "PINSET|dockerfile|yes|no|detail" line per Dockerfile saying whether that
+# file's pins still resolve together. Runs as root (the .NET base images default
+# to a non-root user, which cannot run apt).
+#
+# The pins are probed as a set, not one at a time, because that is what the image
+# build does: a leaf pin can be individually resolvable and still unbuildable
+# alongside its siblings, and vice versa.
 $containerScript = @'
 set -u
 apt-get update -qq >/dev/null 2>&1 || { echo "APTUPDATEFAILED"; exit 0; }
-for spec in "$@"; do
-  pkg="${spec%%|*}"; pinned="${spec##*|}"
+specs="$*"
+for spec in $specs; do
+  pkg="$(printf '%s' "$spec" | cut -d'|' -f1)"
+  pinned="$(printf '%s' "$spec" | cut -d'|' -f2)"
   cand="$(apt-cache policy "$pkg" 2>/dev/null | awk -F': ' '/Candidate:/{print $2}' | tr -d ' ')"
   if [ -z "$cand" ] || [ "$cand" = "(none)" ]; then
     echo "RESULT|$pkg|$pinned|none|no|skip|no"; continue
@@ -165,6 +185,26 @@ for spec in "$@"; do
   fi
   echo "RESULT|$pkg|$pinned|$cand|$newer|$installable|$security"
 done
+for df in $(for spec in $specs; do printf '%s\n' "$spec" | cut -d'|' -f3; done | sort -u); do
+  pinargs=""
+  for spec in $specs; do
+    if [ "$(printf '%s' "$spec" | cut -d'|' -f3)" = "$df" ]; then
+      pinargs="$pinargs $(printf '%s' "$spec" | cut -d'|' -f1)=$(printf '%s' "$spec" | cut -d'|' -f2)"
+    fi
+  done
+  if err="$(apt-get install -y --no-install-recommends --dry-run $pinargs 2>&1)"; then
+    echo "PINSET|$df|yes|"
+  else
+    # Keep the diagnosis (the unmet dependency lines and apt's E: summary) rather
+    # than the first 300 characters, which are all boilerplate about impossible
+    # situations and the unstable distribution.
+    detail="$(printf '%s' "$err" | grep -E 'Depends:|Conflicts:|Breaks:|^E:' | tr '\n|' '  ' | cut -c1-300)"
+    if [ -z "$detail" ]; then
+      detail="$(printf '%s' "$err" | tr '\n|' '  ' | tail -c 300)"
+    fi
+    echo "PINSET|$df|no|$detail"
+  fi
+done
 '@
 
 # Normalise to LF: this file may be checked out with CRLF line endings (git
@@ -173,6 +213,7 @@ done
 $containerScript = $containerScript -replace "`r", ''
 
 $results = @()
+$pinSets = @()
 $queryFailures = @()
 
 foreach ($group in ($pins | Group-Object image_ref)) {
@@ -186,7 +227,8 @@ foreach ($group in ($pins | Group-Object image_ref)) {
     docker image inspect $imageRef *> $null
     if ($LASTEXITCODE -ne 0) { throw "base image not available locally and could not be pulled: $imageRef" }
 
-    $specs = @($group.Group | ForEach-Object { "$($_.package)|$($_.version)" })
+    $specs = @($group.Group | ForEach-Object { "$($_.package)|$($_.version)|$($_.dockerfile)" })
+    $groupDockerfiles = @($group.Group | Select-Object -ExpandProperty dockerfile -Unique)
 
     # Pass the script as a `bash -c` argument with the specs as positional
     # parameters ($@). This is more portable than piping the script on stdin
@@ -195,28 +237,43 @@ foreach ($group in ($pins | Group-Object image_ref)) {
     $raw = docker run --rm --platform $platform --user root --entrypoint bash $imageRef -c $containerScript -- @specs 2>&1 | Out-String
 
     $rowCount = 0
+    $pinSetCount = 0
     foreach ($rln in ($raw -split "`n")) {
-        if ($rln -notmatch '^RESULT\|') { continue }
-        $rowCount++
-        $f = $rln.Trim() -split '\|'
-        $results += [pscustomobject]@{
-            image_ref   = $imageRef
-            package     = $f[1]
-            pinned      = $f[2]
-            candidate   = $f[3]
-            newer       = ($f[4] -eq 'yes')
-            installable = $f[5]
-            security    = ($f[6] -eq 'yes')
+        if ($rln -match '^RESULT\|') {
+            $rowCount++
+            $f = $rln.Trim() -split '\|'
+            $results += [pscustomobject]@{
+                image_ref   = $imageRef
+                package     = $f[1]
+                pinned      = $f[2]
+                candidate   = $f[3]
+                newer       = ($f[4] -eq 'yes')
+                installable = $f[5]
+                security    = ($f[6] -eq 'yes')
+            }
+            continue
+        }
+
+        if ($rln -match '^PINSET\|') {
+            $pinSetCount++
+            $f = $rln.Trim() -split '\|', 4
+            $pinSets += [pscustomobject]@{
+                image_ref   = $imageRef
+                dockerfile  = $f[1]
+                installable = ($f[2] -eq 'yes')
+                detail      = $f[3]
+            }
         }
     }
 
     # A query that returns no rows for an image we have pins for means the check
     # did not actually run (e.g. apt-get update failed, or the container errored).
     # Treat that as a hard failure, never as "all current": a silent false
-    # negative would leave the pins unmonitored while looking healthy.
-    if ($rowCount -lt $specs.Count) {
+    # negative would leave the pins unmonitored while looking healthy. The same
+    # goes for a missing pinned-set verdict.
+    if ($rowCount -lt $specs.Count -or $pinSetCount -lt $groupDockerfiles.Count) {
         $queryFailures += $imageRef
-        Write-Host "ERROR: expected $($specs.Count) result(s) from $imageRef but got $rowCount. Container output:"
+        Write-Host "ERROR: expected $($specs.Count) result(s) and $($groupDockerfiles.Count) pinned-set verdict(s) from $imageRef but got $rowCount and $pinSetCount. Container output:"
         Write-Host ($raw.Trim())
     }
 }
@@ -233,49 +290,27 @@ if ($queryFailures.Count -gt 0) {
 $updates = @($results | Where-Object { $_.newer -and $_.installable -eq 'yes' })
 $blocked = @($results | Where-Object { $_.newer -and $_.installable -eq 'no' })
 
-Write-Host ''
-Write-Host '== apt pin status =='
-foreach ($r in $results) {
-    $state = if (-not $r.newer) { 'current' }
-             elseif ($r.installable -eq 'yes') { 'UPDATE' + ($(if ($r.security) { ' (security)' } else { '' })) }
-             elseif ($r.installable -eq 'no') { 'update-not-installable' }
-             else { 'unknown' }
-    Write-Host ("  {0,-22} {1,-40} -> {2,-40} {3}" -f $r.package, $r.pinned, $r.candidate, $state)
-}
-Write-Host ''
-
-if ($blocked.Count -gt 0) {
-    Write-Host "WARNING: $($blocked.Count) package(s) have a newer candidate that did not resolve via apt (skipped, not proposed)."
-}
-
-if ($updates.Count -eq 0) {
-    Write-Host 'All pinned apt packages are current. Nothing to evaluate.'
-    exit 0
-}
-
-Write-Host "$($updates.Count) pinned apt package(s) have an installable update available to evaluate."
-
-# Build a markdown body fragment for the PR, and expose machine-readable outputs.
-$bodyLines = @('| Dockerfile | Package | Pinned | Available | Source |', '| --- | --- | --- | --- | --- |')
-foreach ($u in $updates) {
-    foreach ($pin in ($pins | Where-Object { $_.image_ref -eq $u.image_ref -and $_.package -eq $u.package })) {
-        $src = if ($u.security) { '`-security`' } else { 'updates' }
-        $bodyLines += "| $($pin.dockerfile) | $($u.package) | $($u.pinned) | $($u.candidate) | $src |"
+# Writes the PR-body table and, under -Apply, rewrites the pins. Kept in a
+# function so it can run before the unbuildable check decides the exit code: a
+# base image that has dropped a pinned version needs BOTH the loud failure and
+# the bump PR that fixes it, and a bare `exit 3` above this would suppress the
+# very proposal that clears the failure.
+function Publish-BumpProposal {
+    $bodyLines = @('| Dockerfile | Package | Pinned | Available | Source |', '| --- | --- | --- | --- | --- |')
+    foreach ($u in $updates) {
+        foreach ($pin in ($pins | Where-Object { $_.image_ref -eq $u.image_ref -and $_.package -eq $u.package })) {
+            $src = if ($u.security) { '`-security`' } else { 'updates' }
+            $bodyLines += "| $($pin.dockerfile) | $($u.package) | $($u.pinned) | $($u.candidate) | $src |"
+        }
     }
-}
-$body = $bodyLines -join "`n"
 
-# Write the PR-body table to a file (consumed by open-apt-pin-pr.ps1). Writing a
-# file rather than threading multi-line text through GITHUB_OUTPUT avoids
-# here-string / indentation fragility in the workflow.
-Set-Content -Path (Join-Path $repoRoot 'apt-pin-pr-body.md') -Value $body -Encoding utf8
+    # Write the PR-body table to a file (consumed by open-pin-pr.ps1). Writing a
+    # file rather than threading multi-line text through GITHUB_OUTPUT avoids
+    # here-string / indentation fragility in the workflow.
+    Set-Content -Path (Join-Path $repoRoot 'apt-pin-pr-body.md') -Value ($bodyLines -join "`n") -Encoding utf8
 
-if ($env:GITHUB_OUTPUT) {
-    "has_updates=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-    "update_count=$($updates.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-}
+    if (-not $Apply) { return }
 
-if ($Apply) {
     Write-Host ''
     Write-Host 'Applying validated bumps to Dockerfiles ...'
     foreach ($u in $updates) {
@@ -293,4 +328,58 @@ if ($Apply) {
     }
 }
 
+Write-Host ''
+Write-Host '== apt pin status =='
+foreach ($r in $results) {
+    $state = if (-not $r.newer) { 'current' }
+             elseif ($r.installable -eq 'yes') { 'UPDATE' + ($(if ($r.security) { ' (security)' } else { '' })) }
+             elseif ($r.installable -eq 'no') { 'update-not-installable' }
+             else { 'unknown' }
+    Write-Host ("  {0,-22} {1,-40} -> {2,-40} {3}" -f $r.package, $r.pinned, $r.candidate, $state)
+}
+Write-Host ''
+
+if ($blocked.Count -gt 0) {
+    Write-Host "WARNING: $($blocked.Count) package(s) have a newer candidate that did not resolve via apt (skipped, not proposed)."
+}
+
+# --- Can each image still be built at all? ----------------------------------
+
+$unbuildable = @($pinSets | Where-Object { -not $_.installable })
+
+Write-Host '== pinned set installability =='
+foreach ($ps in $pinSets) {
+    $verdict = if ($ps.installable) { 'resolves' } else { "CANNOT BE INSTALLED: $($ps.detail)" }
+    Write-Host ("  {0,-32} {1}" -f $ps.dockerfile, $verdict)
+}
+Write-Host ''
+
+if ($env:GITHUB_OUTPUT) {
+    "has_updates=$($updates.Count -gt 0)".ToLowerInvariant() | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "update_count=$($updates.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "unbuildable=$($unbuildable.Count -gt 0)".ToLowerInvariant() | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "unbuildable_dockerfiles=$(@($unbuildable | Select-Object -ExpandProperty dockerfile) -join ', ')" |
+        Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}
+
+if ($updates.Count -eq 0) {
+    Write-Host 'All pinned apt packages are current. Nothing to evaluate.'
+    # Not `exit 0`: an image that cannot be built has to be reported whether or
+    # not there is a bump to propose, and the exit-code decision is made once, at
+    # the end of the script.
+} else {
+    Write-Host "$($updates.Count) pinned apt package(s) have an installable update available to evaluate."
+    Publish-BumpProposal
+}
+
+if ($unbuildable.Count -gt 0) {
+    Write-Host ''
+    Write-Host "FATAL: $($unbuildable.Count) Dockerfile(s) pin a package set that can no longer be installed in the base image:"
+    foreach ($ps in $unbuildable) { Write-Host "  $($ps.dockerfile) [$($ps.image_ref)]: $($ps.detail)" }
+    Write-Host 'That image cannot be built from the current pins, so this is reported loudly rather than'
+    Write-Host 'left to surface at release time. Land the bump above (or correct the pins by hand) to clear it.'
+    exit 3
+}
+
+if ($updates.Count -eq 0) { exit 0 }
 exit 2

--- a/.github/scripts/check-tooling-pins.ps1
+++ b/.github/scripts/check-tooling-pins.ps1
@@ -28,6 +28,14 @@
       2. Queries the upstream registry (npm or NuGet) for the latest stable
          version.
       3. Flags any tool whose pinned version is behind the latest.
+      4. Checks that the pinned version ITSELF is still published. A version that
+         has been unpublished (npm) or deleted (NuGet) cannot be installed, so
+         the devcontainer can no longer be built, and asking only "is something
+         newer available?" would report that pin as perfectly current. This is
+         the tooling equivalent of #1374, where an Ubuntu archive rotation left
+         `main` unable to build the Worker image with every check green. Both
+         registry documents already carry the full version list, so it costs no
+         extra request.
 
     Default mode reports findings as a table. `-Apply` additionally rewrites the
     bumps into the pin files in place (used by the tooling-pin-check workflow to
@@ -46,11 +54,15 @@
     script only reports.
 
 .NOTES
-    Exit codes:
+    Exit codes (the highest applicable one wins):
       0  success; no updates available (or -Apply applied them cleanly)
       1  an error occurred (a registry query failed, a pin could not be parsed)
       2  updates are available (lets a scheduled check branch on "is there
          anything to evaluate")
+      3  a pinned version is no longer published upstream, so it can no longer be
+         installed. Reported after any bumps have been applied and written out,
+         so the workflow can still raise the PR that fixes it and then fail the
+         run.
 
     Like the apt pin check, a registry query that fails is treated as a hard
     error (exit 1), never as "current": a silent false negative would leave the
@@ -95,24 +107,34 @@ $tools = @(
 
 # --- Registry queries --------------------------------------------------------
 
-function Get-LatestNpmVersion {
+# Both return the latest stable version AND every version the registry still
+# offers, so the caller can ask the two separate questions: is the pin behind,
+# and is the pin still there at all.
+
+function Get-NpmRegistryInfo {
     param([string]$Id)
     # Scoped names (@scope/name) must have the slash encoded for the registry path.
     $encoded = $Id -replace '/', '%2F'
     $resp = Invoke-RestMethod -Uri "https://registry.npmjs.org/$encoded" -TimeoutSec 30
     $latest = $resp.'dist-tags'.latest
     if (-not $latest) { throw "npm returned no dist-tags.latest for $Id." }
-    return $latest
+    # An unpublished version is removed from the packument's versions map, which
+    # is exactly what "this pin can no longer be installed" looks like on npm.
+    $versions = @($resp.versions.PSObject.Properties.Name)
+    if ($versions.Count -eq 0) { throw "npm returned no versions for $Id." }
+    return [pscustomobject]@{ latest = $latest; versions = $versions }
 }
 
-function Get-LatestNuGetVersion {
+function Get-NuGetRegistryInfo {
     param([string]$Id)
     # The flat-container id segment is lower-cased.
     $resp = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$($Id.ToLower())/index.json" -TimeoutSec 30
+    $versions = @($resp.versions)
+    if ($versions.Count -eq 0) { throw "NuGet returned no versions for $Id." }
     # Versions are ascending; exclude prereleases (a '-' suffix) and take the last.
-    $stable = @($resp.versions | Where-Object { $_ -notmatch '-' })
+    $stable = @($versions | Where-Object { $_ -notmatch '-' })
     if ($stable.Count -eq 0) { throw "NuGet returned no stable versions for $Id." }
-    return $stable[-1]
+    return [pscustomobject]@{ latest = $stable[-1]; versions = $versions }
 }
 
 function Compare-Version {
@@ -140,7 +162,8 @@ function Get-PinnedVersion {
 # --- Detect ------------------------------------------------------------------
 
 $queryFailures = @()
-$findings = @()  # one per tool that is behind
+$findings = @()      # one per tool that is behind
+$withdrawn = @()     # one per tool whose pinned version is no longer published
 
 foreach ($tool in $tools) {
     # Read every location's current version. They should all agree; if they have
@@ -158,9 +181,9 @@ foreach ($tool in $tools) {
     $current = (@($distinct | Sort-Object { [version]$_ }))[0]
 
     try {
-        $latest = switch ($tool.registry) {
-            'npm'   { Get-LatestNpmVersion   -Id $tool.id }
-            'nuget' { Get-LatestNuGetVersion -Id $tool.id }
+        $info = switch ($tool.registry) {
+            'npm'   { Get-NpmRegistryInfo   -Id $tool.id }
+            'nuget' { Get-NuGetRegistryInfo -Id $tool.id }
             default { throw "Unknown registry '$($tool.registry)' for $($tool.name)." }
         }
     } catch {
@@ -169,9 +192,26 @@ foreach ($tool in $tools) {
         continue
     }
 
+    $latest = $info.latest
+
+    # Every version actually pinned in a file has to still exist upstream, not
+    # just the lowest: a drifted pair could have one live location and one dead.
+    $gone = @($distinct | Where-Object { $info.versions -notcontains $_ })
+
     $behind = Compare-Version -Candidate $latest -Current $current
-    $state = if ($behind) { 'UPDATE' } else { 'current' }
+    $state = if ($gone.Count -gt 0) { "WITHDRAWN from $($tool.registry)" }
+             elseif ($behind) { 'UPDATE' }
+             else { 'current' }
     Write-Host ("  {0,-22} {1,-12} -> {2,-12} {3}" -f $tool.name, $current, $latest, $state)
+
+    if ($gone.Count -gt 0) {
+        $withdrawn += [pscustomobject]@{
+            name     = $tool.name
+            registry = $tool.registry
+            versions = ($gone -join ', ')
+            files    = (@($tool.locations | ForEach-Object { $_.file } | Select-Object -Unique) -join ', ')
+        }
+    }
 
     if ($behind) {
         $findings += [pscustomobject]@{
@@ -191,31 +231,21 @@ if ($queryFailures.Count -gt 0) {
     exit 1
 }
 
-Write-Host ''
-if ($findings.Count -eq 0) {
-    Write-Host 'All manually-pinned tooling is current. Nothing to evaluate.'
-    exit 0
-}
+# --- PR body + apply ---------------------------------------------------------
 
-Write-Host "$($findings.Count) pinned tool(s) have a newer version available to evaluate."
+# Kept in a function so it can run before the withdrawn-pin check decides the
+# exit code: a pin the registry has dropped needs BOTH the loud failure and the
+# bump PR that fixes it, and a bare `exit 3` above this would suppress the very
+# proposal that clears the failure.
+function Publish-BumpProposal {
+    $bodyLines = @('| Tool | Pinned | Available | Files |', '| --- | --- | --- | --- |')
+    foreach ($f in $findings) {
+        $bodyLines += "| ``$($f.name)`` | $($f.current) | $($f.latest) | $($f.files) |"
+    }
+    Set-Content -Path (Join-Path $repoRoot 'tooling-pin-pr-body.md') -Value ($bodyLines -join "`n") -Encoding utf8
 
-# --- PR body + machine-readable outputs --------------------------------------
+    if (-not $Apply) { return }
 
-$bodyLines = @('| Tool | Pinned | Available | Files |', '| --- | --- | --- | --- |')
-foreach ($f in $findings) {
-    $bodyLines += "| ``$($f.name)`` | $($f.current) | $($f.latest) | $($f.files) |"
-}
-$body = $bodyLines -join "`n"
-Set-Content -Path (Join-Path $repoRoot 'tooling-pin-pr-body.md') -Value $body -Encoding utf8
-
-if ($env:GITHUB_OUTPUT) {
-    "has_updates=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-    "update_count=$($findings.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-}
-
-# --- Apply -------------------------------------------------------------------
-
-if ($Apply) {
     Write-Host ''
     Write-Host 'Applying bumps to pin files ...'
     foreach ($f in $findings) {
@@ -231,4 +261,36 @@ if ($Apply) {
     }
 }
 
+Write-Host ''
+
+if ($env:GITHUB_OUTPUT) {
+    "has_updates=$($findings.Count -gt 0)".ToLowerInvariant() | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "update_count=$($findings.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "unavailable=$($withdrawn.Count -gt 0)".ToLowerInvariant() | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "unavailable_tools=$(@($withdrawn | ForEach-Object { $_.name }) -join ', ')" |
+        Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}
+
+if ($findings.Count -eq 0) {
+    Write-Host 'All manually-pinned tooling is current. Nothing to evaluate.'
+    # Not `exit 0`: a pin the registry no longer offers has to be reported
+    # whether or not there is a bump to propose, and the exit-code decision is
+    # made once, at the end of the script.
+} else {
+    Write-Host "$($findings.Count) pinned tool(s) have a newer version available to evaluate."
+    Publish-BumpProposal
+}
+
+if ($withdrawn.Count -gt 0) {
+    Write-Host ''
+    Write-Host "FATAL: $($withdrawn.Count) pinned tool version(s) are no longer published upstream:"
+    foreach ($w in $withdrawn) {
+        Write-Host "  $($w.name) $($w.versions) is gone from $($w.registry) (pinned in $($w.files))"
+    }
+    Write-Host 'That version can no longer be installed, so the devcontainer cannot be built from these pins.'
+    Write-Host 'Land the bump above, or repin by hand to a version the registry still offers.'
+    exit 3
+}
+
+if ($findings.Count -eq 0) { exit 0 }
 exit 2

--- a/.github/scripts/open-pin-pr.ps1
+++ b/.github/scripts/open-pin-pr.ps1
@@ -120,23 +120,36 @@ if (-not $Repository) { throw 'Repository not set. Pass -Repository owner/repo o
 # call below checks $LASTEXITCODE rather than relying on try/catch.
 function Invoke-Gh { param([string[]]$GhArgs) & gh @GhArgs }
 
+# The SINGULAR git/ref/heads/<name> endpoint, which is an exact lookup. The
+# plural git/refs/heads/<name> matches by PREFIX and returns every ref beneath
+# it, so probing "automation/apt-pin-updates" with it answers "exists" purely on
+# the strength of "automation/apt-pin-updates-staging" being there. That is not
+# hypothetical: it is how the first live run of this script failed, updating a
+# ref that had never been created.
 function Test-BotRef {
     param([string]$Name)
-    Invoke-Gh @('api', "repos/$Repository/git/refs/heads/$Name", '--silent') *> $null
+    Invoke-Gh @('api', "repos/$Repository/git/ref/heads/$Name", '--silent') *> $null
     return ($LASTEXITCODE -eq 0)
 }
 
-# Create-or-move, so no caller has to care whether the ref already exists.
+# Create-or-move, so no caller has to care whether the ref already exists. The
+# probe decides which call to try first; whichever it picks, the other is tried
+# before giving up, so a misjudged probe costs an extra request rather than the
+# run.
 function Set-BotRef {
     param([string]$Name, [string]$Sha)
 
-    if (Test-BotRef -Name $Name) {
-        Invoke-Gh @('api', '-X', 'PATCH', "repos/$Repository/git/refs/heads/$Name", '-f', "sha=$Sha", '-F', 'force=true') | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "Failed to move $Name to $Sha." }
-    } else {
-        Invoke-Gh @('api', '-X', 'POST', "repos/$Repository/git/refs", '-f', "ref=refs/heads/$Name", '-f', "sha=$Sha") | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "Failed to create $Name at $Sha." }
+    $update = { Invoke-Gh @('api', '-X', 'PATCH', "repos/$Repository/git/refs/heads/$Name", '-f', "sha=$Sha", '-F', 'force=true') | Out-Null }
+    $create = { Invoke-Gh @('api', '-X', 'POST', "repos/$Repository/git/refs", '-f', "ref=refs/heads/$Name", '-f', "sha=$Sha") | Out-Null }
+
+    $ordered = if (Test-BotRef -Name $Name) { @($update, $create) } else { @($create, $update) }
+
+    foreach ($attempt in $ordered) {
+        & $attempt
+        if ($LASTEXITCODE -eq 0) { return }
     }
+
+    throw "Failed to point $Name at $Sha (both create and update were refused)."
 }
 
 function Remove-BotRef {

--- a/.github/scripts/open-pin-pr.ps1
+++ b/.github/scripts/open-pin-pr.ps1
@@ -3,8 +3,9 @@
 
 <#
 .SYNOPSIS
-    Opens (or updates) a pull request publishing the version-pin bumps that a
-    `check-*-pins.ps1 -Apply` step has rewritten in the working tree.
+    Opens (or updates, reopens, or deliberately closes) a pull request publishing
+    the version-pin bumps that a `check-*-pins.ps1 -Apply` step has rewritten in
+    the working tree.
 
 .DESCRIPTION
     Run after a detection script (check-apt-pins.ps1, check-tooling-pins.ps1, ...)
@@ -27,10 +28,24 @@
          (e.g. check-apt-pins.ps1 proves installability); this script only
          publishes what that step validated.
 
-    Idempotency: each bot uses a single stable branch. On each run the branch is
-    reset to the tip of the base branch and a fresh single commit is applied, so
-    an already-open PR is updated in place rather than duplicated, and the branch
-    never accumulates stale history.
+    Idempotency: each bot uses a single stable branch carrying exactly one commit
+    off the tip of the base branch, so an already-open PR is updated in place
+    rather than duplicated, and the branch never accumulates superseded bumps.
+
+    That commit is built on a throwaway staging ref and the bot branch is then
+    moved straight from its previous bump commit to the new one, in a single ref
+    update. The obvious implementation, resetting the bot branch to the base tip
+    and committing on top, is what #1374 was: between those two calls the head
+    branch carries no commits ahead of its base, GitHub closes a pull request
+    that enters that state, and the close landed in the window. It closed #1364
+    mid-run, leaving a security pin unlandable while `main` could not build the
+    Worker image at all. The bot branch must therefore never be pointed at the
+    base tip, however briefly.
+
+    Belt and braces, because the close is asynchronous and a future change could
+    reintroduce a window: a bump PR found closed (and unmerged) at the start of a
+    run is reopened rather than duplicated, and the PR's state is confirmed once
+    more after the push.
 
     Requires: GH_TOKEN set to a token carrying `contents: write` and
     `pull-requests: write`. In the pin-check workflows this is a GitHub App
@@ -59,13 +74,20 @@
     The label applied to a newly-created PR. Defaults to 'dependencies'.
 
 .PARAMETER BaseBranch
-    The branch to target and reset from. Defaults to 'main'.
+    The branch to target and build the bump commit on. Defaults to 'main'.
 
 .PARAMETER Branch
     The bot's working branch. Defaults to 'automation/apt-pin-updates'.
 
 .PARAMETER Repository
     owner/repo. Defaults to $env:GITHUB_REPOSITORY.
+
+.PARAMETER CloseStalePr
+    When there is nothing to propose, close the bot's open PR with the reason
+    stated in a comment. Opt-in, and intended for the workflows, which only reach
+    this script with a clean tree when their detection step has succeeded and
+    reported no updates. A developer running the script by hand against a clean
+    checkout will not close the bot's pull request.
 
 .PARAMETER DryRun
     Print the actions and the GraphQL payload instead of calling the API. For
@@ -86,12 +108,59 @@ image. Raised for evaluation by the apt-pin-check workflow.
     [string]$BaseBranch = 'main',
     [string]$Branch = 'automation/apt-pin-updates',
     [string]$Repository = $env:GITHUB_REPOSITORY,
+    [switch]$CloseStalePr,
     [switch]$DryRun
 )
 
 $ErrorActionPreference = 'Stop'
 
 if (-not $Repository) { throw 'Repository not set. Pass -Repository owner/repo or set GITHUB_REPOSITORY.' }
+
+# Native `gh` failures do NOT raise a terminating error in PowerShell, so every
+# call below checks $LASTEXITCODE rather than relying on try/catch.
+function Invoke-Gh { param([string[]]$GhArgs) & gh @GhArgs }
+
+function Test-BotRef {
+    param([string]$Name)
+    Invoke-Gh @('api', "repos/$Repository/git/refs/heads/$Name", '--silent') *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Create-or-move, so no caller has to care whether the ref already exists.
+function Set-BotRef {
+    param([string]$Name, [string]$Sha)
+
+    if (Test-BotRef -Name $Name) {
+        Invoke-Gh @('api', '-X', 'PATCH', "repos/$Repository/git/refs/heads/$Name", '-f', "sha=$Sha", '-F', 'force=true') | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "Failed to move $Name to $Sha." }
+    } else {
+        Invoke-Gh @('api', '-X', 'POST', "repos/$Repository/git/refs", '-f', "ref=refs/heads/$Name", '-f', "sha=$Sha") | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "Failed to create $Name at $Sha." }
+    }
+}
+
+function Remove-BotRef {
+    param([string]$Name)
+    Invoke-Gh @('api', '-X', 'DELETE', "repos/$Repository/git/refs/heads/$Name") *> $null
+    if ($LASTEXITCODE -ne 0) { Write-Host "WARNING: could not delete $Name; a later run will reuse it." }
+}
+
+# Every pull request ever raised from the bot branch, newest first, as the raw
+# JSON. A string rather than a parsed array, because PowerShell unrolls a
+# function's array output: returning one would hand back $null for no pull
+# requests and a bare object for one, so every caller would have to re-wrap it.
+# Callers parse it themselves, where the shape is plain to read.
+function Get-BotPrJson {
+    $json = (Invoke-Gh @('pr', 'list', '--repo', $Repository, '--head', $Branch, '--state', 'all',
+        '--limit', '10', '--json', 'number,state')) | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "Failed to list pull requests for $Branch." }
+    if (-not $json.Trim()) { return '[]' }
+    return $json.Trim()
+}
+
+$ghBaseArgs = @('--repo', $Repository)
+
+# --- Nothing to propose ------------------------------------------------------
 
 # Files changed by the -Apply step. Scope strictly to the pin files via the
 # caller-supplied pattern: the bump only ever rewrites pinned versions in those
@@ -100,13 +169,29 @@ if (-not $Repository) { throw 'Repository not set. Pass -Repository owner/repo o
 $changed = @(git diff --name-only | Where-Object { $_ -match $FilePattern })
 if ($changed.Count -eq 0) {
     Write-Host 'No working-tree changes; nothing to propose.'
+
+    if ($CloseStalePr -and -not $DryRun) {
+        # A close here is a deliberate decision with its reason recorded, which
+        # is the opposite of #1374's silent close as a side effect of a push.
+        $staleComment = @'
+Closing deliberately: the versions this pull request proposed are no longer behind, so there is nothing left to land. Either the bump has already landed, or the version it proposed is no longer offered upstream.
+
+The pin check will raise a fresh pull request the next time a bump is available.
+'@
+        $openPrs = @(@(ConvertFrom-Json (Get-BotPrJson)) | Where-Object { $_.state -eq 'OPEN' })
+        foreach ($pr in $openPrs) {
+            Write-Host "Closing stale PR #$($pr.number): nothing left to propose."
+            Invoke-Gh (@('pr', 'close', "$($pr.number)") + $ghBaseArgs + @('--comment', $staleComment)) | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "Failed to close stale PR #$($pr.number)." }
+        }
+    }
+
     exit 0
 }
 
 Write-Host "Changed files:"; $changed | ForEach-Object { Write-Host "  $_" }
 
 $prBody = if ($BodyFile -and (Test-Path $BodyFile)) { Get-Content -Path $BodyFile -Raw } else { '' }
-$commitHeadline = $CommitHeadline
 $commitBody = @"
 $CommitBodyIntro
 
@@ -121,13 +206,17 @@ $additions = foreach ($path in $changed) {
     }
 }
 
-# Tip of the base branch: the commit we reset the bot branch to and expect as the
-# parent of the new commit.
-function Invoke-Gh { param([string[]]$GhArgs) & gh @GhArgs }
-
-$baseSha = (Invoke-Gh @('api', "repos/$Repository/git/ref/heads/$BaseBranch", '--jq', '.object.sha')).Trim()
+# Tip of the base branch: the parent the bump commit is built on, so the branch
+# carries exactly one commit and its diff is the bump alone.
+$baseSha = (Invoke-Gh @('api', "repos/$Repository/git/ref/heads/$BaseBranch", '--jq', '.object.sha'))
+if ($LASTEXITCODE -ne 0) { throw "Could not resolve $BaseBranch sha." }
+$baseSha = "$baseSha".Trim()
 if (-not $baseSha) { throw "Could not resolve $BaseBranch sha." }
 Write-Host "$BaseBranch is at $baseSha"
+
+# The staging ref exists only to give createCommitOnBranch somewhere to build on
+# that no pull request is watching, so resetting it to the base tip is harmless.
+$stagingBranch = "$Branch-staging"
 
 $mutation = @'
 mutation($input: CreateCommitOnBranchInput!) {
@@ -136,18 +225,18 @@ mutation($input: CreateCommitOnBranchInput!) {
 '@
 
 $commitInput = @{
-    branch          = @{ repositoryNameWithOwner = $Repository; branchName = $Branch }
-    message         = @{ headline = $commitHeadline; body = $commitBody }
+    branch          = @{ repositoryNameWithOwner = $Repository; branchName = $stagingBranch }
+    message         = @{ headline = $CommitHeadline; body = $commitBody }
     fileChanges     = @{ additions = @($additions) }
     expectedHeadOid = $baseSha
 }
-$variables = @{ input = $commitInput }
-$payload = @{ query = $mutation; variables = $variables } | ConvertTo-Json -Depth 10 -Compress
+$payload = @{ query = $mutation; variables = @{ input = $commitInput } } | ConvertTo-Json -Depth 10 -Compress
 
 if ($DryRun) {
     Write-Host ''
-    Write-Host '== DRY RUN: would reset branch and create signed commit =='
-    Write-Host "  branch:  $Branch (reset to $baseSha)"
+    Write-Host '== DRY RUN: would create a signed commit and move the bump branch onto it =='
+    Write-Host "  staging: $stagingBranch (at $baseSha, deleted afterwards)"
+    Write-Host "  branch:  $Branch (moved straight onto the new commit, never onto $baseSha)"
     Write-Host "  files:   $($changed -join ', ')"
     Write-Host "  PR:      $Branch -> $BaseBranch"
     Write-Host ''
@@ -161,22 +250,9 @@ if ($DryRun) {
     exit 0
 }
 
-# Reset (or create) the bot branch at the base tip so the PR contains exactly one
-# fresh commit and updates cleanly in place. Note: native `gh` failures do NOT
-# raise a terminating error in PowerShell, so branch existence is probed via
-# $LASTEXITCODE, not try/catch, and each mutation's exit code is checked.
-$refPath = "repos/$Repository/git/refs/heads/$Branch"
-Invoke-Gh @('api', $refPath, '--silent') 2>$null
-$branchExists = ($LASTEXITCODE -eq 0)
-if ($branchExists) {
-    Write-Host "Resetting $Branch to $baseSha"
-    Invoke-Gh @('api', '-X', 'PATCH', $refPath, '-f', "sha=$baseSha", '-F', 'force=true') | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "Failed to reset branch $Branch to $baseSha." }
-} else {
-    Write-Host "Creating $Branch at $baseSha"
-    Invoke-Gh @('api', '-X', 'POST', "repos/$Repository/git/refs", '-f', "ref=refs/heads/$Branch", '-f', "sha=$baseSha") | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "Failed to create branch $Branch at $baseSha." }
-}
+# --- Publish the bump --------------------------------------------------------
+
+Set-BotRef -Name $stagingBranch -Sha $baseSha
 
 # Create the signed commit via GraphQL. Parse the response explicitly so a
 # GraphQL-level error (which still exits 0 in some cases) is caught.
@@ -185,21 +261,61 @@ try {
     $payload | Out-File -FilePath $tmp -Encoding utf8
     $resp = Get-Content -Raw $tmp | & gh api graphql --input -
     if ($LASTEXITCODE -ne 0) { throw "createCommitOnBranch call failed (exit $LASTEXITCODE): $resp" }
-    $commitOid = ($resp | ConvertFrom-Json).data.createCommitOnBranch.commit.oid
+    $commitOid = ("$resp" | ConvertFrom-Json).data.createCommitOnBranch.commit.oid
     if (-not $commitOid) { throw "createCommitOnBranch returned no commit oid: $resp" }
-    Write-Host "Created signed commit $commitOid on $Branch"
+    Write-Host "Created signed commit $commitOid on $stagingBranch"
 } finally {
     Remove-Item $tmp -ErrorAction SilentlyContinue
 }
 
-# Open the PR if one is not already open for this branch; otherwise it has been
-# updated in place by the branch reset + new commit.
-$openPr = (Invoke-Gh @('pr', 'list', '--repo', $Repository, '--head', $Branch, '--state', 'open', '--json', 'number', '--jq', '.[0].number')).Trim()
+# The whole point: one ref update, from the previous bump commit straight onto
+# the new one. The branch is never equal to $BaseBranch, so the pull request
+# never becomes empty and is never auto-closed (#1374).
+Write-Host "Moving $Branch onto $commitOid"
+Set-BotRef -Name $Branch -Sha $commitOid
+
+# Delete the staging ref only after the bump branch holds the commit, so it is
+# reachable from a ref throughout.
+Remove-BotRef -Name $stagingBranch
+
+# --- Reconcile the pull request ----------------------------------------------
+
+$prs = @(ConvertFrom-Json (Get-BotPrJson))
+$openPr = @($prs | Where-Object { $_.state -eq 'OPEN' })[0]
+$closedPr = @($prs | Where-Object { $_.state -eq 'CLOSED' })[0]
+
 if ($openPr) {
-    Write-Host "Updated existing PR #$openPr"
-    Invoke-Gh @('pr', 'edit', $openPr, '--repo', $Repository, '--body', $commitBody) | Out-Null
+    Write-Host "Updated existing PR #$($openPr.number)"
+    Invoke-Gh (@('pr', 'edit', "$($openPr.number)") + $ghBaseArgs + @('--body', $commitBody)) | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to update the body of PR #$($openPr.number)." }
+    $prNumber = $openPr.number
+} elseif ($closedPr) {
+    # The bump is still needed and the branch still exists, so a closed PR is a
+    # PR that should not be closed. Reopening beats raising a second one: the
+    # evaluation history stays in one place.
+    Write-Host "WARNING: PR #$($closedPr.number) was found closed while its bump is still needed; reopening it."
+    Invoke-Gh (@('pr', 'reopen', "$($closedPr.number)") + $ghBaseArgs) | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to reopen PR #$($closedPr.number)." }
+    Invoke-Gh (@('pr', 'edit', "$($closedPr.number)") + $ghBaseArgs + @('--body', $commitBody)) | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to update the body of PR #$($closedPr.number)." }
+    $prNumber = $closedPr.number
 } else {
     Write-Host 'Opening new PR ...'
-    Invoke-Gh @('pr', 'create', '--repo', $Repository, '--base', $BaseBranch, '--head', $Branch,
-        '--title', $commitHeadline, '--body', $commitBody, '--label', $Label) | Out-Null
+    Invoke-Gh (@('pr', 'create') + $ghBaseArgs + @('--base', $BaseBranch, '--head', $Branch,
+        '--title', $CommitHeadline, '--body', $commitBody, '--label', $Label)) | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to open a PR for $Branch." }
+    $prNumber = @(@(ConvertFrom-Json (Get-BotPrJson)) | Where-Object { $_.state -eq 'OPEN' })[0].number
 }
+
+# Confirm the run ends with the PR open. GitHub's close is asynchronous, so this
+# can miss one that lands after the check; the reconciliation above is what
+# guarantees the next run recovers. This catches the rest.
+$latest = @(ConvertFrom-Json (Get-BotPrJson))
+$finalState = @($latest | Where-Object { $_.number -eq $prNumber })[0].state
+if ($finalState -ne 'OPEN') {
+    Write-Host "WARNING: PR #$prNumber is $finalState after the push; reopening it."
+    Invoke-Gh (@('pr', 'reopen', "$prNumber") + $ghBaseArgs) | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "PR #$prNumber was $finalState after the push and could not be reopened." }
+}
+
+Write-Host "PR #$prNumber is open with the current bump."

--- a/.github/workflows/apt-pin-check.yml
+++ b/.github/workflows/apt-pin-check.yml
@@ -54,22 +54,43 @@ jobs:
         shell: pwsh
         run: |
           ./.github/scripts/check-apt-pins.ps1 -Apply
-          # Exit 2 means "updates applied"; treat as success for the workflow.
-          if ($LASTEXITCODE -eq 2) { exit 0 }
+          # 2 means "updates applied" and 3 means "a pinned set can no longer be
+          # installed". Neither stops the run here: the bump PR is raised first,
+          # and the unbuildable state is failed on at the end, so the run that
+          # reports the problem is also the run that proposes the fix.
+          if ($LASTEXITCODE -in @(2, 3)) { exit 0 }
           exit $LASTEXITCODE
 
+      # Minted unconditionally: with no bump to propose the next step still has
+      # a stale bump PR to close deliberately.
       - name: Mint GitHub App installation token
-        if: steps.check.outputs.has_updates == 'true'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.JIM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.JIM_AUTOMATION_PRIVATE_KEY }}
 
-      - name: Open or update bump PR
-        if: steps.check.outputs.has_updates == 'true'
+      - name: Open, update or close the bump PR
         shell: pwsh
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: ./.github/scripts/open-pin-pr.ps1 -BodyFile apt-pin-pr-body.md
+        run: |
+          # Close a stale bump PR only when detection actually reported nothing
+          # to propose. A clean tree for any other reason (a bump that failed to
+          # apply, say) leaves the PR alone.
+          $nothingToPropose = '${{ steps.check.outputs.has_updates }}' -ne 'true'
+          ./.github/scripts/open-pin-pr.ps1 -BodyFile apt-pin-pr-body.md -CloseStalePr:$nothingToPropose
+
+      # Deliberately the last step, and deliberately a failure. A pinned version
+      # the archive has withdrawn means `main` cannot build that image, and
+      # nothing else in CI notices: build-and-test compiles and runs tests rather
+      # than building the production images. In #1374 that state lasted two days
+      # with every required check green.
+      - name: Fail when a pinned package set can no longer be installed
+        if: steps.check.outputs.unbuildable == 'true'
+        shell: pwsh
+        run: |
+          $files = '${{ steps.check.outputs.unbuildable_dockerfiles }}'
+          Write-Host "::error title=Production image cannot be built::Pinned apt packages no longer resolve in the base image for: $files. See the job log for apt's diagnosis, and land the bump PR this run raised."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       shell: pwsh
       run: |
         $config = New-PesterConfiguration
-        $config.Run.Path = @("./src/JIM.PowerShell/Tests", "./scripts/Tests")
+        $config.Run.Path = @("./src/JIM.PowerShell/Tests", "./scripts/Tests", "./.github/scripts/Tests")
         $config.Run.Exit = $true
         $config.Output.Verbosity = "Detailed"
         $config.TestResult.Enabled = $true

--- a/.github/workflows/tooling-pin-check.yml
+++ b/.github/workflows/tooling-pin-check.yml
@@ -59,16 +59,16 @@ jobs:
           if ($LASTEXITCODE -eq 2) { exit 0 }
           exit $LASTEXITCODE
 
+      # Minted unconditionally: with no bump to propose the next step still has
+      # a stale bump PR to close deliberately.
       - name: Mint GitHub App installation token
-        if: steps.check.outputs.has_updates == 'true'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.JIM_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.JIM_AUTOMATION_PRIVATE_KEY }}
 
-      - name: Open or update bump PR
-        if: steps.check.outputs.has_updates == 'true'
+      - name: Open, update or close the bump PR
         shell: pwsh
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -80,10 +80,15 @@ jobs:
           for evaluation by the tooling-pin-check workflow. Where a tool is pinned in
           more than one file, every location has been moved to the same version.
           '@
+          # Close a stale bump PR only when detection actually reported nothing
+          # to propose. A clean tree for any other reason (a bump that failed to
+          # apply, say) leaves the PR alone.
+          $nothingToPropose = '${{ steps.check.outputs.has_updates }}' -ne 'true'
           ./.github/scripts/open-pin-pr.ps1 `
             -BodyFile tooling-pin-pr-body.md `
             -FilePattern '(^|/)(setup\.sh|\.mcp\.json)$' `
             -Branch 'automation/tooling-pin-updates' `
             -CommitHeadline 'chore(deps): bump pinned development tooling versions' `
             -CommitBodyIntro $intro `
-            -Label 'dependencies'
+            -Label 'dependencies' `
+            -CloseStalePr:$nothingToPropose

--- a/.github/workflows/tooling-pin-check.yml
+++ b/.github/workflows/tooling-pin-check.yml
@@ -55,8 +55,11 @@ jobs:
         shell: pwsh
         run: |
           ./.github/scripts/check-tooling-pins.ps1 -Apply
-          # Exit 2 means "updates applied"; treat as success for the workflow.
-          if ($LASTEXITCODE -eq 2) { exit 0 }
+          # 2 means "updates applied" and 3 means "a pinned version is no longer
+          # published". Neither stops the run here: the bump PR is raised first,
+          # and the withdrawn pin is failed on at the end, so the run that
+          # reports the problem is also the run that proposes the fix.
+          if ($LASTEXITCODE -in @(2, 3)) { exit 0 }
           exit $LASTEXITCODE
 
       # Minted unconditionally: with no bump to propose the next step still has
@@ -92,3 +95,16 @@ jobs:
             -CommitBodyIntro $intro `
             -Label 'dependencies' `
             -CloseStalePr:$nothingToPropose
+
+      # Deliberately the last step, and deliberately a failure. A pinned version
+      # the registry no longer offers cannot be installed, so the devcontainer
+      # cannot be built from these pins, and asking only "is something newer
+      # available?" would have reported that pin as current. Same shape as the
+      # apt check's gate, for the same reason (#1374).
+      - name: Fail when a pinned tool version is no longer published
+        if: steps.check.outputs.unavailable == 'true'
+        shell: pwsh
+        run: |
+          $tools = '${{ steps.check.outputs.unavailable_tools }}'
+          Write-Host "::error title=Pinned tooling withdrawn upstream::The pinned version of $tools is no longer published. See the job log, and land the bump PR this run raised."
+          exit 1


### PR DESCRIPTION
> **Correction (post-merge).** Two claims in the original description were wrong, and are corrected in place below: the tooling bot was **not** silently doing nothing, and `gh pr create` was **not** being refused. See "What the tooling bot's history showed". The code change is unaffected; only the account of what it was reacting to.

## Description

`apt-pin-check` detected the `libgssapi-krb5-2` security bump correctly, raised it correctly, and then its own next run closed the pull request it had raised (#1364). The bump could not land, and while it sat unlanded `main` could not build the Worker image at all, with every required check green.

The close was not a decision. `open-pin-pr.ps1` reset its bot branch to the tip of the base branch and then committed on top, so between those two API calls the head branch carried no commits ahead of base. GitHub closes a pull request that enters that state, and the close landed in the window. That also explains why it fired on one run and not the previous one: the window is a race.

**It reached further than #1364.** The same bug closed **#1073** on 21 July, and the tooling bot has been churning pull requests ever since: each auto-close orphaned the open one, and the next run raised a fresh one in its place.

**The fix, in five parts:**

1. **The window is gone.** The commit is built on a throwaway staging ref, and the bot branch moves straight from its previous bump commit onto the new one in a single ref update, so it is never equal to the base branch, however briefly. The branch still carries exactly one commit off the base tip, which is what the reset bought.
2. **Belt and braces**, since the close is asynchronous and a future change could reintroduce a window: a bump PR found closed but still needed is reopened rather than duplicated, and the PR's state is confirmed once more after the push.
3. **Closing is now deliberate.** With nothing left to propose the bot closes its open PR with the reason stated in a comment, under an opt-in switch so a developer running the script by hand against a clean checkout does not.
4. **Every `gh` call now checks its exit code.** `gh pr create` in particular was piped to `Out-Null` with its result unexamined, so a run that raised nothing would still have reported success. This is a latent gap rather than an observed outage (see the correction below), but a bot whose whole job is to report a state must not be able to report green having done nothing.
5. **The unbuildable image is reported loudly.** `check-apt-pins.ps1` only ever asked whether a *newer* version was installable; it never asked whether the version already pinned still was. It now probes each Dockerfile's pins as a set (which is what the image build does) and exits 3 when a set no longer resolves. `check-tooling-pins.ps1` had the identical blind spot for npm unpublishes and NuGet deletions, and now checks the same way. Both workflows fail on it, but only *after* the bump PR has been raised, so the run that reports the problem is also the run that proposes the fix.

Both pin bots share `open-pin-pr.ps1`, so parts 1-4 fix `tooling-pin-check` at the same time.

Closes #1374

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [ ] `dotnet build JIM.sln` succeeds with zero errors — n/a, no .NET code changed
- [ ] `dotnet test JIM.sln` passes — n/a, no .NET code changed
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

**Tests.** 22 Pester tests across two new files, wired into the Pester paths CI already runs.

`OpenPinPr.Tests.ps1` runs the real script against a fake GitHub that models refs, commits, pull requests and *the auto-close rule itself*; without that rule the sequence of API calls looks perfectly healthy. Eight of the fifteen fail against the previous implementation, including "leaves the pull request open" and "never points the bump branch at the base branch tip".

`CheckToolingPins.Tests.ps1` fakes the registry by shadowing `Invoke-RestMethod`, with the real pin files as fixtures so the script's own regexes are exercised. Four of the seven fail against the previous implementation; the three that pin existing behaviour pass either way, which is what says the fake is faithful.

### Live verification on this branch

Dispatched both workflows against this branch rather than trusting the diff. That is what found the defect below and what proves the acceptance criteria.

**It caught a real defect in the fix itself.** The first `tooling-pin-check` dispatch ([run 15](https://github.com/TetronIO/JIM/actions/runs/32028386822)) failed. GitHub's plural `git/refs/heads/<name>` endpoint matches by **prefix**, so probing `automation/tooling-pin-updates` answered "exists" purely on the strength of the `-staging` ref this change introduces beside it; the script then updated a ref that had never been created and died on a 422 with the signed commit already built. It bites exactly where the old implementation could not, on any bot's first run. Fixed by using the singular exact-lookup endpoint, with a create/update fallback so a misjudged probe costs a request rather than a run. The fake now models the prefix semantics (it reproduces the failure verbatim) and a test covers it.

**Then the acceptance criteria, live:**

| Run | What happened |
| --- | --- |
| [16](https://github.com/TetronIO/JIM/actions/runs/32028586600) | Created the bump branch, then **found PR #1073 closed while its bump was still needed and reopened it**. |
| [17](https://github.com/TetronIO/JIM/actions/runs/32028953162) | `Updated existing PR #1073`. Not a reopen: the push never closed it. |

After the two consecutive runs, #1073 was open, its head had moved to a fresh commit, it still carried **exactly one commit**, no duplicate PR was raised, and the `-staging` ref was gone from the branch list. That is "survives consecutive runs" and "the branch never accumulates history", verified against the real API rather than the fake.

`apt-pin-check` was also dispatched ([run 83](https://github.com/TetronIO/JIM/actions/runs/32028101473)): green end to end, exercising the unconditional token mint, the new outputs, and the stale-close guard declining to fire. A post-merge dispatch from `main` ([run 18](https://github.com/TetronIO/JIM/actions/runs/32041740245), attempt 2) confirms the merged code runs clean there too.

### What the tooling bot's history showed

**This section replaces an earlier version that was wrong.** It claimed `gh pr create` was being refused and that the bot had raised nothing for four weeks. Both are false: PRs #1080, #1291 and #1385 were all raised by the bot on that branch and all merged, #1385 as recently as this morning.

What the logs do show is the close, and the churn it caused. [Run #10](https://github.com/TetronIO/JIM/actions/runs/29800469939), the morning after #1073 was raised:

```
04:09:50  Resetting automation/tooling-pin-updates to 5f6a643
04:09:52  Created signed commit 5c4f9157cb041861a400be3ebf647b79e0aa0315
04:09:53  Opening new PR ...
```

`Opening new PR ...` is only printed when the search for an open pull request on the bot's own branch comes back empty, and it ran 2.4 seconds after the reset: #1073 had already been auto-closed inside the window. Same signature as #1364, which #1374 records as closing in the same second as its commit. Two seconds later the run opened **#1080** in its place.

So the failure mode on the tooling side was not silence but substitution: every auto-close orphaned an open pull request and the next run raised a new number for the same job, discarding whatever review had accumulated on the old one. Bumps still landed; the pull request they landed through kept changing identity, and #1073 was left behind entirely.

**Runtime verification of the detection scripts:**

- `check-apt-pins.ps1` run with Docker against both production base images: the current pins resolve and it exits 0.
- With `libgssapi-krb5-2` put back to the withdrawn `1.20.1-6ubuntu2.7`, it reproduces apt's own diagnosis from the issue, still applies the bump and writes the PR body, and exits 3:

```
== pinned set installability ==
  src/JIM.Worker/Dockerfile        CANNOT BE INSTALLED:  libgssapi-krb5-2 : Depends: libkrb5-3
  (= 1.20.1-6ubuntu2.7) but 1.20.1-6ubuntu2.8 is to be installed  Depends: libkrb5support0
  (= 1.20.1-6ubuntu2.7) but 1.20.1-6ubuntu2.8 is to be installed E: Unable to correct problems,
  you have held broken packages.

Applying validated bumps to Dockerfiles ...
  src/JIM.Worker/Dockerfile: libgssapi-krb5-2=1.20.1-6ubuntu2.7 -> libgssapi-krb5-2=1.20.1-6ubuntu2.8
```

- `check-tooling-pins.ps1` run against the real npm and NuGet registries: both pinned versions confirmed still published.
- Full Pester suite green (1,484 tests). Copyright header lint passes. All three touched workflows parse.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

<!-- Docs: n/a - CI automation only; no user-facing behaviour, so no changelog entry either (per CLAUDE.md, CI/CD changes are exempt). -->

## Additional context

**Why a staging ref rather than reopening the PR.** Reopening after the push masks the symptom without removing the window, and the issue says so. `createCommitOnBranch` builds on the branch's current head, so the only way to get a single-commit branch off the base tip without the branch ever *being* the base tip is to build the commit somewhere no pull request is watching. The staging ref is deleted only after the bump branch holds the commit, so the commit is reachable throughout.

**Two behaviour changes worth knowing:**

1. Both workflows now mint the App token and run the PR script on *every* run, not only when there is a bump. That is what makes the deliberate stale close possible.
2. The failure gate is the last step, so a run with a withdrawn pin goes red *and* leaves a bump PR behind. Failing earlier would suppress the fix.

**One judgement call, now settled.** The recovery path cannot tell a close caused by this bug from a human closing a bump they do not want. The logs above show #1073 was the bug, so no guard is needed today. If one is ever wanted, it is a single extra call (`issues/{n}` → `closed_by`): reopen only when the closer is the automation App.

**Still open, deliberately out of scope:** `build-and-test` never builds the production images, which is why archive drift was invisible to everything except the pin bot. Raised separately as #1400.