### PR TITLE
docs: JIM SQL Connector guide, delta-import setup pages and third-party notices (#170)

### DIFF
--- a/.github/diagrams/containers-dark.svg
+++ b/.github/diagrams/containers-dark.svg
@@ -106,7 +106,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity in development.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems, enterprise databases and cloud applications.</desc>
   <defs>
     <mask id="jimdg-ct-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="750">
       <rect x="0" y="0" width="1160" height="750" fill="#ffffff"/>
@@ -182,9 +182,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-spoke" x1="580" y1="516" x2="580" y2="656"/>
     <circle class="jimdg-link-end" cx="580" cy="516" r="3.5"/>
     <circle class="jimdg-link-end" cx="580" cy="656" r="3.5"/>
-    <line class="jimdg-spoke-planned" x1="630" y1="516" x2="810" y2="656"/>
-    <circle class="jimdg-link-end-planned" cx="630" cy="516" r="3.5"/>
-    <circle class="jimdg-link-end-planned" cx="810" cy="656" r="3.5"/>
+    <line class="jimdg-spoke" x1="630" y1="516" x2="810" y2="656"/>
+    <circle class="jimdg-link-end" cx="630" cy="516" r="3.5"/>
+    <circle class="jimdg-link-end" cx="810" cy="656" r="3.5"/>
     <line class="jimdg-spoke" x1="680" y1="516" x2="1040" y2="656"/>
     <circle class="jimdg-link-end" cx="680" cy="516" r="3.5"/>
     <circle class="jimdg-link-end" cx="1040" cy="656" r="3.5"/>
@@ -200,9 +200,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <rect class="jimdg-system" x="480" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="580" y="684">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
-    <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (in development)</text>
+    <rect class="jimdg-system" x="710" y="656" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="810" y="684">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="810" y="705">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>
@@ -224,6 +224,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-1.1s" repeatCount="indefinite" path="M810,656 L630,516"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-1.1s" repeatCount="indefinite"/>
     </circle>
   </g>
   </g>

--- a/.github/diagrams/containers-light.svg
+++ b/.github/diagrams/containers-light.svg
@@ -106,7 +106,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity in development.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems, enterprise databases and cloud applications.</desc>
   <defs>
     <mask id="jimdg-ct-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="750">
       <rect x="0" y="0" width="1160" height="750" fill="#ffffff"/>
@@ -182,9 +182,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-spoke" x1="580" y1="516" x2="580" y2="656"/>
     <circle class="jimdg-link-end" cx="580" cy="516" r="3.5"/>
     <circle class="jimdg-link-end" cx="580" cy="656" r="3.5"/>
-    <line class="jimdg-spoke-planned" x1="630" y1="516" x2="810" y2="656"/>
-    <circle class="jimdg-link-end-planned" cx="630" cy="516" r="3.5"/>
-    <circle class="jimdg-link-end-planned" cx="810" cy="656" r="3.5"/>
+    <line class="jimdg-spoke" x1="630" y1="516" x2="810" y2="656"/>
+    <circle class="jimdg-link-end" cx="630" cy="516" r="3.5"/>
+    <circle class="jimdg-link-end" cx="810" cy="656" r="3.5"/>
     <line class="jimdg-spoke" x1="680" y1="516" x2="1040" y2="656"/>
     <circle class="jimdg-link-end" cx="680" cy="516" r="3.5"/>
     <circle class="jimdg-link-end" cx="1040" cy="656" r="3.5"/>
@@ -200,9 +200,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <rect class="jimdg-system" x="480" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="580" y="684">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
-    <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (in development)</text>
+    <rect class="jimdg-system" x="710" y="656" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="810" y="684">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="810" y="705">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>
@@ -224,6 +224,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-1.1s" repeatCount="indefinite" path="M810,656 L630,516"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-1.1s" repeatCount="indefinite"/>
     </circle>
   </g>
   </g>

--- a/.github/diagrams/system-context-dark.svg
+++ b/.github/diagrams/system-context-dark.svg
@@ -100,7 +100,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is in development.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, reads and writes enterprise databases over SQL, and synchronises with cloud applications over SCIM 2.0.</desc>
   <defs>
     <mask id="jimdg-sc-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="630">
       <rect x="0" y="0" width="1160" height="630" fill="#ffffff"/>
@@ -144,9 +144,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <rect class="jimdg-system" x="480" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="580" y="548">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
-    <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (in development)</text>
+    <rect class="jimdg-system" x="705" y="520" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="805" y="548">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="805" y="569">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>
@@ -167,9 +167,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-spoke" x1="580" y1="390" x2="580" y2="510"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(580,380) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(580,520) rotate(90)"/>
-    <line class="jimdg-spoke-planned" x1="647.6" y1="386.5" x2="797.4" y2="513.5"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
+    <line class="jimdg-spoke" x1="647.6" y1="386.5" x2="797.4" y2="513.5"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
     <line class="jimdg-spoke" x1="709.2" y1="383.9" x2="1020.8" y2="516.1"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,380) rotate(203)"/>
@@ -186,6 +186,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M709,384 L1021,516"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M648,387 L797,513"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
   </g>
   </g>

--- a/.github/diagrams/system-context-light.svg
+++ b/.github/diagrams/system-context-light.svg
@@ -100,7 +100,7 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
 @media (prefers-reduced-motion: reduce) { .jimdg-packet { display: none; } }
 </style>
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is in development.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, reads and writes enterprise databases over SQL, and synchronises with cloud applications over SCIM 2.0.</desc>
   <defs>
     <mask id="jimdg-sc-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="630">
       <rect x="0" y="0" width="1160" height="630" fill="#ffffff"/>
@@ -144,9 +144,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <rect class="jimdg-system" x="480" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="580" y="548">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
-    <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (in development)</text>
+    <rect class="jimdg-system" x="705" y="520" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="805" y="548">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="805" y="569">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>
@@ -167,9 +167,9 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <line class="jimdg-spoke" x1="580" y1="390" x2="580" y2="510"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(580,380) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(580,520) rotate(90)"/>
-    <line class="jimdg-spoke-planned" x1="647.6" y1="386.5" x2="797.4" y2="513.5"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
+    <line class="jimdg-spoke" x1="647.6" y1="386.5" x2="797.4" y2="513.5"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
     <line class="jimdg-spoke" x1="709.2" y1="383.9" x2="1020.8" y2="516.1"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,380) rotate(203)"/>
@@ -186,6 +186,10 @@ svg { font-family: "IBM Plex Sans", -apple-system, "Segoe UI", sans-serif; }
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M709,384 L1021,516"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M648,387 L797,513"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
   </g>
   </g>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ JIM is a modern Identity Management system designed for organisations with compl
 - Built-in scheduler that supports parallel operations
 - Validated at 500,000-user scale (with tens of thousands of groups of up to 495,000 members)
 - Transform data using expressions with extensive built-in functions for common identity operations
-- Built-in LDAP and File connectors, more in development, including a custom connector framework
+- Built-in LDAP, File, SCIM 2.0 and SQL (Microsoft SQL Server, Oracle Database) connectors, plus a custom connector framework
 - Modern Web Portal and REST API with interactive Scalar [API reference](https://docs.junctional.io/api/reference/)
 - PowerShell automation for Identity as Code (IDaC) - deploy JIM instances in minutes, not months
 - Real-time activity monitoring, pushed from the database rather than polled
@@ -148,6 +148,8 @@ JIM is built in the open and we'd love to hear from people running it, evaluatin
 
 ## Licensing
 JIM uses a Source-Available model where it is free to use in non-production scenarios, but requires a commercial license for use in production scenarios. [﻿Full details can be found here](https://junctional.io/license).
+
+Third-party components shipped inside the images carry their own licences; see [third-party-notices](third-party-notices/README.md).
 
 ## More Information
 - **Product site:** [junctional.io](https://junctional.io)

--- a/docs/assets/diagrams/connector-components.svg
+++ b/docs/assets/diagrams/connector-components.svg
@@ -18,7 +18,7 @@
 <!-- expressed with <g> groups instead. -->
 <svg class="jim-diagram" viewBox="0 0 1160 500" role="img" aria-labelledby="jimdg-cc-title jimdg-cc-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-cc-title">Inside the Connectors library</title>
-  <desc id="jimdg-cc-desc">The JIM.Worker import and export processors invoke the connectors in the JIM.Connectors library. The LDAP Connector reads and writes Directory Services over LDAP and LDAPS; the File Connector reads and writes CSV and flat files, including HR exports; the SCIM 2.0 Connector reads and writes cloud applications that publish a SCIM 2.0 service provider interface. The SQL Connector, one connector covering SQL Server, PostgreSQL, MySQL and Oracle, is in development.</desc>
+  <desc id="jimdg-cc-desc">The JIM.Worker import and export processors invoke the connectors in the JIM.Connectors library. The LDAP Connector reads and writes Directory Services over LDAP and LDAPS; the File Connector reads and writes CSV and flat files, including HR exports; the SCIM 2.0 Connector reads and writes cloud applications that publish a SCIM 2.0 service provider interface; the SQL Connector reads and writes enterprise databases, Microsoft SQL Server and Oracle Database, through managed drivers.</desc>
   <g id="jimdg-cc-worker">
     <rect class="jimdg-stage" x="430" y="20" width="300" height="64" rx="8"/>
     <text class="jimdg-stage-label" x="580" y="46">JIM.Worker</text>
@@ -34,9 +34,9 @@
     <rect class="jimdg-chip" x="355" y="220" width="210" height="70" rx="8"/>
     <text class="jimdg-chip-label" x="460" y="250">File Connector</text>
     <text class="jimdg-chip-sub" x="460" y="270">CSV &amp; flat files</text>
-    <rect class="jimdg-chip-planned" x="595" y="220" width="210" height="70" rx="8"/>
-    <text class="jimdg-chip-label-planned" x="700" y="250">SQL Connector</text>
-    <text class="jimdg-chip-sub-planned" x="700" y="270">(in development)</text>
+    <rect class="jimdg-chip" x="595" y="220" width="210" height="70" rx="8"/>
+    <text class="jimdg-chip-label" x="700" y="250">SQL Connector</text>
+    <text class="jimdg-chip-sub" x="700" y="270">SQL Server · Oracle</text>
     <rect class="jimdg-chip" x="835" y="220" width="210" height="70" rx="8"/>
     <text class="jimdg-chip-label" x="940" y="250">SCIM 2.0 Connector</text>
     <text class="jimdg-chip-sub" x="940" y="270">SCIM 2.0 · HTTPS</text>
@@ -48,9 +48,9 @@
     <rect class="jimdg-system" x="350" y="410" width="220" height="64" rx="8"/>
     <text class="jimdg-system-name" x="460" y="438">File Systems</text>
     <text class="jimdg-system-sub" x="460" y="459">CSV · HR exports</text>
-    <rect class="jimdg-system-planned" x="590" y="410" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="700" y="438">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="700" y="459">SQL (in development)</text>
+    <rect class="jimdg-system" x="590" y="410" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="700" y="438">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="700" y="459">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="830" y="410" width="220" height="64" rx="8"/>
     <text class="jimdg-system-name" x="940" y="438">Cloud Applications</text>
     <text class="jimdg-system-sub" x="940" y="459">SCIM 2.0 service providers</text>
@@ -60,8 +60,8 @@
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(220,220) rotate(159.3)"/>
     <line class="jimdg-flow" x1="580" y1="84" x2="466.6" y2="212.5"/>
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(460,220) rotate(131.4)"/>
-    <line class="jimdg-spoke-planned" x1="580" y1="84" x2="693.4" y2="212.5"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,220) rotate(48.6)"/>
+    <line class="jimdg-flow" x1="580" y1="84" x2="693.4" y2="212.5"/>
+    <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,220) rotate(48.6)"/>
     <line class="jimdg-flow" x1="580" y1="84" x2="930.6" y2="216.5"/>
     <polygon class="jimdg-flow-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,220) rotate(20.7)"/>
     <line class="jimdg-spoke" x1="220" y1="300" x2="220" y2="400"/>
@@ -70,8 +70,9 @@
     <line class="jimdg-spoke" x1="460" y1="300" x2="460" y2="400"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(460,290) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(460,410) rotate(90)"/>
-    <line class="jimdg-spoke-planned" x1="700" y1="290" x2="700" y2="400"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,410) rotate(90)"/>
+    <line class="jimdg-spoke" x1="700" y1="300" x2="700" y2="400"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,290) rotate(-90)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,410) rotate(90)"/>
     <line class="jimdg-spoke" x1="940" y1="300" x2="940" y2="400"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,290) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(940,410) rotate(90)"/>
@@ -92,6 +93,14 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.4s" begin="-1.6s" repeatCount="indefinite" path="M580,86 L468,211"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-1.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="2.2s" begin="-0.3s" repeatCount="indefinite" path="M700,302 L700,398"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-0.3s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="2.2s" begin="-1.4s" repeatCount="indefinite" path="M700,398 L700,302"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.2s" begin="-1.4s" repeatCount="indefinite"/>
     </circle>
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.2s" begin="-1.7s" repeatCount="indefinite" path="M940,302 L940,398"/>

--- a/docs/assets/diagrams/containers.svg
+++ b/docs/assets/diagrams/containers.svg
@@ -15,7 +15,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 750" role="img" aria-labelledby="jimdg-ct-title jimdg-ct-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-ct-title">JIM Containers</title>
-  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems and cloud applications, with enterprise database connectivity in development.</desc>
+  <desc id="jimdg-ct-desc">JIM deploys as a set of containers. Administrators use the Web Application's Blazor UI, or the PowerShell Module which wraps the REST API; automation clients call the REST API directly; an OIDC Identity Provider authenticates sign-in. The Web Application, Scheduler Service and Worker Service all use the PostgreSQL database, which also acts as the task queue: the Scheduler queues tasks and the Worker polls them. The Worker Service runs the synchronisation pipeline and hosts the Connectors, connecting to Directory Services, HR systems, file systems, enterprise databases and cloud applications.</desc>
   <defs>
     <mask id="jimdg-ct-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="750">
       <rect x="0" y="0" width="1160" height="750" fill="#ffffff"/>
