### PR TITLE
fix: return one outcome from Invoke-IntegrationScenario, not an array

### DIFF
--- a/test/integration/utils/Invoke-IntegrationScenario.Tests.ps1
+++ b/test/integration/utils/Invoke-IntegrationScenario.Tests.ps1
@@ -196,5 +196,22 @@ return @{ Success = $true }
 
             $emitted | Should -BeLike '*a line the operator needs to see*'
         }
+
+        It 'returns a single outcome even when the scenario also writes pipeline output' {
+            # The regression this pins: passing non-result objects back out through the function's own
+            # output stream turned the return value into an array whenever a scenario emitted anything,
+            # and the runner's $outcome.ExitCode then threw under strict mode. Scenario 16 (all
+            # Write-Host) never tripped it; Scenario 8 did, on the first Phase 0 baseline run for #288.
+            $path = New-TestScenario -Name 'NoisyPipeline' -NoDirtyExitCode -Body @'
+Write-Output "pipeline noise before the verdict"
+"another stray pipeline object"
+return @{ Success = $true }
+'@
+
+            $outcome = Invoke-IntegrationScenario -Path $path 6> $null
+
+            $outcome -is [System.Collections.IDictionary] | Should -BeTrue
+            $outcome.ExitCode | Should -Be 0
+        }
     }
 }

--- a/test/integration/utils/Invoke-IntegrationScenario.ps1
+++ b/test/integration/utils/Invoke-IntegrationScenario.ps1
@@ -49,12 +49,19 @@ function Invoke-IntegrationScenario {
 
     # Collected through a list rather than a variable assignment because the ForEach-Object
     # block runs in its own scope; a method call on an object resolved from this scope works
-    # regardless. Everything that is not the result object is passed straight back out, so
-    # the scenario's output still streams to the operator as it is produced.
+    # regardless. Everything that is not the result object goes to the information stream via
+    # Write-Host, NOT back out of this function: the caller assigns this function's output to
+    # a variable, so anything emitted here would be captured into that variable rather than
+    # shown, and the return value would become an array whose .ExitCode throws under strict
+    # mode the moment a scenario writes anything to the pipeline (Scenario 8 does; the all-
+    # Write-Host scenarios never tripped it). Out-String preserves the console formatting the
+    # object would have had; per-object formatting can repeat table headers across a sequence,
+    # which scenario output (overwhelmingly strings) does not encounter in practice.
     $results = [System.Collections.Generic.List[object]]::new()
 
     & $Path @Parameters | ForEach-Object {
-        if (Test-ScenarioResultObject -Candidate $_) { $results.Add($_) } else { $_ }
+        if (Test-ScenarioResultObject -Candidate $_) { $results.Add($_) }
+        else { ($_ | Out-String).TrimEnd() | Write-Host }
     }
 
     $exitCode = $LASTEXITCODE


### PR DESCRIPTION
## Description

Stacked on the #288 Phase 0 branch, because Phase 0 discovered it: the first Scenario 8 baseline run **passed every step** and still exited 1, with *"The property 'ExitCode' cannot be found on this object"*.

The #1382 invoker (`Invoke-IntegrationScenario`, merged yesterday) passes every non-result pipeline object back out through its own output stream, intending to keep the scenario's output visible to the operator. But the runner assigns the function's output to a variable, so those objects are captured rather than shown, and the return value becomes an **array** whenever a scenario emits anything to the pipeline. `.ExitCode` on that array throws under strict mode, and the catch turns a green run red. Scenario 16 (all `Write-Host`) never tripped it; Scenario 8 did.

The fix routes non-result objects to the information stream via `Write-Host`, with their console formatting preserved through `Out-String`. The operator sees them live, the existing "still emits the scenario output" test keeps passing unchanged (it captures `6>&1`, which is exactly the stream `Write-Host` writes), and the function returns exactly one outcome.

Every Phase 1 extraction PR of the #288 plan gates on this scenario's exit code, which is why it is fixed now rather than filed.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [ ] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

`.ps1` only; the build/test exception applies to `dotnet`. Red-first Pester: the new case reproduces the array return against the old implementation (11 passed, 1 failed), and the suite is 12/12 after the fix. The originating failure was observed live on a full Scenario 8 Small run in the sandbox.

## Documentation

- [x] No documentation needed

Docs: n/a - integration test tooling fix; no user-facing behaviour changed.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

One cosmetic trade recorded in the code comment: per-object `Out-String` formatting can repeat table headers across a sequence of objects, which scenario output (overwhelmingly strings) does not encounter in practice.

This is a stack layer on `feature/sync-preview-engine-phase0`; the sandbox cannot link stacks natively, so it lands bottom-up per the CLAUDE.md flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR

---
_Generated by [Claude Code](https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR)_