### PR TITLE
docs: JIM SQL Connector guide rewritten in the customer's voice; roadmap row for PostgreSQL/MySQL is Planned

### DIFF
--- a/docs/connectors/jim-sql-connector-delta-import-change-log.md
+++ b/docs/connectors/jim-sql-connector-delta-import-change-log.md
@@ -136,7 +136,7 @@ GRANT SELECT ON HR.IDM_CHANGE_LOG TO jim_sync;
 
 ## 4. Configure the Object Type
 
-Add a `changeLog` to **every Object Type that is selected for synchronisation** in the Connected System's **Object Types** document. Choosing Change-Log Table mode while a selected Object Type has no `changeLog` is refused when you save, because a Delta Import that skipped an Object Type would report success while leaving its objects to drift. An Object Type that is not selected (a table JIM only exports to, say) takes no part in a Delta Import and needs no change log.
+Add a `changeLog` to **every Object Type that is selected for synchronisation** in the Connected System's **Object Types** document. If a selected Object Type has no `changeLog` when this mode is chosen, saving is refused and the message names the Object Type; otherwise a Delta Import could report success while that Object Type's changes went unread. An Object Type that is not selected (a table JIM only exports to, say) takes no part in a Delta Import and needs no change log.
 
 ```json title="Object Types with a change log"
 {
@@ -183,7 +183,7 @@ A value may appear in only one list, and no value may be blank. Where your appli
 
 ## 5. Choose the mode and save
 
-On the Connected System's Settings tab, set **Delta Import Mode** to **Change-Log Table** and save. Validation runs at this point: any selected Object Type without a `changeLog`, any change-type value that means two things, and any missing field is reported now, at the keyboard, rather than by an overnight run. The same check runs when you select an Object Type on the Schema tab (or through the REST API or PowerShell), so selecting one that lacks a `changeLog` while this mode is set is refused at that point rather than by the next Delta Import; deselect it, or give it a change log.
+On the Connected System's Settings tab, set **Delta Import Mode** to **Change-Log Table** and save. The configuration is checked as you save: a selected Object Type without a `changeLog`, a change-type value listed under two kinds of change, or a missing field is reported immediately. The same check runs when you select an Object Type on the Schema tab (or through the REST API or PowerShell): selecting one that has no `changeLog` while this mode is set is refused there and then, so give it a change log first, or leave it unselected.
 
 ## 6. Baseline with a Full Import
 
@@ -197,7 +197,7 @@ Schedule the Delta Import at whatever cadence the application warrants, and a Fu
 
 ## 8. Keep the change log short
 
-JIM never purges the change log. Purge rows yourself once they are comfortably older than the interval between Delta Imports; a job that deletes rows older than thirty days is typical. A row purged before JIM has read it is a change lost until the next Full Import, so purge on age, generously, rather than on anything cleverer.
+JIM never deletes from the change log, so schedule a purge of your own. Delete rows by age, keeping them for comfortably longer than the gap between your Delta Imports; thirty days is typical. A row deleted before JIM has read it is a change JIM will not see until the next Full Import.
 
 ```sql title="Microsoft SQL Server"
 DELETE FROM HR.IDM_CHANGE_LOG WHERE CHANGED_AT < DATEADD(DAY, -30, SYSUTCDATETIME());
@@ -210,7 +210,7 @@ DELETE FROM HR.IDM_CHANGE_LOG WHERE CHANGED_AT < SYSTIMESTAMP - INTERVAL '30' DA
 ## Troubleshooting
 
 **"No `Delta Import Mode` has been chosen for this Connected System"**<br />
-The mode is unanswered. JIM refuses rather than guessing, because a scheduled Delta Import quietly costing a Full Import every cycle would hide the omission for ever. Choose the mode and save.
+The **Delta Import Mode** setting is blank. Choose **Change-Log Table** (or **Watermark Column**) on the Connected System's Settings tab and save; JIM does not assume a mode, because a Delta Import with no change source would have to read everything every time.
 
 **"A Delta Import was requested, but JIM holds no watermark ... A Full Import was performed instead"**<br />
 Expected on the first run and after changing the mode. If it recurs, the Full Import is not completing; check its Activity.
@@ -219,7 +219,7 @@ Expected on the first run and after changing the mode. If it recurs, the Full Im
 The application wrote a change-type value you have not listed. Add it to `createValues`, `updateValues` or `deleteValues`, and re-run: the object is reported as an error until it is.
 
 **"Object Type 'Person' has a change-log row with a NULL value in anchor column"**<br />
-A trigger logged a row it could not attribute to an object, most likely from a related table whose join column was `NULL`. Fix the trigger to skip such rows; the run fails until the row is corrected, because a change that belongs to nobody cannot be applied.
+A trigger logged a row with no key in it, most likely from a related table whose join column was `NULL`. Correct or delete the row, and change the trigger to skip rows with no key; the Delta Import cannot continue while a change it cannot attribute to an object is in the log.
 
 **Objects that were deleted are still in JIM**<br />
 Check that the delete path is logged (a bulk `DELETE` fires a statement-level trigger on SQL Server exactly as a single-row one does, but an application that soft-deletes by flag writes an update, not a delete). Where the application soft-deletes, JIM sees an updated row and it is a Synchronisation Rule's scope, not the change log, that should retire the object.