@@ -91,9 +91,9 @@
     <line class="jimdg-spoke" x1="580" y1="516" x2="580" y2="656"/>
     <circle class="jimdg-link-end" cx="580" cy="516" r="3.5"/>
     <circle class="jimdg-link-end" cx="580" cy="656" r="3.5"/>
-    <line class="jimdg-spoke-planned" x1="630" y1="516" x2="810" y2="656"/>
-    <circle class="jimdg-link-end-planned" cx="630" cy="516" r="3.5"/>
-    <circle class="jimdg-link-end-planned" cx="810" cy="656" r="3.5"/>
+    <line class="jimdg-spoke" x1="630" y1="516" x2="810" y2="656"/>
+    <circle class="jimdg-link-end" cx="630" cy="516" r="3.5"/>
+    <circle class="jimdg-link-end" cx="810" cy="656" r="3.5"/>
     <line class="jimdg-spoke" x1="680" y1="516" x2="1040" y2="656"/>
     <circle class="jimdg-link-end" cx="680" cy="516" r="3.5"/>
     <circle class="jimdg-link-end" cx="1040" cy="656" r="3.5"/>
@@ -109,9 +109,9 @@
     <rect class="jimdg-system" x="480" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="580" y="684">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="705">CSV &amp; flat files</text>
-    <rect class="jimdg-system-planned" x="710" y="656" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="810" y="684">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="810" y="705">SQL (in development)</text>
+    <rect class="jimdg-system" x="710" y="656" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="810" y="684">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="810" y="705">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="940" y="656" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1040" y="684">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1040" y="705">SCIM 2.0</text>
@@ -133,6 +133,10 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M680,516 L1040,656"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-1.1s" repeatCount="indefinite" path="M810,656 L630,516"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-1.1s" repeatCount="indefinite"/>
     </circle>
   </g>
   </g>

--- a/docs/assets/diagrams/hub-and-spoke.svg
+++ b/docs/assets/diagrams/hub-and-spoke.svg
@@ -10,7 +10,7 @@
 <!-- expressed with <g> groups instead. -->
 <svg class="jim-diagram" viewBox="0 0 1160 640" role="img" aria-labelledby="jimdg-hs-title jimdg-hs-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-hs-title">JIM hub-and-spoke synchronisation concept</title>
-  <desc id="jimdg-hs-desc">Source systems on the left and target systems on the right connect to JIM in the centre. Inside JIM, Connectors pass imported data through the Import, Synchronise and Export pipeline, which correlates and projects identities into the Metaverse, the authoritative data store for fused identities. Every flow passes through JIM; no data moves directly between Connected Systems. Enterprise database connectivity is in development.</desc>
+  <desc id="jimdg-hs-desc">Source systems on the left and target systems on the right connect to JIM in the centre. Inside JIM, Connectors pass imported data through the Import, Synchronise and Export pipeline, which correlates and projects identities into the Metaverse, the authoritative data store for fused identities. Every flow passes through JIM; no data moves directly between Connected Systems.</desc>
   <defs>
     <mask id="jimdg-hs-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="640">
       <rect x="0" y="0" width="1160" height="640" fill="#ffffff"/>
@@ -29,9 +29,8 @@
       <text class="jimdg-chip-label" x="400" y="157">LDAP</text>
       <rect class="jimdg-chip" x="464" y="130" width="112" height="44" rx="8"/>
       <text class="jimdg-chip-label" x="520" y="157">File / CSV</text>
-      <rect class="jimdg-chip-planned" x="584" y="130" width="112" height="44" rx="8"/>
-      <text class="jimdg-chip-label-planned" x="640" y="148">SQL</text>
-      <text class="jimdg-chip-sub-planned" x="640" y="164">(in development)</text>
+      <rect class="jimdg-chip" x="584" y="130" width="112" height="44" rx="8"/>
+      <text class="jimdg-chip-label" x="640" y="157">SQL</text>
       <rect class="jimdg-chip" x="704" y="130" width="112" height="44" rx="8"/>
       <text class="jimdg-chip-label" x="760" y="157">SCIM 2.0</text>
     </g>
@@ -71,9 +70,9 @@
     <rect class="jimdg-system" x="20" y="288" width="220" height="64" rx="8"/>
     <text class="jimdg-system-name" x="130" y="316">Legacy Directory</text>
     <text class="jimdg-system-sub" x="130" y="337">LDAP</text>
-    <rect class="jimdg-system-planned" x="20" y="458" width="220" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="130" y="486">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="130" y="507">SQL (in development)</text>
+    <rect class="jimdg-system" x="20" y="458" width="220" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="130" y="486">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="130" y="507">SQL</text>
   </g>
   <g id="jimdg-hs-targets">
     <rect class="jimdg-system" x="920" y="118" width="220" height="64" rx="8"/>
@@ -92,8 +91,8 @@
     <polygon class="jimdg-arrow" points="300,150 290,144.5 290,155.5"/>
     <line class="jimdg-spoke" x1="240" y1="320" x2="290" y2="320"/>
     <polygon class="jimdg-arrow" points="300,320 290,314.5 290,325.5"/>
-    <line class="jimdg-spoke-planned" x1="240" y1="490" x2="290" y2="490"/>
-    <polygon class="jimdg-arrow-planned" points="300,490 290,484.5 290,495.5"/>
+    <line class="jimdg-spoke" x1="240" y1="490" x2="290" y2="490"/>
+    <polygon class="jimdg-arrow" points="300,490 290,484.5 290,495.5"/>
     <line class="jimdg-spoke" x1="870" y1="150" x2="910" y2="150"/>
     <polygon class="jimdg-arrow" points="860,150 870,144.5 870,155.5"/>
     <polygon class="jimdg-arrow" points="920,150 910,144.5 910,155.5"/>
@@ -110,6 +109,10 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.4s" begin="-1.3s" repeatCount="indefinite" path="M240,320 L289,320"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-1.3s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="2.4s" begin="-0.7s" repeatCount="indefinite" path="M240,490 L289,490"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="2.4s" begin="-0.7s" repeatCount="indefinite"/>
     </circle>
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="2.6s" begin="-0.6s" repeatCount="indefinite" path="M400,186 L400,251"/>

--- a/docs/assets/diagrams/system-context.svg
+++ b/docs/assets/diagrams/system-context.svg
@@ -9,7 +9,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 630" role="img" aria-labelledby="jimdg-sc-title jimdg-sc-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-sc-title">JIM System Context</title>
-  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, and synchronises with cloud applications over SCIM 2.0. Enterprise database connectivity over SQL is in development.</desc>
+  <desc id="jimdg-sc-desc">Administrators manage JIM through the web UI and PowerShell, and automation clients call its REST API. An OIDC Identity Provider authenticates sign-in. JIM synchronises with Directory Services over LDAP and LDAPS, imports from HR systems via CSV, reads and writes file systems, reads and writes enterprise databases over SQL, and synchronises with cloud applications over SCIM 2.0.</desc>
   <defs>
     <mask id="jimdg-sc-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="630">
       <rect x="0" y="0" width="1160" height="630" fill="#ffffff"/>
@@ -53,9 +53,9 @@
     <rect class="jimdg-system" x="480" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="580" y="548">File Systems</text>
     <text class="jimdg-system-sub" x="580" y="569">CSV &amp; flat files</text>
-    <rect class="jimdg-system-planned" x="705" y="520" width="200" height="64" rx="8"/>
-    <text class="jimdg-system-name-planned" x="805" y="548">Enterprise Databases</text>
-    <text class="jimdg-system-sub-planned" x="805" y="569">SQL (in development)</text>
+    <rect class="jimdg-system" x="705" y="520" width="200" height="64" rx="8"/>
+    <text class="jimdg-system-name" x="805" y="548">Enterprise Databases</text>
+    <text class="jimdg-system-sub" x="805" y="569">SQL Server · Oracle</text>
     <rect class="jimdg-system" x="930" y="520" width="200" height="64" rx="8"/>
     <text class="jimdg-system-name" x="1030" y="548">Cloud Applications</text>
     <text class="jimdg-system-sub" x="1030" y="569">SCIM 2.0</text>
@@ -76,9 +76,9 @@
     <line class="jimdg-spoke" x1="580" y1="390" x2="580" y2="510"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(580,380) rotate(-90)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(580,520) rotate(90)"/>
-    <line class="jimdg-spoke-planned" x1="647.6" y1="386.5" x2="797.4" y2="513.5"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
-    <polygon class="jimdg-arrow-planned" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
+    <line class="jimdg-spoke" x1="647.6" y1="386.5" x2="797.4" y2="513.5"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(805,520) rotate(40.3)"/>
+    <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(640,380) rotate(220.3)"/>
     <line class="jimdg-spoke" x1="709.2" y1="383.9" x2="1020.8" y2="516.1"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(1030,520) rotate(23)"/>
     <polygon class="jimdg-arrow" points="0,0 -10,-5.5 -10,5.5" transform="translate(700,380) rotate(203)"/>
@@ -95,6 +95,10 @@
     <circle class="jimdg-packet" r="4.5">
       <animateMotion dur="3s" begin="-0.75s" repeatCount="indefinite" path="M709,384 L1021,516"/>
       <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-0.75s" repeatCount="indefinite"/>
+    </circle>
+    <circle class="jimdg-packet" r="4.5">
+      <animateMotion dur="3s" begin="-2.25s" repeatCount="indefinite" path="M648,387 L797,513"/>
+      <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;0.15;0.85;1" dur="3s" begin="-2.25s" repeatCount="indefinite"/>
     </circle>
   </g>
   </g>

--- a/docs/assets/diagrams/worker-components.svg
+++ b/docs/assets/diagrams/worker-components.svg
@@ -9,7 +9,7 @@
 <!-- snippets inlines this into markdown); structure uses <g> groups. -->
 <svg class="jim-diagram" viewBox="0 0 1160 690" role="img" aria-labelledby="jimdg-wk-title jimdg-wk-desc" xmlns="http://www.w3.org/2000/svg">
   <title id="jimdg-wk-title">Inside the Worker Service</title>
-  <desc id="jimdg-wk-desc">The Worker Host polls the PostgreSQL task queue and dispatches processors for import, synchronisation and export; the service reads and writes staged and Metaverse data in the same database. Import processors stage data arriving through the Connectors; synchronisation processors use the Sync Engine to apply projection, attribute flow, and deletion and matching rules; the export processor sends outbound changes back through the Connectors to Connected Systems. The Connectors layer hosts the LDAP, File/CSV and SCIM 2.0 connectors, with a SQL connector in development.</desc>
+  <desc id="jimdg-wk-desc">The Worker Host polls the PostgreSQL task queue and dispatches processors for import, synchronisation and export; the service reads and writes staged and Metaverse data in the same database. Import processors stage data arriving through the Connectors; synchronisation processors use the Sync Engine to apply projection, attribute flow, and deletion and matching rules; the export processor sends outbound changes back through the Connectors to Connected Systems. The Connectors layer hosts the LDAP, File/CSV, SQL and SCIM 2.0 connectors.</desc>
   <defs>
     <mask id="jimdg-wk-labelcut" maskUnits="userSpaceOnUse" x="0" y="0" width="1160" height="690">
       <rect x="0" y="0" width="1160" height="690" fill="#ffffff"/>
@@ -59,9 +59,8 @@
     <text class="jimdg-chip-label" x="436" y="573">LDAP</text>
     <rect class="jimdg-chip" x="549" y="546" width="160" height="44" rx="8"/>
     <text class="jimdg-chip-label" x="629" y="573">File / CSV</text>
-    <rect class="jimdg-chip-planned" x="741" y="546" width="160" height="44" rx="8"/>
-    <text class="jimdg-chip-label-planned" x="821" y="564">SQL</text>
-    <text class="jimdg-chip-sub-planned" x="821" y="580">(in development)</text>
+    <rect class="jimdg-chip" x="741" y="546" width="160" height="44" rx="8"/>
+    <text class="jimdg-chip-label" x="821" y="573">SQL</text>
     <rect class="jimdg-chip" x="934" y="546" width="160" height="44" rx="8"/>
     <text class="jimdg-chip-label" x="1014" y="573">SCIM 2.0</text>
   </g>

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -23,7 +23,7 @@ The following diagram shows JIM in the context of the systems and users it inter
 
 --8<-- "assets/diagrams/system-context.svg"
 
