### PR TITLE
Test an Expression where it is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ An Expression can now be tested where it is written. Choosing Expression as an Attribute Flow's source offers a box for each attribute the Expression reads, resolved from the Expression itself, and **Run test** shows what it produces and the type it evaluated to. Leaving a box empty tests the Expression as an object with no value for that attribute, which is how a concatenation that quietly produces a malformed value (`ada.@corp.local` for a person with no surname) can be seen before the Synchronisation Rule is saved rather than after a synchronisation has carried it. The same evaluation has been available over the REST API and `Test-JIMExpression` since Expression support shipped; this brings it to the portal. (#1405)
+
 ### Fixed
 
 - 🐛 A Connected System whose outbound Synchronisation Rules export different Object Types for different people no longer completes every synchronisation with warnings. When two Rules with non-overlapping Scoping Criteria share one Connected System, each person correctly holds an object of the type their Rule provisions; the other Rule, finding them outside its own scope, then checked whether it had anything to deprovision, found the other Rule's object occupying the system's one slot, and reported it as a conflict, one warning per correctly provisioned person, on every run. An administrator could never see such a configuration complete cleanly, and real problems had to be found among the noise. Deprovisioning an object is always the job of the Rule that provisions its type, so this encounter is now recognised as the configuration working as designed and passed over quietly. The genuine misconfiguration, two overlapping Rules contending for the same person's slot, is still reported exactly as before. (#1399)

