### PR TITLE
test: Phase 0 of the Sync Preview Engine - baseline and isolation instrument (#288)

### DIFF
--- a/engineering/plans/doing/SYNC_PREVIEW_ENGINE.md
+++ b/engineering/plans/doing/SYNC_PREVIEW_ENGINE.md
@@ -56,10 +56,10 @@ Each phase lands as its own PR (Phase 1 as a short sequence of PRs, one per meth
 
 ## Implementation Phases
 
-### Phase 0: Baseline and guardrails
+### Phase 0: Baseline and guardrails ✅
 
-- [ ] Capture the Scenario 8 performance baseline on current `main` (default fast-writes mode, recorded in `results/performance/`), so every Phase 1 PR has a fixed comparison point. Record template and host alongside.
-- [ ] Add the isolation-assertion helper the PRD requires (req. 10): given a database, snapshot Pending Export count, MVO count and attribute versions, CSO count, RPEI count, Activity count; assert unchanged after a preview call. Built now so every later phase can use it from its first test.
+- [x] Capture the Scenario 8 performance baseline on current `main` (default fast-writes mode, recorded in `results/performance/`), so every Phase 1 PR has a fixed comparison point. Record template and host alongside. **Captured 2026-08-18** in the cloud sandbox: Small template, OpenLDAP, scenario execution **329.0s** (`TestDurationMs` 328,980; 67 operation timings in the JSON), full scenario green. One caveat that binds every later gate: `results/` is gitignored and sandbox hosts are ephemeral, so a baseline is only comparable **within the session that captured it**. Each Phase 1 session therefore baselines `main` first and compares its branch in the same sandbox; the figure recorded here is the shape of the cost, not a cross-host constant. Two sandbox potholes hit and recorded on the way: the CA guidance in `test/CLAUDE.md` was wrong twice over (fixed there), and the first passing run still exited 1 because of a #1382 regression in the scenario invoker, fixed as this phase's stack layer so Phase 1's gates can trust the exit code.
+- [x] Add the isolation-assertion helper the PRD requires (req. 10): given a database, snapshot Pending Export count, MVO count and attribute versions, CSO count, RPEI count, Activity count; assert unchanged after a preview call. Built now so every later phase can use it from its first test. **Delivered** as `DatabaseIsolationSnapshot` (JIM.TestSupport), watching eight tables (the PRD's five populations plus the attribute-value and change child tables that give them content) with a row count **and a content digest** per table, because an in-place UPDATE leaves the count identical and is exactly the leak a count-only assertion cannot see. Reads through raw Npgsql so the instrument shares nothing with the code it checks; a watched table going missing fails the capture by name rather than silently narrowing the guarantee. Written red-first; six pure comparison tests plus four `RequiresPostgres` tests, including the update-in-place case, all green.
 
 ### Phase 1: Outbound extraction (the unbraiding)
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -259,10 +259,14 @@ These flags are for human developer iteration only. Claude must not use them bec
 
 When the sandbox has a working Docker daemon (the SessionStart hook starts one where the environment supports it; `docker info` confirms), the full `Run-IntegrationTests.ps1` path works, including the Docker image builds, with ONE bridge: `dotnet restore` inside the build stages fails with `NU1301 ... UntrustedRoot` because the egress proxy re-terminates TLS and the build containers do not trust its CA.
 
-**Set one environment variable; do not edit the Dockerfiles.** All three build stages already accept an `EXTRA_CA_CERTS_BASE64` build argument for exactly this case (corporate TLS inspection), and `docker-compose.yml` wires it to `JIM_BUILD_EXTRA_CA_BASE64` for `jim.web`, `jim.worker` and `jim.scheduler`:
+**Set one environment variable; do not edit the Dockerfiles.** All three build stages already accept an `EXTRA_CA_CERTS_BASE64` build argument for exactly this case (corporate TLS inspection), and `docker-compose.yml` wires it to `JIM_BUILD_EXTRA_CA_BASE64` for `jim.web`, `jim.worker` and `jim.scheduler`. **Do NOT base64 the whole of `/root/.ccr/ca-bundle.crt` into it**: at ~310KB encoded it exceeds the kernel's 128KB per-argument `execve` limit, so every child process in the pipeline dies with "Argument list too long" before Docker is even reached. And `agent-proxy-ca.crt` alone is not enough either: containers cannot reach the local agent proxy on 127.0.0.1, so their traffic is intercepted by the **outer egress gateway**, which signs with a different CA ("Egress Gateway SDS Issuing CA") that only appears inside the big bundle. Capture the gateway's own chain from inside a container and use that (verified 2026-08-18):
 
 ```bash
-export JIM_BUILD_EXTRA_CA_BASE64=$(base64 -w0 /root/.ccr/ca-bundle.crt)
+docker run --rm mcr.microsoft.com/dotnet/sdk:10.0-noble bash -c \
+  'echo | openssl s_client -connect api.nuget.org:443 -servername api.nuget.org -showcerts 2>/dev/null' \
+  | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' | awk 'BEGIN{c=-1} /BEGIN CERTIFICATE/{c++} c>=1' > /tmp/egress-cas.pem
+cat /root/.ccr/agent-proxy-ca.crt >> /tmp/egress-cas.pem   # ~9KB base64 total; well under the limit
+export JIM_BUILD_EXTRA_CA_BASE64=$(base64 -w0 /tmp/egress-cas.pem)
 ./test/integration/Run-IntegrationTests.ps1 -Scenario Scenario14-AttributePriority -DirectoryType OpenLDAP
 ```
 

--- a/test/JIM.InMemoryData.Tests/packages.lock.json
+++ b/test/JIM.InMemoryData.Tests/packages.lock.json
@@ -196,6 +196,14 @@
           "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
       "Serilog": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -204,15 +212,15 @@
       "jim.data": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.inmemorydata": {
         "type": "Project",
         "dependencies": {
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )"
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.models": {
@@ -225,13 +233,14 @@
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
           "Serilog": "[4.4.0, )"
         }
       }

--- a/test/JIM.Models.Tests/packages.lock.json
+++ b/test/JIM.Models.Tests/packages.lock.json
@@ -190,6 +190,14 @@
           "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
       "Serilog": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -205,13 +213,14 @@
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
           "Serilog": "[4.4.0, )"
         }
       }