--- a/docs/connectors/jim-sql-connector-delta-import-watermark.md
+++ b/docs/connectors/jim-sql-connector-delta-import-watermark.md
@@ -6,21 +6,21 @@ This guide sets up a Delta Import for the [JIM SQL Connector](jim-sql-connector.
 
 Each Object Type's source, and each of its related tables, names a **watermark column**: a last-modified timestamp or a version number that goes up whenever the row changes. On each Delta Import, JIM:
 
-1. Notes the highest value in each watermark column before reading anything. Those are the watermarks it will save when the run completes, one per source, never one maximum across them all.
+1. Notes the highest value in each watermark column before reading anything. Those are the watermarks it will save when the run completes, one per table.
 2. Selects every row of the Object Type's source whose watermark column has moved past the value saved last time, **or** that has a related-table row whose watermark has, so a phone number replaced or a group membership added is detected as a change to the object it belongs to.
-3. Imports each selected object whole, exactly as a Full Import would deliver it. Every one is reported as an update, because a last-modified column cannot tell a create from one; JIM creates the Connected System Object where it holds none.
+3. Imports each selected object whole, exactly as a Full Import would. A last-modified column cannot tell a new row from a changed one, so every object is reported as an update; JIM creates the Connected System Object if it does not have one yet.
 
 ## What it cannot see
 
-**A deleted row has no column left to move.** Its absence never reaches the query, so a deletion in the source is invisible to this mode, and so is a row that has fallen out of a view. Deletions are found by a **Full Import**, which reads everything and notices what has gone. Schedule one at whatever interval your deprovisioning needs allow; a Delta Import strategy without a periodic Full Import is incomplete in this mode.
+**Deleted rows.** A deleted row has no last-modified value left to compare, so this mode cannot see that it has gone; the same is true of a row that has dropped out of a view. Deletions are found by a **Full Import**, which reads everything and notices what is missing. Schedule a Full Import at whatever interval your deprovisioning can tolerate; in this mode it is part of the design, not a fallback.
 
-The same applies one level down. A row **removed** from a related table is a change to the parent, and it is detected wherever your table records the removal: a soft-delete flag or a tombstone row that moves the row's own watermark, or a watermark on the parent that the application bumps. Where a related table hard-deletes its rows instead, there is nothing left for any watermark to compare, so a revoked membership stays in JIM until the next Full Import.
+The same applies to related tables. A row **removed** from a related table (a revoked group membership, a deleted phone number) is a change to the parent object, and is detected only if the table records the removal somewhere a watermark can see: a soft-delete flag or a tombstone row that updates the row's own last-modified value, or an application that touches the parent's last-modified value as well. If the related table simply deletes its rows, the removal is invisible until the next Full Import.
 
 If deletions must reach JIM promptly, use a [change-log table](jim-sql-connector-delta-import-change-log.md) instead.
 
 ## 1. Choose the watermark columns
 
-The Object Type's source needs one, and **every** related table needs one too; JIM refuses to save the configuration otherwise, because a related row added or removed changes the object without touching its own row, and without a watermark there that change could never be detected.
+The Object Type's table needs one, and so does **every** related table: a phone number added to a child table changes the person without touching the person's own row, so without a watermark on the child table that change could never be detected. JIM checks this when you save.
 
 Any column type with a total order works: a timestamp, a whole number, a version counter. It must only ever go up.
 
@@ -120,16 +120,16 @@ Schedule the Delta Import at the cadence the application warrants, and a Full Im
 ## Troubleshooting
 
 **"`Delta Import Mode` is 'Watermark Column', but Object Type 'Person' has related table attribute 'PhoneNumbers' with no 'watermarkColumn'"**<br />
-Every related table needs one. Add the column to the table (a default is enough for insert-only tables) and name it in the configuration.
+Every related table of a selected Object Type needs one. Add the column to the table (a default value is enough for a table whose rows are only ever inserted) and name it in the configuration.
 
 **A Delta Import read every row**<br />
-Either no watermark existed yet (the first run, or the first after changing the mode, which is expected and reported as a warning) or a related table had no watermark recorded, in which case JIM correlates on existence alone for that run: one expensive run beats a missed change. The next run is incremental.
+Either no watermark existed yet (the first run, or the first after changing the mode; expected, and reported as a warning on the Activity) or a related table had no watermark recorded yet, in which case JIM reads every parent that has any related rows for that one run rather than risk missing a change. The next run is incremental.
 
 **A change to a phone number or a membership was not picked up**<br />
 The related table's watermark did not move. Check the default fills the column on insert, the trigger updates it on update, and, for a removal, that the table records it somewhere a watermark can see; a hard delete is invisible until the next Full Import.
 
 **Deleted employees are still in JIM**<br />
-By design in this mode. Run, or schedule, a Full Import; or move to a change-log table.
+This mode cannot detect deletions; see [What it cannot see](#what-it-cannot-see). Run, or schedule, a Full Import; or move to a change-log table.
 
 **A row updated during a long transaction was missed**<br />
 JIM captures the highest watermark value at the start of the run. A row given a lower value inside a transaction that commits after that capture is behind the watermark and is not read until a Full Import. Keep write transactions short.

--- a/docs/connectors/jim-sql-connector.md
+++ b/docs/connectors/jim-sql-connector.md
@@ -2,208 +2,115 @@
 
 ## Overview
 
-The JIM SQL Connector synchronises identities with relational databases: HR systems, payroll, student records, and the line-of-business applications that keep their users in a table. It reads and writes **Microsoft SQL Server** and **Oracle Database** through fully managed ADO.NET drivers, so nothing native is installed on the JIM host and JIM stays air-gap deployable.
+The JIM SQL Connector connects JIM to identity data held in a relational database: an HR or payroll system, a student record system, or any line-of-business application that keeps its users, groups and departments in tables. JIM can read those tables as a source of identity, write to them as a target, or both.
 
 **Capabilities:** Full Import, Delta Import, Export
 
-One Connected System covers a whole database at once. An **Object Types** document names each table or view JIM should synchronise, the columns that identify a row, the columns that carry another object's identifier as a reference, and any related table whose rows gather onto the parent as a multi-valued attribute. Everything else, the columns and their types, is discovered from the database's own catalogue.
+One Connected System covers one database, and can synchronise several of its tables at once. You describe which tables (or views) hold which kind of object in a short JSON document; JIM discovers the columns and their types from the database itself.
 
-!!! note "Not a JIM database setting"
-    This page is about databases JIM synchronises *with*. JIM's own store is PostgreSQL and is configured at deployment; see [Deployment](../administration/deployment.md).
+!!! note "This page is about databases JIM synchronises with"
+    JIM's own data store is PostgreSQL and is configured when JIM is deployed; see [Deployment](../administration/deployment.md). Nothing on this page affects it.
 
-## Supported Databases
+## Supported databases
 
-| Database | Notes |
-|----------|-------|
-| **Microsoft SQL Server** | Connected through `Microsoft.Data.SqlClient`. Named instances (`SERVER\INSTANCE`), TLS on by default, database-generated keys read back through `OUTPUT INSERTED`. |
-| **Oracle Database** | Connected through `Oracle.ManagedDataAccess.Core` (ODP.NET managed driver). Addressed by service name or SID, Native Network Encryption on by default, database-generated keys read back through `RETURNING ... INTO`. Oracle Database Free 23ai works as-is, and is what JIM's own tests run against. |
+| Database | Connection | Notes |
+|----------|------------|-------|
+| **Microsoft SQL Server** | Host, optional port, database name; named instances supported (`SERVER\INSTANCE`) | Encrypted by default. Identity columns and defaults are read back when JIM creates a row. |
+| **Oracle Database** | Host, optional port, service name or SID | Encrypted by default with Native Network Encryption. Sequence-backed and identity keys are read back when JIM creates a row. Oracle Database Free 23ai works without changes. |
 
-The two databases are dialects behind one connector: the same Object Types document, the same import and export behaviour, and the same settings apart from the connection details each one needs. Support for further engines is planned as additional dialects of this same connector rather than as separate connectors; see [Wider database support](#wider-database-support).
+Both databases use the same settings and the same Object Types document, and behave the same way; only the connection details differ. Support for PostgreSQL and MySQL is planned as further dialects of this same connector; see [Wider database support](#wider-database-support).
 
-## Features
+## What the connector can do
 
-| Capability | Supported | Notes |
+| Capability | Supported | What it means for you |
 |---|---|---|
-| Full Import | ✅ | Pages through each table by keyset, so a large table costs the same per page from the first row to the last. See [Full Import](#full-import). |
-| Delta Import | ✅ | Reads a change-log table your database maintains, or a last-modified column. See [Delta Import](#delta-import). |
-| Export | ✅ | Inserts, updates and deletes rows, each object in a transaction of its own. See [Export](#export). |
-| Paging | ✅ | The Run Profile's Page Size is the number of rows read per query. |
-| Multi-valued attributes | ✅ | A related table of one row per value (phone numbers, group members) becomes a multi-valued attribute on the parent. |
-| References | ✅ | A column holding another row's identifier is a Reference once you say which Object Type it points at; JIM resolves it to the referenced Connected System Object on import and writes that object's own identifier on export. |
-| Partitions and Containers | ❌ | A database has no equivalent of a directory's naming contexts; a Connected System addresses one database, and each Object Type names its own table within it. |
-| Parallel Export | ❌ | Deliberately off in this release: parallel batches against one database can deadlock on hot pages. |
-| Password set | ❌ | Passwords held in a database are the owning application's concern, stored however it chose, so there is no password channel to offer. |
+| Full Import | ✅ | Reads every row of each table or view you have selected. Large tables are read a page at a time, so a table of half a million rows is a routine import. See [Full Import](#full-import). |
+| Delta Import | ✅ | Reads only what has changed since the last import, using either a change-log table your database maintains or a last-modified column. See [Delta Import](#delta-import). |
+| Export | ✅ | Creates, updates and deletes rows, including the rows of related tables (phone numbers, group members). See [Export](#export). |
+| Multi-valued attributes | ✅ | A table holding one row per value (a person's phone numbers, a group's members) becomes a multi-valued attribute on the parent object. |
+| References | ✅ | A column holding another row's key (a manager, a department) is synchronised as a reference to that object, not as a bare number. |
+| Paging | ✅ | The Run Profile's Page Size sets how many rows are read per query. |
+| Partitions and Containers | ❌ | Not applicable to databases. Each Object Type names its own table, which is all the scoping a database needs. |
+| Parallel Export | ❌ | Exports are written one object at a time, each in its own transaction. |
+| Password set | ❌ | JIM does not write passwords to databases. Applications that hold passwords in a table store them in their own format, which JIM cannot safely produce. |
 
-### Schema Discovery
+## Before you begin
 
-Importing the schema reads the database's catalogue for every table and view the Object Types document names, and presents each Object Type with one attribute per column, typed from the column's declared SQL type. See [Type mapping](#type-mapping) for the full table.
+You will need:
 
-Discovery also:
+- **A database account for JIM**, with only the permissions the Run Profiles you plan to run need: read access for import, read and write access for export. Concrete grants for both databases are in [Database account permissions](#database-account-permissions). Create a dedicated account rather than sharing one.
+- **Network access** from the JIM host to the database server on its listening port (1433 for SQL Server, 1521 for Oracle, or whatever your DBA has set).
+- **The server's certificate authority**, if the database uses a certificate your operating system does not already trust (an internal CA or a self-signed certificate). Add it under **Admin > Certificates** first, or add it when the connection test shows you the certificate; see [When the connection test fails on the certificate](#when-the-connection-test-fails-on-the-certificate).
+- **To know your tables**: which table or view holds each kind of object, which column (or columns) identifies a row, and which columns hold other rows' keys. A DBA can usually answer this in minutes.
+- **The time zone the database records in**, if it stores dates and times without an offset. Most do; see [Dates and times](#dates-and-times).
 
-- **Chooses the External ID for you.**<br /> The anchor column you named becomes the Object Type's recommended External ID attribute. Where an Object Type has a composite anchor (two or more columns), JIM composes a single read-only Text attribute from them, named by joining the column names with `+` (`REGION+EMPLOYEE_NO`), because a Connected System Object is identified by one value.
-- **Records what it inferred a type from.**<br /> Every attribute's Description begins `Source column type: NUMBER(10).` (or `nvarchar(100)`, `datetime2`, and so on), so you can see the declaration a type came from before deciding whether to disagree with it. See [Overriding an inferred type](../configuration/connected-systems.md#overriding-an-inferred-type).
-- **Marks writability from the source.**<br /> Columns of a table are writable, and its anchor columns are writable on creation only (a primary key is set when the row is inserted and never rewritten). Columns of a view, or of a `select` statement, are read-only, because JIM cannot write through either.
-- **Suggests references from foreign keys, but never assumes them.**<br /> Where a table declares a foreign key to another Object Type's anchor column, the attribute's Description says so and shows the `referencesObjectType` line to add. The column stays typed as the database declares it until you configure it as a Reference; a foreign key is a strong hint, but only you know whether JIM should follow it.
-- **Skips what it cannot type, and says so.**<br /> A column of a type JIM has no equivalent for (an `xml` or `geography` column, say) is left out with a warning naming it. The same column in a load-bearing position, as an anchor, a configured reference, or a related table's value or join column, fails the discovery instead, because a schema missing one of those would be wrong rather than incomplete.
+## Setting up a Connected System
 
-Object Types and attributes are selected for synchronisation on the Connected System's Schema tab in the usual way; an Object Type in the document that you have not selected is skipped by every Run Profile.
+### Step 1: Create the Connected System
 
-### Full Import
+Create a Connected System and choose **JIM SQL Connector**. Fill in the settings below, then use **Test Connection** before going further; it confirms the host, credentials and encryption in one step.
 
-A Full Import reads every row of each selected Object Type's source, a page at a time.
+#### Database Server
 
-- **Keyset paging, never `OFFSET`.**<br /> Each page is read as `WHERE anchor > last-anchor-of-previous-page ORDER BY anchor`, so the cost of reading page 500 is the same as page 1. This is what makes a 500,000-row table practical, and it is why the anchor columns must be listed in key order in the Object Types document.
-- **One query per related table per page.**<br /> Multi-valued attributes are gathered for the whole page in one statement, not one per row. Rows whose join column is `NULL` belong to no parent and are skipped; `NULL` values are skipped.
-- **A row count first.**<br /> The first page of each Object Type reports `SELECT COUNT(*)` from its source, so the Activity shows a real percentage and time remaining, and the counters move while a page is still being read.
-- **Failures are asymmetric on purpose.**<br /> A value that cannot be converted (text in a column JIM was told holds a number, a fractional value in a whole-number attribute) errors that one object and the import continues. Configuration that cannot work (a source the account cannot see, a `NULL` in an anchor column, a number too wide for JIM to hold exactly) fails the run, because every object would be affected.
+| Setting | Required | What to enter |
+|---------|----------|---------------|
+| Database Type | Yes | **Microsoft SQL Server** or **Oracle Database**. The settings that follow change to suit. |
+| Host | Yes | The database server's hostname or IP address. For a named SQL Server instance, `SERVER\INSTANCE`. |
+| Port | No | Leave blank for the default (1433 for SQL Server; 1521 for Oracle, or 2484 for Oracle over TLS). |
+| Database Name | SQL Server | The database on that server. |
+| Oracle Database Identified By | Oracle | **Service Name** (use this unless your DBA gives you a SID) or **SID**. |
+| Oracle Service Name | Oracle, by service name | For example `HRPROD.example.com`. On Oracle Database Free the pluggable database is `FREEPDB1`. |
+| Oracle SID | Oracle, by SID | For example `HRPROD`. |
 
-!!! note "Whole numbers stay whole"
-    A fractional value arriving in an attribute you have recorded as a whole number is refused for that object rather than rounded: `4200.7` silently becoming `4201` is the kind of error nobody finds. Either record the attribute as a Decimal on the Schema tab, or correct the source.
+JIM builds the connection string from these values; there is nothing to paste, and the connection details never appear in a log.
 
-### Delta Import
+#### Credentials
 
-A database has no change feed of its own, so a Delta Import needs one of two things you provide. The **Delta Import Mode** setting chooses which:
+| Setting | Required | What to enter |
+|---------|----------|---------------|
+| Username | Yes | The database account JIM connects as. |
+| Password | Yes | Its password. Stored encrypted and never shown or logged again. |
 
-| Mode | How JIM finds changes | Detects |
-|------|-----------------------|---------|
-| **Change-Log Table** (recommended) | Reads a table or view your database maintains, holding one row per change with the object's anchor, a change type and a monotonic sequence or timestamp. | Creates, updates and **deletions**. |
-| **Watermark Column** | Reads a last-modified or version column on each Object Type's own source, and one on each related table, selecting every row that has moved past the last value JIM saw. | Creates and updates only. **A deleted row has no column left to move**, so deletions are found only by a Full Import. |
+#### Transport Security
 
-Each mode has its own end-to-end setup guide, including the table and trigger definitions for both databases:
+| Setting | Applies to | Default | What it does |
+|---------|------------|---------|--------------|
+| Encrypt Connection | SQL Server | On | Encrypts the connection with TLS. If the server cannot encrypt, the connection fails rather than falling back to plain text. The server's certificate is checked against your operating system's trusted authorities and any certificates you have added under **Admin > Certificates**. |
+| Oracle Encryption | Oracle | Native Network Encryption | **Native Network Encryption** encrypts the session on the ordinary listener with no certificates to manage, and is how most Oracle estates encrypt client traffic. **TCPS (TLS)** uses a TLS listener (usually port 2484) and a server certificate. **None** sends data unencrypted; use it only in a lab. |
+| Connection Timeout | Both | 30 seconds | How long to wait for the server before giving up. |
 
-- [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md)
-- [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md)
+#### Date and Time
 
-Whichever mode you choose, JIM keeps a watermark per source (each Object Type, and in Watermark Column mode each related table too), never one maximum across them all. It is captured before a single change is read, and saved only once the run has read its last page, so a run that dies half way through re-reads its changes rather than skipping them. There is no upper bound on a run: a change arriving while the run is in flight is read by this run or the next one, and possibly both, because re-importing an unchanged row costs a comparison whereas an upper bound would silently drop anything committed inside it.
+| Setting | Default | What to enter |
+|---------|---------|---------------|
+| Database Time Zone | `UTC` | The time zone that the database's date and time columns are recorded in, for columns that do not carry their own offset. Enter `UTC` or an IANA name such as `Europe/London`. See [Dates and times](#dates-and-times). |
 
-!!! important "The first Delta Import after configuring is a Full Import"
-    JIM holds no watermark until an import has completed, so the first Delta Import you run, or the first after changing the Delta Import Mode, performs a Full Import instead and says so on the Activity as a warning. That run establishes the watermark, and the next Delta Import runs normally. Where the mode has never been chosen at all, a Delta Import is refused rather than quietly costing a Full Import every cycle.
+#### Type Mapping (Oracle only)
 
-### Export
+| Setting | Default | When to turn it on |
+|---------|---------|--------------------|
+| Treat NUMBER(1) Columns as Boolean | Off | When `NUMBER(1)` columns in this database are yes/no flags. Oracle has no boolean column type, so flags are usually stored this way, but a single-digit column can equally be a small number; the setting applies to every `NUMBER(1)` column, so turn it on only if that is true of all of them. |
+| Treat RAW(16) Columns as Guid | Off | When `RAW(16)` columns in this database hold GUIDs rather than other 16-byte values such as hashes. |
 
-An Export writes Pending Exports to the Object Type's table. Each object is written inside a transaction of its own: its row and every related-table row belonging to it are committed together or rolled back together, because a half-written object is worse than an unwritten one.
+Where a database mixes the two meanings, leave the setting off; the columns import as numbers or binary values, and you can convert the ones that are really flags or GUIDs in an Attribute Flow, or expose them through a view under a clearer type.
 
-| Change | What JIM does |
-|--------|---------------|
-| Create | Inserts the row, then its related rows. Where the table generates the key (an identity column, a sequence, a default), JIM reads the generated value back and records it as the External ID; where you flow the key yourself (a natural identifier), JIM writes it. |
-| Update | Updates only the columns whose values changed. Anchor columns are never rewritten: an update that would touch one is refused with an explanation, because a rewritten primary key would orphan the object without any error. |
-| Delete | Deletes the related rows first, then the parent row, without relying on the schema declaring a cascade. A row that has already gone counts as success. |
-| Multi-valued add / remove | Inserts or deletes rows of the related table. |
-| Reference | Writes the referenced Connected System Object's own identifier, converted to whatever type the column holds. A row whose reference cannot be resolved yet is still inserted, without that column; the reference is written once the referenced object has been provisioned into this database and its key is known. A reference column declared `NOT NULL` therefore refuses such a row, and the export reports an ordinary error for it. See [Unresolved reference handling](../configuration/connected-systems.md#on-export). |
+#### Object Type Configuration
 
-Every write reads its affected-row count back and answers for it. A statement that raised no error but changed nothing (a trigger discarding the insert, a row deleted outside JIM) fails that object with a message saying what to check, rather than confirming an object the table does not hold. A failure is confined to its object; the batch continues, and the failed export enters JIM's normal retry and backoff.
+| Setting | Required | What to enter |
+|---------|----------|---------------|
+| Object Types | Yes | The JSON document describing your tables. Step 2 explains it. |
 
-Because a committed transaction is a verified write, an export needs no confirming import to be trusted: the connector reports **auto-confirm export**.
+#### Delta Import
 
-!!! note "Views and statements are read-only"
-    An Object Type whose source is a view or a `select` statement cannot be exported to. Point the Object Type at a table to write to it; import through the view where the view is what the application maintains.
+| Setting | Required | What to enter |
+|---------|----------|---------------|
+| Delta Import Mode | No | **Change-Log Table** or **Watermark Column**, once you have set up the database side for one of them. Leave it blank if this Connected System will only run Full Imports. See [Delta Import](#delta-import). |
 
-### Type mapping
+### Step 2: Describe your tables
 
-Every column is typed from its declared SQL type. Microsoft SQL Server's named types state their width exactly and map by name; Oracle has one numeric type, `NUMBER`, so JIM reads its declared precision and scale and picks the narrowest JIM type guaranteed to hold every value the declaration permits.
+The **Object Types** setting tells JIM which tables hold which objects. Each entry names an Object Type, the table or view it comes from, and the column or columns that identify a row. The example below describes a person whose manager is another person, with phone numbers held in a child table:
 
-| JIM type | Microsoft SQL Server | Oracle Database |
-|----------|----------------------|-----------------|
-| Text | `char`, `nchar`, `varchar`, `nvarchar`, `text`, `ntext` | `CHAR`, `NCHAR`, `VARCHAR2`, `NVARCHAR2`, `CLOB`, `NCLOB`, `LONG` |
-| Number | `int`, `smallint`, `tinyint` | `NUMBER(p,0)` with p up to 9 |
-| Long Number | `bigint` | `NUMBER(p,0)` with p from 10 to 18 |
-| Decimal | `decimal`, `numeric`, `money`, `smallmoney`, `float`, `real` | `NUMBER(p,0)` with p of 19 or more; `NUMBER(p,s)` with a scale; `NUMBER` with no precision; `BINARY_FLOAT`, `BINARY_DOUBLE` |
-| Boolean | `bit` | `NUMBER(1)`, only with **Treat NUMBER(1) Columns as Boolean** on |
-| Date/Time | `date`, `datetime`, `datetime2`, `smalldatetime`, `datetimeoffset` | `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, `TIMESTAMP WITH LOCAL TIME ZONE` |
-| GUID | `uniqueidentifier` | `RAW(16)`, only with **Treat RAW(16) Columns as Guid** on |
-| Binary | `binary`, `varbinary`, `image`, `timestamp` / `rowversion` | `RAW`, `LONG RAW`, `BLOB` |
-| Reference | any column you configure with `referencesObjectType` | any column you configure with `referencesObjectType` |
-
-Two things about that table are worth knowing before you build on it:
-
-- **Oracle's `NUMBER(10)` is a Long Number, not a Number.** Ten digits already exceed a 32-bit whole number, so the ordinary sequence-backed identifier lands one step wider than you might expect. Where such a column needs to reach a built-in Metaverse Attribute that is a Number (`Employee Number` is the usual case), record it as a Number on the Schema tab; JIM permits the override precisely because Oracle's declaration cannot say. The full inference table and the override procedure are in [Attribute data types](../configuration/connected-systems.md#attribute-data-types).
-- **Approximate types round-trip approximately.** `float`, `real`, `BINARY_FLOAT` and `BINARY_DOUBLE` are read as Decimal so that numeric comparison still works, but a binary floating-point value converted to decimal and back is not bit-exact. Prefer an exact numeric column where JIM is authoritative for the value.
-
-A Decimal attribute holds 28 to 29 significant digits. A value wider than that fails the run rather than being rounded, with a message naming the column; narrow the column, stop selecting the attribute, or expose the source through a view that casts it down. Column types with no JIM equivalent (`xml`, `XMLTYPE`, `sql_variant`, `hierarchyid`, `geography`, `geometry`, `INTERVAL`, `time`, `ROWID`, `BFILE`) are skipped by discovery with a warning; expose them through a view that casts to a supported type if they need synchronising.
-
-### Date and time
-
-JIM stores every date and time in UTC. A column that carries its own offset (`datetimeoffset`, `TIMESTAMP WITH TIME ZONE`) needs no interpreting and is converted exactly. A column that carries none (`datetime2`, `DATE`, `TIMESTAMP`) is interpreted in the Connected System's **Database Time Zone** on import, and converted back into that zone on export. The default is UTC, which is the one answer that never silently shifts a value by an hour twice a year; enter an IANA name such as `Europe/London` where the application genuinely records local time.
-
-A zone that observes daylight saving has two wall-clock hours a year that need a rule. A time in the hour the clocks skip when daylight saving starts never happened, but a column can hold one all the same (a `LAST_MODIFIED` defaulted to "now" by a server whose own clock is UTC, or a value migrated in from another zone); JIM reads it with the offset in force just before the clocks moved, which is where the clock jumped to, exactly as PostgreSQL and Java do, rather than failing the row. A time in the hour the clocks repeat when daylight saving ends happens twice, and JIM takes the later, standard-time reading. Neither case arises with UTC.
-
-On Oracle, JIM also pins the session's time zone to the same value when it connects, which is what makes `TIMESTAMP WITH LOCAL TIME ZONE` read consistently. An Oracle Database whose own time zone file does not know the region you named refuses the connection with a message saying so, rather than reading dates in whatever zone the JIM host happens to use.
-
-## Connection Settings
-
-Settings are grouped exactly as they appear on the Connected System's Settings tab. Every setting explains itself in the portal too; this table is the same text, gathered.
-
-### Database Server
-
-| Setting | Required | Description |
-|---------|----------|-------------|
-| Database Type | Yes | **Microsoft SQL Server** or **Oracle Database**. Decides which details are asked for below, and which dialect JIM speaks. |
-| Host | Yes | The database server's hostname or IP address. For a named Microsoft SQL Server instance, use the `SERVER\INSTANCE` form. |
-| Port | No | Leave blank for the default: 1433 for Microsoft SQL Server, 1521 for Oracle Database, or 2484 for Oracle Database over TCPS. |
-| Database Name | SQL Server | The database to connect to on this server. |
-| Oracle Database Identified By | Oracle | **Service Name** (the modern form, and the one to use unless the estate still addresses the database by SID) or **SID**. |
-| Oracle Service Name | Oracle, by service name | The service name, for example `HRPROD.example.com`. Oracle Database Free's pluggable database is `FREEPDB1`. |
-| Oracle SID | Oracle, by SID | The System Identifier, for example `HRPROD`. |
-
-JIM builds the connection string itself from these values; there is no connection string to paste, and nothing in it is logged.
-
-### Credentials
-
-| Setting | Required | Description |
-|---------|----------|-------------|
-| Username | Yes | The database account JIM connects as. Give it the least privilege the Run Profiles need: read-only on an import-only Connected System. See [Database account permissions](#database-account-permissions). |
-| Password | Yes | Stored encrypted, decrypted only to hand to the driver, and never written to a log or a configuration snapshot. |
-
-A SQL Server connection identifies itself with the application name `JIM`, so a DBA can attribute sessions and locks to it. Connections are not pooled on either database: nothing stays open on your database between runs.
-
-### Transport Security
-
-| Setting | Applies to | Default | Description |
-|---------|------------|---------|-------------|
-| Encrypt Connection | SQL Server | On | Encrypt the connection with TLS. When on, the connection **fails** rather than falling back to plain text if the server cannot encrypt. The server's certificate is always validated, against the operating system's certificate bundle and any certificates added in **Admin > Certificates**; JIM never trusts whatever certificate the server happens to present. |
-| Oracle Encryption | Oracle | Native Network Encryption | **Native Network Encryption** encrypts the session on the ordinary listener with no certificate at either end (AES, with SHA-2 integrity checking, both required rather than negotiable), and is how Oracle estates usually encrypt client traffic. **TCPS (TLS)** needs a separately configured listener, usually on port 2484, and a server certificate. **None** sends the session in clear and should be reserved for a lab. |
-| Connection Timeout | Both | 30 seconds | How long to wait before giving up on connecting. |
-
-#### When a connection test fails on the certificate
-
-For SQL Server, a server certificate JIM does not yet trust (an internal certificate authority, or a self-signed certificate) fails the connection test, and JIM shows you the certificate the server presented: its subject, the names it was issued for, its issuer, validity dates and thumbprint, and which check it failed. Add the issuing authority (or the certificate itself, for a self-signed one) under **Admin > Certificates** and test again.
-
-Trust is strictly additive. JIM connects with the operating system's trust anchors first, and only when the driver refuses does it look at the certificate the server presented; only a certificate that JIM's own store vouches for, and that passes JIM's own checks of validity period and name, is then handed to the driver as an additional anchor. An expired certificate, or one issued for a different name from the one you connect to, is still refused, and JIM says which.
-
-For Oracle over TCPS the same certificate detail is shown on failure, but the ODP.NET managed driver offers no way for JIM to add a trust anchor of its own: a TCPS certificate must be one the operating system on the JIM host already vouches for. Native Network Encryption is unaffected, using no certificate at all, which is one reason it is the default.
-
-### Date and Time
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| Database Time Zone | `UTC` | The time zone that date and time columns carrying no offset are recorded in. See [Date and time](#date-and-time). Enter `UTC`, or an IANA time zone name such as `Europe/London`. A name this deployment does not recognise is refused when you save. |
-
-### Type Mapping
-
-| Setting | Applies to | Default | Description |
-|---------|------------|---------|-------------|
-| Treat NUMBER(1) Columns as Boolean | Oracle | Off | Oracle has no boolean column type, so flags are usually held as `NUMBER(1)`. Turn this on if that is what `NUMBER(1)` columns mean in this database; leave it off and they import as numbers. It applies to every `NUMBER(1)` column in the schema, so only turn it on where that is true of all of them. |
-| Treat RAW(16) Columns as Guid | Oracle | Off | Oracle holds GUIDs in `RAW(16)` columns, but so it does digests and other binary values, and the catalogue cannot tell them apart. Turn this on if `RAW(16)` columns in this database hold GUIDs; leave it off and they import as binary values. |
-
-Both are opt-ins because a wrong guess in either direction would be a silent one. Where a database mixes the two meanings, leave the setting off: the columns import as Numbers or as binary values, and the ones that are really flags or GUIDs can be converted in the Attribute Flow, or exposed through a view under a type that says what they are.
-
-### Object Type Configuration
-
-| Setting | Required | Description |
-|---------|----------|-------------|
-| Object Types | Yes | The JSON document naming each Object Type this database holds and where its objects come from. See [The Object Types document](#the-object-types-document). |
-
-### Delta Import
-
-| Setting | Required | Description |
-|---------|----------|-------------|
-| Delta Import Mode | No | **Change-Log Table** or **Watermark Column**. Leave it unanswered where this Connected System only runs Full Imports; JIM will not default it, because that would have it read changes from a table nobody has said exists. See [Delta Import](#delta-import). |
-
-## The Object Types document
-
-The **Object Types** setting is a JSON document with one entry per Object Type. It is validated when you save the Connected System, strictly: an unknown field name is an error rather than ignored, because a typo that parses is a defect that only surfaces as missing data much later. Every refusal names the Object Type and the field.
-
-```json title="A person with a manager reference and a related table of phone numbers"
+```json title="A Person with a manager reference and a related table of phone numbers"
 {
   "objectTypes": [
     {
@@ -228,38 +135,133 @@ The **Object Types** setting is a JSON document with one entry per Object Type. 
 }
 ```
 
-### Object Type fields
+You do not list the ordinary columns; JIM discovers them. You only say what the database cannot: which table is which object, what identifies a row, which columns point at other objects, and which child tables belong to which parent.
 
-| Field | Required | Meaning |
-|-------|----------|---------|
-| `name` | Yes | What JIM calls the Object Type. Must be unique within the document. A standard name (`User`, `Group`, `Person`) lets JIM map it to a Metaverse Object Type automatically. |
-| `table` | One of `table` / `select` | The table **or view** objects are read from. |
-| `schema` | No | Qualifies `table`. Leave it out and JIM resolves the name from the catalogue; a least-privilege account usually sees exactly one object of a given name. Where the name exists in more than one schema JIM asks you to say which. Not allowed with `select`. |
-| `select` | One of `table` / `select` | A `SELECT` statement standing in for a table or view, for the cases where a view cannot be created. Must begin `SELECT` or `WITH`, must be a single statement with no terminator, and cannot be exported to. JIM asks the database to plan it at discovery without reading a row, so a statement the database would not accept is refused when you save. |
-| `anchorColumns` | Yes | The column or columns whose values identify a row, **in key order**. The order is what makes a keyset page boundary reproducible between runs, so JIM never sorts it. |
-| `columns` | No | Per-column configuration; today that means naming the Object Type a column's values point at, so JIM resolves it as a Reference. Each entry is `{ "name": ..., "referencesObjectType": ... }`, and the referenced Object Type must be declared in the same document. The declared target is carried into JIM's schema and used by import reference resolution: the reference resolves within that Object Type alone, which is what lets two Object Types (a table and a view over it, say) share an anchor value space without ambiguity. |
-| `relatedTables` | No | Multi-valued attributes, one entry per attribute. See below. |
-| `watermarkColumn` | Watermark Column mode | The last-modified or version column on this Object Type's own source. See [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md). |
-| `changeLog` | Change-Log Table mode | The change-log table for this Object Type. See [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md). |
+The document is checked when you save. A mistake is reported immediately, naming the Object Type and field, and an unrecognised field name is treated as a mistake rather than ignored, so a typo cannot silently leave data out.
 
-### Related table fields
+#### Object Type fields
 
-A related table turns a table of one row per value into a multi-valued attribute on the parent. Group membership is exactly this shape: a `GROUP_MEMBERS` table of `(GROUP_ID, MEMBER_ID)` becomes a `Members` attribute on the `Group` Object Type, and with `referencesObjectType` its values are References to `Person` objects.
+| Field | Required | What it is |
+|-------|----------|------------|
+| `name` | Yes | What JIM will call the Object Type. Use a standard name (`User`, `Group`, `Person`) where one fits, and JIM maps it to the matching Metaverse Object Type automatically. |
+| `table` | One of `table` / `select` | The table or view to read from. |
+| `schema` | No | The schema the table is in. Leave it out and JIM finds the table by name; if the same name exists in more than one schema, JIM asks you to say which. |
+| `select` | One of `table` / `select` | A `SELECT` statement to read from instead of a table or view, for when you cannot create a view. It must be a single statement beginning `SELECT` or `WITH`, with no semicolon. An Object Type read this way can be imported but not exported to. |
+| `anchorColumns` | Yes | The column or columns whose values identify a row, in the order of the table's key. |
+| `columns` | No | Columns that hold another object's key. Each entry is `{ "name": "...", "referencesObjectType": "..." }`; the referenced Object Type must be in the same document. |
+| `relatedTables` | No | Child tables that hold one row per value for a multi-valued attribute. See below. |
+| `watermarkColumn` | For Watermark Column Delta Import | The last-modified column on this table; see [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md). |
+| `changeLog` | For Change-Log Table Delta Import | The change-log table for this Object Type; see [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md). |
 
-| Field | Required | Meaning |
-|-------|----------|---------|
-| `attributeName` | Yes | What the multi-valued attribute is called on the Object Type. Named by you because a value column's own name (`PHONE_NUMBER`) rarely reads as the plural attribute it becomes. Must not clash with a column of the parent. |
-| `table` / `schema` | Yes / No | The related table, qualified as for an Object Type. |
-| `valueColumn` | Yes | The column holding the value. Its SQL type decides the attribute's type. |
-| `joinColumns` | Yes | The columns that join a row back to its parent: **one per anchor column, in the same order**. Joining on part of an anchor would gather another object's values onto this one, so JIM refuses a mismatch. |
-| `referencesObjectType` | No | Where the values are References, the Object Type they point at. |
-| `watermarkColumn` | Watermark Column mode | The column that moves when a row of this table changes. |
+#### Related table fields
+
+A related table turns a child table into a multi-valued attribute. The commonest case is group membership: a `GROUP_MEMBERS` table of `(GROUP_ID, EMPLOYEE_ID)` becomes a `Members` attribute on the `Group` Object Type, and with `referencesObjectType` each member is a reference to a `Person`.
+
+| Field | Required | What it is |
+|-------|----------|------------|
+| `attributeName` | Yes | The name the multi-valued attribute will have on the parent Object Type, for example `PhoneNumbers` or `Members`. It must not be the name of one of the parent's own columns. |
+| `table` / `schema` | Yes / No | The child table. |
+| `valueColumn` | Yes | The column holding each value. |
+| `joinColumns` | Yes | The child table's columns that hold the parent's key, one per anchor column, in the same order. |
+| `referencesObjectType` | No | If the values are keys of another Object Type, name it and the attribute becomes a reference. |
+| `watermarkColumn` | For Watermark Column Delta Import | The last-modified column on the child table. |
+
+### Step 3: Import the schema and choose what to synchronise
+
+On the Connected System's **Schema** tab, import the schema. JIM reads the database's catalogue for every table in your document and shows one Object Type per entry, with one attribute per column. Select the Object Types and attributes you want to synchronise.
+
+What you will see:
+
+- **The External ID is chosen for you.** The anchor column becomes the Object Type's External ID attribute. Where an Object Type has a two-or-more-column key, JIM composes a single read-only Text attribute from them, named by joining the column names with `+` (`REGION+EMPLOYEE_NO`).
+- **Each attribute's data type**, decided from the column's SQL type; the full mapping is in [Type mapping](#type-mapping). The attribute's Description tells you the column type it was decided from (`Source column type: NUMBER(10).`), and where the database cannot be definitive (Oracle's `NUMBER` columns in particular) you can change the type on the Schema tab. See [Attribute data types](../configuration/connected-systems.md#attribute-data-types) for when you would want to.
+- **Writability.** Columns of a table are writable; the key columns are set when JIM creates a row and never changed afterwards; columns of a view or a `select` statement are read-only.
+- **Reference hints.** Where a table has a foreign key to another Object Type's key column, the attribute's Description says so and shows you the `referencesObjectType` line to add to your document. JIM suggests; you decide.
+- **Columns JIM cannot synchronise.** A column of a type JIM has no equivalent for (`xml`, `geography`, and the others listed under [Type mapping](#type-mapping)) is left out, and the schema import's warnings name it. Expose it through a view that casts it to a supported type if you need it.
+
+### Step 4: Run Profiles and Synchronisation Rules
+
+Create [Run Profiles](../configuration/run-profiles.md) for the operations you need (Full Import, Delta Import, Export) and [Synchronisation Rules](../configuration/synchronisation-rules.md) to say what flows where, exactly as for any other Connected System. The sections below describe how each operation behaves against a database, and what to expect.
+
+## How the connector behaves
+
+### Full Import
+
+A Full Import reads every row of each selected Object Type, a page at a time (the Run Profile's Page Size), and reads the related tables for each page in one query rather than one per row. The first page of each Object Type reports the row count, so the Activity shows a real percentage and time remaining.
+
+Most problems affect one row and are reported against that one object, leaving the rest of the import to continue: a value that cannot be converted to the attribute's type, for example, or a fractional value in a column you have recorded as a whole number (JIM reports it rather than rounding it). A problem that would affect every row fails the run with a message saying what to change: a table the account cannot see, a `NULL` in an anchor column, or a number too wide for JIM to hold exactly.
+
+### Delta Import
+
+A database keeps no record of what changed unless you give it one, so a Delta Import needs one of two things on the database side. The **Delta Import Mode** setting says which you have set up:
+
+| Mode | What you provide | What it detects |
+|------|------------------|-----------------|
+| **Change-Log Table** (recommended) | A table your database writes a row to for every change: the object's key, what kind of change it was, and a sequence number or timestamp. Usually filled by a trigger. | Creates, updates and **deletes**. |
+| **Watermark Column** | A last-modified or version column on each table, and on each related table. | Creates and updates. **Deletes are not detected**, because a deleted row has nothing left to compare; schedule a Full Import to pick those up. |
+
+Each mode has a step-by-step guide with the table and trigger definitions for both databases:
+
+- [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md)
+- [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md)
+
+!!! note "The first Delta Import runs as a Full Import"
+    JIM has nothing to compare against until one import has completed, so the first Delta Import you run (and the first after changing the Delta Import Mode) performs a Full Import instead, with a warning on the Activity saying so. From then on Delta Imports read only changes. A Delta Import run with no mode chosen is refused, so you cannot accidentally schedule one that does a Full Import every time.
+
+### Export
+
+An Export writes each Pending Export to the Object Type's table. Everything belonging to one object (its row and its related-table rows) is written in one transaction, so a row is never left half-written.
+
+| Change | What JIM does |
+|--------|---------------|
+| Create | Inserts the row, then its related-table rows. If the table generates the key (an identity column, a sequence, a default), JIM reads the generated value back and records it as the object's External ID. If your Synchronisation Rule flows the key (a natural identifier such as an employee number), JIM writes it. |
+| Update | Updates only the columns whose values changed. Key columns are never rewritten. |
+| Delete | Deletes the related-table rows, then the row. A row that has already gone counts as deleted. |
+| Add or remove a multi-valued value | Inserts or deletes one row of the related table. |
+| Reference | Writes the referenced object's own key. If the referenced object does not exist in this database yet, JIM writes the rest of the object now and fills the reference in on a later run, once it does; see [Unresolved reference handling](../configuration/connected-systems.md#unresolved-reference-handling) for how a reference that cannot be resolved is reported. |
+
+JIM checks every write took effect. A statement the database accepted but which changed nothing (a trigger discarding the insert, a row deleted outside JIM) is reported as a failure for that object, with a message saying what to check, rather than being recorded as done. One object's failure never stops the rest of the batch, and the failed export is retried with JIM's normal backoff.
+
+Because a committed database transaction is a confirmed write, exports to a database do not need a confirming import.
+
+!!! note "Views and SELECT statements are read-only"
+    An Object Type read from a view or a `select` statement cannot be exported to. If the application reads through a view but accepts writes to the table, point the Object Type at the table.
+
+### Type mapping
+
+JIM decides each attribute's type from the column's declared SQL type:
+
+| JIM type | Microsoft SQL Server | Oracle Database |
+|----------|----------------------|-----------------|
+| Text | `char`, `nchar`, `varchar`, `nvarchar`, `text`, `ntext` | `CHAR`, `NCHAR`, `VARCHAR2`, `NVARCHAR2`, `CLOB`, `NCLOB`, `LONG` |
+| Number | `int`, `smallint`, `tinyint` | `NUMBER(p,0)` with p up to 9 |
+| Long Number | `bigint` | `NUMBER(p,0)` with p from 10 to 18 |
+| Decimal | `decimal`, `numeric`, `money`, `smallmoney`, `float`, `real` | `NUMBER(p,0)` with p of 19 or more; `NUMBER(p,s)` with a scale; `NUMBER` with no precision; `BINARY_FLOAT`, `BINARY_DOUBLE` |
+| Boolean | `bit` | `NUMBER(1)`, when **Treat NUMBER(1) Columns as Boolean** is on |
+| Date/Time | `date`, `datetime`, `datetime2`, `smalldatetime`, `datetimeoffset` | `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, `TIMESTAMP WITH LOCAL TIME ZONE` |
+| GUID | `uniqueidentifier` | `RAW(16)`, when **Treat RAW(16) Columns as Guid** is on |
+| Binary | `binary`, `varbinary`, `image`, `timestamp` / `rowversion` | `RAW`, `LONG RAW`, `BLOB` |
+| Reference | Any column you list under `columns` with `referencesObjectType` | Any column you list under `columns` with `referencesObjectType` |
+
+Two things to know:
+
+- **An Oracle `NUMBER(10)` key is a Long Number, not a Number.** Oracle's single `NUMBER` type can only be narrowed by its declared precision, and ten digits is more than a 32-bit number holds. If such a column needs to flow to a built-in Metaverse Attribute that is a Number (`Employee Number` is the usual one), change the attribute's type to Number on the Schema tab; the procedure is in [Attribute data types](../configuration/connected-systems.md#attribute-data-types).
+- **Floating-point columns are approximate.** `float`, `real`, `BINARY_FLOAT` and `BINARY_DOUBLE` are read as Decimal so that they can be compared numerically, but a binary floating-point value does not round-trip to decimal exactly. Prefer an exact numeric column where JIM is authoritative for the value.
+
+A Decimal attribute holds 28 significant digits. A value wider than that is reported rather than rounded, naming the column. Column types JIM has no equivalent for (`xml`, `XMLTYPE`, `sql_variant`, `hierarchyid`, `geography`, `geometry`, `INTERVAL`, `time`, `ROWID`, `BFILE`) are left out of the schema with a warning; expose them through a view that casts to a supported type if they need synchronising.
+
+### Dates and times
+
+JIM stores every date and time in UTC. A column that carries its own offset (`datetimeoffset`, `TIMESTAMP WITH TIME ZONE`) is converted exactly. A column that does not (`datetime2`, `DATE`, `TIMESTAMP`) is read as being in the Connected System's **Database Time Zone**, and written back in that zone on export. The default, `UTC`, is right for a database whose server clock is UTC; enter the IANA name of the zone (`Europe/London`, `Australia/Sydney`) for an application that records local time.
+
+In a zone with daylight saving, the hour the clocks skip in spring and the hour they repeat in autumn are handled for you: a value in the skipped hour is read with the offset in force just before the clocks moved, as PostgreSQL and Java read it, rather than failing the row; a value in the repeated hour is taken as standard time.
+
+On Oracle, JIM also sets the database session's time zone to the same value, which is what makes `TIMESTAMP WITH LOCAL TIME ZONE` columns read correctly. If the Oracle server does not recognise the zone name you entered, the connection is refused with a message saying so.
 
 ## Worked examples
 
 ### Microsoft SQL Server: an HR application
 
-`dbo.Employees` is keyed on an `IDENTITY` column, holds a self-referencing `ManagerId`, and has a child table of phone numbers. Departments live in their own table and are referenced by key.
+`dbo.Employees` has an `IDENTITY` key, a `ManagerId` pointing at another employee and a `DepartmentId` pointing at `dbo.Departments`; phone numbers are in `dbo.EmployeePhones`.
 
 ```json title="Object Types for a SQL Server HR schema"
 {
@@ -293,11 +295,11 @@ A related table turns a table of one row per value into a multi-valued attribute
 }
 ```
 
-What you get: `EmployeeId` (`int`) is the External ID and is set on creation only; `ManagerId` and `DepartmentId` are References; `PhoneNumbers` is a multi-valued Text attribute; `HireDate` (`datetime2`) is interpreted in the Database Time Zone; `IsActive` (`bit`) is a Boolean. Exporting a new `Person` inserts the row without `EmployeeId`, reads the identity value back and records it as the External ID, then inserts its phone numbers.
+After the schema import: `EmployeeId` (`int`) is the External ID and is set only when a row is created; `ManagerId` and `DepartmentId` are references; `PhoneNumbers` is a multi-valued Text attribute; `HireDate` (`datetime2`) is read in the Database Time Zone; `IsActive` (`bit`) is a Boolean. Exporting a new `Person` inserts the row, reads the identity value back as the External ID, then inserts the phone numbers.
 
-### Oracle Database: an HR view over a sequence-keyed table
+### Oracle Database: an HR schema with groups
 
-The application exposes `HR.V_EMPLOYEES` for reading and expects writes to go to `HR.EMPLOYEES`, whose `EMPLOYEE_ID NUMBER(10)` is filled by a sequence-backed default. Group membership is a related table of References.
+`HR.EMPLOYEES` has a sequence-backed `EMPLOYEE_ID NUMBER(10)` key and a `MANAGER_ID`; `HR.GROUPS` has members in `HR.GROUP_MEMBERS`.
 
 ```json title="Object Types for an Oracle HR schema"
 {
@@ -331,24 +333,20 @@ The application exposes `HR.V_EMPLOYEES` for reading and expects writes to go to
 }
 ```
 
-What you get: `EMPLOYEE_ID` discovers as a Long Number (`NUMBER(10)`); record it as a Number on the Schema tab if it is to flow to the built-in `Employee Number`. `IS_ACTIVE NUMBER(1)` is a Number unless **Treat NUMBER(1) Columns as Boolean** is on. `HIRE_DATE` (`DATE`) is interpreted in the Database Time Zone. `Members` is a multi-valued Reference to `Person`; exporting a `Group` inserts its row and one `GROUP_MEMBERS` row per member, in one transaction.
+After the schema import: `EMPLOYEE_ID` is a Long Number (change it to Number on the Schema tab if it is to flow to `Employee Number`); `IS_ACTIVE NUMBER(1)` is a Number unless **Treat NUMBER(1) Columns as Boolean** is on; `HIRE_DATE` (`DATE`) is read in the Database Time Zone; `Members` is a multi-valued reference to `Person`. Exporting a `Group` inserts its row and one `GROUP_MEMBERS` row per member in one transaction.
 
-!!! tip "Read through the view, write to the table"
-    Where the application maintains a view for readers, you can point an import-only Connected System at the view and a second Connected System at the table for writes, or point one Connected System at the table for both. A single Object Type cannot read from the view and write to the table.
+!!! tip "Reading through a view and writing to a table"
+    If the application publishes a view for readers but takes writes on the underlying table, either point one Connected System at the table for both directions, or use two Connected Systems: one on the view for import, one on the table for export. A single Object Type reads and writes the same source.
 
-## Security Considerations
-
-### Trust model
-
-The Object Types document, including any `select` statement, is privileged administrator input: it names the tables JIM reads and writes, exactly as a Synchronisation Rule decides what flows where. Everything JIM binds into a statement is bound as a parameter, never interpolated; identifiers cannot be parameterised, so JIM quotes and validates every one it uses. Those two are the injection surface, and neither depends on the document being trusted.
+## Security
 
 ### Database account permissions
 
-Create a dedicated database account for JIM and grant it only what the Run Profiles you configure will use.
+Create a dedicated database account for JIM and grant it only what the Run Profiles you configure will use:
 
-- **For schema discovery and import**<br /> `SELECT` on each table or view named in the Object Types document, on each related table, and (in Change-Log Table mode) on each change-log table. JIM reads the catalogue through `INFORMATION_SCHEMA` and `sys` views on SQL Server and the `ALL_*` views on Oracle, which show exactly the objects the account can already read; nothing wider is needed.
-- **For export**<br /> `INSERT`, `UPDATE` and `DELETE` on each Object Type's table and each related table, alongside `SELECT`, which the export uses to read the column catalogue and check its writes.
-- **Nothing else.**<br /> JIM creates no objects, alters no schema, and never needs `db_owner`, `DBA`, or `SELECT ANY TABLE`.
+- **For schema discovery and import**<br /> `SELECT` on each table or view in the Object Types document, on each related table, and (for Change-Log Table Delta Imports) on each change-log table. JIM reads the database's own catalogue views, which show the account exactly the objects it can already read; no wider catalogue permission is needed.
+- **For export**<br /> `INSERT`, `UPDATE` and `DELETE` on each Object Type's table and each related table, in addition to `SELECT`.
+- **Nothing else.**<br /> JIM creates no objects and changes no schema. It does not need `db_owner`, `DBA`, or `SELECT ANY TABLE`.
 
 ```sql title="Microsoft SQL Server: an import-only account"
 CREATE LOGIN jim_sync WITH PASSWORD = '<a strong password>';
@@ -372,70 +370,80 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON HR.EMPLOYEES TO jim_sync;
 GRANT SELECT, INSERT, UPDATE, DELETE ON HR.EMPLOYEE_PHONES TO jim_sync;
 ```
 
-Grant per object on Oracle rather than `SELECT ANY TABLE`; the `ALL_*` catalogue views then show JIM exactly, and only, what it should see, and a discovery error saying an object "cannot be seen" is a permission you have not granted rather than a mystery.
+On Oracle, grant per object rather than `SELECT ANY TABLE`. The account then sees exactly what JIM should, and a schema import that reports a table "cannot be seen" means a grant is missing, not that something is wrong with JIM.
 
 ### Encryption in transit
 
-- **SQL Server** connections are encrypted by default and fail rather than fall back to plain text. `TrustServerCertificate` is never set: the certificate is always validated.
-- **Oracle** connections use Native Network Encryption by default (AES with SHA-2 integrity checking, both required), or TCPS where the listener offers it. Choose **None** only in a lab.
-- Neither database's driver needs anything installed on the JIM host beyond JIM itself, and neither connection reaches anything but the host you name, so the connector works unchanged in an air-gapped deployment.
+- **SQL Server** connections are encrypted by default and fail rather than fall back to plain text. The server's certificate is always validated; JIM never accepts an unvalidated certificate.
+- **Oracle** connections use Native Network Encryption by default (AES, with SHA-2 integrity checking), or TLS over a TCPS listener if you choose it. Choose **None** only in a lab.
+- Nothing needs installing on the JIM host for either database, and JIM connects only to the host you name, so the connector works unchanged in an air-gapped deployment.
 
-### Credentials and logs
+#### When the connection test fails on the certificate
 
-The password is stored encrypted, decrypted only to hand to the driver's connection string builder, and appears in no log, Activity, or configuration snapshot. The driver's own error messages never carry it either.
+For SQL Server, if the server presents a certificate JIM does not yet trust (one issued by an internal authority, or self-signed), the connection test fails and shows you the certificate: who issued it, what name it was issued for, its validity dates and its thumbprint, and which check it failed. Add the issuing authority (or, for a self-signed certificate, the certificate itself) under **Admin > Certificates** and test again. An expired certificate, or one issued for a different name from the host you connect to, is still refused; renew it, or connect by a name the certificate carries.
 
-## Third-party licence notice
+For Oracle over TCPS, JIM shows the same detail, but the certificate must be one your operating system already trusts; the Oracle driver does not accept additional trust anchors. Native Network Encryption needs no certificate at all, which is one reason it is the default.
 
-The Oracle dialect is provided through **Oracle Data Provider for .NET, Managed Driver** (`Oracle.ManagedDataAccess.Core`), which Oracle distributes under the **Oracle Free Distribution, Hosting, and Use Terms and Conditions**. Those terms permit the driver to be redistributed unmodified and used in your business operations at no charge, on conditions that include a copy of the terms accompanying any distribution and Oracle's proprietary notices being left in place. JIM ships a copy of the terms in every image, under `/app/third-party-notices/`, and in the repository under [`third-party-notices/`](https://github.com/TetronIO/JIM/tree/main/third-party-notices). If your organisation has its own licence agreement with Oracle covering the driver, that agreement governs your use of it instead. Nothing here is legal advice; read the terms.
+### Credentials and logging
 
-The Microsoft SQL Server dialect is provided through `Microsoft.Data.SqlClient`, which is MIT licensed.
+The password is stored encrypted and is used only to open the connection. It does not appear in any log, Activity or configuration history, and the database driver's error messages never include it.
+
+### What you are trusting
+
+The Object Types document, including any `select` statement, is administrator configuration: it decides which tables JIM reads and writes, just as a Synchronisation Rule decides what flows where. Everything JIM sends to the database as data is sent as a parameter, never pasted into a statement, and every table and column name is validated and quoted.
+
+## Licensing notice
+
+The Oracle dialect uses **Oracle Data Provider for .NET, Managed Driver** (`Oracle.ManagedDataAccess.Core`), which Oracle distributes under the **Oracle Free Distribution, Hosting, and Use Terms and Conditions**. Those terms allow the driver to be redistributed unmodified and used in your business operations at no charge, provided a copy of the terms accompanies any distribution and Oracle's notices are left in place. JIM ships a copy of the terms in every image at `/app/third-party-notices/` and in the repository under [`third-party-notices/`](https://github.com/TetronIO/JIM/tree/main/third-party-notices). If your organisation has its own licence agreement with Oracle covering the driver, that agreement applies instead. Please read the terms; this notice is not legal advice.
+
+The SQL Server dialect uses `Microsoft.Data.SqlClient`, which is MIT licensed.
 
 ## Wider database support
 
-The connector is built as one connector with a dialect per database, so a further database is an addition behind the same settings and the same Object Types document rather than a new connector. PostgreSQL and MySQL are next on the [roadmap](../reference/roadmap.md). If you need another engine, or need one of those sooner, say so in the [Ideas category of GitHub Discussions](https://github.com/TetronIO/JIM/discussions/categories/ideas); which dialect comes next is decided by who asks.
+PostgreSQL and MySQL are planned as further dialects of this connector, with the same settings and the same Object Types document; see the [roadmap](../reference/roadmap.md). If you need another database engine, or need one of those sooner, tell us in the [Ideas category of GitHub Discussions](https://github.com/TetronIO/JIM/discussions/categories/ideas); what comes next is decided by who asks.
 
 ## Troubleshooting
 
 **"Unable to connect. Message: ..."**<br />
-The driver's own message follows. A wrong host or a closed port times out after the Connection Timeout; a wrong Database Name, service name or SID is refused immediately with the database's own wording; a wrong password is an authentication failure. On Oracle, check that you have chosen the right form (service name or SID) as well as the right value.
+The database driver's own message follows. A wrong host or blocked port times out after the Connection Timeout; a wrong database name, service name or SID is rejected immediately in the database's own words; a wrong password is an authentication failure. On Oracle, check you have chosen the right form (service name or SID) as well as the right value.
 
 **The connection test fails on the certificate (SQL Server)**<br />
-JIM shows the certificate the server presented and which check failed. An untrusted issuer is fixed by adding the authority under **Admin > Certificates**; an expired certificate has to be renewed on the server; a name mismatch means connecting by a name the certificate carries. See [When a connection test fails on the certificate](#when-a-connection-test-fails-on-the-certificate).
+See [When the connection test fails on the certificate](#when-the-connection-test-fails-on-the-certificate).
 
 **"Object Type 'X' reads from HR.TABLE, which this database account cannot see"**<br />
-Either the name is wrong, or the schema is, or the account has not been granted `SELECT` on it. On Oracle a grant is per object; see [Database account permissions](#database-account-permissions).
+The name or schema is wrong, or the account has not been granted `SELECT` on it. On Oracle, grants are per table; see [Database account permissions](#database-account-permissions).
 
 **"Object Type 'X' names 'TABLE', which exists in more than one schema"**<br />
-Add a `schema` to the Object Type to say which one.
+Add `"schema"` to that Object Type.
 
-**An attribute is missing after schema discovery**<br />
-Check the discovery's warnings: a column of a type JIM has no equivalent for is skipped and named. Expose it through a view that casts it to a supported type.
+**An attribute is missing after the schema import**<br />
+Check the import's warnings: a column whose type JIM cannot synchronise is named there. Expose it through a view that casts it to a supported type.
 
-**A whole-number attribute reports "the value has a fractional part"**<br />
-The column is fractional but the attribute was recorded as a Number or Long Number, usually through an override. Record it as a Decimal on the Schema tab, or correct the source.
+**"The value has a fractional part, and this attribute's data type is Number"**<br />
+The column holds fractional values but the attribute's type is a whole number, usually because the type was changed on the Schema tab. Change it to Decimal, or correct the source data.
 
-**A Delta Import performed a Full Import instead**<br />
-Expected the first time, and after a change of Delta Import Mode: no usable watermark existed, so the run established one. If it happens on every run, check the Activity's warning for the reason.
+**A Delta Import ran as a Full Import**<br />
+Expected on the first run, and after changing the Delta Import Mode. If it happens every time, read the warning on the Activity for the reason.
 
-**A Delta Import never sees deletions**<br />
-Watermark Column mode cannot; a deleted row has no column left to move. Use a change-log table, or schedule a periodic Full Import. See [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md).
+**Deleted rows are not removed by a Delta Import**<br />
+Watermark Column mode cannot see deletions. Use a change-log table, or schedule a periodic Full Import. See [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md).
 
 **An export reports "No row was written ... though the database raised no error"**<br />
-A trigger or a rule on the table is discarding the insert, or the account may not write to it. JIM rolls the object back rather than confirming a row the table does not hold; check the table's triggers and the account's grants.
+A trigger or rule on the table discarded the insert, or the account cannot write to the table. Check the table's triggers and the account's grants.
 
 **An export reports "No row ... is identified by this Connected System Object's external ID"**<br />
-The row was deleted outside JIM, or its key was changed. Run a Full Import to reconcile the Connected System with the table.
+The row was deleted or re-keyed outside JIM. Run a Full Import to bring JIM back in line with the table.
 
-**An Oracle export fails with "returned no value for its anchor column"**<br />
-The table's key is neither flowed by a Synchronisation Rule nor generated by the database. Back the column with a sequence-based default or an identity column, or flow the key.
+**An Oracle export reports "returned no value for its anchor column"**<br />
+The table's key is neither flowed by a Synchronisation Rule nor generated by the database. Back the column with a sequence-based default or an identity column, or flow the key from JIM.
 
-**Dates are an hour out**<br />
-The column carries no offset and the Database Time Zone does not match what the application writes. Set it to the zone the application records in; columns with their own offset are unaffected either way.
+**Dates are out by an hour**<br />
+The column carries no offset and the Database Time Zone does not match what the application records. Set it to the zone the application uses; columns that carry their own offset are unaffected.
 
 ## Related
 
 - [Delta Import with a change-log table](jim-sql-connector-delta-import-change-log.md)
 - [Delta Import with a watermark column](jim-sql-connector-delta-import-watermark.md)
 - [Attribute data types](../configuration/connected-systems.md#attribute-data-types)
-- [Connectors](index.md)
 - [Connected Systems](../configuration/connected-systems.md)
+- [Connectors](index.md)

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -25,7 +25,7 @@ Expanding the range of systems JIM can connect to out of the box. The SCIM 2.0 C
 |---|---|---|
 | [JIM SCIM 2.0 Client Connector](../connectors/jim-scim-connector.md) | SCIM 2.0 endpoints | ✅ Available |
 | [JIM SQL Connector](../connectors/jim-sql-connector.md) | Microsoft SQL Server and Oracle Database | ✅ Available |
-| JIM SQL Connector: PostgreSQL and MySQL | The same connector, extended to two further engines | 🚧 In development |
+| JIM SQL Connector: PostgreSQL and MySQL | The same connector, extended to two further engines | Planned |
 | JIM PowerShell Connector | PowerShell Core scripts | Planned |
 | JIM REST Connector | REST API web services | Planned |
 


### PR DESCRIPTION
## Summary

The public SQL Connector pages read as engineering notes rather than customer documentation (the capability table said "Deliberately off in this release: parallel batches against one database can deadlock on hot pages", and the rest of the page explained JIM's reasoning to itself rather than telling an administrator what to do). Rewritten from the customer's point of view:

- `docs/connectors/jim-sql-connector.md`: overview, supported databases, **what the connector can do** (outcomes, not rationale), **before you begin** (account, network, certificate, knowing your tables, time zone), a four-step set-up (create the Connected System with every setting explained as "what to enter", describe your tables, import the schema and choose what to synchronise, Run Profiles and Synchronisation Rules), how each operation behaves, worked examples for both databases, security (grants for both databases, encryption, certificate failures, credentials), licensing notice, wider database support, troubleshooting. No release-relative wording; no "because a wrong guess would be silent"-style reasoning.
- The two delta-import guides: the same treatment in the passages that had slipped into internal voice (refusal rationale, "purge on anything cleverer", "correlates on existence alone").
- `docs/reference/roadmap.md`: the PostgreSQL and MySQL row said "🚧 In development"; nothing is, and #1452 now tracks it, so it reads **Planned**.

Facts are unchanged from the previous text (verified against source earlier; #1414, #1430 and #1431 wording carried forward). Links and anchors checked by script.

## Testing

Docs only; no build/test per the build/test exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)