--- a/docs/concepts/expressions.md
+++ b/docs/concepts/expressions.md
@@ -443,9 +443,25 @@ If the attribute has the values Admin, Users, and Developers, this produces: `Ad
 
 ## Validation and Troubleshooting
 
+### Testing an expression
+
+The Attribute Flow dialog tests an expression as you write it, so you find out what it produces before you save it rather than from the next synchronisation.
+
+Choose **Expression** as the source type and type your expression. JIM reads the attributes the expression references and offers a box for each one, labelled as the expression addresses it (`cs["givenName"]`, `mv["Display Name"]`). Fill in sample values, choose **Run test**, and the output appears below with the type it evaluated to.
+
+**Leave a box empty to see what happens when the object has no value for that attribute.** An empty box is passed to the expression as no value, not as an empty string, so this is how you check an expression against the hazard the previous section describes:
+
+```csharp
+Lower(cs["givenName"]) + "." + Lower(cs["sn"]) + "@corp.local"
+```
+
+With both values supplied this produces `ada.lovelace@corp.local`. Clear the surname box and it produces `ada.@corp.local`: a syntactically fine string that is not an email address, which nothing downstream can tell apart from a good one. Seeing that before saving is the point.
+
+The same evaluation is available outside the portal, over [`Test-JIMExpression`](../powershell/expressions.md) and the REST API, for testing an expression from a script.
+
 ### Validation
 
-JIM validates expressions when you save a Synchronisation Rule. If an expression has a syntax error, you will see an error message indicating what went wrong and where in the expression the problem is.
+JIM validates expressions when you save a Synchronisation Rule. If an expression has a syntax error, you will see an error message indicating what went wrong and where in the expression the problem is. The tester reports the same errors, so a malformed expression is caught while you are writing it.
 
 Common errors:
 
@@ -461,7 +477,7 @@ When an expression does not produce the result you expect:
 1. **Check the attribute name spelling**<br /> Attribute names are matched case-insensitively, so `mv["department"]` and `mv["Department"]` are equivalent; casing is never the cause. Do check the name is spelled correctly and matches an attribute that exists in the JIM admin UI.
 2. **Use `Eq()` for text comparisons**<br /> Using `==` for text is a common mistake (see [String Comparison](#string-comparison)).
 3. **Check for missing values**<br /> If an attribute does not exist on the object, it returns nothing (null), which can clear the target or, in a concatenation, produce a malformed value. Use `Coalesce()` or `IsNullOrEmpty()` to handle this; see [Nulls, Missing Inputs, and Whitespace](#nulls-missing-inputs-and-whitespace) for the full picture.
-4. **Test with sample data**<br /> Use the expression test feature in the Synchronisation Rule editor to try your expression with real attribute values before saving.
+4. **Test with sample data**<br /> Use the tester in the Attribute Flow dialog to try your expression with sample values, including leaving an input empty to see what an object without that attribute would produce (see [Testing an expression](#testing-an-expression)).
 5. **Check the worker logs**<br /> If expressions fail during sync, the worker service logs the error details.
 
 ## Best Practices

--- a/src/JIM.Application/Expressions/ExpressionInputResolver.cs
+++ b/src/JIM.Application/Expressions/ExpressionInputResolver.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Text.RegularExpressions;
+using JIM.Models.Expressions;
+
+namespace JIM.Application.Expressions;
+
+/// <summary>
+/// Resolves the attributes an Expression reads, from the Expression's own text.
+/// </summary>
+/// <remarks>
+/// Expressions address attributes through two accessors the evaluator binds as parameters,
+/// <c>mv["Attribute Name"]</c> and <c>cs["Attribute Name"]</c> (see <c>DynamicExpressoEvaluator</c>), so the set of
+/// inputs is readable without evaluating anything. That is what lets the portal offer a sample value per input, and
+/// what a "which inputs could be missing?" check would ask for.
+///
+/// This reads the text rather than the parse tree: DynamicExpresso exposes no syntax tree, and an accessor is a
+/// literal-indexed parameter, so there is nothing to infer. The consequence is that an accessor whose attribute name
+/// is computed rather than written out (<c>cs[someVariable]</c>) is not an input this can see; nothing in JIM
+/// produces one today, and a caller must treat the result as "the inputs written down", not "everything reachable".
+/// </remarks>
+public static partial class ExpressionInputResolver
+{
+    /// <summary>
+    /// Returns every attribute the Expression reads, in the order it first mentions them, without duplicates.
+    /// </summary>
+    /// <remarks>
+    /// The same attribute name on both sides yields two inputs: <c>mv["mail"]</c> and <c>cs["mail"]</c> hold
+    /// different values, and collapsing them would test the Expression with one value where it reads two.
+    /// An attribute name carrying escaped quotes is returned exactly as written in the Expression.
+    /// </remarks>
+    /// <param name="expression">The Expression text. Null, empty or whitespace yields no inputs.</param>
+    public static IReadOnlyList<ExpressionInput> Resolve(string? expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+            return Array.Empty<ExpressionInput>();
+
+        var inputs = new List<ExpressionInput>();
+        var seen = new HashSet<(ExpressionInputSource Source, string AttributeName)>();
+
+        foreach (var match in AccessorRegex().Matches(expression).Cast<Match>())
+        {
+            var source = match.Groups[1].Value == "mv"
+                ? ExpressionInputSource.Metaverse
+                : ExpressionInputSource.ConnectedSystem;
+            var attributeName = match.Groups[2].Value;
+
+            if (seen.Add((source, attributeName)))
+                inputs.Add(new ExpressionInput(source, attributeName));
+        }
+
+        return inputs;
+    }
+
+    /// <summary>
+    /// Matches an accessor and captures its side and attribute name. The leading word boundary keeps an identifier
+    /// that merely ends in the accessor's name (<c>abcs["x"]</c>) from being read as one.
+    /// </summary>
+    [GeneratedRegex(@"\b(mv|cs)\s*\[\s*""((?:[^""\\]|\\.)*)""\s*\]", RegexOptions.CultureInvariant)]
+    private static partial Regex AccessorRegex();
+}

--- a/src/JIM.Models/Expressions/ExpressionEnums.cs
+++ b/src/JIM.Models/Expressions/ExpressionEnums.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Expressions;
+
+/// <summary>
+/// Which side of the Metaverse an Expression reads an input from.
+/// </summary>
+public enum ExpressionInputSource
+{
+    /// <summary>
+    /// A Metaverse Object attribute, written as mv["Attribute Name"].
+    /// </summary>
+    Metaverse,
+
+    /// <summary>
+    /// A Connected System Object attribute, written as cs["Attribute Name"].
+    /// </summary>
+    ConnectedSystem
+}

--- a/src/JIM.Models/Expressions/ExpressionInput.cs
+++ b/src/JIM.Models/Expressions/ExpressionInput.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+namespace JIM.Models.Expressions;
+
+/// <summary>
+/// An attribute an Expression reads, resolved from the Expression's own text.
+/// </summary>
+/// <param name="Source">Which side of the Metaverse the attribute is read from.</param>
+/// <param name="AttributeName">The attribute name as written in the Expression.</param>
+public record ExpressionInput(ExpressionInputSource Source, string AttributeName)
+{
+    /// <summary>
+    /// The input as it appears in the Expression, for example <c>mv["Display Name"]</c>. Used as a
+    /// display label and as the key a caller supplies a sample value against.
+    /// </summary>
+    public string Accessor => Source == ExpressionInputSource.Metaverse
+        ? $"mv[\"{AttributeName}\"]"
+        : $"cs[\"{AttributeName}\"]";
+}

--- a/src/JIM.Web/Pages/Admin/Components/SyncRuleAttributeFlowTab.razor
+++ b/src/JIM.Web/Pages/Admin/Components/SyncRuleAttributeFlowTab.razor
@@ -427,6 +427,11 @@
                         Label="Expression" Placeholder="e.g. IIF(mv[&quot;Active&quot;] == true, Upper(cs[&quot;Name&quot;]), null)"
                         Required="true" Class="mt-5" Variant="Variant.Outlined"
                         Lines="3" MaxLines="10" Sizing="InputSizing.Auto" Immediate="true" />
+
+                    @* Expression tester (#1405): the Expression field is where an administrator finds out whether
+                       their Expression does what they meant, and until now the answer only arrived from a
+                       Synchronisation. Immediate="true" above is what lets the tester follow the text as it is typed. *@
+                    <ExpressionTester Expression="@_attributeFlowMappingSource.Expression" />
                     break;
             }
 

--- a/src/JIM.Web/Shared/ExpressionTester.razor
+++ b/src/JIM.Web/Shared/ExpressionTester.razor
@@ -1,0 +1,149 @@
+@using JIM.Models.Expressions
+@using JIM.Models.Interfaces
+@using JIM.Application.Expressions
+@inject IExpressionEvaluator ExpressionEvaluator
+
+@* Copyright (c) Tetron Limited. All rights reserved. *@
+@* Licensed under the Tetron Commercial License. See LICENSE file in the project root. *@
+
+@if (!string.IsNullOrWhiteSpace(Expression))
+{
+    <MudText Typo="Typo.subtitle2" Class="mt-5">Test this Expression</MudText>
+    <MudText Typo="Typo.body2" Class="mud-text-secondary mb-2">
+        Supply a sample value for each attribute the Expression reads and see what it produces, before saving it and
+        finding out from a Synchronisation. Leave an input empty to see what the Expression does when the object has
+        no value for it.
+    </MudText>
+
+    @if (_inputs.Count == 0)
+    {
+        <MudText Typo="Typo.body2" Class="mud-text-secondary">
+            This Expression reads no attributes, so it produces the same value for every object. Run the test to see it.
+        </MudText>
+    }
+    else
+    {
+        <MudGrid Spacing="2" Class="mt-1">
+            @foreach (var input in _inputs)
+            {
+                var accessor = input.Accessor;
+                <MudItem xs="12" sm="6">
+                    <MudTextField T="string" Label="@accessor" Variant="Variant.Outlined" Margin="Margin.Dense"
+                                  Immediate="true" Clearable="true"
+                                  Value="@GetSampleValue(accessor)"
+                                  ValueChanged="@(v => SetSampleValue(accessor, v))" />
+                </MudItem>
+            }
+        </MudGrid>
+    }
+
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Class="mt-3"
+               OnClick="RunTest">Run test</MudButton>
+
+    @if (_result != null)
+    {
+        @if (_result.IsValid)
+        {
+            <MudPaper Outlined="true" Class="pa-3 mt-3">
+                <MudText Typo="Typo.caption" Class="mud-text-secondary">Output</MudText>
+                @if (_result.Result == null)
+                {
+                    <MudText Typo="Typo.body1"><EmptyValue /></MudText>
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                        The Expression returned no value. JIM treats that as an authoritative "no value" from this
+                        contribution, resolved by Attribute Priority and "Null is a value".
+                    </MudText>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body1" Class="jim-expression-output">@_result.Result.ToString()</MudText>
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">Type: @_result.ResultType</MudText>
+                }
+            </MudPaper>
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mt-3">
+                @_result.ErrorMessage
+                @if (_errorPosition.HasValue)
+                {
+                    var position = _errorPosition.Value;
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">Position @position</MudText>
+                }
+            </MudAlert>
+        }
+    }
+}
+
+@code {
+    /// <summary>
+    /// The Expression to test. The inputs offered below are resolved from it, so they follow it as it is edited.
+    /// </summary>
+    [Parameter]
+    public string? Expression { get; set; }
+
+    private IReadOnlyList<ExpressionInput> _inputs = Array.Empty<ExpressionInput>();
+    private readonly Dictionary<string, string?> _sampleValues = new();
+    private ExpressionTestResult? _result;
+    private int? _errorPosition;
+    private string? _resolvedFrom;
+
+    protected override void OnParametersSet()
+    {
+        // Re-resolve only when the Expression itself changed: the sample values are keyed on accessors, so
+        // re-resolving on every render would discard nothing, but the result below must not outlive its Expression.
+        if (_resolvedFrom == Expression)
+            return;
+
+        _resolvedFrom = Expression;
+        _inputs = ExpressionInputResolver.Resolve(Expression);
+        _result = null;
+        _errorPosition = null;
+    }
+
+    private string? GetSampleValue(string accessor) => _sampleValues.GetValueOrDefault(accessor);
+
+    private void SetSampleValue(string accessor, string? value)
+    {
+        _sampleValues[accessor] = value;
+
+        // The displayed output belongs to the values that produced it; keeping it beside changed inputs would
+        // read as the answer to a question that was not asked.
+        _result = null;
+        _errorPosition = null;
+    }
+
+    private void RunTest()
+    {
+        if (string.IsNullOrWhiteSpace(Expression))
+            return;
+
+        var validation = ExpressionEvaluator.Validate(Expression);
+        if (!validation.IsValid)
+        {
+            _result = ExpressionTestResult.Failure(validation.ErrorMessage ?? "The Expression could not be parsed.");
+            _errorPosition = validation.ErrorPosition;
+            return;
+        }
+
+        _errorPosition = null;
+
+        var metaverseAttributes = new Dictionary<string, object?>();
+        var connectedSystemAttributes = new Dictionary<string, object?>();
+
+        foreach (var input in _inputs)
+        {
+            // An empty box means the object has no value for that attribute, which is the case worth being able to
+            // see: an Expression that reads it will produce whatever it produces from nothing.
+            var sampleValue = _sampleValues.GetValueOrDefault(input.Accessor);
+            var value = string.IsNullOrEmpty(sampleValue) ? null : (object)sampleValue;
+
+            if (input.Source == ExpressionInputSource.Metaverse)
+                metaverseAttributes[input.AttributeName] = value;
+            else
+                connectedSystemAttributes[input.AttributeName] = value;
+        }
+
+        _result = ExpressionEvaluator.Test(Expression, new ExpressionContext(metaverseAttributes, connectedSystemAttributes));
+    }
+}

--- a/test/JIM.Web.Tests/ExpressionTesterTests.cs
+++ b/test/JIM.Web.Tests/ExpressionTesterTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using Bunit;
+using JIM.Application.Expressions;
+using JIM.Models.Interfaces;
+using JIM.Web.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using NUnit.Framework;
+
+namespace JIM.Web.Tests;
+
+/// <summary>
+/// Component tests for the Expression tester (#1405), which lets an administrator see what an Expression produces
+/// before saving it. The real evaluator is registered rather than a stub: what is under test is the wiring between
+/// the inputs the component resolves, the sample values it collects and the output it shows, and a stub evaluator
+/// would let a wiring fault pass by returning whatever the test expected.
+/// </summary>
+[TestFixture]
+public class ExpressionTesterTests : JimComponentTestContext
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Services.AddSingleton<IExpressionEvaluator, DynamicExpressoEvaluator>();
+    }
+
+    /// <summary>
+    /// Clicks Run test by its label. A field rendered with Clearable also renders a button, and it comes first in
+    /// the markup, so finding "the button" clears an input instead of running anything.
+    /// </summary>
+    private static void ClickRunTest(IRenderedComponent<ExpressionTester> cut) =>
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Run test")).Click();
+
+    [Test]
+    public void ExpressionTester_NoExpression_RendersNothing()
+    {
+        var cut = Render<ExpressionTester>(p => p.Add(c => c.Expression, ""));
+
+        Assert.That(cut.Markup.Trim(), Is.Empty,
+            "an empty Expression has nothing to test, so the tester must not take up room in the dialog");
+    }
+
+    [Test]
+    public void ExpressionTester_ExpressionReadingTwoAttributes_OffersAFieldForEach()
+    {
+        var cut = Render<ExpressionTester>(p => p.Add(c => c.Expression,
+            "Lower(cs[\"firstName\"]) + \".\" + Lower(cs[\"lastName\"])"));
+
+        var labels = cut.FindComponents<MudTextField<string>>().Select(f => f.Instance.Label).ToList();
+
+        Assert.That(labels, Is.EquivalentTo(new[] { "cs[\"firstName\"]", "cs[\"lastName\"]" }),
+            "one field per attribute the Expression reads, labelled as the Expression addresses it");
+    }
+
+    [Test]
+    public async Task ExpressionTester_WithSampleValues_ShowsTheOutputAsync()
+    {
+        var cut = Render<ExpressionTester>(p => p.Add(c => c.Expression,
+            "Lower(cs[\"firstName\"]) + \".\" + Lower(cs[\"lastName\"]) + \"@corp.local\""));
+
+        var fields = cut.FindComponents<MudTextField<string>>();
+        // Through the renderer's dispatcher, as a real edit arrives: invoking the callback directly throws
+        // "The current thread is not associated with the Dispatcher".
+        await cut.InvokeAsync(() => fields.Single(f => f.Instance.Label == "cs[\"firstName\"]").Instance.ValueChanged.InvokeAsync("Ada"));
+        await cut.InvokeAsync(() => fields.Single(f => f.Instance.Label == "cs[\"lastName\"]").Instance.ValueChanged.InvokeAsync("Lovelace"));
+        ClickRunTest(cut);
+
+        Assert.That(cut.Markup, Does.Contain("ada.lovelace@corp.local"));
+    }
+
+    [Test]
+    public void ExpressionTester_AnEmptyInput_IsTestedAsAbsentRatherThanAsAnEmptyString()
+    {
+        // The whole reason to have this beside the Expression field is seeing what happens when an object has no
+        // value for an input. An empty box must therefore reach the evaluator as no value, which is what produces
+        // the degenerate output worth catching; passing "" would test something the administrator never asked about.
+        var cut = Render<ExpressionTester>(p => p.Add(c => c.Expression,
+            "IIF(IsNullOrEmpty(cs[\"nickname\"]), \"no nickname\", cs[\"nickname\"])"));
+
+        ClickRunTest(cut);
+
+        Assert.That(cut.Markup, Does.Contain("no nickname"));
+    }
+
+    [Test]
+    public void ExpressionTester_ExpressionEdited_DiscardsThePreviousOutput()
+    {
+        // An output left standing beside a changed Expression reads as the answer to the question now on screen.
+        var cut = Render<ExpressionTester>(p => p.Add(c => c.Expression, "\"first answer\""));
+        ClickRunTest(cut);
+        Assert.That(cut.Markup, Does.Contain("first answer"));
+
+        cut.Render(p => p.Add(c => c.Expression, "\"second answer\""));
+
+        Assert.That(cut.Markup, Does.Not.Contain("first answer"),
+            "the previous output belongs to the previous Expression and must not survive it");
+    }
+
+    [Test]
+    public void ExpressionTester_ExpressionThatCannotBeParsed_ShowsTheReason()
+    {
+        var cut = Render<ExpressionTester>(p => p.Add(c => c.Expression, "cs[\"unclosed\""));
+
+        ClickRunTest(cut);
+
+        Assert.That(cut.HasComponent<MudAlert>(), Is.True,
+            "a malformed Expression must say so here rather than at the next Synchronisation");
+    }
+}

--- a/test/JIM.Worker.Tests/Expressions/ExpressionInputResolverTests.cs
+++ b/test/JIM.Worker.Tests/Expressions/ExpressionInputResolverTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application.Expressions;
+using JIM.Models.Expressions;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Expressions;
+
+/// <summary>
+/// Resolving the attributes an Expression reads, which is what lets the portal offer a sample value per input
+/// rather than asking an administrator to assemble a request by hand.
+/// </summary>
+[TestFixture]
+public class ExpressionInputResolverTests
+{
+    [Test]
+    public void Resolve_MetaverseAndConnectedSystemAccessors_ReturnsBothWithTheirSide()
+    {
+        var inputs = ExpressionInputResolver.Resolve("mv[\"Display Name\"] + cs[\"employeeNumber\"]");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(inputs, Has.Count.EqualTo(2));
+            Assert.That(inputs[0].Source, Is.EqualTo(ExpressionInputSource.Metaverse));
+            Assert.That(inputs[0].AttributeName, Is.EqualTo("Display Name"));
+            Assert.That(inputs[1].Source, Is.EqualTo(ExpressionInputSource.ConnectedSystem));
+            Assert.That(inputs[1].AttributeName, Is.EqualTo("employeeNumber"));
+        }
+    }
+
+    [Test]
+    public void Resolve_TheSameAttributeTwice_ReturnsItOnce()
+    {
+        // A tester offering the same input twice would ask for the same value twice and then disagree with itself.
+        var inputs = ExpressionInputResolver.Resolve("cs[\"givenName\"] + \" \" + cs[\"givenName\"]");
+
+        Assert.That(inputs, Has.Count.EqualTo(1));
+        Assert.That(inputs[0].AttributeName, Is.EqualTo("givenName"));
+    }
+
+    [Test]
+    public void Resolve_SameNameOnBothSides_ReturnsBoth()
+    {
+        // mv["mail"] and cs["mail"] are different inputs holding different values; collapsing them would
+        // silently test the Expression with one value where it reads two.
+        var inputs = ExpressionInputResolver.Resolve("IIF(IsNullOrEmpty(cs[\"mail\"]), mv[\"mail\"], cs[\"mail\"])");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(inputs, Has.Count.EqualTo(2));
+            Assert.That(inputs.Any(i => i.Source == ExpressionInputSource.ConnectedSystem && i.AttributeName == "mail"), Is.True);
+            Assert.That(inputs.Any(i => i.Source == ExpressionInputSource.Metaverse && i.AttributeName == "mail"), Is.True);
+        }
+    }
+
+    [Test]
+    public void Resolve_AccessorsWrittenWithWhitespace_AreStillFound()
+    {
+        var inputs = ExpressionInputResolver.Resolve("mv [ \"Job Title\" ]");
+
+        Assert.That(inputs, Has.Count.EqualTo(1));
+        Assert.That(inputs[0].AttributeName, Is.EqualTo("Job Title"));
+    }
+
+    [Test]
+    public void Resolve_AnAttributeNameContainingAnEscapedQuote_KeepsTheWholeName()
+    {
+        var inputs = ExpressionInputResolver.Resolve("cs[\"say \\\"hello\\\"\"]");
+
+        Assert.That(inputs, Has.Count.EqualTo(1));
+        Assert.That(inputs[0].AttributeName, Is.EqualTo("say \\\"hello\\\""));
+    }
+
+    [Test]
+    public void Resolve_AnIdentifierMerelyEndingInMvOrCs_IsNotAnInput()
+    {
+        // "abcs" ends in "cs" but is not the accessor; a word-boundary-free match would invent an input.
+        var inputs = ExpressionInputResolver.Resolve("abcs[\"nope\"] + xmv[\"alsoNope\"]");
+
+        Assert.That(inputs, Is.Empty);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("\"a literal with no accessors\"")]
+    public void Resolve_NothingToFind_ReturnsEmpty(string? expression)
+    {
+        Assert.That(ExpressionInputResolver.Resolve(expression), Is.Empty);
+    }
+}


### PR DESCRIPTION
## Description

Choosing **Expression** as an Attribute Flow's source now offers a box for each attribute the Expression reads, resolved from the Expression itself, and a **Run test** button showing what it produces and the type it evaluated to.

Every part of this existed except the screen. `POST /test-expression` takes sample Metaverse and Connected System values, `Test-JIMExpression` wraps it, both since Expression support shipped in #193, and `docs/concepts/expressions.md` has been telling administrators to "use the expression test feature in the Synchronisation Rule editor" for as long. There was no such feature. The portal was the one surface without it.

Closes #1405

### An empty box means the object has no value

This is the design decision worth reviewing. An empty box is passed to the evaluator as **no value**, not as an empty string, which is what makes the tester worth having beside the field rather than being a convenience:

```
Lower(cs["givenName"]) + "." + Lower(cs["sn"]) + "@corp.local"
```

With both supplied: `ada.lovelace@corp.local`. With the surname box cleared: `ada.@corp.local`, a syntactically fine string that is not an email address, and one nothing downstream can tell from a good one. That is the hazard `docs/concepts/expressions.md` devotes its longest section to, and it is now visible before the Synchronisation Rule is saved rather than after a synchronisation has carried it.

### Inputs are resolved, not declared

`ExpressionInputResolver` reads the Expression text. The accessors are literal-indexed parameters the evaluator binds (`mv["..."]`, `cs["..."]`), so there is nothing to infer, and DynamicExpresso exposes no syntax tree to walk. It is a resolver of its own rather than something the component does privately, because #1361 (Missing Input Behaviour) and #880 (attribute-dependency tracking for export evaluation) both need the same list.

Its limits are stated where it lives: an accessor whose attribute name is computed rather than written out is not something reading the text can see. Nothing in JIM produces one today.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

`dotnet test JIM.sln`: 8,226 passed, 0 failed across seven projects.

- `ExpressionInputResolverTests` (10): both accessors, de-duplication, the same name on both sides staying two inputs, whitespace inside the accessor, escaped quotes, and an identifier merely ending in `mv`/`cs` not being read as one. Written red against a stub returning nothing.
- `ExpressionTesterTests` (6, bUnit): a field per input labelled as the Expression addresses it, the output for supplied values, an empty box reaching the evaluator as absent, a previous output being discarded when the Expression is edited, and a malformed Expression reporting here rather than at the next synchronisation. The real evaluator is registered rather than a stub, so a wiring fault cannot pass by returning what the test expected.

**Runtime verification:** driven in the portal against a real Connected System, on the light stack, both with values supplied and with an input left empty. Screenshots are attached to the issue conversation.

One thing worth knowing for future component tests: a `MudTextField` rendered with `Clearable` also renders a button, and it comes first in the markup, so `cut.Find("button")` clears an input rather than clicking the action. The fixture finds Run test by its label and says why.

## Documentation

- [x] Public documentation updated (`docs/`); page(s): `docs/concepts/expressions.md`
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [ ] No documentation needed

A "Testing an expression" section under Validation and Troubleshooting, covering the empty-box semantic and the worked `ada.@corp.local` example, plus the Troubleshooting item that pointed at the feature that did not exist.

## Additional context

The tester is a shared component (`JIM.Web/Shared/ExpressionTester.razor`) taking the Expression as a parameter, so #1361's authoring-time preview extends it rather than growing a second one. It follows the dialog's existing idiom: `subtitle2` heading, secondary body text, `Immediate="true"` on the inputs so the resolved list follows the Expression as it is typed.


---
_Generated by [Claude Code](https://claude.ai/code/session_019qDeQrotfXrgy8hFopWkZ6)_