--- a/test/JIM.TestSupport/DatabaseIsolationSnapshot.cs
+++ b/test/JIM.TestSupport/DatabaseIsolationSnapshot.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using Npgsql;
+using NUnit.Framework;
+
+namespace JIM.TestSupport;
+
+/// <summary>
+/// The state of one watched table: how many rows it holds and a digest of their content, so an in-place update
+/// is as visible as an insert or a delete.
+/// </summary>
+public readonly record struct DatabaseTableState(long RowCount, string ContentDigest);
+
+/// <summary>
+/// The preview isolation assertion (#288, PRD requirement 10): capture the synchronisation-integrity tables
+/// before a preview, capture again after, and prove nothing changed. A preview that leaks a single Pending
+/// Export or Metaverse Object write is worse than no preview, because administrators will trust it; this is the
+/// test-side instrument that makes the zero-side-effect guarantee checkable rather than asserted.
+/// </summary>
+/// <remarks>
+/// Content is compared by digest, not only by count, because an in-place UPDATE leaves the count identical.
+/// Captures read through raw Npgsql rather than an EF context so the instrument shares nothing with the code it
+/// is checking. Test-scale databases only: the digest orders and hashes every row of every watched table, which
+/// is exactly right for a scenario database and wrong for a production one.
+/// </remarks>
+public sealed class DatabaseIsolationSnapshot
+{
+    /// <summary>
+    /// The tables PRD requirement 10 names, plus the attribute-value child tables that give the Metaverse Object
+    /// and Connected System Object counts their content. Pinned by a test; trim or rename only deliberately.
+    /// </summary>
+    public static readonly IReadOnlyList<string> SyncIntegrityTables =
+    [
+        "PendingExports",
+        "PendingExportAttributeValueChanges",
+        "MetaverseObjects",
+        "MetaverseObjectAttributeValues",
+        "ConnectedSystemObjects",
+        "ConnectedSystemObjectAttributeValues",
+        "ActivityRunProfileExecutionItems",
+        "Activities"
+    ];
+
+    private readonly IReadOnlyDictionary<string, DatabaseTableState> _tables;
+
+    /// <summary>
+    /// Builds a snapshot from already-known table states. Public as the seam the pure comparison tests use;
+    /// production test code captures with <see cref="CaptureAsync(string, CancellationToken)"/> instead.
+    /// </summary>
+    public DatabaseIsolationSnapshot(IReadOnlyDictionary<string, DatabaseTableState> tables)
+    {
+        _tables = tables;
+    }
+
+    /// <summary>
+    /// Captures the state of the synchronisation-integrity tables.
+    /// </summary>
+    public static Task<DatabaseIsolationSnapshot> CaptureAsync(string connectionString, CancellationToken cancellationToken = default) =>
+        CaptureAsync(connectionString, SyncIntegrityTables, cancellationToken);
+
+    /// <summary>
+    /// Captures the state of a specific set of tables. A watched table that does not exist fails the capture by
+    /// name: a schema rename must break the snapshot loudly, or every isolation assertion in the suite quietly
+    /// watches fewer tables than it claims.
+    /// </summary>
+    public static async Task<DatabaseIsolationSnapshot> CaptureAsync(
+        string connectionString, IReadOnlyList<string> tables, CancellationToken cancellationToken = default)
+    {
+        // The table names are compile-time constants (or a test's own literals), never user input, but they are
+        // interpolated into SQL as identifiers, so hold the line anyway: letters, digits and underscores only.
+        var invalidName = tables.FirstOrDefault(t => t.Length == 0 || !t.All(c => char.IsAsciiLetterOrDigit(c) || c == '_'));
+        if (invalidName != null)
+            throw new ArgumentException($"'{invalidName}' is not a plain identifier and cannot be watched.", nameof(tables));
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using (var existsCommand = new NpgsqlCommand(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = ANY(@tables)", connection))
+        {
+            existsCommand.Parameters.AddWithValue("tables", tables.ToArray());
+            var found = new HashSet<string>(StringComparer.Ordinal);
+            await using var existsReader = await existsCommand.ExecuteReaderAsync(cancellationToken);
+            while (await existsReader.ReadAsync(cancellationToken))
+                found.Add(existsReader.GetString(0));
+
+            var missing = tables.Where(t => !found.Contains(t)).ToList();
+            if (missing.Count > 0)
+                throw new InvalidOperationException(
+                    $"Cannot capture an isolation snapshot: watched table(s) do not exist: {string.Join(", ", missing)}. " +
+                    "If a table was renamed, update DatabaseIsolationSnapshot.SyncIntegrityTables and its pinning test.");
+        }
+
+        var states = new Dictionary<string, DatabaseTableState>(StringComparer.Ordinal);
+        foreach (var table in tables)
+        {
+            await using var command = new NpgsqlCommand(
+                $"SELECT count(*), COALESCE(md5(string_agg(t::text, '|' ORDER BY t::text)), 'empty') FROM \"{table}\" t",
+                connection);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            await reader.ReadAsync(cancellationToken);
+            states[table] = new DatabaseTableState(reader.GetInt64(0), reader.GetString(1));
+        }
+
+        return new DatabaseIsolationSnapshot(states);
+    }
+
+    /// <summary>
+    /// Describes every difference between two snapshots, one message per changed table, in terms a test failure
+    /// can act on: "PendingExports: 3 -> 4 rows" names the leak; "content changed" distinguishes an in-place
+    /// update from an insert or delete. Empty when nothing changed.
+    /// </summary>
+    public static List<string> Diff(DatabaseIsolationSnapshot before, DatabaseIsolationSnapshot after)
+    {
+        if (!before._tables.Keys.ToHashSet().SetEquals(after._tables.Keys))
+            throw new ArgumentException(
+                "The two snapshots watched different table sets and cannot be compared honestly.");
+
+        var differences = new List<string>();
+        foreach (var (table, beforeState) in before._tables.OrderBy(t => t.Key, StringComparer.Ordinal))
+        {
+            var afterState = after._tables[table];
+            if (beforeState == afterState)
+                continue;
+
+            differences.Add(beforeState.RowCount != afterState.RowCount
+                ? $"{table}: {beforeState.RowCount} -> {afterState.RowCount} rows"
+                : $"{table}: content changed ({afterState.RowCount} rows, count unchanged)");
+        }
+
+        return differences;
+    }
+
+    /// <summary>
+    /// Asserts nothing changed between <paramref name="before"/> and this snapshot, failing with every changed
+    /// table named. This is the call that sits immediately after a preview in every isolation scenario.
+    /// </summary>
+    public void AssertUnchangedSince(DatabaseIsolationSnapshot before)
+    {
+        var differences = Diff(before, this);
+        if (differences.Count > 0)
+            Assert.Fail("The operation was required to leave the database untouched, and did not. " +
+                        $"Changed: {string.Join("; ", differences)}");
+    }
+}

--- a/test/JIM.TestSupport/JIM.TestSupport.csproj
+++ b/test/JIM.TestSupport/JIM.TestSupport.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.6.1" />
+    <!-- Same version the solution already resolves transitively via Npgsql.EntityFrameworkCore.PostgreSQL 10.0.3
+         in JIM.PostgresData; referenced directly here so DatabaseIsolationSnapshot reads through raw ADO rather
+         than an EF context, sharing nothing with the code it checks. Not a new dependency. -->
+    <PackageReference Include="Npgsql" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/test/JIM.TestSupport/packages.lock.json
+++ b/test/JIM.TestSupport/packages.lock.json
@@ -2,11 +2,33 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Npgsql": {
+        "type": "Direct",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
       "NUnit": {
         "type": "Direct",
         "requested": "[4.6.1, )",
         "resolved": "4.6.1",
         "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "L3AdmZ1WOK4XXT5YFPEwyt0ep6l8lGIPs7F5OOBZc77Zqeo01Of7XXICy47628sdVl0v/owxYJTe86DTgFwKCA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "FU/IfjDfwaMuKr414SSQNTIti/69bHEMb+QKrskRb26oVqpx3lNFXMjs/RC9ZUuhBhcwDM2BwOgoMw+PZ+beqQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
       }
     }
   }