-<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 ## Containers
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -6,7 +6,7 @@ For per-object documentation (Connected Systems, Synchronisation Rules, Schedule
 
 --8<-- "assets/diagrams/hub-and-spoke.svg"
 
-<p class="jim-diagram-caption">The Connected Systems shown are illustrative examples. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data flowing through JIM.</span></p>
+<p class="jim-diagram-caption">The Connected Systems shown are illustrative examples.<span class="jimdg-caption-motion"> Moving dots trace identity data flowing through JIM.</span></p>
 
 ## 🏗️ Architecture
 

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -14,7 +14,7 @@ When a connector imports data from an external system, it does not write directl
 
 --8<-- "assets/diagrams/hub-and-spoke.svg"
 
-<p class="jim-diagram-caption">Connectors sit at JIM's edge, carrying data between Connected Systems and the synchronisation pipeline; every flow passes through the Metaverse, never directly between systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">Connectors sit at JIM's edge, carrying data between Connected Systems and the synchronisation pipeline; every flow passes through the Metaverse, never directly between systems.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 Each Connected System in JIM has:
 
@@ -35,17 +35,7 @@ JIM ships with the following built-in connectors:
 | [JIM File Connector](jim-file-connector.md) | CSV and delimited text files | Full Import, Export |
 | [JIM LDAP Connector](jim-ldap-connector.md) | Active Directory, OpenLDAP, 389 Directory Server, and other RFC 4512-compliant directories | Full Import, Delta Import, Export |
 | [JIM SCIM 2.0 Client Connector](jim-scim-connector.md) | Any system exposing a SCIM 2.0 service provider interface (RFC 7643/7644) | Full Import, Delta Import, Export |
-| JIM SQL Connector | Microsoft SQL Server and Oracle Database, through fully managed ADO.NET drivers | Full Import, Delta Import, Export |
-
-The JIM SQL Connector is selectable when creating a Connected System. Its settings document themselves:
-each one explains what it is for and what goes wrong if it is not right. A full guide, covering the Object
-Types document and a worked example for each supported database, is still being written.
-
-One Connected System covers several tables and views at once. Each Object Type names its own table or
-view, the columns forming its anchor, any column carrying another object's anchor as a reference, and any
-related table whose rows gather onto the parent as a multi-valued attribute. Date and time columns that
-carry no offset are interpreted in the Database Time Zone declared on the Connected System, and that
-interpretation is inverted on export; columns stating their own offset are left alone.
+| [JIM SQL Connector](jim-sql-connector.md) | Microsoft SQL Server and Oracle Database, through fully managed ADO.NET drivers | Full Import, Delta Import, Export |
 
 ## 🗺️ Upcoming Connectors
 

--- a/docs/connectors/jim-sql-connector-delta-import-change-log.md
+++ b/docs/connectors/jim-sql-connector-delta-import-change-log.md
@@ -1,0 +1,234 @@
+# Delta Import with a change-log table
+
+This guide sets up a Delta Import for the [JIM SQL Connector](jim-sql-connector.md) in **Change-Log Table** mode, from an empty database to a scheduled run. It is the recommended mode, and the only one that observes a deletion.
+
+## How it works
+
+Your database keeps a table (or a view over one it already keeps) holding one row per change: the changed object's anchor, what kind of change it was, and a value that only ever goes up. On each Delta Import, JIM:
+
+1. Notes the highest sequence value in the change log before reading anything. That is the watermark it will save when the run completes.
+2. Reads every row above the watermark it saved last time, in sequence order, a page at a time.
+3. Keeps only the last change recorded for each object in the page: an object created and then updated three times is one import, not four, and importing the earlier states would be work the later one immediately undoes.
+4. For creates and updates, reads the object **as it now stands** from the Object Type's own table or view, related tables included. The change log says *which* objects changed; the source says what they now hold.
+5. For deletions, imports the anchor alone, which is what tells JIM the object has gone.
+
+A create or update whose row has since disappeared produces nothing: the change log holds a deletion for it further on. A row whose change type is a value your configuration does not list is reported as an error against that object, naming the value, so a new code appearing in the log is something you hear about rather than something that is skipped.
+
+!!! note "Rows must become visible in sequence order"
+    JIM captures the highest sequence value at the start of the run and never looks below it again. A change-log row is written in the same transaction as the change it records, so a long-running transaction can commit a *lower* sequence value after a higher one has already been read, and that row is then behind the watermark for ever. Keep the transactions that write to synchronised tables short, and schedule a periodic Full Import as the backstop that every Delta Import strategy needs.
+
+## 1. Create the change-log table
+
+One change-log table can serve several Object Types if it carries every Object Type's anchor columns, but one table per Object Type is simpler to reason about and to purge. The table needs:
+
+| Column | Purpose | Notes |
+|--------|---------|-------|
+| Sequence | Orders the changes and is the watermark. | Any type with a total order that only goes up: an identity or sequence-backed integer is the safest choice; a timestamp works but is subject to clock adjustments and to two changes sharing a value (JIM orders ties by anchor, so nothing is skipped, but a clock stepped backwards can leave rows behind the watermark). |
+| Anchor column(s) | Which object changed. | One per anchor column of the Object Type, in the same order, holding the same values. |
+| Change type | What happened. | Any values you like; you tell JIM which of them mean a create, an update and a deletion. Matched case-insensitively. |
+
+Anything else in the table (who made the change, when, from which application) is yours to keep and is ignored by JIM.
+
+```sql title="Microsoft SQL Server"
+CREATE TABLE HR.IDM_CHANGE_LOG (
+    CHANGE_ID    BIGINT IDENTITY(1, 1) NOT NULL PRIMARY KEY,
+    EMPLOYEE_ID  INT           NOT NULL,
+    CHANGE_TYPE  CHAR(1)       NOT NULL,   -- I, U or D
+    CHANGED_AT   DATETIME2     NOT NULL DEFAULT SYSUTCDATETIME()
+);
+```
+
+```sql title="Oracle Database"
+CREATE TABLE HR.IDM_CHANGE_LOG (
+    CHANGE_ID    NUMBER(19) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    EMPLOYEE_ID  NUMBER(10)  NOT NULL,
+    CHANGE_TYPE  CHAR(1)     NOT NULL,     -- I, U or D
+    CHANGED_AT   TIMESTAMP   DEFAULT SYSTIMESTAMP NOT NULL
+);
+```
+
+The primary key on the sequence column doubles as the index JIM's `WHERE CHANGE_ID > :watermark ORDER BY CHANGE_ID` reads through, so no further index is needed for JIM's own query.
+
+!!! tip "An audit table you already have"
+    Where the application already records its changes, a **view** that presents that table with the three columns JIM needs is a change log too. Name the view as the `table` in the configuration below. The view must be able to express the deletion rows; an audit trail that records nothing for a delete cannot serve as a change log, and Watermark Column mode plus a periodic Full Import is the alternative.
+
+## 2. Write the changes into it
+
+A trigger on the Object Type's table is the usual way, because it runs inside the same transaction as the change and cannot be forgotten by an application path. Log a change to a **related table** as an update to its parent: JIM re-reads the parent whole, related rows included, so a phone number added or a membership revoked is picked up as a change to the person or the group it belongs to.
+
+```sql title="Microsoft SQL Server"
+CREATE TRIGGER HR.TR_EMPLOYEES_IDM_CHANGE_LOG
+ON HR.EMPLOYEES
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- Inserts and updates: rows in "inserted"; an update also has the row in "deleted".
+    INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE)
+    SELECT i.EMPLOYEE_ID, CASE WHEN d.EMPLOYEE_ID IS NULL THEN 'I' ELSE 'U' END
+    FROM inserted AS i
+    LEFT JOIN deleted AS d ON d.EMPLOYEE_ID = i.EMPLOYEE_ID;
+
+    -- Deletes: rows in "deleted" with no counterpart in "inserted".
+    INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE)
+    SELECT d.EMPLOYEE_ID, 'D'
+    FROM deleted AS d
+    LEFT JOIN inserted AS i ON i.EMPLOYEE_ID = d.EMPLOYEE_ID
+    WHERE i.EMPLOYEE_ID IS NULL;
+END;
+GO
+
+-- A related table's change is a change to its parent.
+CREATE TRIGGER HR.TR_EMPLOYEE_PHONES_IDM_CHANGE_LOG
+ON HR.EMPLOYEE_PHONES
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE)
+    SELECT EMPLOYEE_ID, 'U' FROM inserted
+    UNION
+    SELECT EMPLOYEE_ID, 'U' FROM deleted;
+END;
+GO
+```
+
+```sql title="Oracle Database"
+CREATE OR REPLACE TRIGGER HR.TRG_EMPLOYEES_IDM_CHANGE_LOG
+AFTER INSERT OR UPDATE OR DELETE ON HR.EMPLOYEES
+FOR EACH ROW
+BEGIN
+    IF INSERTING THEN
+        INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE) VALUES (:NEW.EMPLOYEE_ID, 'I');
+    ELSIF UPDATING THEN
+        INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE) VALUES (:NEW.EMPLOYEE_ID, 'U');
+    ELSE
+        INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE) VALUES (:OLD.EMPLOYEE_ID, 'D');
+    END IF;
+END;
+/
+
+-- A related table's change is a change to its parent.
+CREATE OR REPLACE TRIGGER HR.TRG_EMPLOYEE_PHONES_IDM_CHANGE_LOG
+AFTER INSERT OR UPDATE OR DELETE ON HR.EMPLOYEE_PHONES
+FOR EACH ROW
+BEGIN
+    INSERT INTO HR.IDM_CHANGE_LOG (EMPLOYEE_ID, CHANGE_TYPE)
+    VALUES (COALESCE(:NEW.EMPLOYEE_ID, :OLD.EMPLOYEE_ID), 'U');
+END;
+/
+```
+
+Where the Object Type reads from a **view**, put the triggers on the underlying table or tables, logging the anchor as the view exposes it.
+
+## 3. Let JIM read it
+
+Grant the JIM account `SELECT` on the change-log table alongside the grants it already has on the Object Type's source. Nothing else: JIM never writes to the change log and never purges it.
+
+```sql title="Microsoft SQL Server"
+GRANT SELECT ON HR.IDM_CHANGE_LOG TO jim_sync;
+```
+
+```sql title="Oracle Database"
+GRANT SELECT ON HR.IDM_CHANGE_LOG TO jim_sync;
+```
+
+## 4. Configure the Object Type
+
+Add a `changeLog` to **every** Object Type in the Connected System's **Object Types** document. Choosing Change-Log Table mode with an Object Type that has no `changeLog` is refused when you save, because a Delta Import that skipped an Object Type would report success while leaving its objects to drift.
+
+```json title="Object Types with a change log"
+{
+  "objectTypes": [
+    {
+      "name": "Person",
+      "schema": "HR",
+      "table": "V_EMPLOYEES",
+      "anchorColumns": [ "EMPLOYEE_ID" ],
+      "relatedTables": [
+        {
+          "attributeName": "PhoneNumbers",
+          "schema": "HR",
+          "table": "EMPLOYEE_PHONES",
+          "valueColumn": "PHONE_NUMBER",
+          "joinColumns": [ "EMPLOYEE_ID" ]
+        }
+      ],
+      "changeLog": {
+        "schema": "HR",
+        "table": "IDM_CHANGE_LOG",
+        "anchorColumns": [ "EMPLOYEE_ID" ],
+        "sequenceColumn": "CHANGE_ID",
+        "changeTypeColumn": "CHANGE_TYPE",
+        "createValues": [ "I" ],
+        "updateValues": [ "U" ],
+        "deleteValues": [ "D" ]
+      }
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `table` / `schema` | The change-log table or view. |
+| `anchorColumns` | The change log's columns carrying the changed object's anchor: one per anchor column of the Object Type, in the same order. |
+| `sequenceColumn` | The column that orders the changes. It becomes the watermark. |
+| `changeTypeColumn` | The column saying what kind of change a row records. |
+| `createValues` / `updateValues` | Your own values meaning "created" and "updated". At least one of the two lists is required. |
+| `deleteValues` | Your values meaning "deleted". Required: observing deletions is what a change-log table is for, and a database that cannot record them should use [Watermark Column mode](jim-sql-connector-delta-import-watermark.md) instead. |
+
+A value may appear in only one list, and no value may be blank. Where your application records finer-grained codes (say `INSERT`, `MERGE`, `RESTORE` for things that leave a row present), list them all under `createValues` or `updateValues`; the two are treated the same way, since JIM reads the row as it stands either way.
+
+## 5. Choose the mode and save
+
+On the Connected System's Settings tab, set **Delta Import Mode** to **Change-Log Table** and save. Validation runs at this point: any Object Type without a `changeLog`, any change-type value that means two things, and any missing field is reported now, at the keyboard, rather than by an overnight run.
+
+## 6. Baseline with a Full Import
+
+Create a **Full Import** Run Profile and a **Delta Import** Run Profile for the Connected System, then run the Full Import once. As well as loading every object, a Full Import records the change log's current high-water mark **before it reads a single row**, so a change made while the Full Import is running is read by the first Delta Import rather than lost between the two.
+
+If you run the Delta Import first instead, JIM performs a Full Import in its place, says so on the Activity as a warning, and establishes the watermark that way; the next Delta Import runs normally.
+
+## 7. Schedule it
+
+Schedule the Delta Import at whatever cadence the application warrants, and a Full Import at a longer interval as the reconciliation backstop. See [Schedules](../configuration/schedules.md).
+
+## 8. Keep the change log short
+
+JIM never purges the change log. Purge rows yourself once they are comfortably older than the interval between Delta Imports; a job that deletes rows older than thirty days is typical. A row purged before JIM has read it is a change lost until the next Full Import, so purge on age, generously, rather than on anything cleverer.
+
+```sql title="Microsoft SQL Server"
+DELETE FROM HR.IDM_CHANGE_LOG WHERE CHANGED_AT < DATEADD(DAY, -30, SYSUTCDATETIME());
+```
+
+```sql title="Oracle Database"
+DELETE FROM HR.IDM_CHANGE_LOG WHERE CHANGED_AT < SYSTIMESTAMP - INTERVAL '30' DAY;
+```
+
+## Troubleshooting
+
+**"No `Delta Import Mode` has been chosen for this Connected System"**<br />
+The mode is unanswered. JIM refuses rather than guessing, because a scheduled Delta Import quietly costing a Full Import every cycle would hide the omission for ever. Choose the mode and save.
+
+**"A Delta Import was requested, but JIM holds no watermark ... A Full Import was performed instead"**<br />
+Expected on the first run and after changing the mode. If it recurs, the Full Import is not completing; check its Activity.
+
+**"Column 'CHANGE_TYPE' holds 'X', which the change-log configuration for Object Type 'Person' does not account for"**<br />
+The application wrote a change-type value you have not listed. Add it to `createValues`, `updateValues` or `deleteValues`, and re-run: the object is reported as an error until it is.
+
+**"Object Type 'Person' has a change-log row with a NULL value in anchor column"**<br />
+A trigger logged a row it could not attribute to an object, most likely from a related table whose join column was `NULL`. Fix the trigger to skip such rows; the run fails until the row is corrected, because a change that belongs to nobody cannot be applied.
+
+**Objects that were deleted are still in JIM**<br />
+Check that the delete path is logged (a bulk `DELETE` fires a statement-level trigger on SQL Server exactly as a single-row one does, but an application that soft-deletes by flag writes an update, not a delete). Where the application soft-deletes, JIM sees an updated row and it is a Synchronisation Rule's scope, not the change log, that should retire the object.
+
+**The Delta Import reports more changes than objects**<br />
+Normal. The count JIM reports before reading is a count of change-log rows, which is an upper bound: an object changed three times is three rows and one object.
+
+## Related
+
+- [JIM SQL Connector](jim-sql-connector.md)
+- [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md)
+- [Run Profiles](../configuration/run-profiles.md)

--- a/docs/connectors/jim-sql-connector-delta-import-watermark.md
+++ b/docs/connectors/jim-sql-connector-delta-import-watermark.md
@@ -1,0 +1,141 @@
+# Delta Import with a watermark column
+
+This guide sets up a Delta Import for the [JIM SQL Connector](jim-sql-connector.md) in **Watermark Column** mode. It needs nothing extra in the database beyond a column that moves when a row changes, which many application tables already carry, and it detects creates and updates only. Read [What it cannot see](#what-it-cannot-see) before choosing it.
+
+## How it works
+
+Each Object Type's source, and each of its related tables, names a **watermark column**: a last-modified timestamp or a version number that goes up whenever the row changes. On each Delta Import, JIM:
+
+1. Notes the highest value in each watermark column before reading anything. Those are the watermarks it will save when the run completes, one per source, never one maximum across them all.
+2. Selects every row of the Object Type's source whose watermark column has moved past the value saved last time, **or** that has a related-table row whose watermark has, so a phone number replaced or a group membership added is detected as a change to the object it belongs to.
+3. Imports each selected object whole, exactly as a Full Import would deliver it. Every one is reported as an update, because a last-modified column cannot tell a create from one; JIM creates the Connected System Object where it holds none.
+
+## What it cannot see
+
+**A deleted row has no column left to move.** Its absence never reaches the query, so a deletion in the source is invisible to this mode, and so is a row that has fallen out of a view. Deletions are found by a **Full Import**, which reads everything and notices what has gone. Schedule one at whatever interval your deprovisioning needs allow; a Delta Import strategy without a periodic Full Import is incomplete in this mode.
+
+The same applies one level down. A row **removed** from a related table is a change to the parent, and it is detected wherever your table records the removal: a soft-delete flag or a tombstone row that moves the row's own watermark, or a watermark on the parent that the application bumps. Where a related table hard-deletes its rows instead, there is nothing left for any watermark to compare, so a revoked membership stays in JIM until the next Full Import.
+
+If deletions must reach JIM promptly, use a [change-log table](jim-sql-connector-delta-import-change-log.md) instead.
+
+## 1. Choose the watermark columns
+
+The Object Type's source needs one, and **every** related table needs one too; JIM refuses to save the configuration otherwise, because a related row added or removed changes the object without touching its own row, and without a watermark there that change could never be detected.
+
+Any column type with a total order works: a timestamp, a whole number, a version counter. It must only ever go up.
+
+```sql title="Microsoft SQL Server: add a last-modified column"
+ALTER TABLE HR.EMPLOYEES
+    ADD LAST_MODIFIED DATETIME2 NOT NULL CONSTRAINT DF_EMPLOYEES_LAST_MODIFIED DEFAULT SYSUTCDATETIME();
+ALTER TABLE HR.EMPLOYEE_PHONES
+    ADD LAST_MODIFIED DATETIME2 NOT NULL CONSTRAINT DF_EMPLOYEE_PHONES_LAST_MODIFIED DEFAULT SYSUTCDATETIME();
+CREATE INDEX IX_EMPLOYEES_LAST_MODIFIED ON HR.EMPLOYEES (LAST_MODIFIED);
+CREATE INDEX IX_EMPLOYEE_PHONES_LAST_MODIFIED ON HR.EMPLOYEE_PHONES (LAST_MODIFIED);
+```
+
+```sql title="Oracle Database: add a last-modified column"
+ALTER TABLE HR.EMPLOYEES ADD LAST_MODIFIED TIMESTAMP DEFAULT SYSTIMESTAMP NOT NULL;
+ALTER TABLE HR.EMPLOYEE_PHONES ADD LAST_MODIFIED TIMESTAMP DEFAULT SYSTIMESTAMP NOT NULL;
+CREATE INDEX HR.IX_EMPLOYEES_LAST_MODIFIED ON HR.EMPLOYEES (LAST_MODIFIED);
+CREATE INDEX HR.IX_EMPLOYEE_PHONES_LAST_MODIFIED ON HR.EMPLOYEE_PHONES (LAST_MODIFIED);
+```
+
+Index the column: JIM's query is `WHERE LAST_MODIFIED > :watermark`, and without an index that is a table scan on every Delta Import.
+
+!!! tip "SQL Server's rowversion"
+    A `rowversion` column is maintained by SQL Server itself, is unique and increasing across the whole database, and needs no trigger, which makes it a good watermark. JIM's schema discovery records it as a Binary attribute, which is correct; as a watermark it is compared as the database compares it.
+
+## 2. Keep it moving
+
+A default fills the column on insert. Updates need a trigger unless the application sets the column itself, and applications that do are the exception.
+
+```sql title="Microsoft SQL Server"
+CREATE TRIGGER HR.TR_EMPLOYEES_LAST_MODIFIED
+ON HR.EMPLOYEES
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE e SET LAST_MODIFIED = SYSUTCDATETIME()
+    FROM HR.EMPLOYEES AS e
+    INNER JOIN inserted AS i ON i.EMPLOYEE_ID = e.EMPLOYEE_ID;
+END;
+GO
+```
+
+```sql title="Oracle Database"
+CREATE OR REPLACE TRIGGER HR.TRG_EMPLOYEES_LAST_MODIFIED
+BEFORE UPDATE ON HR.EMPLOYEES
+FOR EACH ROW
+BEGIN
+    :NEW.LAST_MODIFIED := SYSTIMESTAMP;
+END;
+/
+```
+
+Repeat for each related table. A related table whose rows are only ever inserted and deleted (a membership table, typically) needs no update trigger, but does need the default, so an added row is seen; see [What it cannot see](#what-it-cannot-see) for the removed one.
+
+Where the Object Type reads from a **view**, expose the underlying table's watermark column through the view and name that.
+
+## 3. Configure the Object Type
+
+Add a `watermarkColumn` to every Object Type and to every related table in the Connected System's **Object Types** document.
+
+```json title="Object Types with watermark columns"
+{
+  "objectTypes": [
+    {
+      "name": "Person",
+      "schema": "HR",
+      "table": "V_EMPLOYEES",
+      "anchorColumns": [ "EMPLOYEE_ID" ],
+      "watermarkColumn": "LAST_MODIFIED",
+      "relatedTables": [
+        {
+          "attributeName": "PhoneNumbers",
+          "schema": "HR",
+          "table": "EMPLOYEE_PHONES",
+          "valueColumn": "PHONE_NUMBER",
+          "joinColumns": [ "EMPLOYEE_ID" ],
+          "watermarkColumn": "LAST_MODIFIED"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 4. Choose the mode and save
+
+On the Connected System's Settings tab, set **Delta Import Mode** to **Watermark Column** and save. Any Object Type or related table without a `watermarkColumn` is reported now, naming it.
+
+## 5. Baseline with a Full Import
+
+Create a **Full Import** Run Profile and a **Delta Import** Run Profile, then run the Full Import once. A Full Import records every watermark column's current high value **before it reads a single row**, so a change made during the Full Import is read by the first Delta Import rather than lost between the two. Run the Delta Import first instead and JIM performs a Full Import in its place, with a warning on the Activity saying so.
+
+## 6. Schedule both
+
+Schedule the Delta Import at the cadence the application warrants, and a Full Import at the longest interval your deprovisioning can tolerate, because the Full Import is what finds deletions. See [Schedules](../configuration/schedules.md).
+
+## Troubleshooting
+
+**"`Delta Import Mode` is 'Watermark Column', but Object Type 'Person' has related table attribute 'PhoneNumbers' with no 'watermarkColumn'"**<br />
+Every related table needs one. Add the column to the table (a default is enough for insert-only tables) and name it in the configuration.
+
+**A Delta Import read every row**<br />
+Either no watermark existed yet (the first run, or the first after changing the mode, which is expected and reported as a warning) or a related table had no watermark recorded, in which case JIM correlates on existence alone for that run: one expensive run beats a missed change. The next run is incremental.
+
+**A change to a phone number or a membership was not picked up**<br />
+The related table's watermark did not move. Check the default fills the column on insert, the trigger updates it on update, and, for a removal, that the table records it somewhere a watermark can see; a hard delete is invisible until the next Full Import.
+
+**Deleted employees are still in JIM**<br />
+By design in this mode. Run, or schedule, a Full Import; or move to a change-log table.
+
+**A row updated during a long transaction was missed**<br />
+JIM captures the highest watermark value at the start of the run. A row given a lower value inside a transaction that commits after that capture is behind the watermark and is not read until a Full Import. Keep write transactions short.
+
+## Related
+
+- [JIM SQL Connector](jim-sql-connector.md)
+- [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md)
+- [Run Profiles](../configuration/run-profiles.md)

--- a/docs/connectors/jim-sql-connector.md
+++ b/docs/connectors/jim-sql-connector.md
@@ -1,0 +1,439 @@
+# JIM SQL Connector
+
+## Overview
+
+The JIM SQL Connector synchronises identities with relational databases: HR systems, payroll, student records, and the line-of-business applications that keep their users in a table. It reads and writes **Microsoft SQL Server** and **Oracle Database** through fully managed ADO.NET drivers, so nothing native is installed on the JIM host and JIM stays air-gap deployable.
+
+**Capabilities:** Full Import, Delta Import, Export
+
+One Connected System covers a whole database at once. An **Object Types** document names each table or view JIM should synchronise, the columns that identify a row, the columns that carry another object's identifier as a reference, and any related table whose rows gather onto the parent as a multi-valued attribute. Everything else, the columns and their types, is discovered from the database's own catalogue.
+
+!!! note "Not a JIM database setting"
+    This page is about databases JIM synchronises *with*. JIM's own store is PostgreSQL and is configured at deployment; see [Deployment](../administration/deployment.md).
+
+## Supported Databases
+
+| Database | Notes |
+|----------|-------|
+| **Microsoft SQL Server** | Connected through `Microsoft.Data.SqlClient`. Named instances (`SERVER\INSTANCE`), TLS on by default, database-generated keys read back through `OUTPUT INSERTED`. |
+| **Oracle Database** | Connected through `Oracle.ManagedDataAccess.Core` (ODP.NET managed driver). Addressed by service name or SID, Native Network Encryption on by default, database-generated keys read back through `RETURNING ... INTO`. Oracle Database Free 23ai works as-is, and is what JIM's own tests run against. |
+
+The two databases are dialects behind one connector: the same Object Types document, the same import and export behaviour, and the same settings apart from the connection details each one needs. Support for further engines is planned as additional dialects of this same connector rather than as separate connectors; see [Wider database support](#wider-database-support).
+
+## Features
+
+| Capability | Supported | Notes |
+|---|---|---|
+| Full Import | ✅ | Pages through each table by keyset, so a large table costs the same per page from the first row to the last. See [Full Import](#full-import). |
+| Delta Import | ✅ | Reads a change-log table your database maintains, or a last-modified column. See [Delta Import](#delta-import). |
+| Export | ✅ | Inserts, updates and deletes rows, each object in a transaction of its own. See [Export](#export). |
+| Paging | ✅ | The Run Profile's Page Size is the number of rows read per query. |
+| Multi-valued attributes | ✅ | A related table of one row per value (phone numbers, group members) becomes a multi-valued attribute on the parent. |
+| References | ✅ | A column holding another row's identifier is a Reference once you say which Object Type it points at; JIM resolves it to the referenced Connected System Object on import and writes that object's own identifier on export. |
+| Partitions and Containers | ❌ | A database has no equivalent of a directory's naming contexts; a Connected System addresses one database, and each Object Type names its own table within it. |
+| Parallel Export | ❌ | Deliberately off in this release: parallel batches against one database can deadlock on hot pages. |
+| Password set | ❌ | Passwords held in a database are the owning application's concern, stored however it chose, so there is no password channel to offer. |
+
+### Schema Discovery
+
+Importing the schema reads the database's catalogue for every table and view the Object Types document names, and presents each Object Type with one attribute per column, typed from the column's declared SQL type. See [Type mapping](#type-mapping) for the full table.
+
+Discovery also:
+
+- **Chooses the External ID for you.**<br /> The anchor column you named becomes the Object Type's recommended External ID attribute. Where an Object Type has a composite anchor (two or more columns), JIM composes a single read-only Text attribute from them, named by joining the column names with `+` (`REGION+EMPLOYEE_NO`), because a Connected System Object is identified by one value.
+- **Records what it inferred a type from.**<br /> Every attribute's Description begins `Source column type: NUMBER(10).` (or `nvarchar(100)`, `datetime2`, and so on), so you can see the declaration a type came from before deciding whether to disagree with it. See [Overriding an inferred type](../configuration/connected-systems.md#overriding-an-inferred-type).
+- **Marks writability from the source.**<br /> Columns of a table are writable, and its anchor columns are writable on creation only (a primary key is set when the row is inserted and never rewritten). Columns of a view, or of a `select` statement, are read-only, because JIM cannot write through either.
+- **Suggests references from foreign keys, but never assumes them.**<br /> Where a table declares a foreign key to another Object Type's anchor column, the attribute's Description says so and shows the `referencesObjectType` line to add. The column stays typed as the database declares it until you configure it as a Reference; a foreign key is a strong hint, but only you know whether JIM should follow it.
+- **Skips what it cannot type, and says so.**<br /> A column of a type JIM has no equivalent for (an `xml` or `geography` column, say) is left out with a warning naming it. The same column in a load-bearing position, as an anchor, a configured reference, or a related table's value or join column, fails the discovery instead, because a schema missing one of those would be wrong rather than incomplete.
+
+Object Types and attributes are selected for synchronisation on the Connected System's Schema tab in the usual way; an Object Type in the document that you have not selected is skipped by every Run Profile.
+
+### Full Import
+
+A Full Import reads every row of each selected Object Type's source, a page at a time.
+
+- **Keyset paging, never `OFFSET`.**<br /> Each page is read as `WHERE anchor > last-anchor-of-previous-page ORDER BY anchor`, so the cost of reading page 500 is the same as page 1. This is what makes a 500,000-row table practical, and it is why the anchor columns must be listed in key order in the Object Types document.
+- **One query per related table per page.**<br /> Multi-valued attributes are gathered for the whole page in one statement, not one per row. Rows whose join column is `NULL` belong to no parent and are skipped; `NULL` values are skipped.
+- **A row count first.**<br /> The first page of each Object Type reports `SELECT COUNT(*)` from its source, so the Activity shows a real percentage and time remaining, and the counters move while a page is still being read.
+- **Failures are asymmetric on purpose.**<br /> A value that cannot be converted (text in a column JIM was told holds a number, a fractional value in a whole-number attribute) errors that one object and the import continues. Configuration that cannot work (a source the account cannot see, a `NULL` in an anchor column, a number too wide for JIM to hold exactly) fails the run, because every object would be affected.
+
+!!! note "Whole numbers stay whole"
+    A fractional value arriving in an attribute you have recorded as a whole number is refused for that object rather than rounded: `4200.7` silently becoming `4201` is the kind of error nobody finds. Either record the attribute as a Decimal on the Schema tab, or correct the source.
+
+### Delta Import
+
+A database has no change feed of its own, so a Delta Import needs one of two things you provide. The **Delta Import Mode** setting chooses which:
+
+| Mode | How JIM finds changes | Detects |
+|------|-----------------------|---------|
+| **Change-Log Table** (recommended) | Reads a table or view your database maintains, holding one row per change with the object's anchor, a change type and a monotonic sequence or timestamp. | Creates, updates and **deletions**. |
+| **Watermark Column** | Reads a last-modified or version column on each Object Type's own source, and one on each related table, selecting every row that has moved past the last value JIM saw. | Creates and updates only. **A deleted row has no column left to move**, so deletions are found only by a Full Import. |
+
+Each mode has its own end-to-end setup guide, including the table and trigger definitions for both databases:
+
+- [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md)
+- [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md)
+
+Whichever mode you choose, JIM keeps a watermark per source (each Object Type, and in Watermark Column mode each related table too), never one maximum across them all. It is captured before a single change is read, and saved only once the run has read its last page, so a run that dies half way through re-reads its changes rather than skipping them. There is no upper bound on a run: a change arriving while the run is in flight is read by this run or the next one, and possibly both, because re-importing an unchanged row costs a comparison whereas an upper bound would silently drop anything committed inside it.
+
+!!! important "The first Delta Import after configuring is a Full Import"
+    JIM holds no watermark until an import has completed, so the first Delta Import you run, or the first after changing the Delta Import Mode, performs a Full Import instead and says so on the Activity as a warning. That run establishes the watermark, and the next Delta Import runs normally. Where the mode has never been chosen at all, a Delta Import is refused rather than quietly costing a Full Import every cycle.
+
+### Export
+
+An Export writes Pending Exports to the Object Type's table. Each object is written inside a transaction of its own: its row and every related-table row belonging to it are committed together or rolled back together, because a half-written object is worse than an unwritten one.
+
+| Change | What JIM does |
+|--------|---------------|
+| Create | Inserts the row, then its related rows. Where the table generates the key (an identity column, a sequence, a default), JIM reads the generated value back and records it as the External ID; where you flow the key yourself (a natural identifier), JIM writes it. |
+| Update | Updates only the columns whose values changed. Anchor columns are never rewritten: an update that would touch one is refused with an explanation, because a rewritten primary key would orphan the object without any error. |
+| Delete | Deletes the related rows first, then the parent row, without relying on the schema declaring a cascade. A row that has already gone counts as success. |
+| Multi-valued add / remove | Inserts or deletes rows of the related table. |
+| Reference | Writes the referenced Connected System Object's own identifier, converted to whatever type the column holds. An export whose reference has not yet been provisioned into this database is deferred and retried once it has. |
+
+Every write reads its affected-row count back and answers for it. A statement that raised no error but changed nothing (a trigger discarding the insert, a row deleted outside JIM) fails that object with a message saying what to check, rather than confirming an object the table does not hold. A failure is confined to its object; the batch continues, and the failed export enters JIM's normal retry and backoff.
+
+Because a committed transaction is a verified write, an export needs no confirming import to be trusted: the connector reports **auto-confirm export**.
+
+!!! note "Views and statements are read-only"
+    An Object Type whose source is a view or a `select` statement cannot be exported to. Point the Object Type at a table to write to it; import through the view where the view is what the application maintains.
+
+### Type mapping
+
+Every column is typed from its declared SQL type. Microsoft SQL Server's named types state their width exactly and map by name; Oracle has one numeric type, `NUMBER`, so JIM reads its declared precision and scale and picks the narrowest JIM type guaranteed to hold every value the declaration permits.
+
+| JIM type | Microsoft SQL Server | Oracle Database |
+|----------|----------------------|-----------------|
+| Text | `char`, `nchar`, `varchar`, `nvarchar`, `text`, `ntext` | `CHAR`, `NCHAR`, `VARCHAR2`, `NVARCHAR2`, `CLOB`, `NCLOB`, `LONG` |
+| Number | `int`, `smallint`, `tinyint` | `NUMBER(p,0)` with p up to 9 |
+| Long Number | `bigint` | `NUMBER(p,0)` with p from 10 to 18 |
+| Decimal | `decimal`, `numeric`, `money`, `smallmoney`, `float`, `real` | `NUMBER(p,0)` with p of 19 or more; `NUMBER(p,s)` with a scale; `NUMBER` with no precision; `BINARY_FLOAT`, `BINARY_DOUBLE` |
+| Boolean | `bit` | `NUMBER(1)`, only with **Treat NUMBER(1) Columns as Boolean** on |
+| Date/Time | `date`, `datetime`, `datetime2`, `smalldatetime`, `datetimeoffset` | `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, `TIMESTAMP WITH LOCAL TIME ZONE` |
+| GUID | `uniqueidentifier` | `RAW(16)`, only with **Treat RAW(16) Columns as Guid** on |
+| Binary | `binary`, `varbinary`, `image`, `timestamp` / `rowversion` | `RAW`, `LONG RAW`, `BLOB` |
+| Reference | any column you configure with `referencesObjectType` | any column you configure with `referencesObjectType` |
+
+Two things about that table are worth knowing before you build on it:
+
+- **Oracle's `NUMBER(10)` is a Long Number, not a Number.** Ten digits already exceed a 32-bit whole number, so the ordinary sequence-backed identifier lands one step wider than you might expect. Where such a column needs to reach a built-in Metaverse Attribute that is a Number (`Employee Number` is the usual case), record it as a Number on the Schema tab; JIM permits the override precisely because Oracle's declaration cannot say. The full inference table and the override procedure are in [Attribute data types](../configuration/connected-systems.md#attribute-data-types).
+- **Approximate types round-trip approximately.** `float`, `real`, `BINARY_FLOAT` and `BINARY_DOUBLE` are read as Decimal so that numeric comparison still works, but a binary floating-point value converted to decimal and back is not bit-exact. Prefer an exact numeric column where JIM is authoritative for the value.
+
+A Decimal attribute holds 28 to 29 significant digits. A value wider than that fails the run rather than being rounded, with a message naming the column; narrow the column, stop selecting the attribute, or expose the source through a view that casts it down. Column types with no JIM equivalent (`xml`, `XMLTYPE`, `sql_variant`, `hierarchyid`, `geography`, `geometry`, `INTERVAL`, `time`, `ROWID`, `BFILE`) are skipped by discovery with a warning; expose them through a view that casts to a supported type if they need synchronising.
+
+### Date and time
+
+JIM stores every date and time in UTC. A column that carries its own offset (`datetimeoffset`, `TIMESTAMP WITH TIME ZONE`) needs no interpreting and is converted exactly. A column that carries none (`datetime2`, `DATE`, `TIMESTAMP`) is interpreted in the Connected System's **Database Time Zone** on import, and converted back into that zone on export. The default is UTC, which is the one answer that never silently shifts a value by an hour twice a year; enter an IANA name such as `Europe/London` where the application genuinely records local time.
+
+On Oracle, JIM also pins the session's time zone to the same value when it connects, which is what makes `TIMESTAMP WITH LOCAL TIME ZONE` read consistently. An Oracle Database whose own time zone file does not know the region you named refuses the connection with a message saying so, rather than reading dates in whatever zone the JIM host happens to use.
+
+## Connection Settings
+
+Settings are grouped exactly as they appear on the Connected System's Settings tab. Every setting explains itself in the portal too; this table is the same text, gathered.
+
+### Database Server
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| Database Type | Yes | **Microsoft SQL Server** or **Oracle Database**. Decides which details are asked for below, and which dialect JIM speaks. |
+| Host | Yes | The database server's hostname or IP address. For a named Microsoft SQL Server instance, use the `SERVER\INSTANCE` form. |
+| Port | No | Leave blank for the default: 1433 for Microsoft SQL Server, 1521 for Oracle Database, or 2484 for Oracle Database over TCPS. |
+| Database Name | SQL Server | The database to connect to on this server. |
+| Oracle Database Identified By | Oracle | **Service Name** (the modern form, and the one to use unless the estate still addresses the database by SID) or **SID**. |
+| Oracle Service Name | Oracle, by service name | The service name, for example `HRPROD.example.com`. Oracle Database Free's pluggable database is `FREEPDB1`. |
+| Oracle SID | Oracle, by SID | The System Identifier, for example `HRPROD`. |
+
+JIM builds the connection string itself from these values; there is no connection string to paste, and nothing in it is logged.
+
+### Credentials
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| Username | Yes | The database account JIM connects as. Give it the least privilege the Run Profiles need: read-only on an import-only Connected System. See [Database account permissions](#database-account-permissions). |
+| Password | Yes | Stored encrypted, decrypted only to hand to the driver, and never written to a log or a configuration snapshot. |
+
+A SQL Server connection identifies itself with the application name `JIM`, so a DBA can attribute sessions and locks to it. Connections are not pooled on either database: nothing stays open on your database between runs.
+
+### Transport Security
+
+| Setting | Applies to | Default | Description |
+|---------|------------|---------|-------------|
+| Encrypt Connection | SQL Server | On | Encrypt the connection with TLS. When on, the connection **fails** rather than falling back to plain text if the server cannot encrypt. The server's certificate is always validated, against the operating system's certificate bundle and any certificates added in **Admin > Certificates**; JIM never trusts whatever certificate the server happens to present. |
+| Oracle Encryption | Oracle | Native Network Encryption | **Native Network Encryption** encrypts the session on the ordinary listener with no certificate at either end (AES, with SHA-2 integrity checking, both required rather than negotiable), and is how Oracle estates usually encrypt client traffic. **TCPS (TLS)** needs a separately configured listener, usually on port 2484, and a server certificate. **None** sends the session in clear and should be reserved for a lab. |
+| Connection Timeout | Both | 30 seconds | How long to wait before giving up on connecting. |
+
+#### When a connection test fails on the certificate
+
+For SQL Server, a server certificate JIM does not yet trust (an internal certificate authority, or a self-signed certificate) fails the connection test, and JIM shows you the certificate the server presented: its subject, the names it was issued for, its issuer, validity dates and thumbprint, and which check it failed. Add the issuing authority (or the certificate itself, for a self-signed one) under **Admin > Certificates** and test again.
+
+Trust is strictly additive. JIM connects with the operating system's trust anchors first, and only when the driver refuses does it look at the certificate the server presented; only a certificate that JIM's own store vouches for, and that passes JIM's own checks of validity period and name, is then handed to the driver as an additional anchor. An expired certificate, or one issued for a different name from the one you connect to, is still refused, and JIM says which.
+
+For Oracle over TCPS the same certificate detail is shown on failure, but the ODP.NET managed driver offers no way for JIM to add a trust anchor of its own: a TCPS certificate must be one the operating system on the JIM host already vouches for. Native Network Encryption is unaffected, using no certificate at all, which is one reason it is the default.
+
+### Date and Time
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Database Time Zone | `UTC` | The time zone that date and time columns carrying no offset are recorded in. See [Date and time](#date-and-time). Enter `UTC`, or an IANA time zone name such as `Europe/London`. A name this deployment does not recognise is refused when you save. |
+
+### Type Mapping
+
+| Setting | Applies to | Default | Description |
+|---------|------------|---------|-------------|
+| Treat NUMBER(1) Columns as Boolean | Oracle | Off | Oracle has no boolean column type, so flags are usually held as `NUMBER(1)`. Turn this on if that is what `NUMBER(1)` columns mean in this database; leave it off and they import as numbers. It applies to every `NUMBER(1)` column in the schema, so only turn it on where that is true of all of them. |
+| Treat RAW(16) Columns as Guid | Oracle | Off | Oracle holds GUIDs in `RAW(16)` columns, but so it does digests and other binary values, and the catalogue cannot tell them apart. Turn this on if `RAW(16)` columns in this database hold GUIDs; leave it off and they import as binary values. |
+
+Both are opt-ins because a wrong guess in either direction would be a silent one. Where a database mixes the two meanings, leave the setting off: the columns import as Numbers or as binary values, and the ones that are really flags or GUIDs can be converted in the Attribute Flow, or exposed through a view under a type that says what they are.
+
+### Object Type Configuration
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| Object Types | Yes | The JSON document naming each Object Type this database holds and where its objects come from. See [The Object Types document](#the-object-types-document). |
+
+### Delta Import
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| Delta Import Mode | No | **Change-Log Table** or **Watermark Column**. Leave it unanswered where this Connected System only runs Full Imports; JIM will not default it, because that would have it read changes from a table nobody has said exists. See [Delta Import](#delta-import). |
+
+## The Object Types document
+
+The **Object Types** setting is a JSON document with one entry per Object Type. It is validated when you save the Connected System, strictly: an unknown field name is an error rather than ignored, because a typo that parses is a defect that only surfaces as missing data much later. Every refusal names the Object Type and the field.
+
+```json title="A person with a manager reference and a related table of phone numbers"
+{
+  "objectTypes": [
+    {
+      "name": "Person",
+      "schema": "HR",
+      "table": "V_EMPLOYEES",
+      "anchorColumns": [ "EMPLOYEE_ID" ],
+      "columns": [
+        { "name": "MANAGER_EMPLOYEE_ID", "referencesObjectType": "Person" }
+      ],
+      "relatedTables": [
+        {
+          "attributeName": "PhoneNumbers",
+          "schema": "HR",
+          "table": "EMPLOYEE_PHONES",
+          "valueColumn": "PHONE_NUMBER",
+          "joinColumns": [ "EMPLOYEE_ID" ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Object Type fields
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `name` | Yes | What JIM calls the Object Type. Must be unique within the document. A standard name (`User`, `Group`, `Person`) lets JIM map it to a Metaverse Object Type automatically. |
+| `table` | One of `table` / `select` | The table **or view** objects are read from. |
+| `schema` | No | Qualifies `table`. Leave it out and JIM resolves the name from the catalogue; a least-privilege account usually sees exactly one object of a given name. Where the name exists in more than one schema JIM asks you to say which. Not allowed with `select`. |
+| `select` | One of `table` / `select` | A `SELECT` statement standing in for a table or view, for the cases where a view cannot be created. Must begin `SELECT` or `WITH`, must be a single statement with no terminator, and cannot be exported to. JIM asks the database to plan it at discovery without reading a row, so a statement the database would not accept is refused when you save. |
+| `anchorColumns` | Yes | The column or columns whose values identify a row, **in key order**. The order is what makes a keyset page boundary reproducible between runs, so JIM never sorts it. |
+| `columns` | No | Per-column configuration; today that means naming the Object Type a column's values point at, so JIM resolves it as a Reference. Each entry is `{ "name": ..., "referencesObjectType": ... }`, and the referenced Object Type must be declared in the same document. |
+| `relatedTables` | No | Multi-valued attributes, one entry per attribute. See below. |
+| `watermarkColumn` | Watermark Column mode | The last-modified or version column on this Object Type's own source. See [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md). |
+| `changeLog` | Change-Log Table mode | The change-log table for this Object Type. See [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md). |
+
+### Related table fields
+
+A related table turns a table of one row per value into a multi-valued attribute on the parent. Group membership is exactly this shape: a `GROUP_MEMBERS` table of `(GROUP_ID, MEMBER_ID)` becomes a `Members` attribute on the `Group` Object Type, and with `referencesObjectType` its values are References to `Person` objects.
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `attributeName` | Yes | What the multi-valued attribute is called on the Object Type. Named by you because a value column's own name (`PHONE_NUMBER`) rarely reads as the plural attribute it becomes. Must not clash with a column of the parent. |
+| `table` / `schema` | Yes / No | The related table, qualified as for an Object Type. |
+| `valueColumn` | Yes | The column holding the value. Its SQL type decides the attribute's type. |
+| `joinColumns` | Yes | The columns that join a row back to its parent: **one per anchor column, in the same order**. Joining on part of an anchor would gather another object's values onto this one, so JIM refuses a mismatch. |
+| `referencesObjectType` | No | Where the values are References, the Object Type they point at. |
+| `watermarkColumn` | Watermark Column mode | The column that moves when a row of this table changes. |
+
+## Worked examples
+
+### Microsoft SQL Server: an HR application
+
+`dbo.Employees` is keyed on an `IDENTITY` column, holds a self-referencing `ManagerId`, and has a child table of phone numbers. Departments live in their own table and are referenced by key.
+
+```json title="Object Types for a SQL Server HR schema"
+{
+  "objectTypes": [
+    {
+      "name": "Person",
+      "schema": "dbo",
+      "table": "Employees",
+      "anchorColumns": [ "EmployeeId" ],
+      "columns": [
+        { "name": "ManagerId", "referencesObjectType": "Person" },
+        { "name": "DepartmentId", "referencesObjectType": "Department" }
+      ],
+      "relatedTables": [
+        {
+          "attributeName": "PhoneNumbers",
+          "schema": "dbo",
+          "table": "EmployeePhones",
+          "valueColumn": "PhoneNumber",
+          "joinColumns": [ "EmployeeId" ]
+        }
+      ]
+    },
+    {
+      "name": "Department",
+      "schema": "dbo",
+      "table": "Departments",
+      "anchorColumns": [ "DepartmentId" ]
+    }
+  ]
+}
+```
+
+What you get: `EmployeeId` (`int`) is the External ID and is set on creation only; `ManagerId` and `DepartmentId` are References; `PhoneNumbers` is a multi-valued Text attribute; `HireDate` (`datetime2`) is interpreted in the Database Time Zone; `IsActive` (`bit`) is a Boolean. Exporting a new `Person` inserts the row without `EmployeeId`, reads the identity value back and records it as the External ID, then inserts its phone numbers.
+
+### Oracle Database: an HR view over a sequence-keyed table
+
+The application exposes `HR.V_EMPLOYEES` for reading and expects writes to go to `HR.EMPLOYEES`, whose `EMPLOYEE_ID NUMBER(10)` is filled by a sequence-backed default. Group membership is a related table of References.
+
+```json title="Object Types for an Oracle HR schema"
+{
+  "objectTypes": [
+    {
+      "name": "Person",
+      "schema": "HR",
+      "table": "EMPLOYEES",
+      "anchorColumns": [ "EMPLOYEE_ID" ],
+      "columns": [
+        { "name": "MANAGER_ID", "referencesObjectType": "Person" }
+      ]
+    },
+    {
+      "name": "Group",
+      "schema": "HR",
+      "table": "GROUPS",
+      "anchorColumns": [ "GROUP_ID" ],
+      "relatedTables": [
+        {
+          "attributeName": "Members",
+          "schema": "HR",
+          "table": "GROUP_MEMBERS",
+          "valueColumn": "EMPLOYEE_ID",
+          "joinColumns": [ "GROUP_ID" ],
+          "referencesObjectType": "Person"
+        }
+      ]
+    }
+  ]
+}
+```
+
+What you get: `EMPLOYEE_ID` discovers as a Long Number (`NUMBER(10)`); record it as a Number on the Schema tab if it is to flow to the built-in `Employee Number`. `IS_ACTIVE NUMBER(1)` is a Number unless **Treat NUMBER(1) Columns as Boolean** is on. `HIRE_DATE` (`DATE`) is interpreted in the Database Time Zone. `Members` is a multi-valued Reference to `Person`; exporting a `Group` inserts its row and one `GROUP_MEMBERS` row per member, in one transaction.
+
+!!! tip "Read through the view, write to the table"
+    Where the application maintains a view for readers, you can point an import-only Connected System at the view and a second Connected System at the table for writes, or point one Connected System at the table for both. A single Object Type cannot read from the view and write to the table.
+
+## Security Considerations
+
+### Trust model
+
+The Object Types document, including any `select` statement, is privileged administrator input: it names the tables JIM reads and writes, exactly as a Synchronisation Rule decides what flows where. Everything JIM binds into a statement is bound as a parameter, never interpolated; identifiers cannot be parameterised, so JIM quotes and validates every one it uses. Those two are the injection surface, and neither depends on the document being trusted.
+
+### Database account permissions
+
+Create a dedicated database account for JIM and grant it only what the Run Profiles you configure will use.
+
+- **For schema discovery and import**<br /> `SELECT` on each table or view named in the Object Types document, on each related table, and (in Change-Log Table mode) on each change-log table. JIM reads the catalogue through `INFORMATION_SCHEMA` and `sys` views on SQL Server and the `ALL_*` views on Oracle, which show exactly the objects the account can already read; nothing wider is needed.
+- **For export**<br /> `INSERT`, `UPDATE` and `DELETE` on each Object Type's table and each related table, alongside `SELECT`, which the export uses to read the column catalogue and check its writes.
+- **Nothing else.**<br /> JIM creates no objects, alters no schema, and never needs `db_owner`, `DBA`, or `SELECT ANY TABLE`.
+
+```sql title="Microsoft SQL Server: an import-only account"
+CREATE LOGIN jim_sync WITH PASSWORD = '<a strong password>';
+CREATE USER jim_sync FOR LOGIN jim_sync;
+GRANT SELECT ON SCHEMA::HR TO jim_sync;
+```
+
+```sql title="Microsoft SQL Server: an account that also exports"
+GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::HR TO jim_sync;
+```
+
+```sql title="Oracle Database: an import-only account"
+CREATE USER jim_sync IDENTIFIED BY "<a strong password>";
+GRANT CREATE SESSION TO jim_sync;
+GRANT SELECT ON HR.V_EMPLOYEES TO jim_sync;
+GRANT SELECT ON HR.EMPLOYEE_PHONES TO jim_sync;
+```
+
+```sql title="Oracle Database: an account that also exports"
+GRANT SELECT, INSERT, UPDATE, DELETE ON HR.EMPLOYEES TO jim_sync;
+GRANT SELECT, INSERT, UPDATE, DELETE ON HR.EMPLOYEE_PHONES TO jim_sync;
+```
+
+Grant per object on Oracle rather than `SELECT ANY TABLE`; the `ALL_*` catalogue views then show JIM exactly, and only, what it should see, and a discovery error saying an object "cannot be seen" is a permission you have not granted rather than a mystery.
+
+### Encryption in transit
+
+- **SQL Server** connections are encrypted by default and fail rather than fall back to plain text. `TrustServerCertificate` is never set: the certificate is always validated.
+- **Oracle** connections use Native Network Encryption by default (AES with SHA-2 integrity checking, both required), or TCPS where the listener offers it. Choose **None** only in a lab.
+- Neither database's driver needs anything installed on the JIM host beyond JIM itself, and neither connection reaches anything but the host you name, so the connector works unchanged in an air-gapped deployment.
+
+### Credentials and logs
+
+The password is stored encrypted, decrypted only to hand to the driver's connection string builder, and appears in no log, Activity, or configuration snapshot. The driver's own error messages never carry it either.
+
+## Third-party licence notice
+
+The Oracle dialect is provided through **Oracle Data Provider for .NET, Managed Driver** (`Oracle.ManagedDataAccess.Core`), which Oracle distributes under the **Oracle Free Distribution, Hosting, and Use Terms and Conditions**. Those terms permit the driver to be redistributed unmodified and used in your business operations at no charge, on conditions that include a copy of the terms accompanying any distribution and Oracle's proprietary notices being left in place. JIM ships a copy of the terms in every image, under `/app/third-party-notices/`, and in the repository under [`third-party-notices/`](https://github.com/TetronIO/JIM/tree/main/third-party-notices). If your organisation has its own licence agreement with Oracle covering the driver, that agreement governs your use of it instead. Nothing here is legal advice; read the terms.
+
+The Microsoft SQL Server dialect is provided through `Microsoft.Data.SqlClient`, which is MIT licensed.
+
+## Wider database support
+
+The connector is built as one connector with a dialect per database, so a further database is an addition behind the same settings and the same Object Types document rather than a new connector. PostgreSQL and MySQL are next on the [roadmap](../reference/roadmap.md). If you need another engine, or need one of those sooner, say so in the [Ideas category of GitHub Discussions](https://github.com/TetronIO/JIM/discussions/categories/ideas); which dialect comes next is decided by who asks.
+
+## Troubleshooting
+
+**"Unable to connect. Message: ..."**<br />
+The driver's own message follows. A wrong host or a closed port times out after the Connection Timeout; a wrong Database Name, service name or SID is refused immediately with the database's own wording; a wrong password is an authentication failure. On Oracle, check that you have chosen the right form (service name or SID) as well as the right value.
+
+**The connection test fails on the certificate (SQL Server)**<br />
+JIM shows the certificate the server presented and which check failed. An untrusted issuer is fixed by adding the authority under **Admin > Certificates**; an expired certificate has to be renewed on the server; a name mismatch means connecting by a name the certificate carries. See [When a connection test fails on the certificate](#when-a-connection-test-fails-on-the-certificate).
+
+**"Object Type 'X' reads from HR.TABLE, which this database account cannot see"**<br />
+Either the name is wrong, or the schema is, or the account has not been granted `SELECT` on it. On Oracle a grant is per object; see [Database account permissions](#database-account-permissions).
+
+**"Object Type 'X' names 'TABLE', which exists in more than one schema"**<br />
+Add a `schema` to the Object Type to say which one.
+
+**An attribute is missing after schema discovery**<br />
+Check the discovery's warnings: a column of a type JIM has no equivalent for is skipped and named. Expose it through a view that casts it to a supported type.
+
+**A whole-number attribute reports "the value has a fractional part"**<br />
+The column is fractional but the attribute was recorded as a Number or Long Number, usually through an override. Record it as a Decimal on the Schema tab, or correct the source.
+
+**A Delta Import performed a Full Import instead**<br />
+Expected the first time, and after a change of Delta Import Mode: no usable watermark existed, so the run established one. If it happens on every run, check the Activity's warning for the reason.
+
+**A Delta Import never sees deletions**<br />
+Watermark Column mode cannot; a deleted row has no column left to move. Use a change-log table, or schedule a periodic Full Import. See [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md).
+
+**An export reports "No row was written ... though the database raised no error"**<br />
+A trigger or a rule on the table is discarding the insert, or the account may not write to it. JIM rolls the object back rather than confirming a row the table does not hold; check the table's triggers and the account's grants.
+
+**An export reports "No row ... is identified by this Connected System Object's external ID"**<br />
+The row was deleted outside JIM, or its key was changed. Run a Full Import to reconcile the Connected System with the table.
+
+**An Oracle export fails with "returned no value for its anchor column"**<br />
+The table's key is neither flowed by a Synchronisation Rule nor generated by the database. Back the column with a sequence-based default or an identity column, or flow the key.
+
+**Dates are an hour out**<br />
+The column carries no offset and the Database Time Zone does not match what the application writes. Set it to the zone the application records in; columns with their own offset are unaffected either way.
+
+## Related
+
+- [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md)
+- [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md)
+- [Attribute data types](../configuration/connected-systems.md#attribute-data-types)
+- [Connectors](index.md)
+- [Connected Systems](../configuration/connected-systems.md)

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -10,7 +10,7 @@ JIM implements an enterprise identity management system using the metaverse patt
 
 --8<-- "assets/diagrams/system-context.svg"
 
-<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">Administrators and automation clients work through JIM's UI and API; JIM synchronises with the surrounding systems.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 ## Layered Architecture
 
@@ -77,7 +77,7 @@ The component views use the docs site's hand-authored diagram system and are sim
 
 --8<-- "assets/diagrams/connector-components.svg"
 
-<p class="jim-diagram-caption">The Worker's import and export processors invoke the connectors, which carry data to and from the external systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace data in flight.</span></p>
+<p class="jim-diagram-caption">The Worker's import and export processors invoke the connectors, which carry data to and from the external systems.<span class="jimdg-caption-motion"> Moving dots trace data in flight.</span></p>
 
 ### Scheduler Service
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hide:
 
 --8<-- "assets/diagrams/system-context.svg"
 
-<p class="jim-diagram-caption">JIM in context: administrators and automation work through its UI and API while it synchronises identity data with your systems. Dashed elements are not yet available.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
+<p class="jim-diagram-caption">JIM in context: administrators and automation work through its UI and API while it synchronises identity data with your systems.<span class="jimdg-caption-motion"> Moving dots trace identity data in flight.</span></p>
 
 ## ✨ Key Features
 

--- a/docs/powershell/connected-systems.md
+++ b/docs/powershell/connected-systems.md
@@ -701,7 +701,7 @@ Set-JIMConnectedSystemAttribute -ConnectedSystemId 3 -ObjectTypeId 1 -AttributeI
 ```
 
 ```powershell title="Correct the data type of an Oracle NUMBER column"
-# Oracle has one numeric type, so a NUMBER(10) employee identifier is read as a Decimal by default.
+# Oracle has one numeric type, so a NUMBER(10) employee identifier is read as a Long Number by default.
 # Recording it as a whole number lets it flow into the built-in Employee Number Metaverse Attribute.
 Set-JIMConnectedSystemAttribute -ConnectedSystemId 3 -ObjectTypeId 1 -AttributeId 5 -Type Integer
 ```

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -24,7 +24,7 @@ Expanding the range of systems JIM can connect to out of the box. The SCIM 2.0 C
 | Connector | Description | Status |
 |---|---|---|
 | [JIM SCIM 2.0 Client Connector](../connectors/jim-scim-connector.md) | SCIM 2.0 endpoints | ✅ Available |
-| JIM SQL Connector | Microsoft SQL Server and Oracle Database | ✅ Available |
+| [JIM SQL Connector](../connectors/jim-sql-connector.md) | Microsoft SQL Server and Oracle Database | ✅ Available |
 | JIM SQL Connector: PostgreSQL and MySQL | The same connector, extended to two further engines | 🚧 In development |
 | JIM PowerShell Connector | PowerShell Core scripts | Planned |
 | JIM REST Connector | REST API web services | Planned |

--- a/engineering/DEPENDENCY_PINNING.md
+++ b/engineering/DEPENDENCY_PINNING.md
@@ -38,6 +38,8 @@ Pinning stops substitution at build time; the following controls verify what is 
 
 Adding a **new** NuGet package or other third-party dependency is a separate process from updating a pinned version: it requires explicit user approval before it is added. See root `CLAUDE.md` > "Third-Party Dependency Governance" for the full notify-research-present-approve flow and the maintainer preference order (Microsoft-maintained > established corporate-backed > .NET Foundation > well-maintained OSS with identifiable maintainers).
 
+Where an approved dependency's licence obliges a distribution to carry its terms (the Oracle managed driver's Free Distribution, Hosting, and Use Terms do), the licence text goes in `third-party-notices/` with a row in its `README.md`; every image copies that directory to `/app/third-party-notices/`, and the customer-facing connector page states the terms.
+
 ## Operations
 
 **When a locked-mode restore fails locally** (a direct package version changed and the lock file has not caught up):

--- a/engineering/JIM_AI_ASSISTANT_CONTEXT.md
+++ b/engineering/JIM_AI_ASSISTANT_CONTEXT.md
@@ -4,9 +4,9 @@
 >
 > **Repository**: https://github.com/TetronIO/JIM
 >
-> **Document Version**: 1.7
+> **Document Version**: 1.8
 >
-> **Last Updated**: 2026-04-22
+> **Last Updated**: 2026-08-17
 >
 > **Note**: This is a snapshot. For current implementation details, check the repository or ask the user to provide updated code/docs.
 
@@ -189,13 +189,14 @@ Grace periods allow time before actual deletion (e.g., 30 days).
 | **LDAP/Active Directory** | ✓ | ✓ | Full CRUD, includes Samba AD, SSL/TLS, container creation |
 | **OpenLDAP/RFC 4512** | ✓ | ✓ | OpenLDAP, 389 Directory Server, RFC 4512-compliant directories; parallel imports, accesslog delta import, partition-scoped imports |
 | **File (CSV/Text)** | ✓ | ✓ | Configurable delimiters, auto-confirm export |
+| **SCIM 2.0 Client** | ✓ | ✓ | Any RFC 7643/7644 service provider; last-modified delta import, optional bulk operations, rate-limit aware |
+| **SQL** | ✓ | ✓ | Microsoft SQL Server and Oracle Database through managed ADO.NET drivers; one Connected System per database with an Object Types document naming tables/views, anchors, references and related tables; keyset-paged full import; delta import from a change-log table or a watermark column; transactional export with generated-key capture; auto-confirm export |
 
-### Planned Connectors (Post-MVP)
+### Planned Connectors
 
 | Connector | Notes |
 |-----------|-------|
-| **SCIM 2.0** | Standard protocol (design doc exists) |
-| **SQL** | Database connector (SQL Server, PostgreSQL, MySQL, Oracle) |
+| **SQL: PostgreSQL and MySQL** | Further dialects of the same SQL Connector |
 | **PowerShell** | Custom scripts |
 | **Web Services/REST** | OAuth2/API key auth |
 
@@ -449,7 +450,7 @@ Development follows sequenced milestones (see [GitHub Milestones](https://github
 |-----------|-------|
 | **v0.9-STABILISATION** | Configuration controls, identity fusing, lifecycle state management (JML triggers), sync engine refinement, architectural foundation for extensibility |
 | **v1.0-ILM-COMPLETE** | First production-ready release: robust Synchronisation Rules, lifecycle automation, scheduling, error handling, operational monitoring |
-| **v1.x-CONNECTORS** | Expanding connector coverage: broader LDAP support, SQL databases, SCIM endpoints, HR systems, connector framework improvements |
+| **v1.x-CONNECTORS** | Expanding connector coverage: SQL Connector shipped for SQL Server and Oracle (PostgreSQL and MySQL dialects next), SCIM 2.0 Client shipped, HR systems, connector framework improvements |
 | **v2.0-IGA-FOUNDATION** | Direct in-JIM management of MVOs (no longer dependent on Source-of-Record systems): Entitlement Management (group management + governance: reviews/attestation, delegated admin, dynamic & time-based memberships, self-service, approvals, etc.), Identity Lifecycle Management (user management, self-service for locally-managed attributes, lifecycle workflows), and fine-grained RBAC for custom permission models |
 
 ---

--- a/engineering/plans/doing/SQL_DATABASE_CONNECTOR.md
+++ b/engineering/plans/doing/SQL_DATABASE_CONNECTOR.md
@@ -1,8 +1,8 @@
 # SQL Database Connector: Implementation Plan
 
-- **Status:** Planned
+- **Status:** Doing (Phases 1-6 and 8 complete; Phase 7 matrix at 29 of 36 cells, the Delta cells and the 500,000-row import outstanding)
 - **Issue:** [#170](https://github.com/TetronIO/JIM/issues/170)
-- **PRD:** [PRD_SQL_DATABASE_CONNECTOR.md](../prd/doing/PRD_SQL_DATABASE_CONNECTOR.md)
+- **PRD:** [PRD_SQL_DATABASE_CONNECTOR.md](../../prd/doing/PRD_SQL_DATABASE_CONNECTOR.md)
 
 ## Overview
 
@@ -58,14 +58,14 @@ src/JIM.Connectors/Sql/
 
 Test-driven throughout: each phase writes failing tests first, in `test/JIM.Worker.Tests/Connectors/` following the LDAP/File naming conventions (`MethodName_Scenario_ExpectedResult`).
 
-### Phase 1: Provider abstraction and type mapping
+### Phase 1: Provider abstraction and type mapping ✅
 
 - Add `Microsoft.Data.SqlClient` 7.0.2 and `Oracle.ManagedDataAccess.Core` 23.26.300 to `src/JIM.Connectors/JIM.Connectors.csproj` (exact versions); `dotnet restore JIM.sln --force-evaluate`; review the lock-file diff (ripples into every downstream project's `packages.lock.json`); commit lock files with the version change. Never add `Microsoft.Data.SqlClient.Extensions.Azure`.
 - `ISqlProvider`, `SqlServerProvider`, `OracleProvider`: connection-string construction from discrete settings, identifier quoting, parameter prefixing, keyset-pagination SQL, schema-catalogue queries, generated-key retrieval strategy, trivial-connectivity query.
 - `SqlTypeMapper` implementing the PRD type-mapping table, including the Oracle `NUMBER(1)`-to-Boolean opt-in, `RAW(16)` GUID handling via `IdentifierParser.FromRfc4122Bytes` (big-endian, per `engineering/plans/doing/GUID_UUID_HANDLING.md`), and FLOAT/REAL to Decimal.
 - Unit tests: dialect differences per provider, type-mapping matrix, Decimal canonical round-trip.
 
-### Phase 2: Connector skeleton, settings, validation, registration
+### Phase 2: Connector skeleton, settings, validation, registration ✅
 
 - `SqlConnector` with capability declarations and Connectivity settings per PRD requirements 1-2: Database Type drop-down, Host, Port, database name vs Oracle service name/SID via conditional settings, Username, Password (`StringEncrypted`), TLS options, connection timeout, and the required zoneless time-zone setting with a visible UTC default (`DefaultStringValue`). Do not name any setting "Mode" (File Connector semantics are keyed to that literal in `ConnectedSystemExtensions`).
 - `ValidateSettingValues`: LDAP-thin body; live connectivity test (open, trivial query per provider, close) in try/finally; failure results carry `ErrorMessage` + `Exception`.
@@ -73,13 +73,13 @@ Test-driven throughout: each phase writes failing tests first, in `test/JIM.Work
 - Registration: `ConnectorFactory.CreateConnectorInstance` branch; `SeedingServer.SeedAsync` Connector Definitions region and `SyncBuiltInConnectorDefinitionsAsync` list; invert `Create_SqlConnectorName_ThrowsNotSupportedException` to `ReturnsSqlConnector`; add `SqlConnectorPhaseConformanceTests : ConnectorPhaseConformanceTests`.
 - `SqlConnectorPhases` + `GetPhases()` per run type ("Executing query", "Fetching rows", "Writing rows" vocabulary).
 
-### Phase 3: Schema discovery and object type configuration
+### Phase 3: Schema discovery and object type configuration ✅
 
 - Design decision (recommended approach): object type definitions are richer than the flat settings framework expresses (N object types, each with a primary table/view or admin-supplied `SELECT`, anchor column(s), and N related tables with join conditions). Represent them as a structured JSON document in a `Text` setting in the Schema category ("Object Types"), parsed into `SqlObjectTypeConfiguration`, validated in `ValidateSettingValues` with precise error messages, and documented with copy-paste examples. This is privileged administrator input per the PRD trust model. Alternative (rejected for v1): extending the settings framework with repeating groups; disproportionate for one connector.
 - `GetSchemaAsync`: enumerate tables/views and columns via provider catalogue queries; apply the type mapper; emit one `ConnectorSchemaObjectType` per configured object type with primary-key-derived `RecommendedExternalIdAttribute`; surface related-table value columns as multi-valued attributes; explicit per-column Reference designation from configuration, never inferred. Where declared foreign-key constraints match a configured object type's anchor, surface them as pre-populated Reference suggestions for the administrator to confirm (PRD requirement 6).
 - Unit tests against mocked `DbConnection`/provider fakes; catalogue query correctness verified later by integration tests.
 
-### Phase 4: Full import
+### Phase 4: Full import ✅
 
 - `SqlConnectorImport`: keyset pagination on the anchor (never OFFSET) honouring `ConnectedSystemRunProfile.PageSize`, one `ConnectedSystemPaginationToken` per object type carrying the last-seen anchor (`StringValue`); empty token list terminates.
 - Per page: materialise rows, gather multi-valued attributes from related tables (single batched query per page, keyed on the page's anchors), emit typed attribute values, references as anchor strings in `ReferenceValues`.
@@ -87,14 +87,14 @@ Test-driven throughout: each phase writes failing tests first, in `test/JIM.Work
 - Progress: `EnterPhaseAsync` per object type/page; `ReportExpectedObjectCountAsync` from a cheap `COUNT(*)` on the primary table/view (PRD requirement 21: databases can state result-set sizes cheaply, so a real percentage and time remaining are mandatory, not optional); `ReportObjectsReadAsync` where one call drains multiple provider pages; `ReportAsync` for detail the counts cannot carry.
 - Unit tests: paging termination, related-table gathering, type fidelity, error classification (`ConnectedSystemImportObjectError`) for unparseable values.
 
-### Phase 5: Delta import
+### Phase 5: Delta import ✅
 
 - Two modes per the PRD (change-log table with deletes; watermark column create/update-only), selected per Connected System via an extensible drop-down (SQL Server Change Tracking is a fast-follow member).
 - `SqlConnectorWatermark` serialised to `ConnectedSystemImportResult.PersistedConnectorData` on the first page, following the `LdapConnectorRootDse` round-trip rules exactly (original watermark read on every page; new value saved by the Worker after the run completes).
 - Missing/undeserialisable watermark: `CannotPerformDeltaImportException`, or fallback to full import with `WarningErrorType = ActivityRunProfileExecutionItemErrorType.DeltaImportFallbackToFullImport` (mirrors `LdapConnectorImportDeltaFallbackTests` coverage).
 - Change-log mode emits explicit `Create`/`Update`/`Delete` change types beyond the persisted watermark and advances it transactionally with the read.
 
-### Phase 6: Export
+### Phase 6: Export ✅
 
 - `SqlConnectorExport`: per-object `DbTransaction` spanning the parent row and related-table maintenance; parameterised statements only, identifiers quoted through the provider; provider-specific generated-key retrieval (`OUTPUT INSERTED.*` / `RETURNING ... INTO`) returned as `ConnectedSystemExportResult.Succeeded(externalId)`.
 - Positional result contract; per-object failures return `Failed(...)` without poisoning the batch, feeding the existing retry/backoff machinery.
@@ -110,12 +110,14 @@ Test-driven throughout: each phase writes failing tests first, in `test/JIM.Work
 - Test strategy (PRD, decided 2026-08-02): this matrix scenario is the correctness gate; cross-technology regression breadth follows via the road-mapped Multi-Source Aggregation scenario once the matrix is green. Databases are not retrofitted into scenarios 1-14; if regressions slip past both vehicles, parameterising Scenario 1's HR source (CSV vs SQL) is the one retrofit worth considering.
 - Update `engineering/INTEGRATION_TESTING.md` (Phase 2 sections, port tables, Oracle start-up troubleshooting) and `test/integration/README.md`.
 
-### Phase 8: Documentation and release polish
+### Phase 8: Documentation and release polish ✅
 
 - `docs/connectors/jim-sql-connector.md`: per-provider configuration, object type configuration examples, type mapping, security/least-privilege guidance, the Oracle Free Distribution licence note, and the wider-database-support callout inviting feedback via the [Ideas category of GitHub Discussions](https://github.com/TetronIO/JIM/discussions/categories/ideas).
 - Dedicated delta import setup pages (change-log table; watermark column) linked from the connector page, each covering setup end to end including the watermark mode's documented no-delete semantics.
 - Ship a copy of Oracle's LICENSE.txt with the distribution (third-party notices) per the governance record.
 - Nav/index updates, `docs/concepts/connected-systems.md` and roadmap rows, `JIM_AI_ASSISTANT_CONTEXT.md` connector table + version bump, CHANGELOG entry, PRD to `done/` on issue closure.
+
+Delivered 2026-08-17: `docs/connectors/jim-sql-connector.md` plus the two delta-import setup pages, `third-party-notices/` (the Oracle terms, copied into every image), the concept diagrams and README exports showing the SQL Connector live, and the AI assistant context at version 1.8. `docs/concepts/connected-systems.md` does not exist, so that item had nothing to update; the PRD moves to `done/` when #170 closes.
 
 ## Success Criteria
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,10 @@ nav:
       - JIM File Connector: connectors/jim-file-connector.md
       - JIM LDAP Connector: connectors/jim-ldap-connector.md
       - JIM SCIM 2.0 Client Connector: connectors/jim-scim-connector.md
+      - JIM SQL Connector:
+          - connectors/jim-sql-connector.md
+          - Delta Import with a change-log table: connectors/jim-sql-connector-delta-import-change-log.md
+          - Delta Import with a watermark column: connectors/jim-sql-connector-delta-import-watermark.md
   - API:
       - api/index.md
       - Authentication: api/authentication.md

--- a/src/JIM.Scheduler/Dockerfile
+++ b/src/JIM.Scheduler/Dockerfile
@@ -57,4 +57,7 @@ RUN dotnet publish "JIM.Scheduler.csproj" -c Release -o /app/publish /p:VersionS
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+# Third-party licence texts the image is bound to carry (the Oracle managed driver in particular);
+# see third-party-notices/README.md.
+COPY ["third-party-notices/", "./third-party-notices/"]
 ENTRYPOINT ["dotnet", "JIM.Scheduler.dll"]

--- a/src/JIM.Web/Dockerfile
+++ b/src/JIM.Web/Dockerfile
@@ -148,4 +148,7 @@ FROM ${OPENAPI_STAGE} AS final-source
 FROM base AS final
 WORKDIR /app
 COPY --from=final-source /app/publish .
+# Third-party licence texts the image is bound to carry (the Oracle managed driver in particular);
+# see third-party-notices/README.md.
+COPY ["third-party-notices/", "./third-party-notices/"]
 ENTRYPOINT ["dotnet", "JIM.Web.dll"]

--- a/src/JIM.Worker/Dockerfile
+++ b/src/JIM.Worker/Dockerfile
@@ -85,4 +85,7 @@ RUN dotnet publish "JIM.Worker.csproj" -c Release -o /app/publish /p:VersionSuff
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+# Third-party licence texts the image is bound to carry (the Oracle managed driver in particular);
+# see third-party-notices/README.md.
+COPY ["third-party-notices/", "./third-party-notices/"]
 ENTRYPOINT ["dotnet", "JIM.Worker.dll"]

--- a/third-party-notices/Oracle.ManagedDataAccess.Core-LICENSE.txt
+++ b/third-party-notices/Oracle.ManagedDataAccess.Core-LICENSE.txt
@@ -1,0 +1,42 @@
+Your use of this Program is governed by the Oracle Free Distribution, Hosting, and Use Terms and Conditions set forth below, unless you have received this Program (alone or as part of another Oracle product) under an Oracle license agreement (including but not limited to the Oracle Master Agreement), in which case your use of this Program is governed solely by such license agreement with Oracle.
+
+Oracle Free Distribution, Hosting, and Use Terms and Conditions
+Definitions
+"Oracle" refers to Oracle America, Inc. "You" and "Your" refers to (a) a company or organization (each an "Entity") accessing the Programs, if use of the Programs will be on behalf of such Entity; or (b) an individual accessing the Programs, if use of the Programs will not be on behalf of an Entity. "Program(s)" refers to Oracle software provided by Oracle pursuant to the following terms and any updates, error corrections, and/or Program Documentation provided by Oracle. "Program Documentation" refers to Program user manuals and Program installation manuals, if any. If available, Program Documentation may be delivered with the Programs and/or may be accessed from www.oracle.com/documentation. "Separate Terms" refers to separate license terms that are specified in the Program Documentation, readmes or notice files and that apply to Separately Licensed Technology. "Separately Licensed Technology" refers to Oracle or third party technology that is licensed under Separate Terms and not under the terms of this license.
+
+Separately Licensed Technology
+Oracle may provide certain notices to You in Program Documentation, readmes or notice files in connection with Oracle or third party technology provided as or with the Programs. If specified in the Program Documentation, readmes or notice files, such technology will be licensed to You under Separate Terms. Your rights to use Separately Licensed Technology under Separate Terms are not restricted in any way by the terms herein. For clarity, notwithstanding the existence of a notice, third party technology that is not Separately Licensed Technology shall be deemed part of the Programs licensed to You under the terms of this license.
+
+Source Code for Open Source Software
+For software that You receive from Oracle in binary form that is licensed under an open source license that gives You the right to receive the source code for that binary, You can obtain a copy of the applicable source code from https://oss.oracle.com/sources/ or http://www.oracle.com/goto/opensourcecode. If the source code for such software was not provided to You with the binary, You can also receive a copy of the source code on physical media by submitting a written request pursuant to the instructions in the "Written Offer for Source Code" section of the latter website.
+
+-------------------------------------------------------------------------------
+The following license terms apply to those Programs that are not provided to You under Separate Terms.
+License Rights and Restrictions
+Oracle grants to You, as a recipient of this Program, a nonexclusive, nontransferable, limited license to, subject to the conditions stated herein, use the unmodified Programs, including, without limitation, for the purposes of:
+•	developing, testing, prototyping and demonstrating applications; 
+•	running the unmodified Programs for training, personal use, your business operations, and the business operations of third parties;
+•	making the unmodified Programs available for use by third parties in your hosted environment and in cloud services; 
+•	redistributing unmodified Programs and Programs Documentation under the terms of this License; and
+•	copying the unmodified Programs and Program Documentation to the extent reasonably necessary to exercise the license rights granted herein and for backup purposes.
+For the purposes of this license, compiling, interpreting or configuring an otherwise unmodified Program as necessary to run the Program shall not be considered modification.
+
+Your license is contingent on Your compliance with the following conditions:
+- You include a copy of this license with any distribution by You of the Programs;
+- You do not charge your customers, end users, distributees or other third parties any additional fees for the distribution or use of the Programs; however, for clarity, if you comply with the foregoing condition, distribution or use of the Program as part of your for-fee product or service that adds substantial additional value is permitted; 
+- You do not remove markings or notices of either Oracle's or a licensor's proprietary rights from the Programs or Program Documentation;
+- You comply with all U.S. and applicable export control and economic sanctions laws and regulations that govern Your use of the Programs (including technical data); and
+- You do not cause or permit reverse engineering, disassembly or decompilation of the Programs (except as allowed by law) by You nor allow an associated party to do so.
+Any source code that may be included in the distribution with the Programs may not be modified, unless such source code is under Separate Terms permitting modification.
+Ownership
+Oracle or its licensors retain all ownership and intellectual property rights to the Programs.
+
+Information Collection
+The Programs' installation and/or auto-update processes, if any, may transmit a limited amount of data to Oracle or its service provider about those processes to help Oracle understand and optimize them. Oracle does not associate the data with personally identifiable information. Refer to Oracle's Privacy Policy at www.oracle.com/privacy.
+
+Disclaimer of Warranties; Limitation of Liability
+THE PROGRAMS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. ORACLE FURTHER DISCLAIMS ALL WARRANTIES, EXPRESS AND IMPLIED, INCLUDING WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NONINFRINGEMENT.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW WILL ORACLE BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+Version 1.0 
+Last updated:  28 June 2022

--- a/third-party-notices/README.md
+++ b/third-party-notices/README.md
@@ -1,0 +1,28 @@
+# Third-Party Notices
+
+JIM's container images carry the third-party components listed here under their own licences. Every
+component's licence text sits beside this file, in the repository and at `/app/third-party-notices/`
+inside each image, so a distribution of JIM always carries the terms it is bound by. JIM itself is
+licensed separately; see [LICENSE](../LICENSE) and https://junctional.io/license.
+
+Approval and pinning of every dependency follows `engineering/DEPENDENCY_PINNING.md`.
+
+| Component | Version | Used for | Licence | Text |
+|-----------|---------|----------|---------|------|
+| Oracle Data Provider for .NET, Managed Driver (`Oracle.ManagedDataAccess.Core`) | 23.26.300 | The JIM SQL Connector's Oracle Database dialect | Oracle Free Distribution, Hosting, and Use Terms and Conditions | [Oracle.ManagedDataAccess.Core-LICENSE.txt](Oracle.ManagedDataAccess.Core-LICENSE.txt) |
+
+## Oracle Data Provider for .NET, Managed Driver
+
+The Oracle Free Distribution, Hosting, and Use Terms permit the driver to be redistributed unmodified,
+used in your business operations and hosted for third parties at no charge, on conditions that include
+a copy of the terms accompanying any distribution, no additional fees being charged for the driver
+itself, and Oracle's proprietary notices being left in place. JIM ships the driver unmodified and
+charges nothing for it. If your organisation has received the driver under its own licence agreement
+with Oracle, that agreement governs your use of it instead. Read the terms; nothing here is legal advice.
+
+## Everything else
+
+The remaining NuGet packages, base container images and operating system packages that make up the
+images are under permissive licences (MIT, Apache-2.0, BSD and the like) whose notices are carried
+inside the packages themselves. `engineering/DEPENDENCY_PINNING.md` records how each layer is pinned
+and reviewed.


### PR DESCRIPTION
## Summary

Phase 8 of the SQL Connector plan (#170): the customer-facing documentation and release polish.

- **`docs/connectors/jim-sql-connector.md`**: overview, supported databases, features (schema discovery, full import, delta import, export, type mapping, date and time), every setting grouped as on the Settings tab, the Object Types document reference, worked examples for SQL Server and Oracle, trust model and least-privilege grants for both databases, the Oracle licence note, the wider-database-support callout inviting feedback via GitHub Discussions, troubleshooting.
- **Two delta-import setup guides**, end to end with DDL and triggers for both databases: change-log table (recommended; observes deletions) and watermark column (documents the no-delete semantics and the periodic Full Import it needs).
- **`third-party-notices/`**: the Oracle managed driver's Free Distribution, Hosting, and Use Terms, as the 2026-07-31 governance record requires, plus a notices index; every image's final stage now copies the directory to `/app/third-party-notices/`. README's licensing section and `engineering/DEPENDENCY_PINNING.md` point at it.
- Connector index and roadmap link the guide; mkdocs nav gains the three pages under a JIM SQL Connector section.
- Concept diagrams (`hub-and-spoke`, `system-context`, `containers`, `connector-components`, `worker-components`) show the SQL Connector live rather than dashed "in development"; the now-empty "Dashed elements are not yet available" caption sentence is dropped from the five pages carrying it; README exports regenerated with `Export-ReadmeDiagrams.ps1`.
- `docs/powershell/connected-systems.md`: the `NUMBER(10)` example comment said Decimal; the code maps it to Long Number.
- `engineering/JIM_AI_ASSISTANT_CONTEXT.md` moves SCIM 2.0 and SQL to Available; version 1.8.
- Plan moved to `engineering/plans/doing/` with phases 1-6 and 8 ticked; PRD stays in `doing/` until #170 closes.

## Testing

Docs, diagrams and Dockerfile `COPY` lines only: no `dotnet build`/`test` and no `mkdocs build` per the build/test exceptions. Links and anchors in the new pages verified by script; entity casing and em-dash rules checked. The image `COPY` of `third-party-notices/` is exercised by CI's image builds rather than locally (no Docker on this host by design).

Docs: this PR is the docs; no changelog entry (documentation and packaging notice only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)