--- a/test/JIM.Utilities.Tests/packages.lock.json
+++ b/test/JIM.Utilities.Tests/packages.lock.json
@@ -190,6 +190,14 @@
           "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
       "Serilog": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -205,13 +213,14 @@
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
           "Serilog": "[4.4.0, )"
         }
       }

--- a/test/JIM.Web.Api.Tests/packages.lock.json
+++ b/test/JIM.Web.Api.Tests/packages.lock.json
@@ -782,10 +782,10 @@
         "type": "Project",
         "dependencies": {
           "DynamicExpresso.Core": "[2.19.3, )",
-          "JIM.Connectors": "[0.14.0, )",
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Connectors": "[0.14.0-dev.20260818.604, )",
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.AspNetCore.DataProtection": "[10.0.11, )",
           "Microsoft.AspNetCore.DataProtection.Extensions": "[10.0.11, )",
           "NCrontab": "[3.4.0, )",
@@ -797,9 +797,9 @@
         "type": "Project",
         "dependencies": {
           "CsvHelper": "[33.1.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Scim": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Scim": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )",
           "Oracle.ManagedDataAccess.Core": "[23.26.300, )",
           "System.DirectoryServices.Protocols": "[10.0.11, )"
@@ -808,7 +808,7 @@
       "jim.data": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.models": {
@@ -821,9 +821,9 @@
       "jim.postgresdata": {
         "type": "Project",
         "dependencies": {
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
           "Serilog": "[4.4.0, )"
@@ -832,20 +832,21 @@
       "jim.scim": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
           "Serilog": "[4.4.0, )"
         }
       },
@@ -855,10 +856,10 @@
           "Asp.Versioning.Mvc": "[10.2.1, )",
           "Asp.Versioning.Mvc.ApiExplorer": "[10.2.1, )",
           "Humanizer.Core": "[3.0.10, )",
-          "JIM.Application": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.PostgresData": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Application": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.PostgresData": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.11, )",
           "Microsoft.AspNetCore.Authentication.OpenIdConnect": "[10.0.11, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.11, )",

--- a/test/JIM.Web.Tests/packages.lock.json
+++ b/test/JIM.Web.Tests/packages.lock.json
@@ -889,10 +889,10 @@
         "type": "Project",
         "dependencies": {
           "DynamicExpresso.Core": "[2.19.3, )",
-          "JIM.Connectors": "[0.14.0, )",
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Connectors": "[0.14.0-dev.20260818.604, )",
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.AspNetCore.DataProtection": "[10.0.11, )",
           "Microsoft.AspNetCore.DataProtection.Extensions": "[10.0.11, )",
           "NCrontab": "[3.4.0, )",
@@ -904,9 +904,9 @@
         "type": "Project",
         "dependencies": {
           "CsvHelper": "[33.1.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Scim": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Scim": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )",
           "Oracle.ManagedDataAccess.Core": "[23.26.300, )",
           "System.DirectoryServices.Protocols": "[10.0.11, )"
@@ -915,7 +915,7 @@
       "jim.data": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.models": {
@@ -928,9 +928,9 @@
       "jim.postgresdata": {
         "type": "Project",
         "dependencies": {
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
           "Serilog": "[4.4.0, )"
@@ -939,20 +939,21 @@
       "jim.scim": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
           "Serilog": "[4.4.0, )"
         }
       },
@@ -962,10 +963,10 @@
           "Asp.Versioning.Mvc": "[10.2.1, )",
           "Asp.Versioning.Mvc.ApiExplorer": "[10.2.1, )",
           "Humanizer.Core": "[3.0.10, )",
-          "JIM.Application": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.PostgresData": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Application": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.PostgresData": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.11, )",
           "Microsoft.AspNetCore.Authentication.OpenIdConnect": "[10.0.11, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.11, )",

--- a/test/JIM.Worker.Tests/Support/DatabaseIsolationSnapshotDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Support/DatabaseIsolationSnapshotDatabaseTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Activities;
+using JIM.PostgresData;
+using JIM.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Support;
+
+/// <summary>
+/// Real-PostgreSQL verification of the preview isolation snapshot (#288, PRD requirement 10): that a capture
+/// reflects the database it was taken over, that an insert and an in-place update are both detected, and that a
+/// watched table going missing fails loudly instead of silently weakening the guarantee. The in-memory provider
+/// cannot execute the raw digest SQL, so only this fixture can prove any of it.
+/// </summary>
+/// <remarks>
+/// Opt-in via the same <c>JIM_TEST_RESET_*</c> environment variables as the other database-backed tests; ignored
+/// when <c>JIM_TEST_RESET_DB</c> is absent.
+/// </remarks>
+[TestFixture]
+[Category("RequiresPostgres")]
+public class DatabaseIsolationSnapshotDatabaseTests
+{
+    private string _connectionString = null!;
+
+    private JimDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseNpgsql(_connectionString)
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new JimDbContext(options);
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var dbName = Environment.GetEnvironmentVariable("JIM_TEST_RESET_DB");
+        if (string.IsNullOrEmpty(dbName))
+            Assert.Ignore("JIM_TEST_RESET_DB not set; skipping real-PostgreSQL isolation snapshot tests.");
+
+        var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
+        var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
+        var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
+
+        using var ctx = NewContext();
+        ctx.Database.Migrate();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(@"
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+                FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '__EFMigrationsHistory') LOOP
+                    EXECUTE 'TRUNCATE TABLE ""' || r.tablename || '"" RESTART IDENTITY CASCADE';
+                END LOOP;
+            END $$;");
+    }
+
+    [Test]
+    public async Task Capture_NothingHappensBetweenCaptures_AssertsUnchangedAsync()
+    {
+        var before = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+        var after = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+
+        Assert.That(() => after.AssertUnchangedSince(before), Throws.Nothing);
+    }
+
+    [Test]
+    public async Task Capture_ActivityInsertedBetweenCaptures_FailsNamingActivitiesAsync()
+    {
+        var before = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+
+        await using (var ctx = NewContext())
+        {
+            ctx.Activities.Add(new Activity
+            {
+                TargetOperationType = ActivityTargetOperationType.Update,
+                Status = ActivityStatus.Complete
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var after = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+
+        Assert.That(() => after.AssertUnchangedSince(before),
+            Throws.InstanceOf<AssertionException>().With.Message.Contain("Activities"));
+    }
+
+    [Test]
+    public async Task Capture_RowUpdatedInPlaceWithNoCountChange_StillFailsAsync()
+    {
+        // The case a count-only snapshot cannot see: same number of rows, different content. A preview that
+        // rewrote an Activity's message would otherwise pass the isolation assertion.
+        await using (var ctx = NewContext())
+        {
+            ctx.Activities.Add(new Activity
+            {
+                TargetOperationType = ActivityTargetOperationType.Update,
+                Status = ActivityStatus.Complete,
+                Message = "before"
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var before = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+
+        await using (var ctx = NewContext())
+            await ctx.Database.ExecuteSqlRawAsync("UPDATE \"Activities\" SET \"Message\" = 'after'");
+
+        var after = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+
+        Assert.That(() => after.AssertUnchangedSince(before),
+            Throws.InstanceOf<AssertionException>()
+                .With.Message.Contain("Activities").And.Message.Contain("content changed"));
+    }
+
+    [Test]
+    public void Capture_WatchedTableDoesNotExist_ThrowsNamingIt()
+    {
+        // A schema rename must break the snapshot loudly. Skipping a missing table would leave every isolation
+        // assertion in the suite quietly watching seven tables while claiming to watch eight.
+        Assert.That(async () => await DatabaseIsolationSnapshot.CaptureAsync(
+                _connectionString, ["Activities", "NoSuchTable"]),
+            Throws.InvalidOperationException.With.Message.Contain("NoSuchTable"));
+    }
+}

--- a/test/JIM.Worker.Tests/Support/DatabaseIsolationSnapshotTests.cs
+++ b/test/JIM.Worker.Tests/Support/DatabaseIsolationSnapshotTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.TestSupport;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Support;
+
+/// <summary>
+/// The comparison half of the preview isolation assertion (#288, PRD requirement 10): given two snapshots of the
+/// synchronisation-integrity tables, say precisely what changed. Pure logic, so it is tested here without a
+/// database; whether a capture reflects reality is <see cref="DatabaseIsolationSnapshotDatabaseTests"/>' job.
+/// </summary>
+[TestFixture]
+public class DatabaseIsolationSnapshotTests
+{
+    [Test]
+    public void Diff_IdenticalSnapshots_ReportsNothing()
+    {
+        var before = Snapshot(("PendingExports", 3, "abc"), ("Activities", 10, "def"));
+        var after = Snapshot(("PendingExports", 3, "abc"), ("Activities", 10, "def"));
+
+        Assert.That(DatabaseIsolationSnapshot.Diff(before, after), Is.Empty);
+    }
+
+    [Test]
+    public void Diff_RowCountChanged_NamesTheTableAndBothCounts()
+    {
+        // The count is the actionable part of the message: "PendingExports: 3 -> 4 rows" tells the reader what
+        // leaked; a bare "changed" sends them off to diff the database by hand.
+        var before = Snapshot(("PendingExports", 3, "abc"));
+        var after = Snapshot(("PendingExports", 4, "zzz"));
+
+        var diff = DatabaseIsolationSnapshot.Diff(before, after);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(diff, Has.Count.EqualTo(1));
+            Assert.That(diff[0], Does.Contain("PendingExports"));
+            Assert.That(diff[0], Does.Contain("3"));
+            Assert.That(diff[0], Does.Contain("4"));
+        }
+    }
+
+    [Test]
+    public void Diff_ContentChangedWithSameRowCount_SaysSoRatherThanClaimingACountChange()
+    {
+        // An in-place UPDATE leaves the count identical, and a snapshot that only counted rows would pass. The
+        // digest exists for exactly this case, and the message has to distinguish it from an insert or delete.
+        var before = Snapshot(("MetaverseObjectAttributeValues", 5, "abc"));
+        var after = Snapshot(("MetaverseObjectAttributeValues", 5, "different"));
+
+        var diff = DatabaseIsolationSnapshot.Diff(before, after);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(diff, Has.Count.EqualTo(1));
+            Assert.That(diff[0], Does.Contain("MetaverseObjectAttributeValues"));
+            Assert.That(diff[0], Does.Contain("content changed"));
+        }
+    }
+
+    [Test]
+    public void Diff_SnapshotsOverDifferentTableSets_Throws()
+    {
+        // Two snapshots that watched different tables cannot be compared honestly; a silent intersection would
+        // report "unchanged" about a table only one of them ever looked at.
+        var before = Snapshot(("PendingExports", 3, "abc"));
+        var after = Snapshot(("Activities", 3, "abc"));
+
+        Assert.That(() => DatabaseIsolationSnapshot.Diff(before, after),
+            Throws.ArgumentException.With.Message.Contain("table"));
+    }
+
+    [Test]
+    public void AssertUnchangedSince_SomethingChanged_FailsNamingEveryChangedTable()
+    {
+        var before = Snapshot(("PendingExports", 0, "empty"), ("Activities", 2, "abc"));
+        var after = Snapshot(("PendingExports", 1, "aaa"), ("Activities", 2, "changed"));
+
+        Assert.That(() => after.AssertUnchangedSince(before),
+            Throws.InstanceOf<AssertionException>()
+                .With.Message.Contain("PendingExports").And.Message.Contain("Activities"));
+    }
+
+    [Test]
+    public void SyncIntegrityTables_CoverThePopulationsThePrdNames()
+    {
+        // PRD requirement 10 names Pending Exports, Metaverse Objects and their attribute values, Connected
+        // System Objects, RPEIs and Activities. This pins the watched set so a rename or a trim fails a test
+        // rather than silently weakening every isolation assertion in the suite.
+        Assert.That(DatabaseIsolationSnapshot.SyncIntegrityTables, Is.EquivalentTo(new[]
+        {
+            "PendingExports",
+            "PendingExportAttributeValueChanges",
+            "MetaverseObjects",
+            "MetaverseObjectAttributeValues",
+            "ConnectedSystemObjects",
+            "ConnectedSystemObjectAttributeValues",
+            "ActivityRunProfileExecutionItems",
+            "Activities"
+        }));
+    }
+
+    private static DatabaseIsolationSnapshot Snapshot(params (string Table, long Count, string Digest)[] tables) =>
+        new(tables.ToDictionary(t => t.Table, t => new DatabaseTableState(t.Count, t.Digest)));
+}

--- a/test/JIM.Worker.Tests/packages.lock.json
+++ b/test/JIM.Worker.Tests/packages.lock.json
@@ -881,7 +881,8 @@
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {

--- a/test/JIM.Workflow.Tests/packages.lock.json
+++ b/test/JIM.Workflow.Tests/packages.lock.json
@@ -730,10 +730,10 @@
         "type": "Project",
         "dependencies": {
           "DynamicExpresso.Core": "[2.19.3, )",
-          "JIM.Connectors": "[0.14.0, )",
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Connectors": "[0.14.0-dev.20260818.604, )",
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.AspNetCore.DataProtection": "[10.0.11, )",
           "Microsoft.AspNetCore.DataProtection.Extensions": "[10.0.11, )",
           "NCrontab": "[3.4.0, )",
@@ -745,9 +745,9 @@
         "type": "Project",
         "dependencies": {
           "CsvHelper": "[33.1.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Scim": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Scim": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )",
           "Oracle.ManagedDataAccess.Core": "[23.26.300, )",
           "System.DirectoryServices.Protocols": "[10.0.11, )"
@@ -756,15 +756,15 @@
       "jim.data": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.inmemorydata": {
         "type": "Project",
         "dependencies": {
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )"
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.models": {
@@ -777,9 +777,9 @@
       "jim.postgresdata": {
         "type": "Project",
         "dependencies": {
-          "JIM.Data": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Data": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
           "Serilog": "[4.4.0, )"
@@ -788,30 +788,31 @@
       "jim.scim": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )"
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )"
         }
       },
       "jim.testsupport": {
         "type": "Project",
         "dependencies": {
-          "NUnit": "[4.6.1, )"
+          "NUnit": "[4.6.1, )",
+          "Npgsql": "[10.0.3, )"
         }
       },
       "jim.utilities": {
         "type": "Project",
         "dependencies": {
-          "JIM.Models": "[0.14.0, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
           "Serilog": "[4.4.0, )"
         }
       },
       "jim.worker": {
         "type": "Project",
         "dependencies": {
-          "JIM.Application": "[0.14.0, )",
-          "JIM.Models": "[0.14.0, )",
-          "JIM.PostgresData": "[0.14.0, )",
-          "JIM.Utilities": "[0.14.0, )",
+          "JIM.Application": "[0.14.0-dev.20260818.604, )",
+          "JIM.Models": "[0.14.0-dev.20260818.604, )",
+          "JIM.PostgresData": "[0.14.0-dev.20260818.604, )",
+          "JIM.Utilities": "[0.14.0-dev.20260818.604, )",
           "Microsoft.AspNetCore.DataProtection.Extensions": "[10.0.11, )",
           "Microsoft.Extensions.Hosting": "[10.0.11, )",
           "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.23.0, )",


### PR DESCRIPTION
## Description

Phase 0 of `engineering/plans/doing/SYNC_PREVIEW_ENGINE.md`, both items delivered and ticked in the plan.

**1. The isolation-assertion instrument** (PRD req. 10). `DatabaseIsolationSnapshot` (JIM.TestSupport) captures the eight synchronisation-integrity tables (the PRD's five populations plus the attribute-value and change child tables that give them content), each as a row count **and a content digest**, because an in-place `UPDATE` leaves the count identical and is precisely the leak a count-only assertion cannot see. It reads through raw Npgsql so the instrument shares nothing with the code it will be checking, and a watched table going missing fails the capture by name rather than silently narrowing the guarantee. Written red-first: the fixtures compiled against the absent type before the implementation existed; six pure comparison tests plus four `RequiresPostgres` tests (insert detection, update-in-place detection, no-op pass, missing table), all green against real PostgreSQL.

`JIM.TestSupport` gains a direct `Npgsql` reference at the version the solution already resolves transitively via `Npgsql.EntityFrameworkCore.PostgreSQL` 10.0.3; not a new dependency. Every test project references TestSupport, so all seven `packages.lock.json` files are regenerated (the first commit missed six of them; the follow-up fixes exactly the `NU1004` CI showed).

**2. The Scenario 8 performance baseline.** Captured on current `main` in the cloud sandbox: Small template, OpenLDAP, full run green, scenario execution **329.0s** (67 operation timings in the JSON). The caveat now recorded in the plan: `results/` is gitignored and sandbox hosts are ephemeral, so a baseline is only comparable **within the session that captured it**; each Phase 1 session baselines `main` first and compares its branch in the same sandbox.

Capturing it surfaced two potholes, both dealt with:

- `test/CLAUDE.md`'s sandbox CA guidance failed two ways when followed: the base64 of the whole `ca-bundle.crt` exceeds the kernel's per-argument limit (every child process dies "Argument list too long"), and the small agent-proxy CA is not what containers see anyway, because container traffic bypasses the local proxy and is intercepted by the **outer egress gateway** with a different CA. The working recipe (capture the gateway's chain from inside a container, ~9KB) is documented in place.
- The first fully green run still exited 1: a #1382 regression in `Invoke-IntegrationScenario`. Fixed as this branch's stack layer, **#1409**, because every Phase 1 gate relies on that exit code.

## Type of change

- [x] Other (Phase 0 groundwork: test instrument, performance baseline, engineering docs)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

Targeted: the 10 new tests green (6 pure, 4 `RequiresPostgres` against a real PostgreSQL). Full Scenario 8 Small integration run green in the sandbox as part of capturing the baseline.

## Documentation

- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale

Docs: n/a - test instrument and engineering planning documents; no user-facing behaviour changed and no changelog entry is warranted.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

#1409 stacks on this branch (the sandbox cannot link stacks natively, so the pair lands bottom-up: this PR first, then #1409 rebased onto the new `main` per the CLAUDE.md flow). Phase 1 (the outbound unbraiding) starts once both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR

---
_Generated by [Claude Code](https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR)_