### PR TITLE
feat: preview what changing Object Matching Rules would do (#1457)

### DIFF
--- a/src/JIM.Application/JimApplication.cs
+++ b/src/JIM.Application/JimApplication.cs
@@ -125,7 +125,8 @@ public class JimApplication : IDisposable
                 new ConnectedSystemScopeSelectionPreviewAdapter(this, new SyncEngine()),
                 new SyncRuleDestructiveTogglePreviewAdapter(this, new SyncEngine()),
                 new SyncRuleScopingPreviewAdapter(this, new SyncEngine()),
-                new SyncRuleAttributeFlowPreviewAdapter(this, new SyncEngine())
+                new SyncRuleAttributeFlowPreviewAdapter(this, new SyncEngine()),
+                new ObjectMatchingPreviewAdapter(this)
             ]));
         ConfigurationDiffs = new ConfigurationDiffService();
         ConfigurationDrift = new ConfigurationDriftService(this);

--- a/src/JIM.Application/Servers/ConfigurationChangePreviewServer.cs
+++ b/src/JIM.Application/Servers/ConfigurationChangePreviewServer.cs
@@ -531,6 +531,12 @@ public class ConfigurationChangePreviewServer
             case ConfigurationChangePreviewSurface.ConnectedSystem:
                 activity.ConnectedSystemId = request.TargetId;
                 break;
+            // Object Matching is previewed per Connected System, in both modes and across the switch between them,
+            // so the Activity attaches to the system rather than to whichever object type or Synchronisation Rule
+            // happens to own the rules today.
+            case ConfigurationChangePreviewSurface.ObjectMatching:
+                activity.ConnectedSystemId = request.TargetId;
+                break;
             case ConfigurationChangePreviewSurface.MetaverseObjectType:
                 activity.MetaverseObjectTypeId = request.TargetId;
                 break;

--- a/src/JIM.Application/Servers/ConnectedSystemServer.cs
+++ b/src/JIM.Application/Servers/ConnectedSystemServer.cs
@@ -4607,6 +4607,34 @@ public class ConnectedSystemServer
     }
 
     /// <summary>
+    /// The identifiers of a Connected System's live, unjoined objects of one type: the population a
+    /// synchronisation would put to Object Matching on its next run, and therefore the only population an Object
+    /// Matching change can move (#1457).
+    /// </summary>
+    public async Task<List<Guid>> GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId)
+    {
+        return await Application.Repository.ConnectedSystems.GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(connectedSystemId, connectedSystemObjectTypeId);
+    }
+
+    /// <summary>
+    /// How many live, unjoined objects of one type a Connected System holds; the set-based count behind an Object
+    /// Matching preview's cost estimate.
+    /// </summary>
+    public async Task<int> GetUnjoinedConnectedSystemObjectCountOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId)
+    {
+        return await Application.Repository.ConnectedSystems.GetUnjoinedConnectedSystemObjectCountOfTypeAsync(connectedSystemId, connectedSystemObjectTypeId);
+    }
+
+    /// <summary>
+    /// Connected System Objects by identifier, without change tracking: the batched read behind a population that
+    /// was resolved to identifiers first.
+    /// </summary>
+    public async Task<List<ConnectedSystemObject>> GetConnectedSystemObjectsByIdsNoTrackingAsync(int connectedSystemId, IEnumerable<Guid> connectedSystemObjectIds)
+    {
+        return await Application.Repository.ConnectedSystems.GetConnectedSystemObjectsByIdsNoTrackingAsync(connectedSystemId, connectedSystemObjectIds);
+    }
+
+    /// <summary>
     /// Returns the count of joined Connected System Objects of one type in a Connected System: the population a
     /// destructive Synchronisation Rule toggle preview walks, counted set-based for the dispatch decision (#1115).
     /// </summary>

--- a/src/JIM.Application/Servers/Preview/ObjectMatchingPreviewAdapter.cs
+++ b/src/JIM.Application/Servers/Preview/ObjectMatchingPreviewAdapter.cs
@@ -1,0 +1,513 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Runtime.CompilerServices;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Exceptions;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+
+namespace JIM.Application.Servers.Preview;
+
+/// <summary>
+/// What changing a Connected System's Object Matching Rules would do (#1457, gap G1): the edit that decides which
+/// Metaverse Object each account belongs to.
+///
+/// This is the surface whose mistakes are the hardest to detect afterwards, because none of them fail. A rule
+/// matching one attribute too loosely joins an account to the wrong identity and every value it contributes goes
+/// with it; a rule matching too tightly projects a second identity beside the right one. Both look like a
+/// successful synchronisation. So the preview answers per object, by asking the matching engine itself twice, once
+/// with the stored rules and once with the proposal, and reporting where the two answers differ.
+///
+/// The negative matters as much as the positive here, and it is the first thing the preview says: Object Matching
+/// Rules are evaluated only for objects that have no Metaverse Object yet. An account already joined never
+/// re-matches, so no matching edit can re-home it, and an administrator who has been told the population is
+/// 40,000 accounts needs to know the change stands over only the unjoined few.
+/// </summary>
+public class ObjectMatchingPreviewAdapter : IConfigurationChangePreviewAdapter
+{
+    private readonly JimApplication _application;
+
+    /// <summary>
+    /// How a matching transition is written into a delta row's value columns, so the drill-down reads as the
+    /// identities concerned rather than as an internal transition name.
+    /// </summary>
+    private const string MatchAttributeName = "Object Matching";
+    private const string NoMatchValue = "No match; projects a new identity";
+    private const string AmbiguousValue = "More than one match";
+
+    /// <summary>
+    /// The Connected System attribute types the matching query can compare. Anything else makes the query throw
+    /// at run time, so a proposal naming one is refused before an administrator can save it.
+    /// </summary>
+    /// <summary>
+    /// How many objects are fetched per round trip while evaluating. Batched because the population is read as
+    /// identifiers and the objects behind them are needed in memory to be matched, and a preview over hundreds of
+    /// thousands of accounts must not put all of them there at once.
+    /// </summary>
+    private const int EvaluationBatchSize = 200;
+
+    private static readonly AttributeDataType[] MatchableAttributeTypes =
+        [AttributeDataType.Text, AttributeDataType.Number, AttributeDataType.LongNumber, AttributeDataType.Decimal, AttributeDataType.Guid];
+
+    public ObjectMatchingPreviewAdapter(JimApplication application)
+    {
+        _application = application ?? throw new ArgumentNullException(nameof(application));
+    }
+
+    public ConfigurationChangePreviewSurface Surface => ConfigurationChangePreviewSurface.ObjectMatching;
+
+    public bool ProducesDeltas => true;
+
+    public Type ProposalType => typeof(ObjectMatchingProposal);
+
+    public async Task<List<PreviewValidationFinding>> ValidateAsync(PreviewContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var proposal = context.ProposedAs<ObjectMatchingProposal>();
+        var configuration = await LoadAsync(context);
+        var findings = new List<PreviewValidationFinding>();
+
+        if (configuration.StoredProposal.DescribesSameMatchingAs(proposal))
+        {
+            findings.Add(new PreviewValidationFinding(
+                PreviewValidationSeverity.Information,
+                "The proposed Object Matching Rules match the ones this Connected System already has, so no object " +
+                "would join differently and no impact is counted below.",
+                nameof(ConnectedSystem.ObjectMatchingRuleMode)));
+            return findings;
+        }
+
+        // Said first, and said on every matching preview: it is the single most common misreading of this change.
+        findings.Add(new PreviewValidationFinding(
+            PreviewValidationSeverity.Information,
+            "Object Matching Rules are evaluated only for objects that are not already joined to a Metaverse " +
+            "Object. Objects already joined keep the Metaverse Object they have, whatever this change does, so the " +
+            "impact below covers the unjoined population only.",
+            nameof(ConnectedSystem.ObjectMatchingRuleMode)));
+
+        if (proposal.Mode != configuration.StoredProposal.Mode)
+        {
+            findings.Add(new PreviewValidationFinding(
+                PreviewValidationSeverity.Warning,
+                proposal.Mode == ObjectMatchingRuleMode.SyncRule
+                    ? "The proposal switches this Connected System to Advanced matching, so the rules held against " +
+                      "each Connected System Object Type stop being used and each Synchronisation Rule's own rules " +
+                      "apply instead. A Synchronisation Rule carrying no rules of its own joins nothing."
+                    : "The proposal switches this Connected System to Simple matching, so each Synchronisation " +
+                      "Rule's own rules stop being used and the rules held against each Connected System Object " +
+                      "Type apply instead. An Object Type carrying no rules of its own joins nothing.",
+                nameof(ConnectedSystem.ObjectMatchingRuleMode)));
+        }
+
+        foreach (var finding in DescribeUnusableRules(proposal, configuration))
+            findings.Add(finding);
+
+        foreach (var objectTypeId in configuration.StoredProposal.Rules
+                     .Select(rule => ObjectTypeOf(rule, configuration))
+                     .Where(id => id != null)
+                     .Distinct())
+        {
+            if (proposal.Rules.Any(rule => ObjectTypeOf(rule, configuration) == objectTypeId))
+                continue;
+
+            var objectTypeName = configuration.ObjectTypesById.GetValueOrDefault(objectTypeId!.Value)?.Name ?? "this type";
+            findings.Add(new PreviewValidationFinding(
+                PreviewValidationSeverity.Warning,
+                $"The proposal leaves '{objectTypeName}' with no Object Matching Rule, so no object of that type " +
+                "would ever join an existing Metaverse Object. Every unjoined object would project a new identity " +
+                "instead, which is how duplicate identities are created.",
+                nameof(ConnectedSystemObjectType.ObjectMatchingRules)));
+        }
+
+        return findings;
+    }
+
+    public async Task<PreviewCostEstimate> EstimateCostAsync(PreviewContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var proposal = context.ProposedAs<ObjectMatchingProposal>();
+        var configuration = await LoadAsync(context);
+
+        if (configuration.StoredProposal.DescribesSameMatchingAs(proposal))
+            return new PreviewCostEstimate(0);
+
+        // The unjoined, live population of each affected type, counted set-based. Exactly the objects the change
+        // can move: counting the whole type would state a population many times larger than the one at stake, and
+        // push every preview of a mature system to the worker for no reason.
+        var affected = 0;
+        foreach (var objectTypeId in AffectedObjectTypeIds(proposal, configuration))
+            affected += await _application.ConnectedSystems.GetUnjoinedConnectedSystemObjectCountOfTypeAsync(configuration.ConnectedSystem.Id, objectTypeId);
+
+        return new PreviewCostEstimate(affected);
+    }
+
+    /// <summary>
+    /// Stage 2. Counted from the same evaluation the deltas come from rather than from set-based SQL, because
+    /// matching is a query per object: whether one object matches a different Metaverse Object under the proposal
+    /// is not answerable in aggregate, and a count that guessed would be the confident wrong number this preview
+    /// exists to prevent.
+    /// </summary>
+    public async Task<List<PreviewImpactCount>> CountImpactAsync(PreviewContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var configuration = await LoadAsync(context);
+        var counts = new Dictionary<ActivityRunProfileExecutionItemSyncOutcomeType, int>();
+
+        await foreach (var delta in EvaluateDeltasAsync(context, CancellationToken.None))
+            counts[delta.TransitionType] = counts.GetValueOrDefault(delta.TransitionType) + 1;
+
+        return
+        [
+            .. counts
+                .OrderByDescending(count => count.Value)
+                .ThenBy(count => count.Key)
+                .Select(count => new PreviewImpactCount(count.Key, count.Value, ConnectedSystemId: configuration.ConnectedSystem.Id))
+        ];
+    }
+
+    public async IAsyncEnumerable<PreviewDelta> EvaluateDeltasAsync(PreviewContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var proposal = context.ProposedAs<ObjectMatchingProposal>();
+        var configuration = await LoadAsync(context);
+
+        // No matching change means no object can join differently, so the population is not read at all.
+        if (configuration.StoredProposal.DescribesSameMatchingAs(proposal))
+            yield break;
+
+        foreach (var objectTypeId in AffectedObjectTypeIds(proposal, configuration))
+        {
+            var importRules = configuration.SyncRules
+                .Where(rule => rule.Direction == SyncRuleDirection.Import && rule.ConnectedSystemObjectTypeId == objectTypeId)
+                .OrderBy(rule => rule.Id)
+                .ToList();
+
+            var objectTypeName = configuration.ObjectTypesById.GetValueOrDefault(objectTypeId)?.Name;
+
+            // The population is read as identifiers first, then fetched in batches. Enumerating a result set while
+            // querying inside the loop is what Npgsql refuses outright: one command per connection, and the
+            // matching engine issues a query per object. Streaming the objects instead made every match fail with
+            // "a command is already in progress", which the matching engine reports as no match, so the preview
+            // answered that nothing would change.
+            var population = await _application.ConnectedSystems
+                .GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(configuration.ConnectedSystem.Id, objectTypeId);
+
+            foreach (var batch in population.Chunk(EvaluationBatchSize))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var csos = await _application.ConnectedSystems
+                    .GetConnectedSystemObjectsByIdsNoTrackingAsync(configuration.ConnectedSystem.Id, batch);
+
+                foreach (var cso in csos)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    // Belt and braces over the population query: matching runs at the join step, which only
+                    // unjoined, live objects reach, and reporting a joined object as re-homed would be the worst
+                    // thing this preview could say.
+                    if (cso.MetaverseObjectId != null || cso.MetaverseObject != null)
+                        continue;
+                    if (cso.Status != ConnectedSystemObjectStatus.Normal)
+                        continue;
+
+                    var scopedImportRules = ScopedImportRules(cso, importRules);
+                    if (scopedImportRules == null)
+                        continue;
+
+                    var storedOutcome = await MatchAsync(cso, configuration.StoredProposal, configuration, scopedImportRules);
+                    var proposedOutcome = await MatchAsync(cso, proposal, configuration, scopedImportRules);
+
+                    var delta = Describe(cso, storedOutcome, proposedOutcome, configuration.ConnectedSystem.Id, objectTypeName);
+                    if (delta != null)
+                        yield return delta;
+                }
+            }
+        }
+    }
+
+    #region evaluation
+
+    /// <summary>
+    /// The import Synchronisation Rules the object would be matched under, or null when it never reaches the join
+    /// step at all. Mirrors the synchronisation processor exactly: an object out of scope of every import rule
+    /// carrying criteria is handled as out-of-scope and never matched, and where no rule scopes it in, every rule
+    /// applies.
+    /// </summary>
+    private List<SyncRule>? ScopedImportRules(ConnectedSystemObject cso, List<SyncRule> importRules)
+    {
+        var inScope = importRules
+            .Where(rule => _application.ScopingEvaluation.IsCsoInScopeForImportRule(cso, rule))
+            .ToList();
+
+        if (inScope.Count == 0 && importRules.Exists(rule => rule.ObjectScopingCriteriaGroups.Count > 0))
+            return null;
+
+        return inScope.Count > 0 ? inScope : importRules;
+    }
+
+    /// <summary>
+    /// What the matching engine answers for one object under one matching configuration.
+    /// </summary>
+    private async Task<MatchOutcome> MatchAsync(
+        ConnectedSystemObject cso,
+        ObjectMatchingProposal proposal,
+        MatchingConfiguration configuration,
+        List<SyncRule> scopedImportRules)
+    {
+        var rules = ResolveRules(cso, proposal, configuration, scopedImportRules);
+        if (rules.Count == 0)
+            return MatchOutcome.NoMatch;
+
+        try
+        {
+            var mvo = await _application.ObjectMatching.FindMatchingMetaverseObjectAsync(cso, rules);
+            return mvo == null ? MatchOutcome.NoMatch : new MatchOutcome(MatchKind.Match, mvo);
+        }
+        catch (MultipleMatchesException)
+        {
+            return MatchOutcome.Ambiguous;
+        }
+    }
+
+    /// <summary>
+    /// The rules that would be evaluated for this object, in evaluation order. In Simple mode that is the object
+    /// type's own rules; in Advanced mode it is each in-scope import rule's rules in turn, each searching that
+    /// rule's Metaverse Object Type, which is how the synchronisation processor resolves them.
+    /// </summary>
+    private static List<ObjectMatchingRule> ResolveRules(
+        ConnectedSystemObject cso,
+        ObjectMatchingProposal proposal,
+        MatchingConfiguration configuration,
+        List<SyncRule> scopedImportRules)
+    {
+        if (proposal.Mode == ObjectMatchingRuleMode.ConnectedSystem)
+        {
+            return
+            [
+                .. proposal.RulesFor(cso.TypeId, syncRuleId: null)
+                    .Select(rule => Materialise(rule, configuration, fallback: null))
+            ];
+        }
+
+        var resolved = new List<ObjectMatchingRule>();
+        foreach (var importRule in scopedImportRules)
+        {
+            var fallback = importRule.MetaverseObjectType
+                ?? (importRule.MetaverseObjectTypeId is { } typeId ? configuration.MetaverseObjectTypesById.GetValueOrDefault(typeId) : null);
+
+            resolved.AddRange(proposal.RulesFor(cso.TypeId, importRule.Id)
+                .Select(rule => Materialise(rule, configuration, fallback)));
+        }
+
+        return resolved;
+    }
+
+    private static ObjectMatchingRule Materialise(ObjectMatchingRuleProposal rule, MatchingConfiguration configuration, MetaverseObjectType? fallback) =>
+        ObjectMatchingProposalMaterialiser.Materialise(
+            rule,
+            configuration.ConnectedSystemAttributesById,
+            configuration.MetaverseAttributesById,
+            configuration.MetaverseObjectTypesById,
+            fallback);
+
+    /// <summary>
+    /// The delta for one object, or null where the two answers agree and nothing about the object changes.
+    /// </summary>
+    private static PreviewDelta? Describe(ConnectedSystemObject cso, MatchOutcome stored, MatchOutcome proposed, int connectedSystemId, string? objectTypeName)
+    {
+        if (stored.Kind == proposed.Kind && stored.MetaverseObject?.Id == proposed.MetaverseObject?.Id)
+            return null;
+
+        var transition = (stored.Kind, proposed.Kind) switch
+        {
+            (_, MatchKind.Ambiguous) => ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously,
+            (MatchKind.Match, MatchKind.Match) => ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject,
+            (_, MatchKind.Match) => ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject,
+            _ => ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin
+        };
+
+        return new PreviewDelta(
+            transition,
+            ObjectDisplayName: cso.NameOrId,
+            ObjectTypeName: objectTypeName ?? cso.Type?.Name,
+            MetaverseObjectTypeId: proposed.MetaverseObject?.Type?.Id ?? stored.MetaverseObject?.Type?.Id,
+            // The identity the object would end up on, so a drill-down row answers "joined to what?" rather than
+            // "moved away from what?". Where the proposal joins nothing, the row names the identity being lost.
+            MetaverseObjectId: proposed.MetaverseObject?.Id ?? stored.MetaverseObject?.Id,
+            ConnectedSystemObjectId: cso.Id,
+            ConnectedSystemId: connectedSystemId,
+            AttributeName: MatchAttributeName,
+            OldValue: stored.Describe(),
+            NewValue: proposed.Describe());
+    }
+
+    private enum MatchKind
+    {
+        NoMatch,
+        Match,
+        Ambiguous
+    }
+
+    private record MatchOutcome(MatchKind Kind, MetaverseObject? MetaverseObject)
+    {
+        public static readonly MatchOutcome NoMatch = new(MatchKind.NoMatch, null);
+        public static readonly MatchOutcome Ambiguous = new(MatchKind.Ambiguous, null);
+
+        /// <summary>How this outcome reads in a drill-down row's value column.</summary>
+        public string Describe() => Kind switch
+        {
+            MatchKind.Match => MetaverseObject?.NameOrId ?? NoMatchValue,
+            MatchKind.Ambiguous => AmbiguousValue,
+            _ => NoMatchValue
+        };
+    }
+
+    #endregion
+
+    #region validation helpers
+
+    /// <summary>
+    /// The proposed rules the matching engine could not evaluate. Every one of these throws or silently matches
+    /// nothing at run time, so they are refused here rather than discovered during a synchronisation.
+    /// </summary>
+    private static IEnumerable<PreviewValidationFinding> DescribeUnusableRules(ObjectMatchingProposal proposal, MatchingConfiguration configuration)
+    {
+        foreach (var rule in proposal.Rules)
+        {
+            var where = DescribeRule(rule, configuration);
+
+            if (rule.Sources.Count == 0)
+            {
+                yield return Blocking($"{where} has no source attribute, so it has nothing to match on.");
+                continue;
+            }
+
+            if (rule.Sources.Count > 1)
+                yield return Blocking($"{where} has more than one source. Object Matching Rules support a single source; multi-source (advanced) matching is not implemented.");
+
+            foreach (var source in rule.Sources)
+            {
+                if (!string.IsNullOrWhiteSpace(source.Expression))
+                {
+                    yield return Blocking($"{where} matches on an expression. Object Matching Rules compare attribute values only; expression sources are not supported yet.");
+                    continue;
+                }
+
+                if (source.ConnectedSystemAttributeId is not { } attributeId)
+                {
+                    yield return Blocking($"{where} has a source naming no Connected System attribute.");
+                    continue;
+                }
+
+                var attribute = configuration.ConnectedSystemAttributesById.GetValueOrDefault(attributeId);
+                if (attribute == null)
+                {
+                    yield return Blocking($"{where} matches on a Connected System attribute that is not part of this system's schema.");
+                    continue;
+                }
+
+                if (!MatchableAttributeTypes.Contains(attribute.Type))
+                    yield return Blocking($"{where} matches on '{attribute.Name}', which is of type {attribute.Type}. Object Matching compares Text, Number, Long Number, Decimal and Guid attributes only.");
+            }
+
+            if (rule.TargetMetaverseAttributeId is not { } targetId)
+                yield return Blocking($"{where} names no target Metaverse Attribute, so there is nothing to compare its source against.");
+            else if (!configuration.MetaverseAttributesById.ContainsKey(targetId))
+                yield return Blocking($"{where} targets a Metaverse Attribute that no longer exists.");
+
+            if (proposal.Mode == ObjectMatchingRuleMode.ConnectedSystem && rule.MetaverseObjectTypeId == null)
+                yield return Blocking($"{where} names no Metaverse Object Type to search. Simple mode rules must name one; in Advanced mode the Synchronisation Rule supplies it.");
+        }
+    }
+
+    private static PreviewValidationFinding Blocking(string message) =>
+        new(PreviewValidationSeverity.Blocking, message, nameof(ConnectedSystemObjectType.ObjectMatchingRules));
+
+    /// <summary>
+    /// How a rule is named in a finding, so an administrator can find the one being complained about.
+    /// </summary>
+    private static string DescribeRule(ObjectMatchingRuleProposal rule, MatchingConfiguration configuration)
+    {
+        var owner = rule.SyncRuleId is { } syncRuleId
+            ? configuration.SyncRules.FirstOrDefault(candidate => candidate.Id == syncRuleId)?.Name ?? "a Synchronisation Rule"
+            : configuration.ObjectTypesById.GetValueOrDefault(rule.ConnectedSystemObjectTypeId ?? 0)?.Name ?? "an Object Type";
+
+        return $"Object Matching Rule {rule.Order + 1} on '{owner}'";
+    }
+
+    #endregion
+
+    #region configuration
+
+    /// <summary>
+    /// Everything both evaluations read, loaded once. Held together rather than passed as six parameters because
+    /// the stored configuration and the lookups a proposal is materialised against are one snapshot: reading them
+    /// at different moments would let a concurrent edit put the baseline and the proposal out of step.
+    /// </summary>
+    private sealed record MatchingConfiguration(
+        ConnectedSystem ConnectedSystem,
+        ObjectMatchingProposal StoredProposal,
+        IReadOnlyList<SyncRule> SyncRules,
+        IReadOnlyDictionary<int, ConnectedSystemObjectType> ObjectTypesById,
+        IReadOnlyDictionary<int, ConnectedSystemObjectTypeAttribute> ConnectedSystemAttributesById,
+        IReadOnlyDictionary<int, MetaverseAttribute> MetaverseAttributesById,
+        IReadOnlyDictionary<int, MetaverseObjectType> MetaverseObjectTypesById);
+
+    private async Task<MatchingConfiguration> LoadAsync(PreviewContext context)
+    {
+        if (context.TargetId is not { } connectedSystemId)
+            throw new InvalidOperationException("An Object Matching preview must name the Connected System it is about.");
+
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId)
+            ?? throw new InvalidOperationException($"Connected System {connectedSystemId} was not found, so its Object Matching cannot be previewed.");
+
+        var objectTypes = await _application.ConnectedSystems.GetObjectTypesAsync(connectedSystemId);
+        var syncRules = await _application.ConnectedSystems.GetSyncRulesAsync(connectedSystemId, includeDisabledSyncRules: false);
+        var metaverseObjectTypes = await _application.Metaverse.GetMetaverseObjectTypesAsync(true);
+
+        return new MatchingConfiguration(
+            connectedSystem,
+            ObjectMatchingProposal.FromCurrentConfiguration(connectedSystem, objectTypes, syncRules),
+            syncRules,
+            objectTypes.ToDictionary(objectType => objectType.Id),
+            objectTypes.SelectMany(objectType => objectType.Attributes).GroupBy(attribute => attribute.Id).ToDictionary(group => group.Key, group => group.First()),
+            metaverseObjectTypes.SelectMany(objectType => objectType.Attributes).GroupBy(attribute => attribute.Id).ToDictionary(group => group.Key, group => group.First()),
+            metaverseObjectTypes.ToDictionary(objectType => objectType.Id));
+    }
+
+    /// <summary>
+    /// The Connected System Object Types whose objects could match differently: every type carrying rules on
+    /// either side of the change. A type with no rules before and none after cannot move an object.
+    /// </summary>
+    private static List<int> AffectedObjectTypeIds(ObjectMatchingProposal proposal, MatchingConfiguration configuration) =>
+    [
+        .. proposal.Rules.Concat(configuration.StoredProposal.Rules)
+            .Select(rule => ObjectTypeOf(rule, configuration))
+            .Where(objectTypeId => objectTypeId != null)
+            .Select(objectTypeId => objectTypeId!.Value)
+            .Distinct()
+            .Order()
+    ];
+
+    /// <summary>
+    /// The Connected System Object Type a rule concerns: its own in Simple mode, its owning Synchronisation Rule's
+    /// in Advanced.
+    /// </summary>
+    private static int? ObjectTypeOf(ObjectMatchingRuleProposal rule, MatchingConfiguration configuration) =>
+        rule.ConnectedSystemObjectTypeId
+        ?? (rule.SyncRuleId is { } syncRuleId
+            ? configuration.SyncRules.FirstOrDefault(candidate => candidate.Id == syncRuleId)?.ConnectedSystemObjectTypeId
+            : null);
+
+    #endregion
+}

--- a/src/JIM.Application/Servers/Preview/ObjectMatchingPreviewAdapter.cs
+++ b/src/JIM.Application/Servers/Preview/ObjectMatchingPreviewAdapter.cs
@@ -107,15 +107,20 @@ public class ObjectMatchingPreviewAdapter : IConfigurationChangePreviewAdapter
         foreach (var finding in DescribeUnusableRules(proposal, configuration))
             findings.Add(finding);
 
+        // The types the proposal still covers, gathered once: a Connected System with many Object Types would
+        // otherwise re-scan the proposal for every stored type.
+        var proposedObjectTypeIds = proposal.Rules
+            .Select(rule => ObjectTypeOf(rule, configuration))
+            .Where(objectTypeId => objectTypeId != null)
+            .ToHashSet();
+
         foreach (var objectTypeId in configuration.StoredProposal.Rules
                      .Select(rule => ObjectTypeOf(rule, configuration))
-                     .Where(id => id != null)
+                     .Where(objectTypeId => objectTypeId != null && !proposedObjectTypeIds.Contains(objectTypeId))
+                     .Select(objectTypeId => objectTypeId!.Value)
                      .Distinct())
         {
-            if (proposal.Rules.Any(rule => ObjectTypeOf(rule, configuration) == objectTypeId))
-                continue;
-
-            var objectTypeName = configuration.ObjectTypesById.GetValueOrDefault(objectTypeId!.Value)?.Name ?? "this type";
+            var objectTypeName = configuration.ObjectTypesById.GetValueOrDefault(objectTypeId)?.Name ?? "this type";
             findings.Add(new PreviewValidationFinding(
                 PreviewValidationSeverity.Warning,
                 $"The proposal leaves '{objectTypeName}' with no Object Matching Rule, so no object of that type " +

--- a/src/JIM.Application/Servers/Preview/ObjectMatchingProposalMaterialiser.cs
+++ b/src/JIM.Application/Servers/Preview/ObjectMatchingProposalMaterialiser.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+
+namespace JIM.Application.Servers.Preview;
+
+/// <summary>
+/// Turns a proposed Object Matching Rule back into the entity the matching engine can be asked about (#1457), so a
+/// matching preview puts its questions to the engine's own implementation rather than reimplementing any part of
+/// it.
+/// </summary>
+/// <remarks>
+/// The matching query reads the attribute ENTITIES, not their ids: it needs the source attribute's data type to
+/// pick a comparison, and it filters Metaverse Objects on the target attribute's id read off the navigation. A
+/// stand-in carrying only ids would therefore match nothing while looking perfectly well formed, and the preview
+/// would report every object losing its match.
+/// </remarks>
+internal static class ObjectMatchingProposalMaterialiser
+{
+    /// <summary>
+    /// <paramref name="proposal"/> as a rule the matching engine can evaluate.
+    /// </summary>
+    /// <param name="proposal">The proposed rule.</param>
+    /// <param name="connectedSystemAttributes">The Connected System attributes a source may name, by id.</param>
+    /// <param name="metaverseAttributes">The Metaverse Attributes a target may name, by id.</param>
+    /// <param name="metaverseObjectTypes">The Metaverse Object Types a rule may search, by id.</param>
+    /// <param name="fallbackMetaverseObjectType">
+    /// The type to search when the rule names none: the owning Synchronisation Rule's type in Advanced mode. Null
+    /// in Simple mode, where a rule naming no type searches nothing and the engine skips it.
+    /// </param>
+    public static ObjectMatchingRule Materialise(
+        ObjectMatchingRuleProposal proposal,
+        IReadOnlyDictionary<int, ConnectedSystemObjectTypeAttribute> connectedSystemAttributes,
+        IReadOnlyDictionary<int, MetaverseAttribute> metaverseAttributes,
+        IReadOnlyDictionary<int, MetaverseObjectType> metaverseObjectTypes,
+        MetaverseObjectType? fallbackMetaverseObjectType = null)
+    {
+        ArgumentNullException.ThrowIfNull(proposal);
+        ArgumentNullException.ThrowIfNull(connectedSystemAttributes);
+        ArgumentNullException.ThrowIfNull(metaverseAttributes);
+        ArgumentNullException.ThrowIfNull(metaverseObjectTypes);
+
+        var metaverseObjectType = proposal.MetaverseObjectTypeId is { } typeId
+            ? metaverseObjectTypes.GetValueOrDefault(typeId)
+            : null;
+        metaverseObjectType ??= fallbackMetaverseObjectType;
+
+        var rule = new ObjectMatchingRule
+        {
+            Order = proposal.Order,
+            ConnectedSystemObjectTypeId = proposal.ConnectedSystemObjectTypeId,
+            SyncRuleId = proposal.SyncRuleId,
+            CaseSensitive = proposal.CaseSensitive,
+            MetaverseObjectTypeId = metaverseObjectType?.Id,
+            MetaverseObjectType = metaverseObjectType,
+            TargetMetaverseAttributeId = proposal.TargetMetaverseAttributeId,
+            TargetMetaverseAttribute = proposal.TargetMetaverseAttributeId is { } targetId
+                ? metaverseAttributes.GetValueOrDefault(targetId)
+                : null,
+            Sources = [.. proposal.Sources.OrderBy(source => source.Order).Select(source => new ObjectMatchingRuleSource
+            {
+                Order = source.Order,
+                Expression = source.Expression,
+                ConnectedSystemAttributeId = source.ConnectedSystemAttributeId,
+                ConnectedSystemAttribute = source.ConnectedSystemAttributeId is { } sourceId
+                    ? connectedSystemAttributes.GetValueOrDefault(sourceId)
+                    : null
+            })]
+        };
+
+        return rule;
+    }
+}

--- a/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
+++ b/src/JIM.Data/Repositories/IConnectedSystemRepository.cs
@@ -1087,6 +1087,24 @@ public interface IConnectedSystemRepository
     public Task<int> GetConnectedSystemObjectCountOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId);
 
     /// <summary>
+    /// The identifiers of a Connected System's live, unjoined objects of one type: the population a
+    /// synchronisation would put to Object Matching on its next run.
+    /// </summary>
+    /// <remarks>
+    /// Identifiers rather than objects, and a list rather than a stream, because the caller queries the database
+    /// per object it evaluates. Holding a result-set reader open across those queries is what Npgsql refuses (one
+    /// command per connection), so the population is read once and the objects are fetched in batches behind it.
+    /// </remarks>
+    public Task<List<Guid>> GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId);
+
+    /// <summary>
+    /// How many live, unjoined objects of one type a Connected System holds. The count behind
+    /// <see cref="GetUnjoinedConnectedSystemObjectIdsOfTypeAsync"/>, for callers that need the size before
+    /// deciding whether to read the population at all.
+    /// </summary>
+    public Task<int> GetUnjoinedConnectedSystemObjectCountOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId);
+
+    /// <summary>
     /// Returns the count of joined Connected System Objects of one type in a Connected System: the population a
     /// destructive Synchronisation Rule toggle preview walks, counted set-based for the dispatch decision (#1115).
     /// </summary>

--- a/src/JIM.Models/Activities/ActivityEnums.cs
+++ b/src/JIM.Models/Activities/ActivityEnums.cs
@@ -177,7 +177,38 @@ public enum ActivityRunProfileExecutionItemSyncOutcomeType
     /// be indistinguishable from the ones the edit does not touch. Only failures the proposal introduces are
     /// counted; one the stored configuration already has is not this change's doing.
     /// </summary>
-    WouldFailAttributeFlow
+    WouldFailAttributeFlow,
+
+    /// <summary>
+    /// Preview only (#1457): the Connected System Object joins to one Metaverse Object under the stored Object
+    /// Matching Rules and would join to a different one under the proposal. The most dangerous transition a
+    /// matching change can produce, because nothing about it fails: the account simply becomes part of the wrong
+    /// identity, and every attribute it contributes goes with it. The old and new values name the two Metaverse
+    /// Objects.
+    /// </summary>
+    WouldJoinDifferentMetaverseObject,
+
+    /// <summary>
+    /// Preview only (#1457): the Connected System Object matches nothing today, so its next synchronisation would
+    /// project a new Metaverse Object for it, and under the proposal it would join an existing one instead. The
+    /// benign direction of a matching change, and the one an administrator widening a rule is usually aiming for.
+    /// </summary>
+    WouldJoinInsteadOfProject,
+
+    /// <summary>
+    /// Preview only (#1457): the inverse, and a duplicate-identity risk. The Connected System Object matches a
+    /// Metaverse Object today and would match nothing under the proposal, so its next synchronisation would project
+    /// a second Metaverse Object beside the one it should have joined.
+    /// </summary>
+    WouldProjectInsteadOfJoin,
+
+    /// <summary>
+    /// Preview only (#1457): the proposed Object Matching Rules match more than one Metaverse Object for this
+    /// object, so its next synchronisation fails it with an ambiguous match rather than joining it to anything. Its
+    /// own transition rather than a validation finding, because ambiguity is a property of the data and not of the
+    /// rule: a rule that is unique across every object but two is invisible until those two are counted.
+    /// </summary>
+    WouldMatchAmbiguously
 }
 
 /// <summary>

--- a/src/JIM.Models/Preview/ConfigurationChangePreviewSurfaces.cs
+++ b/src/JIM.Models/Preview/ConfigurationChangePreviewSurfaces.cs
@@ -28,6 +28,7 @@ public static class ConfigurationChangePreviewSurfaces
         ConfigurationChangePreviewSurface.ConnectedSystem => ActivityTargetType.ConnectedSystem,
         ConfigurationChangePreviewSurface.MetaverseObjectType => ActivityTargetType.MetaverseObjectType,
         ConfigurationChangePreviewSurface.MetaverseAttribute => ActivityTargetType.MetaverseAttribute,
+        ConfigurationChangePreviewSurface.ObjectMatching => ActivityTargetType.ObjectMatchingRule,
         _ => throw new ArgumentOutOfRangeException(nameof(surface), surface,
             "Preview surface has no Activity target type. Add it here when adding the surface.")
     };

--- a/src/JIM.Models/Preview/ObjectMatchingProposal.cs
+++ b/src/JIM.Models/Preview/ObjectMatchingProposal.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Globalization;
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Staging;
+
+namespace JIM.Models.Preview;
+
+/// <summary>
+/// The Object Matching configuration an administrator is proposing for a Connected System (#1457): which Metaverse
+/// Object each of its unjoined objects would join to.
+///
+/// The proposal covers both places matching rules live and the switch between them, because they are one decision.
+/// In Simple mode the rules belong to a Connected System Object Type and serve every Synchronisation Rule of that
+/// type; in Advanced mode each Synchronisation Rule carries its own. Flipping
+/// <see cref="ConnectedSystem.ObjectMatchingRuleMode"/> changes which set applies without editing a single rule, so
+/// a proposal that carried only rules could not describe it.
+/// </summary>
+/// <remarks>
+/// A dedicated shape rather than the entity graph, for the reasons every proposal has one: a proposal may be
+/// evaluated in JIM.Worker, so it has to survive a JSON round trip, and <see cref="ObjectMatchingRule"/> carries
+/// whole attribute entities and a backlink to its parent. Whatever materialises a proposal back into rules must
+/// resolve the ids into entities, because the matching query reads the attribute entities themselves.
+/// </remarks>
+/// <param name="Mode">Which set of rules applies: the object type's (Simple) or each rule's own (Advanced).</param>
+/// <param name="Rules">
+/// Every proposed rule across the Connected System, each naming its own parent. Held flat rather than grouped by
+/// parent so that a rule moving between parents is one list, not a diff of two.
+/// </param>
+public record ObjectMatchingProposal(
+    ObjectMatchingRuleMode Mode,
+    IReadOnlyList<ObjectMatchingRuleProposal> Rules)
+{
+    /// <summary>
+    /// The matching configuration currently in force on <paramref name="connectedSystem"/>, as a proposal. What
+    /// "no change" looks like, and the baseline an adapter evaluates a proposal against.
+    /// </summary>
+    /// <param name="connectedSystem">The Connected System whose mode is read.</param>
+    /// <param name="objectTypes">Its object types, carrying the Simple mode rules.</param>
+    /// <param name="syncRules">Its Synchronisation Rules, carrying the Advanced mode rules.</param>
+    public static ObjectMatchingProposal FromCurrentConfiguration(
+        ConnectedSystem connectedSystem,
+        IReadOnlyCollection<ConnectedSystemObjectType> objectTypes,
+        IReadOnlyCollection<SyncRule> syncRules)
+    {
+        ArgumentNullException.ThrowIfNull(connectedSystem);
+        ArgumentNullException.ThrowIfNull(objectTypes);
+        ArgumentNullException.ThrowIfNull(syncRules);
+
+        // Both sets are carried regardless of the mode in force. A preview of a mode switch has to state what the
+        // rules being switched to would do, and they are only readable if they were loaded.
+        var rules = objectTypes
+            .SelectMany(objectType => objectType.ObjectMatchingRules ?? [])
+            .Concat(syncRules.SelectMany(syncRule => syncRule.ObjectMatchingRules))
+            .Select(ObjectMatchingRuleProposal.FromRule)
+            .ToList();
+
+        return new ObjectMatchingProposal(connectedSystem.ObjectMatchingRuleMode, rules);
+    }
+
+    /// <summary>
+    /// The rules that would be evaluated for an object of <paramref name="connectedSystemObjectTypeId"/>, in
+    /// evaluation order: the object type's rules in Simple mode, the named Synchronisation Rule's in Advanced.
+    /// </summary>
+    /// <remarks>
+    /// Ordered rather than merely filtered because matching stops at the first rule that matches. A caller that
+    /// evaluated them in list order would answer a question about a configuration nobody has.
+    /// </remarks>
+    public IEnumerable<ObjectMatchingRuleProposal> RulesFor(int? connectedSystemObjectTypeId, int? syncRuleId) =>
+        (Mode == ObjectMatchingRuleMode.ConnectedSystem
+            ? Rules.Where(rule => rule.ConnectedSystemObjectTypeId == connectedSystemObjectTypeId)
+            : Rules.Where(rule => syncRuleId != null && rule.SyncRuleId == syncRuleId))
+        .OrderBy(rule => rule.Order);
+
+    /// <summary>
+    /// Whether <paramref name="other"/> proposes the same matching as this one. What decides whether a preview an
+    /// administrator is looking at still answers the question they are about to ask.
+    /// </summary>
+    /// <remarks>
+    /// Not the record's own equality: the nested lists compare by reference, so an editor rebuilding its proposal
+    /// on every render would report a change that never happened. Order-SENSITIVE at both levels, unlike the
+    /// Scoping Criteria proposal: rules are evaluated in ascending order until one matches, and a rule's sources
+    /// likewise, so moving one above another changes which Metaverse Object an account joins to.
+    /// </remarks>
+    public bool DescribesSameMatchingAs(ObjectMatchingProposal? other) =>
+        other is not null && CanonicalKey() == other.CanonicalKey();
+
+    private string CanonicalKey() =>
+        $"{Mode}|{string.Join("|", Rules.OrderBy(rule => rule.Order).ThenBy(rule => rule.CanonicalKey(), StringComparer.Ordinal).Select(rule => rule.CanonicalKey()))}";
+}
+
+/// <summary>
+/// One proposed Object Matching Rule: where it lives, what it searches, and what it compares.
+/// </summary>
+/// <param name="Order">Where this rule sits in the cascade; rules are evaluated in ascending order until one matches.</param>
+/// <param name="ConnectedSystemObjectTypeId">The Connected System Object Type owning this rule in Simple mode.</param>
+/// <param name="SyncRuleId">The Synchronisation Rule owning this rule in Advanced mode.</param>
+/// <param name="MetaverseObjectTypeId">
+/// The Metaverse Object Type searched. Required in Simple mode; in Advanced mode the owning Synchronisation Rule's
+/// own type is used, and a rule with neither matches nothing at all.
+/// </param>
+/// <param name="TargetMetaverseAttributeId">The Metaverse Attribute the source values are compared against.</param>
+/// <param name="CaseSensitive">Whether text comparison respects case.</param>
+/// <param name="Sources">What supplies the value to match on, in evaluation order.</param>
+public record ObjectMatchingRuleProposal(
+    int Order,
+    int? ConnectedSystemObjectTypeId,
+    int? SyncRuleId,
+    int? MetaverseObjectTypeId,
+    int? TargetMetaverseAttributeId,
+    bool CaseSensitive,
+    IReadOnlyList<ObjectMatchingRuleSourceProposal> Sources)
+{
+    /// <summary>
+    /// This rule as it currently stands, or as the editor has just built it.
+    /// </summary>
+    public static ObjectMatchingRuleProposal FromRule(ObjectMatchingRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+
+        // Each id falls back to its navigation property's id: the editor builds an UNSAVED rule when an
+        // administrator adds one, so the navigation is set and the foreign key stays unassigned until the
+        // Connected System is saved. Reading the key alone made a rule the editor plainly shows read as naming no
+        // attribute, which the preview reports as a blocking finding (#1450).
+        return new ObjectMatchingRuleProposal(
+            rule.Order,
+            rule.ConnectedSystemObjectTypeId ?? rule.ConnectedSystemObjectType?.Id,
+            rule.SyncRuleId ?? rule.SyncRule?.Id,
+            rule.MetaverseObjectTypeId ?? rule.MetaverseObjectType?.Id,
+            rule.TargetMetaverseAttributeId ?? rule.TargetMetaverseAttribute?.Id,
+            rule.CaseSensitive,
+            [.. rule.Sources.OrderBy(source => source.Order).Select(ObjectMatchingRuleSourceProposal.FromSource)]);
+    }
+
+    internal string CanonicalKey() =>
+        string.Create(CultureInfo.InvariantCulture,
+            $"o={Order};cst={ConnectedSystemObjectTypeId};sr={SyncRuleId};mvt={MetaverseObjectTypeId};" +
+            $"tgt={TargetMetaverseAttributeId};cse={CaseSensitive};" +
+            $"src=[{string.Join(",", Sources.Select(source => source.CanonicalKey()))}]");
+}
+
+/// <summary>
+/// One proposed source of the value a rule matches on: a Connected System attribute, or an expression.
+/// </summary>
+/// <param name="Order">Where this source sits; sources are evaluated in ascending order.</param>
+/// <param name="ConnectedSystemAttributeId">The Connected System attribute read.</param>
+/// <param name="Expression">
+/// An expression producing the value instead. Carried because the model allows it, and refused by the preview's
+/// validation: the matching query reads attributes only, and an expression source fails at match time (#207).
+/// </param>
+public record ObjectMatchingRuleSourceProposal(
+    int Order,
+    int? ConnectedSystemAttributeId,
+    string? Expression = null)
+{
+    /// <summary>
+    /// This source as it currently stands, or as the editor has just built it.
+    /// </summary>
+    public static ObjectMatchingRuleSourceProposal FromSource(ObjectMatchingRuleSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return new ObjectMatchingRuleSourceProposal(
+            source.Order,
+            source.ConnectedSystemAttributeId ?? source.ConnectedSystemAttribute?.Id,
+            source.Expression);
+    }
+
+    internal string CanonicalKey() =>
+        string.Create(CultureInfo.InvariantCulture, $"o={Order};cs={ConnectedSystemAttributeId};e={Expression}");
+}

--- a/src/JIM.Models/Preview/PreviewEnums.cs
+++ b/src/JIM.Models/Preview/PreviewEnums.cs
@@ -60,7 +60,18 @@ public enum ConfigurationChangePreviewSurface
     /// A Synchronisation Rule's Attribute Flow mappings: what the objects it manages would have written to them
     /// (#827 gap G2).
     /// </summary>
-    SynchronisationRuleAttributeFlow = 6
+    SynchronisationRuleAttributeFlow = 6,
+
+    /// <summary>
+    /// A Connected System's Object Matching configuration: the rules that decide which Metaverse Object each of its
+    /// unjoined objects joins to, in both Simple and Advanced modes, and the switch between them (#827 gap G1).
+    /// </summary>
+    /// <remarks>
+    /// One surface across both modes, because they answer the same question from the same data and an administrator
+    /// switching between them is making a matching change like any other. Splitting them by owning entity would
+    /// have made the mode switch previewable by neither adapter.
+    /// </remarks>
+    ObjectMatching = 7
 }
 
 /// <summary>

--- a/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
+++ b/src/JIM.PostgresData/Repositories/ConnectedSystemRepository.cs
@@ -2828,6 +2828,33 @@ public class ConnectedSystemRepository : IConnectedSystemRepository
     }
 
     /// <inheritdoc />
+    public async Task<List<Guid>> GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId)
+    {
+        return await UnjoinedOfType(connectedSystemId, connectedSystemObjectTypeId)
+            .OrderBy(cso => cso.Id)
+            .Select(cso => cso.Id)
+            .ToListAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetUnjoinedConnectedSystemObjectCountOfTypeAsync(int connectedSystemId, int connectedSystemObjectTypeId)
+    {
+        return await UnjoinedOfType(connectedSystemId, connectedSystemObjectTypeId).CountAsync();
+    }
+
+    /// <summary>
+    /// The live, unjoined objects of one type: what a synchronisation would put to Object Matching. Obsolete
+    /// objects are excluded because a synchronisation never reaches the join step for them.
+    /// </summary>
+    private IQueryable<ConnectedSystemObject> UnjoinedOfType(int connectedSystemId, int connectedSystemObjectTypeId) =>
+        Repository.Database.ConnectedSystemObjects
+            .AsNoTracking()
+            .Where(cso => cso.ConnectedSystemId == connectedSystemId &&
+                          cso.TypeId == connectedSystemObjectTypeId &&
+                          cso.MetaverseObjectId == null &&
+                          cso.Status == ConnectedSystemObjectStatus.Normal);
+
+    /// <inheritdoc />
     public async Task<int> GetJoinedConnectedSystemObjectCountAsync(int connectedSystemId, int connectedSystemObjectTypeId)
     {
         return await Repository.Database.ConnectedSystemObjects

--- a/src/JIM.PowerShell/Public/Previews/New-JIMConfigurationChangePreview.ps1
+++ b/src/JIM.PowerShell/Public/Previews/New-JIMConfigurationChangePreview.ps1
@@ -10,7 +10,7 @@ function New-JIMConfigurationChangePreview {
         Starts a Configuration Change Preview: JIM evaluates a proposed change against the objects
         already in the metaverse and reports what would happen to them, changing nothing.
 
-        Three surfaces can be previewed, selected by which identifier you pass:
+        Several surfaces can be previewed, selected by which identifier and proposal you pass:
 
         - -MetaverseObjectTypeId previews a change to that type's deletion settings. The field semantics
           match Set-JIMMetaverseObjectType exactly, so an omitted parameter previews the stored value.
@@ -28,6 +28,11 @@ function New-JIMConfigurationChangePreview {
           objects it would manage at all, and what each movement in or out of scope would cost.
         - -SyncRuleId with -AttributeFlowMapping previews a change to that rule's Attribute Flow: what
           value every object it manages would end up with, per attribute.
+        - -ConnectedSystemId with -MatchingRule previews a change to that system's Object Matching Rules:
+          which of its unjoined objects would join a different Metaverse Object, join instead of projecting
+          a new identity, project instead of joining, or match ambiguously and fail. Add
+          -ObjectMatchingRuleMode to preview the Simple/Advanced switch. Objects already joined are never
+          re-matched, so no matching change can move them, and the preview says so.
 
         Evaluation is asynchronous. Without -Wait this returns as soon as the proposal itself has been
         validated, carrying the ActivityId to poll with Get-JIMConfigurationChangePreview. With -Wait it
@@ -257,6 +262,29 @@ function New-JIMConfigurationChangePreview {
         Applies the tightened Out-of-Scope Action only when the preview found no object would be
         disconnected by it today, and records the preview against the change.
 
+    .EXAMPLE
+        $rules = @(
+            @{
+                order                      = 0
+                connectedSystemObjectTypeId = 9
+                metaverseObjectTypeId       = 3
+                targetMetaverseAttributeId  = 201
+                caseSensitive               = $false
+                sources                     = @(@{ order = 0; connectedSystemAttributeId = 102 })
+            }
+        )
+        $preview = New-JIMConfigurationChangePreview -ConnectedSystemId 5 -MatchingRule $rules -Wait
+        $preview.ImpactCounts | Where-Object transitionType -eq 'WouldJoinDifferentMetaverseObject'
+
+        Previews matching on a different attribute and reports how many accounts would end up on a
+        different identity, which is the count that decides whether the rule is safe to save.
+
+    .EXAMPLE
+        New-JIMConfigurationChangePreview -ConnectedSystemId 5 -MatchingRule @() -Wait
+
+        Previews removing every Object Matching Rule: nothing would join, and every unjoined object would
+        project a new identity instead.
+
     .LINK
         Get-JIMConfigurationChangePreview
         Get-JIMConfigurationChangePreviewDelta
@@ -265,6 +293,7 @@ function New-JIMConfigurationChangePreview {
         Set-JIMConnectedSystemPartition
         Set-JIMConnectedSystemContainer
         Set-JIMSyncRule
+        Set-JIMMatchingRule
     #>
     [CmdletBinding(DefaultParameterSetName = 'MetaverseObjectTypeDeletionSettings')]
     [OutputType([PSCustomObject])]
@@ -287,6 +316,7 @@ function New-JIMConfigurationChangePreview {
         [string]$DeletionTriggerMode,
 
         [Parameter(Mandatory, ParameterSetName = 'ConnectedSystemScopeSelection', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ObjectMatching', ValueFromPipelineByPropertyName)]
         [int]$ConnectedSystemId,
 
         [Parameter(ParameterSetName = 'ConnectedSystemScopeSelection')]
@@ -319,6 +349,14 @@ function New-JIMConfigurationChangePreview {
         [Parameter(Mandatory, ParameterSetName = 'SyncRuleAttributeFlow')]
         [AllowEmptyCollection()]
         [hashtable[]]$AttributeFlowMapping,
+
+        [Parameter(Mandatory, ParameterSetName = 'ObjectMatching')]
+        [AllowEmptyCollection()]
+        [hashtable[]]$MatchingRule,
+
+        [Parameter(ParameterSetName = 'ObjectMatching')]
+        [ValidateSet('ConnectedSystem', 'SyncRule')]
+        [string]$ObjectMatchingRuleMode,
 
         [Parameter()]
         [switch]$FullDataSet,
@@ -400,6 +438,20 @@ function New-JIMConfigurationChangePreview {
             $body.mappings = @($AttributeFlowMapping)
         }
 
+        if ($PSCmdlet.ParameterSetName -eq 'ObjectMatching') {
+            # Always sent, including as an empty array, for the same reason as the mappings above: omitting the
+            # field previews the Connected System's stored rules, while an empty array proposes removing every one
+            # of them, leaving nothing able to join. Wrapped in @() so a single rule serialises as a JSON array
+            # rather than a bare object.
+            $body.rules = @($MatchingRule)
+
+            # The mode is only sent when the caller is changing it; omitted, the preview keeps the stored mode, so
+            # a caller editing rules alone does not have to restate which mode they are in.
+            if ($ObjectMatchingRuleMode) {
+                $body.mode = $ObjectMatchingRuleMode
+            }
+        }
+
         if ($FullDataSet) {
             $body.deltaPersistence = 'Full'
         }
@@ -419,6 +471,10 @@ function New-JIMConfigurationChangePreview {
         elseif ($PSCmdlet.ParameterSetName -eq 'SyncRuleAttributeFlow') {
             $endpoint = "/api/v1/synchronisation/sync-rules/$SyncRuleId/mappings/preview"
             $subject = "Synchronisation Rule $SyncRuleId"
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq 'ObjectMatching') {
+            $endpoint = "/api/v1/synchronisation/connected-systems/$ConnectedSystemId/matching-rules/preview"
+            $subject = "Connected System $ConnectedSystemId"
         }
         else {
             $endpoint = "/api/v1/metaverse/object-types/$MetaverseObjectTypeId/deletion-settings/preview"

--- a/src/JIM.PowerShell/Tests/ConfigurationChangePreviews.Tests.ps1
+++ b/src/JIM.PowerShell/Tests/ConfigurationChangePreviews.Tests.ps1
@@ -382,6 +382,91 @@ Describe 'New-JIMConfigurationChangePreview' {
         }
     }
 
+    Context 'Object Matching previews' {
+        It 'Posts the proposed rules to the Object Matching preview endpoint' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                $script:capturedBody = $null
+                $script:capturedEndpoint = $null
+                Mock Invoke-JIMApi {
+                    $script:capturedBody = $Body
+                    $script:capturedEndpoint = $Endpoint
+                    [PSCustomObject]@{ ActivityId = [guid]::NewGuid(); IsBlocked = $false; Failed = $false; ValidationFindings = @() }
+                }
+
+                $rule = @{
+                    Order = 2
+                    ConnectedSystemObjectTypeId = 9
+                    MetaverseObjectTypeId = 3
+                    TargetMetaverseAttributeId = 201
+                    CaseSensitive = $true
+                    Sources = @(
+                        @{ Order = 0; ConnectedSystemAttributeId = 101 }
+                    )
+                }
+                New-JIMConfigurationChangePreview -ConnectedSystemId 5 -MatchingRule $rule | Out-Null
+
+                $script:capturedEndpoint | Should -Be '/api/v1/synchronisation/connected-systems/5/matching-rules/preview'
+                $script:capturedBody.rules.Count | Should -Be 1
+                # Order and case sensitivity each decide which identity an account joins to, so both have to
+                # reach the API rather than being dropped as decoration.
+                $script:capturedBody.rules[0].Order | Should -Be 2
+                $script:capturedBody.rules[0].CaseSensitive | Should -BeTrue
+                $script:capturedBody.rules[0].Sources[0].ConnectedSystemAttributeId | Should -Be 101
+            }
+        }
+
+        It 'Sends an empty array as an empty array, because that proposes a system that joins nothing' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                $script:capturedBody = $null
+                Mock Invoke-JIMApi {
+                    $script:capturedBody = $Body
+                    [PSCustomObject]@{ ActivityId = [guid]::NewGuid(); IsBlocked = $false; Failed = $false; ValidationFindings = @() }
+                }
+
+                New-JIMConfigurationChangePreview -ConnectedSystemId 5 -MatchingRule @() | Out-Null
+
+                # Omitting the field would preview the stored rules; an empty array is the opposite question.
+                $script:capturedBody.ContainsKey('rules') | Should -BeTrue
+                @($script:capturedBody.rules).Count | Should -Be 0
+            }
+        }
+
+        It 'Sends the mode only when the caller is changing it' {
+            InModuleScope JIM {
+                $script:JIMConnection = [PSCustomObject]@{ Url = 'https://jim.example.com'; AuthMethod = 'ApiKey' }
+                $script:capturedBody = $null
+                Mock Invoke-JIMApi {
+                    $script:capturedBody = $Body
+                    [PSCustomObject]@{ ActivityId = [guid]::NewGuid(); IsBlocked = $false; Failed = $false; ValidationFindings = @() }
+                }
+
+                New-JIMConfigurationChangePreview -ConnectedSystemId 5 -MatchingRule @() | Out-Null
+                $script:capturedBody.ContainsKey('mode') | Should -BeFalse
+
+                New-JIMConfigurationChangePreview -ConnectedSystemId 5 -MatchingRule @() -ObjectMatchingRuleMode SyncRule | Out-Null
+                $script:capturedBody.mode | Should -BeExactly 'SyncRule'
+            }
+        }
+
+        It 'Requires the rules to be stated rather than inferred from silence' {
+            $parameter = (Get-Command New-JIMConfigurationChangePreview).Parameters['MatchingRule']
+            $mandatory = $parameter.Attributes | Where-Object {
+                $_ -is [System.Management.Automation.ParameterAttribute] -and
+                $_.ParameterSetName -eq 'ObjectMatching'
+            }
+            $mandatory.Mandatory | Should -BeTrue
+        }
+
+        It 'Allows the empty collection its mandatory parameter would otherwise reject' {
+            $parameter = (Get-Command New-JIMConfigurationChangePreview).Parameters['MatchingRule']
+            ($parameter.Attributes | Where-Object {
+                $_ -is [System.Management.Automation.AllowEmptyCollectionAttribute]
+            }) | Should -Not -BeNullOrEmpty
+        }
+    }
+
     Context 'Waiting' {
         It 'Returns the start result without polling when the proposal is blocked' {
             InModuleScope JIM {

--- a/src/JIM.Web/Causality/OutcomeDisplayMap.cs
+++ b/src/JIM.Web/Causality/OutcomeDisplayMap.cs
@@ -125,7 +125,23 @@ public static class OutcomeDisplayMap
                 "have their scope-exit action changed"),
         [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] =
             new OutcomeDisplay("Attribute Flow does not evaluate", "Would Fail Attribute Flow", CausalityTone.Error, Icons.Material.Filled.RuleFolder,
-                "have an Attribute Flow that would not evaluate")
+                "have an Attribute Flow that would not evaluate"),
+        // The Object Matching preview's fates (#1457). Error tone on joining a different Metaverse Object and on
+        // projecting instead of joining, because both are identity corruption that nothing reports at run time:
+        // one merges an account into the wrong identity, the other splits one identity into two. Ambiguity is a
+        // Warning because the next synchronisation refuses the object loudly rather than joining it wrongly.
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject] =
+            new OutcomeDisplay("Joins a different Metaverse Object", "Would Join Different Metaverse Object", CausalityTone.Error, Icons.Material.Filled.SwapHoriz,
+                "join a different Metaverse Object"),
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject] =
+            new OutcomeDisplay("Joins instead of projecting", "Would Join Instead Of Project", CausalityTone.Success, Icons.Material.Filled.Link,
+                "join an existing Metaverse Object instead of projecting a new one"),
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin] =
+            new OutcomeDisplay("Projects instead of joining", "Would Project Instead Of Join", CausalityTone.Error, Icons.Material.Filled.CallSplit,
+                "project a new Metaverse Object instead of joining an existing one"),
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously] =
+            new OutcomeDisplay("Matches more than one Metaverse Object", "Would Match Ambiguously", CausalityTone.Warning, Icons.Material.Filled.QuestionMark,
+                "match more than one Metaverse Object")
     };
 
     /// <summary>

--- a/src/JIM.Web/Controllers/Api/SynchronisationController.cs
+++ b/src/JIM.Web/Controllers/Api/SynchronisationController.cs
@@ -4251,6 +4251,80 @@ public class SynchronisationController(
     }
 
     /// <summary>
+    /// Preview an Object Matching change
+    /// </summary>
+    /// <remarks>
+    /// Answers what changing a Connected System's Object Matching Rules would do before anything is saved: which
+    /// of its unjoined objects would join a different Metaverse Object, which would join instead of projecting a
+    /// new identity, which would project instead of joining, and which would match ambiguously and fail.
+    ///
+    /// This matters because none of those outcomes fails at synchronisation time. A rule matched too loosely
+    /// merges an account into the wrong identity and takes every value it contributes with it; a rule matched too
+    /// tightly projects a duplicate identity beside the right one. Both look like a successful run.
+    ///
+    /// The evaluation is the matching engine's own, run twice per object (once against the stored rules, once
+    /// against the proposal) and diffed, so a match is the engine's answer rather than this endpoint's reading of
+    /// the configuration.
+    ///
+    /// Only objects that are not already joined to a Metaverse Object are evaluated, because only they are ever
+    /// matched again. A Connected System Object already joined keeps the Metaverse Object it has, whatever this
+    /// change does.
+    ///
+    /// Omitting `mode` previews the Connected System's stored mode, and omitting `rules` previews its stored
+    /// rules, matching the update endpoints' semantics. Sending an EMPTY `rules` array is a real proposal: it
+    /// removes every rule, so nothing would ever join.
+    ///
+    /// Evaluation is asynchronous. This returns as soon as the proposal itself has been validated, with the
+    /// Activity id to poll; read progress and results from `GET /previews/{activityId}`, drill-down rows from
+    /// `GET /previews/{activityId}/deltas`, and abandon a running preview with `DELETE /previews/{activityId}`.
+    /// </remarks>
+    /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>
+    /// <param name="request">The proposed Object Matching configuration.</param>
+    /// <response code="202">The preview was started. Poll the returned Activity id for results.</response>
+    /// <response code="404">Connected System not found.</response>
+    /// <response code="401">User not authenticated.</response>
+    [HttpPost("connected-systems/{connectedSystemId:int}/matching-rules/preview", Name = "StartObjectMatchingPreview")]
+    [ProducesResponseType(typeof(ConfigurationChangePreviewStartResponse), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> StartObjectMatchingPreviewAsync(int connectedSystemId,
+        [FromBody] StartObjectMatchingPreviewRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var connectedSystem = await _application.ConnectedSystems.GetConnectedSystemAsync(connectedSystemId);
+        if (connectedSystem == null)
+            return NotFound(ApiErrorResponse.NotFound($"Connected System with ID {connectedSystemId} not found."));
+
+        var objectTypes = await _application.ConnectedSystems.GetObjectTypesAsync(connectedSystemId);
+        var syncRules = await _application.ConnectedSystems.GetSyncRulesAsync(connectedSystemId, false);
+        var proposal = request.ToProposal(connectedSystem, objectTypes, syncRules);
+
+        var apiKey = await GetCurrentApiKeyAsync();
+        var user = apiKey == null ? await GetCurrentUserAsync() : null;
+
+        var previewRequest = new ConfigurationChangePreviewRequest
+        {
+            Surface = ConfigurationChangePreviewSurface.ObjectMatching,
+            TargetId = connectedSystem.Id,
+            TargetName = connectedSystem.Name,
+            ProposedConfiguration = proposal,
+            DeltaPersistence = request.DeltaPersistence,
+            InitiatedByType = apiKey != null ? ActivityInitiatorType.ApiKey : ActivityInitiatorType.User,
+            InitiatedById = apiKey?.Id ?? user?.Id,
+            InitiatedByName = apiKey?.Name ?? user?.Name
+        };
+
+        var result = await _application.ConfigurationChangePreviews.StartAndDispatchPreviewAsync(previewRequest);
+
+        _logger.LogInformation("Started Object Matching preview {ActivityId} for Connected System {Id}",
+            result.ActivityId, connectedSystem.Id);
+
+        return AcceptedAtRoute("GetConfigurationChangePreview", new { activityId = result.ActivityId },
+            ConfigurationChangePreviewStartResponse.FromResult(result));
+    }
+
+    /// <summary>
     /// Create an Object Matching Rule
     /// </summary>
     /// <param name="connectedSystemId">The unique identifier of the Connected System.</param>

--- a/src/JIM.Web/Models/Api/StartObjectMatchingPreviewRequest.cs
+++ b/src/JIM.Web/Models/Api/StartObjectMatchingPreviewRequest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Models.Core;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+
+namespace JIM.Web.Models.Api;
+
+/// <summary>
+/// The Object Matching configuration to preview (#1457): which Metaverse Object each of a Connected System's
+/// unjoined objects would join to, before anything is saved.
+/// </summary>
+public class StartObjectMatchingPreviewRequest
+{
+    /// <summary>
+    /// The proposed matching mode. Omitted or null previews the Connected System's stored mode, so a caller
+    /// changing only the rules does not have to restate it. Sending a different mode is a real proposal: it
+    /// changes which rules apply without editing a single rule.
+    /// </summary>
+    public ObjectMatchingRuleMode? Mode { get; set; }
+
+    /// <summary>
+    /// The proposed rules, across both modes.
+    ///
+    /// Omitted or null previews the Connected System's stored rules, matching the update endpoints' semantics: a
+    /// caller proposing nothing is proposing no change, and the preview says so rather than inventing one. An
+    /// explicitly EMPTY array is a real proposal and a very different one: it removes every rule, so nothing would
+    /// ever join and every unjoined object would project a new identity instead.
+    /// </summary>
+    public List<ObjectMatchingRuleRequest>? Rules { get; set; }
+
+    /// <summary>
+    /// Whether drill-down rows are kept in full or capped per summary group. Counts are exact either way; capping
+    /// bounds only what is retained for drill-down. Defaults to Capped, the recommended choice for large
+    /// populations.
+    /// </summary>
+    public ConfigurationChangePreviewDeltaPersistence DeltaPersistence { get; set; } =
+        ConfigurationChangePreviewDeltaPersistence.Capped;
+
+    /// <summary>
+    /// The proposal this request describes, falling back to the Connected System's stored configuration for
+    /// whatever the caller left out.
+    /// </summary>
+    /// <param name="connectedSystem">The Connected System being previewed.</param>
+    /// <param name="objectTypes">Its object types, carrying the Simple mode rules.</param>
+    /// <param name="syncRules">Its Synchronisation Rules, carrying the Advanced mode rules.</param>
+    public ObjectMatchingProposal ToProposal(
+        ConnectedSystem connectedSystem,
+        IReadOnlyCollection<ConnectedSystemObjectType> objectTypes,
+        IReadOnlyCollection<SyncRule> syncRules)
+    {
+        ArgumentNullException.ThrowIfNull(connectedSystem);
+
+        var stored = ObjectMatchingProposal.FromCurrentConfiguration(connectedSystem, objectTypes, syncRules);
+
+        return new ObjectMatchingProposal(
+            Mode ?? stored.Mode,
+            Rules == null ? stored.Rules : [.. Rules.Select(rule => rule.ToProposal())]);
+    }
+}
+
+/// <summary>
+/// One proposed Object Matching Rule: where it lives, what it searches, and what it compares.
+/// </summary>
+/// <remarks>
+/// Exactly one of the two owner ids is set, and which one depends on the mode being proposed: a Simple mode rule
+/// belongs to a Connected System Object Type, an Advanced mode rule to a Synchronisation Rule. A rule owned by the
+/// side the proposed mode does not use is simply never evaluated, which the preview reports rather than working
+/// around.
+/// </remarks>
+public class ObjectMatchingRuleRequest
+{
+    /// <summary>
+    /// Where this rule sits in the cascade. Load-bearing rather than presentational: rules are evaluated in
+    /// ascending order until one matches, so moving one above another changes which identity an account joins to.
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>The Connected System Object Type owning this rule in Simple mode.</summary>
+    public int? ConnectedSystemObjectTypeId { get; set; }
+
+    /// <summary>The Synchronisation Rule owning this rule in Advanced mode.</summary>
+    public int? SyncRuleId { get; set; }
+
+    /// <summary>
+    /// The Metaverse Object Type searched. Required in Simple mode; in Advanced mode the owning Synchronisation
+    /// Rule's own type is used.
+    /// </summary>
+    public int? MetaverseObjectTypeId { get; set; }
+
+    /// <summary>The Metaverse Attribute the source values are compared against.</summary>
+    public int? TargetMetaverseAttributeId { get; set; }
+
+    /// <summary>Whether text comparison respects case.</summary>
+    public bool CaseSensitive { get; set; }
+
+    /// <summary>What supplies the value to match on, in evaluation order.</summary>
+    public List<ObjectMatchingRuleSourceRequest> Sources { get; set; } = [];
+
+    internal ObjectMatchingRuleProposal ToProposal() =>
+        new(Order,
+            ConnectedSystemObjectTypeId,
+            SyncRuleId,
+            MetaverseObjectTypeId,
+            TargetMetaverseAttributeId,
+            CaseSensitive,
+            [.. Sources.Select(source => source.ToProposal())]);
+}
+
+/// <summary>
+/// One proposed source of the value a rule matches on.
+/// </summary>
+public class ObjectMatchingRuleSourceRequest
+{
+    /// <summary>Where this source sits; sources are evaluated in ascending order.</summary>
+    public int Order { get; set; }
+
+    /// <summary>The Connected System attribute read.</summary>
+    public int? ConnectedSystemAttributeId { get; set; }
+
+    /// <summary>
+    /// An Expression producing the value instead. Accepted because the model allows it and refused by the
+    /// preview's validation: Object Matching compares attribute values only.
+    /// </summary>
+    public string? Expression { get; set; }
+
+    internal ObjectMatchingRuleSourceProposal ToProposal() =>
+        new(Order, ConnectedSystemAttributeId, Expression);
+}

--- a/test/JIM.Models.Tests/Activities/SyncOutcomeTypeOrdinalTests.cs
+++ b/test/JIM.Models.Tests/Activities/SyncOutcomeTypeOrdinalTests.cs
@@ -69,7 +69,13 @@ public class SyncOutcomeTypeOrdinalTests
 
         // Synchronisation Rule Attribute Flow preview (#1437): the proposed mapping that would not evaluate at all,
         // so the attribute it targets is not written.
-        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] = 30
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] = 30,
+
+        // Object Matching preview (#1457): how a matching rule change moves an unjoined object's join.
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject] = 31,
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject] = 32,
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin] = 33,
+        [ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously] = 34
     };
 
     [Test]

--- a/test/JIM.Models.Tests/Preview/ObjectMatchingProposalTests.cs
+++ b/test/JIM.Models.Tests/Preview/ObjectMatchingProposalTests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using System.Collections.Generic;
+using System.Linq;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+using NUnit.Framework;
+
+namespace JIM.Models.Tests.Preview;
+
+/// <summary>
+/// The proposal an Object Matching preview is asked about (#1457): the matching rules an administrator has in the
+/// editor, not the ones the database holds.
+///
+/// Two properties carry the weight. The proposal must read an unsaved rule the editor has just built, where the
+/// foreign key is still unassigned and only the navigation property names the attribute (#1450); reading the key
+/// alone reports a rule the administrator can plainly see as naming nothing. And comparison must be
+/// order-SENSITIVE, unlike Scoping Criteria: matching rules are evaluated in ascending order until one matches, so
+/// dragging the second rule above the first changes which Metaverse Object an account joins to.
+/// </summary>
+[TestFixture]
+public class ObjectMatchingProposalTests
+{
+    private static ConnectedSystemObjectTypeAttribute EmployeeIdAttribute => new()
+        { Id = 101, Name = "employeeID", Type = AttributeDataType.Text };
+
+    private static MetaverseAttribute EmployeeIdMetaverseAttribute => new()
+        { Id = 201, Name = "Employee ID", Type = AttributeDataType.Text, AttributePlurality = AttributePlurality.SingleValued };
+
+    private static ObjectMatchingRule SavedRule(int order = 0, bool caseSensitive = false) => new()
+    {
+        Id = 1,
+        Order = order,
+        ConnectedSystemObjectTypeId = 9,
+        MetaverseObjectTypeId = 3,
+        TargetMetaverseAttributeId = 201,
+        CaseSensitive = caseSensitive,
+        Sources = [new ObjectMatchingRuleSource { Id = 1, Order = 0, ConnectedSystemAttributeId = 101 }]
+    };
+
+    [Test]
+    public void FromCurrentConfiguration_SimpleModeRules_AreReadFromTheObjectType()
+    {
+        var objectType = new ConnectedSystemObjectType { Id = 9, Name = "User", ObjectMatchingRules = [SavedRule()] };
+        var connectedSystem = new ConnectedSystem { Id = 5, Name = "HR", ObjectMatchingRuleMode = ObjectMatchingRuleMode.ConnectedSystem };
+
+        var proposal = ObjectMatchingProposal.FromCurrentConfiguration(connectedSystem, [objectType], []);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(proposal.Mode, Is.EqualTo(ObjectMatchingRuleMode.ConnectedSystem));
+            Assert.That(proposal.Rules, Has.Count.EqualTo(1));
+            Assert.That(proposal.Rules[0].ConnectedSystemObjectTypeId, Is.EqualTo(9));
+            Assert.That(proposal.Rules[0].TargetMetaverseAttributeId, Is.EqualTo(201));
+            Assert.That(proposal.Rules[0].Sources[0].ConnectedSystemAttributeId, Is.EqualTo(101));
+        }
+    }
+
+    [Test]
+    public void FromCurrentConfiguration_AdvancedModeRules_AreReadFromTheSynchronisationRules()
+    {
+        var rule = SavedRule();
+        rule.ConnectedSystemObjectTypeId = null;
+        rule.SyncRuleId = 42;
+        var syncRule = new SyncRule { Id = 42, Name = "HR Import", ObjectMatchingRules = [rule] };
+        var connectedSystem = new ConnectedSystem { Id = 5, Name = "HR", ObjectMatchingRuleMode = ObjectMatchingRuleMode.SyncRule };
+
+        var proposal = ObjectMatchingProposal.FromCurrentConfiguration(connectedSystem, [], [syncRule]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(proposal.Mode, Is.EqualTo(ObjectMatchingRuleMode.SyncRule));
+            Assert.That(proposal.Rules, Has.Count.EqualTo(1));
+            Assert.That(proposal.Rules[0].SyncRuleId, Is.EqualTo(42));
+            Assert.That(proposal.Rules[0].ConnectedSystemObjectTypeId, Is.Null);
+        }
+    }
+
+    [Test]
+    public void FromRule_UnsavedRule_ReadsIdsFromNavigationPropertiesWhenForeignKeysAreUnassigned()
+    {
+        // What the editor hands over the moment an administrator adds a rule: the entities are attached, the keys
+        // are still zero because nothing has been saved (#1450).
+        var unsaved = new ObjectMatchingRule
+        {
+            Order = 0,
+            ConnectedSystemObjectType = new ConnectedSystemObjectType { Id = 9, Name = "User" },
+            MetaverseObjectType = new MetaverseObjectType { Id = 3, Name = "Person" },
+            TargetMetaverseAttribute = EmployeeIdMetaverseAttribute,
+            Sources = [new ObjectMatchingRuleSource { Order = 0, ConnectedSystemAttribute = EmployeeIdAttribute }]
+        };
+
+        var proposal = ObjectMatchingRuleProposal.FromRule(unsaved);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(proposal.ConnectedSystemObjectTypeId, Is.EqualTo(9));
+            Assert.That(proposal.MetaverseObjectTypeId, Is.EqualTo(3));
+            Assert.That(proposal.TargetMetaverseAttributeId, Is.EqualTo(201));
+            Assert.That(proposal.Sources[0].ConnectedSystemAttributeId, Is.EqualTo(101));
+        }
+    }
+
+    [Test]
+    public void DescribesSameMatchingAs_IdenticalRulesRebuilt_ReportsNoChange()
+    {
+        var objectType = new ConnectedSystemObjectType { Id = 9, Name = "User", ObjectMatchingRules = [SavedRule()] };
+        var connectedSystem = new ConnectedSystem { Id = 5, Name = "HR", ObjectMatchingRuleMode = ObjectMatchingRuleMode.ConnectedSystem };
+
+        var stored = ObjectMatchingProposal.FromCurrentConfiguration(connectedSystem, [objectType], []);
+        var rebuilt = ObjectMatchingProposal.FromCurrentConfiguration(connectedSystem, [objectType], []);
+
+        Assert.That(stored.DescribesSameMatchingAs(rebuilt), Is.True);
+    }
+
+    [Test]
+    public void DescribesSameMatchingAs_RulesReordered_ReportsAChange()
+    {
+        // Order decides which rule wins, so reordering is a real change; this is where matching parts company with
+        // Scoping Criteria, whose groups combine order-insensitively.
+        var first = SavedRule(order: 0);
+        var second = SavedRule(order: 1);
+        second.TargetMetaverseAttributeId = 202;
+
+        var stored = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem,
+            [ObjectMatchingRuleProposal.FromRule(first), ObjectMatchingRuleProposal.FromRule(second)]);
+
+        first.Order = 1;
+        second.Order = 0;
+        var reordered = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem,
+            [ObjectMatchingRuleProposal.FromRule(first), ObjectMatchingRuleProposal.FromRule(second)]);
+
+        Assert.That(stored.DescribesSameMatchingAs(reordered), Is.False);
+    }
+
+    [Test]
+    public void DescribesSameMatchingAs_CaseSensitivityFlipped_ReportsAChange()
+    {
+        var stored = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem,
+            [ObjectMatchingRuleProposal.FromRule(SavedRule(caseSensitive: false))]);
+        var proposed = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem,
+            [ObjectMatchingRuleProposal.FromRule(SavedRule(caseSensitive: true))]);
+
+        Assert.That(stored.DescribesSameMatchingAs(proposed), Is.False);
+    }
+
+    [Test]
+    public void DescribesSameMatchingAs_ModeSwitchedWithTheSameRules_ReportsAChange()
+    {
+        // The Simple to Advanced switch changes which rules apply even when the rule bodies are untouched.
+        var rules = new List<ObjectMatchingRuleProposal> { ObjectMatchingRuleProposal.FromRule(SavedRule()) };
+
+        var stored = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem, rules);
+        var proposed = new ObjectMatchingProposal(ObjectMatchingRuleMode.SyncRule, rules);
+
+        Assert.That(stored.DescribesSameMatchingAs(proposed), Is.False);
+    }
+
+    [Test]
+    public void DescribesSameMatchingAs_Null_ReportsAChange()
+    {
+        var stored = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem,
+            [ObjectMatchingRuleProposal.FromRule(SavedRule())]);
+
+        Assert.That(stored.DescribesSameMatchingAs(null), Is.False);
+    }
+
+    [Test]
+    public void RulesFor_SimpleMode_SelectsRulesByObjectTypeAndOrdersThem()
+    {
+        var second = ObjectMatchingRuleProposal.FromRule(SavedRule(order: 1));
+        var first = ObjectMatchingRuleProposal.FromRule(SavedRule(order: 0));
+        var otherType = ObjectMatchingRuleProposal.FromRule(SavedRule(order: 0)) with { ConnectedSystemObjectTypeId = 99 };
+
+        var proposal = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem, [second, first, otherType]);
+
+        var selected = proposal.RulesFor(connectedSystemObjectTypeId: 9, syncRuleId: null).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(selected, Has.Count.EqualTo(2));
+            Assert.That(selected[0].Order, Is.EqualTo(0));
+            Assert.That(selected[1].Order, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void RulesFor_AdvancedMode_SelectsRulesBySynchronisationRule()
+    {
+        var mine = ObjectMatchingRuleProposal.FromRule(SavedRule()) with { ConnectedSystemObjectTypeId = null, SyncRuleId = 42 };
+        var theirs = ObjectMatchingRuleProposal.FromRule(SavedRule()) with { ConnectedSystemObjectTypeId = null, SyncRuleId = 43 };
+
+        var proposal = new ObjectMatchingProposal(ObjectMatchingRuleMode.SyncRule, [mine, theirs]);
+
+        var selected = proposal.RulesFor(connectedSystemObjectTypeId: 9, syncRuleId: 42).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(selected, Has.Count.EqualTo(1));
+            Assert.That(selected[0].SyncRuleId, Is.EqualTo(42));
+        }
+    }
+}

--- a/test/JIM.Web.Api.Tests/SynchronisationControllerObjectMatchingPreviewTests.cs
+++ b/test/JIM.Web.Api.Tests/SynchronisationControllerObjectMatchingPreviewTests.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Application.Expressions;
+using JIM.Application.Interfaces;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Interfaces;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+using JIM.Models.Tasking;
+using JIM.Web.Controllers.Api;
+using JIM.Web.Models.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace JIM.Web.Api.Tests;
+
+/// <summary>
+/// The REST surface for previewing a Connected System's Object Matching change (#1457).
+///
+/// Three things are worth pinning. Omitting the rules previews the stored ones, while an EMPTY array is a real
+/// proposal that removes every rule and leaves nothing able to join. Omitting the mode keeps the stored mode,
+/// because a caller editing rules should not have to restate it, and sending a different one is the mode switch
+/// this surface exists to cover. And the proposal crosses a JSON queue on its way to the worker carrying rule
+/// order, source order and case sensitivity, each of which changes which identity an account joins to, so any of
+/// them lost in transit would have the preview answer for a configuration nobody proposed.
+/// </summary>
+[TestFixture]
+public class SynchronisationControllerObjectMatchingPreviewTests
+{
+    private const int ConnectedSystemId = 2;
+    private const int CsoTypeId = 9;
+    private const int MvoTypeId = 3;
+    private const int EmployeeIdAttributeId = 101;
+    private const int MailAttributeId = 102;
+    private const int EmployeeIdMetaverseAttributeId = 201;
+    private const int MailMetaverseAttributeId = 202;
+
+    private Mock<IRepository> _repository = null!;
+    private Mock<IConnectedSystemRepository> _connectedSystemRepo = null!;
+    private Mock<IMetaverseRepository> _metaverseRepo = null!;
+    private Mock<IActivityRepository> _activityRepo = null!;
+    private Mock<IApiKeyRepository> _apiKeyRepo = null!;
+    private Mock<IConfigurationChangePreviewRepository> _previewRepo = null!;
+    private Mock<ITaskingRepository> _taskingRepo = null!;
+    private Mock<IServiceSettingsRepository> _serviceSettingsRepo = null!;
+    private JimApplication _application = null!;
+    private SynchronisationController _controller = null!;
+    private List<WorkerTask> _queuedWorkerTasks = null!;
+    private Activity? _previewActivity;
+    private ConnectedSystem _connectedSystem = null!;
+    private ConnectedSystemObjectType _csoType = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IRepository>();
+        _connectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _metaverseRepo = new Mock<IMetaverseRepository>();
+        _activityRepo = new Mock<IActivityRepository>();
+        _apiKeyRepo = new Mock<IApiKeyRepository>();
+        _previewRepo = new Mock<IConfigurationChangePreviewRepository>();
+        _taskingRepo = new Mock<ITaskingRepository>();
+        _serviceSettingsRepo = new Mock<IServiceSettingsRepository>();
+
+        _repository.Setup(r => r.ConnectedSystems).Returns(_connectedSystemRepo.Object);
+        _repository.Setup(r => r.Metaverse).Returns(_metaverseRepo.Object);
+        _repository.Setup(r => r.Activity).Returns(_activityRepo.Object);
+        _repository.Setup(r => r.ApiKeys).Returns(_apiKeyRepo.Object);
+        _repository.Setup(r => r.ConfigurationChangePreviews).Returns(_previewRepo.Object);
+        _repository.Setup(r => r.Tasking).Returns(_taskingRepo.Object);
+        _repository.Setup(r => r.ServiceSettings).Returns(_serviceSettingsRepo.Object);
+
+        _queuedWorkerTasks = [];
+        _previewActivity = null;
+
+        _activityRepo.Setup(r => r.CreateActivityAsync(It.IsAny<Activity>()))
+            .Callback<Activity>(a =>
+            {
+                if (a.Id == Guid.Empty)
+                    a.Id = Guid.NewGuid();
+                _previewActivity = a;
+            })
+            .Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.UpdateActivityAsync(It.IsAny<Activity>())).Returns(Task.CompletedTask);
+        _activityRepo.Setup(r => r.GetActivityAsync(It.IsAny<Guid>())).ReturnsAsync(() => _previewActivity);
+        _previewRepo.Setup(r => r.CreatePreviewAsync(It.IsAny<ConfigurationChangePreview>())).Returns(Task.CompletedTask);
+        _previewRepo.Setup(r => r.UpdatePreviewAsync(It.IsAny<ConfigurationChangePreview>())).Returns(Task.CompletedTask);
+        _previewRepo.Setup(r => r.GetPreviewAsync(It.IsAny<Guid>())).ReturnsAsync((ConfigurationChangePreview?)null);
+        _taskingRepo.Setup(r => r.CreateWorkerTaskAsync(It.IsAny<WorkerTask>()))
+            .Callback<WorkerTask>(t => _queuedWorkerTasks.Add(t))
+            .Returns(Task.CompletedTask);
+
+        // A stored rule deliberately away from the defaults, so an omitted proposal merged to a default rather
+        // than to the stored configuration is caught.
+        _csoType = new ConnectedSystemObjectType
+        {
+            Id = CsoTypeId,
+            Name = "User",
+            Attributes =
+            [
+                new ConnectedSystemObjectTypeAttribute { Id = EmployeeIdAttributeId, Name = "employeeID", Type = AttributeDataType.Text },
+                new ConnectedSystemObjectTypeAttribute { Id = MailAttributeId, Name = "mail", Type = AttributeDataType.Text }
+            ],
+            ObjectMatchingRules =
+            [
+                new ObjectMatchingRule
+                {
+                    Id = 700,
+                    Order = 2,
+                    CaseSensitive = true,
+                    ConnectedSystemObjectTypeId = CsoTypeId,
+                    MetaverseObjectTypeId = MvoTypeId,
+                    TargetMetaverseAttributeId = EmployeeIdMetaverseAttributeId,
+                    Sources = [new ObjectMatchingRuleSource { Id = 1, Order = 0, ConnectedSystemAttributeId = EmployeeIdAttributeId }]
+                }
+            ]
+        };
+
+        _connectedSystem = new ConnectedSystem
+        {
+            Id = ConnectedSystemId,
+            Name = "HR",
+            ObjectMatchingRuleMode = ObjectMatchingRuleMode.ConnectedSystem
+        };
+
+        _connectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(ConnectedSystemId, It.IsAny<bool>()))
+            .ReturnsAsync(() => _connectedSystem);
+        _connectedSystemRepo.Setup(r => r.GetObjectTypesAsync(ConnectedSystemId)).ReturnsAsync(() => [_csoType]);
+        _connectedSystemRepo.Setup(r => r.GetSyncRulesAsync(ConnectedSystemId, false, It.IsAny<bool>())).ReturnsAsync(() => []);
+        _connectedSystemRepo.Setup(r => r.GetUnjoinedConnectedSystemObjectCountOfTypeAsync(ConnectedSystemId, CsoTypeId)).ReturnsAsync(0);
+        _connectedSystemRepo.Setup(r => r.GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(ConnectedSystemId, CsoTypeId)).ReturnsAsync([]);
+        _metaverseRepo.Setup(r => r.GetMetaverseObjectTypesAsync(It.IsAny<bool>())).ReturnsAsync(() =>
+        [
+            new MetaverseObjectType
+            {
+                Id = MvoTypeId,
+                Name = "Person",
+                Attributes =
+                [
+                    new MetaverseAttribute { Id = EmployeeIdMetaverseAttributeId, Name = "Employee ID", Type = AttributeDataType.Text, AttributePlurality = AttributePlurality.SingleValued },
+                    new MetaverseAttribute { Id = MailMetaverseAttributeId, Name = "Email", Type = AttributeDataType.Text, AttributePlurality = AttributePlurality.SingleValued }
+                ]
+            }
+        ]);
+
+        _application = new JimApplication(_repository.Object);
+        _controller = new SynchronisationController(new Mock<ILogger<SynchronisationController>>().Object, _application,
+            new DynamicExpressoEvaluator(), new Mock<ICredentialProtectionService>().Object);
+
+        var apiKeyId = Guid.NewGuid();
+        _apiKeyRepo.Setup(r => r.GetByIdAsync(apiKeyId)).ReturnsAsync(new JIM.Models.Security.ApiKey
+        {
+            Id = apiKeyId,
+            Name = "TestApiKey",
+            KeyHash = "test-hash",
+            KeyPrefix = "test",
+            IsEnabled = true,
+            Created = DateTime.UtcNow
+        });
+
+        var identity = new ClaimsIdentity(
+        [
+            new Claim("auth_method", "api_key"),
+            new Claim(ClaimTypes.NameIdentifier, apiKeyId.ToString()),
+            new Claim(ClaimTypes.Name, "TestApiKey")
+        ], "ApiKey");
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+    }
+
+    [TearDown]
+    public void TearDown() => _application?.Dispose();
+
+    [Test]
+    public async Task StartObjectMatchingPreview_UnknownConnectedSystem_ReturnsNotFoundAsync()
+    {
+        _connectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(99, It.IsAny<bool>())).ReturnsAsync((ConnectedSystem?)null);
+
+        var result = await _controller.StartObjectMatchingPreviewAsync(99, new StartObjectMatchingPreviewRequest());
+
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+    }
+
+    [Test]
+    public async Task StartObjectMatchingPreview_OmittedRules_PreviewsTheStoredConfigurationAsync()
+    {
+        var result = await _controller.StartObjectMatchingPreviewAsync(ConnectedSystemId, new StartObjectMatchingPreviewRequest());
+
+        Assert.That(result, Is.InstanceOf<AcceptedAtRouteResult>());
+        var proposal = QueuedProposal();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(proposal.Mode, Is.EqualTo(ObjectMatchingRuleMode.ConnectedSystem));
+            Assert.That(proposal.Rules, Has.Count.EqualTo(1));
+            Assert.That(proposal.Rules[0].Order, Is.EqualTo(2), "the stored order, not the default");
+            Assert.That(proposal.Rules[0].CaseSensitive, Is.True, "the stored case sensitivity, not the default");
+            Assert.That(proposal.Rules[0].TargetMetaverseAttributeId, Is.EqualTo(EmployeeIdMetaverseAttributeId));
+            Assert.That(proposal.Rules[0].Sources[0].ConnectedSystemAttributeId, Is.EqualTo(EmployeeIdAttributeId));
+        }
+    }
+
+    [Test]
+    public async Task StartObjectMatchingPreview_EmptyRulesArray_ProposesRemovingEveryRuleAsync()
+    {
+        // The distinction this endpoint exists to keep: an empty array proposes a system that joins nothing, which
+        // is not the same as proposing no change at all.
+        var result = await _controller.StartObjectMatchingPreviewAsync(ConnectedSystemId,
+            new StartObjectMatchingPreviewRequest { Rules = [] });
+
+        Assert.That(result, Is.InstanceOf<AcceptedAtRouteResult>());
+        Assert.That(QueuedProposal().Rules, Is.Empty);
+    }
+
+    [Test]
+    public async Task StartObjectMatchingPreview_OmittedMode_KeepsTheStoredModeAsync()
+    {
+        _connectedSystem.ObjectMatchingRuleMode = ObjectMatchingRuleMode.SyncRule;
+
+        await _controller.StartObjectMatchingPreviewAsync(ConnectedSystemId,
+            new StartObjectMatchingPreviewRequest { Rules = [] });
+
+        Assert.That(QueuedProposal().Mode, Is.EqualTo(ObjectMatchingRuleMode.SyncRule));
+    }
+
+    [Test]
+    public async Task StartObjectMatchingPreview_ModeSwitch_CrossesTheQueueAsync()
+    {
+        await _controller.StartObjectMatchingPreviewAsync(ConnectedSystemId,
+            new StartObjectMatchingPreviewRequest { Mode = ObjectMatchingRuleMode.SyncRule });
+
+        Assert.That(QueuedProposal().Mode, Is.EqualTo(ObjectMatchingRuleMode.SyncRule));
+    }
+
+    [Test]
+    public async Task StartObjectMatchingPreview_ProposedRule_CrossesTheQueueIntactAsync()
+    {
+        // Rule order, source order and case sensitivity each decide which identity an account joins to, so all
+        // three have to survive serialisation to the worker.
+        await _controller.StartObjectMatchingPreviewAsync(ConnectedSystemId, new StartObjectMatchingPreviewRequest
+        {
+            Rules =
+            [
+                new ObjectMatchingRuleRequest
+                {
+                    Order = 5,
+                    ConnectedSystemObjectTypeId = CsoTypeId,
+                    MetaverseObjectTypeId = MvoTypeId,
+                    TargetMetaverseAttributeId = MailMetaverseAttributeId,
+                    CaseSensitive = true,
+                    Sources = [new ObjectMatchingRuleSourceRequest { Order = 3, ConnectedSystemAttributeId = MailAttributeId }]
+                }
+            ]
+        });
+
+        var rule = QueuedProposal().Rules.Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rule.Order, Is.EqualTo(5));
+            Assert.That(rule.CaseSensitive, Is.True);
+            Assert.That(rule.TargetMetaverseAttributeId, Is.EqualTo(MailMetaverseAttributeId));
+            Assert.That(rule.MetaverseObjectTypeId, Is.EqualTo(MvoTypeId));
+            Assert.That(rule.Sources.Single().Order, Is.EqualTo(3));
+            Assert.That(rule.Sources.Single().ConnectedSystemAttributeId, Is.EqualTo(MailAttributeId));
+        }
+    }
+
+    [Test]
+    public async Task StartObjectMatchingPreview_ExpressionSource_IsBlockedRatherThanEvaluatedAsync()
+    {
+        // Accepted on the wire and refused by validation, so the caller is told why rather than having their
+        // proposal silently reshaped into one that matches on nothing. A blocked proposal is never queued: an
+        // evaluation of it could only answer for a configuration that cannot work.
+        var result = await _controller.StartObjectMatchingPreviewAsync(ConnectedSystemId, new StartObjectMatchingPreviewRequest
+        {
+            Rules =
+            [
+                new ObjectMatchingRuleRequest
+                {
+                    Order = 0,
+                    ConnectedSystemObjectTypeId = CsoTypeId,
+                    MetaverseObjectTypeId = MvoTypeId,
+                    TargetMetaverseAttributeId = MailMetaverseAttributeId,
+                    Sources = [new ObjectMatchingRuleSourceRequest { Order = 0, Expression = "Lower(cs[\"mail\"])" }]
+                }
+            ]
+        });
+
+        var response = (ConfigurationChangePreviewStartResponse)((AcceptedAtRouteResult)result).Value!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.IsBlocked, Is.True,
+                "an expression source cannot be matched on, and the caller is told so");
+            Assert.That(response.ValidationFindings.Any(f => f.Severity == PreviewValidationSeverity.Blocking && f.Message.Contains("expression")), Is.True,
+                "the finding names what is wrong rather than merely refusing");
+            Assert.That(_queuedWorkerTasks.OfType<ConfigurationChangePreviewWorkerTask>(), Is.Empty,
+                "a blocked proposal is never evaluated");
+        }
+    }
+
+    private ObjectMatchingProposal QueuedProposal()
+    {
+        var task = _queuedWorkerTasks.OfType<ConfigurationChangePreviewWorkerTask>().SingleOrDefault();
+        Assert.That(task, Is.Not.Null, "the preview should have been queued for evaluation");
+        return JsonSerializer.Deserialize<ObjectMatchingProposal>(task!.ProposedConfigurationPayload)!;
+    }
+}

--- a/test/JIM.Web.Tests/CausalityModelBuilderTests.cs
+++ b/test/JIM.Web.Tests/CausalityModelBuilderTests.cs
@@ -100,7 +100,13 @@ public class CausalityModelBuilderTests
             [ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction] = CausalityLane.Identity,
             // A mapping that would not evaluate leaves a Metaverse Object attribute unwritten, so it belongs beside
             // the other Metaverse-side transitions rather than in the export-side Downstream lane.
-            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] = CausalityLane.Identity
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] = CausalityLane.Identity,
+            // Every Object Matching transition decides which Metaverse Object an account belongs to, which is the
+            // Identity lane's whole subject.
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject] = CausalityLane.Identity,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject] = CausalityLane.Identity,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin] = CausalityLane.Identity,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously] = CausalityLane.Identity
         };
 
         Assert.That(expectedLanes.Keys, Is.EquivalentTo(Enum.GetValues<ActivityRunProfileExecutionItemSyncOutcomeType>()),

--- a/test/JIM.Web.Tests/HelpersOutcomeDelegationTests.cs
+++ b/test/JIM.Web.Tests/HelpersOutcomeDelegationTests.cs
@@ -48,6 +48,10 @@ public class HelpersOutcomeDelegationTests
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldRemainJoined, "Would Remain Joined")]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction, "Would Change Deprovision Action")]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow, "Would Fail Attribute Flow")]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject, "Would Join Different Metaverse Object")]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject, "Would Join Instead Of Project")]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin, "Would Project Instead Of Join")]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously, "Would Match Ambiguously")]
     public void GetOutcomeTypeDisplayName_EveryOutcomeType_ReturnsPreRefactorValue(
         ActivityRunProfileExecutionItemSyncOutcomeType outcomeType, string expected)
     {
@@ -68,6 +72,8 @@ public class HelpersOutcomeDelegationTests
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldRemainJoined, "Keeps its Metaverse Object join")]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction, "Scope-exit action changes")]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow, "Attribute Flow does not evaluate")]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject, "Joins a different Metaverse Object")]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin, "Projects instead of joining")]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.Projected, "Identity created")]
     public void GetOutcomeTypePlainName_EveryOutcomeType_ReturnsThePlainLabel(
         ActivityRunProfileExecutionItemSyncOutcomeType outcomeType, string expected)
@@ -106,6 +112,10 @@ public class HelpersOutcomeDelegationTests
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldRemainJoined, Color.Success)]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction, Color.Warning)]
     [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow, Color.Error)]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject, Color.Error)]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject, Color.Success)]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin, Color.Error)]
+    [TestCase(ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously, Color.Warning)]
     public void GetOutcomeTypeMudBlazorColor_EveryOutcomeType_ReturnsPreRefactorValue(
         ActivityRunProfileExecutionItemSyncOutcomeType outcomeType, Color expected)
     {
@@ -147,7 +157,11 @@ public class HelpersOutcomeDelegationTests
             [ActivityRunProfileExecutionItemSyncOutcomeType.WouldStageDeleteExport] = Icons.Material.Filled.AutoDelete,
             [ActivityRunProfileExecutionItemSyncOutcomeType.WouldRemainJoined] = Icons.Material.Filled.Link,
             [ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction] = Icons.Material.Filled.SwapHoriz,
-            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] = Icons.Material.Filled.RuleFolder
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow] = Icons.Material.Filled.RuleFolder,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject] = Icons.Material.Filled.SwapHoriz,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject] = Icons.Material.Filled.Link,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin] = Icons.Material.Filled.CallSplit,
+            [ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously] = Icons.Material.Filled.QuestionMark
         };
 
         Assert.That(expectedIcons.Keys, Is.EquivalentTo(Enum.GetValues<ActivityRunProfileExecutionItemSyncOutcomeType>()),

--- a/test/JIM.Web.Tests/OutcomeDisplayMapTests.cs
+++ b/test/JIM.Web.Tests/OutcomeDisplayMapTests.cs
@@ -55,7 +55,11 @@ public class OutcomeDisplayMapTests
         (ActivityRunProfileExecutionItemSyncOutcomeType.WouldStageDeleteExport, "Removed from the target system", "Would Stage Delete Export", CausalityTone.Error, Icons.Material.Filled.AutoDelete),
         (ActivityRunProfileExecutionItemSyncOutcomeType.WouldRemainJoined, "Keeps its Metaverse Object join", "Would Remain Joined", CausalityTone.Success, Icons.Material.Filled.Link),
         (ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction, "Scope-exit action changes", "Would Change Deprovision Action", CausalityTone.Warning, Icons.Material.Filled.SwapHoriz),
-        (ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow, "Attribute Flow does not evaluate", "Would Fail Attribute Flow", CausalityTone.Error, Icons.Material.Filled.RuleFolder)
+        (ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow, "Attribute Flow does not evaluate", "Would Fail Attribute Flow", CausalityTone.Error, Icons.Material.Filled.RuleFolder),
+        (ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject, "Joins a different Metaverse Object", "Would Join Different Metaverse Object", CausalityTone.Error, Icons.Material.Filled.SwapHoriz),
+        (ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject, "Joins instead of projecting", "Would Join Instead Of Project", CausalityTone.Success, Icons.Material.Filled.Link),
+        (ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin, "Projects instead of joining", "Would Project Instead Of Join", CausalityTone.Error, Icons.Material.Filled.CallSplit),
+        (ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously, "Matches more than one Metaverse Object", "Would Match Ambiguously", CausalityTone.Warning, Icons.Material.Filled.QuestionMark)
     ];
 
     /// <summary>
@@ -75,7 +79,11 @@ public class OutcomeDisplayMapTests
         ActivityRunProfileExecutionItemSyncOutcomeType.WouldStageDeleteExport,
         ActivityRunProfileExecutionItemSyncOutcomeType.WouldRemainJoined,
         ActivityRunProfileExecutionItemSyncOutcomeType.WouldChangeDeprovisionAction,
-        ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow
+        ActivityRunProfileExecutionItemSyncOutcomeType.WouldFailAttributeFlow,
+        ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject,
+        ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject,
+        ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin,
+        ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously
     ];
 
     [Test]

--- a/test/JIM.Worker.Tests/Servers/ObjectMatchingPreviewAdapterTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ObjectMatchingPreviewAdapterTests.cs
@@ -1,0 +1,534 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Application.Servers.Preview;
+using JIM.Data;
+using JIM.Data.Repositories;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Exceptions;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+using Moq;
+using NUnit.Framework;
+using SyncRepository = JIM.InMemoryData.SyncRepository;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// The Object Matching adapter (#1457): what changing the rules that decide which Metaverse Object an account joins
+/// to would do.
+///
+/// The failures worth testing are the ones an administrator could not detect afterwards. A matching change that
+/// merges an account into the wrong identity does not fail: it succeeds, quietly, and takes every attribute the
+/// account contributes with it. So the adapter has to say which objects move, and it has to be equally clear about
+/// the objects it cannot move: an account already joined to a Metaverse Object never re-runs matching, so a
+/// matching edit cannot touch it, and a count that included the joined population would be a confident number
+/// about a change that does nothing to them.
+/// </summary>
+[TestFixture]
+public class ObjectMatchingPreviewAdapterTests
+{
+    private const int SystemId = 5;
+    private const int CsoTypeId = 9;
+    private const int MvoTypeId = 3;
+    private const int EmployeeIdAttributeId = 101;
+    private const int MailAttributeId = 102;
+    private const int CreatedAttributeId = 103;
+    private const int EmployeeIdMetaverseAttributeId = 201;
+    private const int MailMetaverseAttributeId = 202;
+    private const int ImportRuleId = 42;
+
+    private Mock<IRepository> _repo = null!;
+    private Mock<IConnectedSystemRepository> _connectedSystemRepo = null!;
+    private Mock<IMetaverseRepository> _metaverseRepo = null!;
+    private JimApplication _jim = null!;
+    private ObjectMatchingPreviewAdapter _adapter = null!;
+
+    private ConnectedSystem _connectedSystem = null!;
+    private ConnectedSystemObjectType _csoType = null!;
+    private MetaverseObjectType _mvoType = null!;
+    private SyncRule _importRule = null!;
+    private List<SyncRule> _syncRules = null!;
+    private List<ConnectedSystemObject> _csos = null!;
+
+    private SyncRepository _syncRepo = null!;
+    private MetaverseObject _alice = null!;
+    private MetaverseObject _bob = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        TestUtilities.SetEnvironmentVariables();
+
+        _repo = new Mock<IRepository>();
+        _connectedSystemRepo = new Mock<IConnectedSystemRepository>();
+        _metaverseRepo = new Mock<IMetaverseRepository>();
+        _repo.Setup(r => r.ConnectedSystems).Returns(_connectedSystemRepo.Object);
+        _repo.Setup(r => r.Metaverse).Returns(_metaverseRepo.Object);
+
+        _csoType = new ConnectedSystemObjectType
+        {
+            Id = CsoTypeId,
+            Name = "User",
+            Attributes =
+            [
+                new ConnectedSystemObjectTypeAttribute { Id = EmployeeIdAttributeId, Name = "employeeID", Type = AttributeDataType.Text },
+                new ConnectedSystemObjectTypeAttribute { Id = MailAttributeId, Name = "mail", Type = AttributeDataType.Text },
+                new ConnectedSystemObjectTypeAttribute { Id = CreatedAttributeId, Name = "whenCreated", Type = AttributeDataType.DateTime }
+            ],
+            ObjectMatchingRules = []
+        };
+
+        _mvoType = new MetaverseObjectType
+        {
+            Id = MvoTypeId,
+            Name = "Person",
+            Attributes =
+            [
+                new MetaverseAttribute { Id = EmployeeIdMetaverseAttributeId, Name = "Employee ID", Type = AttributeDataType.Text, AttributePlurality = AttributePlurality.SingleValued },
+                new MetaverseAttribute { Id = MailMetaverseAttributeId, Name = "Email", Type = AttributeDataType.Text, AttributePlurality = AttributePlurality.SingleValued }
+            ]
+        };
+
+        _connectedSystem = new ConnectedSystem
+        {
+            Id = SystemId,
+            Name = "HR",
+            ObjectMatchingRuleMode = ObjectMatchingRuleMode.ConnectedSystem
+        };
+
+        _importRule = new SyncRule
+        {
+            Id = ImportRuleId,
+            Name = "HR Import",
+            ConnectedSystemId = SystemId,
+            ConnectedSystemObjectTypeId = CsoTypeId,
+            ConnectedSystemObjectType = _csoType,
+            MetaverseObjectTypeId = MvoTypeId,
+            MetaverseObjectType = _mvoType,
+            Direction = SyncRuleDirection.Import,
+            Enabled = true
+        };
+        _syncRules = [_importRule];
+
+        // Real Metaverse Objects put to the real matching implementation, rather than a stub answering by rule.
+        // The adapter's whole design is that it asks the matching engine instead of reimplementing it, so a test
+        // that stubbed the engine would be testing nothing but its own arithmetic.
+        _alice = MetaverseObjectWith("Alice Smith", employeeId: "E1", email: "alice.smith@example.com");
+        _bob = MetaverseObjectWith("Bob Jones", employeeId: "E9", email: "alice@example.com");
+        _csos = [];
+
+        _syncRepo = new SyncRepository();
+        _syncRepo.SeedMetaverseObject(_alice);
+        _syncRepo.SeedMetaverseObject(_bob);
+
+        _connectedSystemRepo.Setup(r => r.GetConnectedSystemAsync(SystemId, It.IsAny<bool>())).ReturnsAsync(() => _connectedSystem);
+        _connectedSystemRepo.Setup(r => r.GetObjectTypesAsync(SystemId)).ReturnsAsync(() => [_csoType]);
+        _connectedSystemRepo.Setup(r => r.GetSyncRulesAsync(SystemId, It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync(() => _syncRules);
+        // The population query is what excludes the joined and the obsolete, exactly as the real one does; the
+        // adapter's own guards over it are belt and braces, and the database fixture proves the SQL.
+        _connectedSystemRepo.Setup(r => r.GetUnjoinedConnectedSystemObjectIdsOfTypeAsync(SystemId, CsoTypeId))
+            .ReturnsAsync(() => [.. Unjoined().Select(cso => cso.Id)]);
+        _connectedSystemRepo.Setup(r => r.GetUnjoinedConnectedSystemObjectCountOfTypeAsync(SystemId, CsoTypeId))
+            .ReturnsAsync(() => Unjoined().Count());
+        _connectedSystemRepo.Setup(r => r.GetConnectedSystemObjectsByIdsNoTrackingAsync(SystemId, It.IsAny<IEnumerable<Guid>>()))
+            .ReturnsAsync((int _, IEnumerable<Guid> ids) => [.. _csos.Where(cso => ids.Contains(cso.Id))]);
+        _metaverseRepo.Setup(r => r.GetMetaverseObjectTypesAsync(It.IsAny<bool>())).ReturnsAsync(() => [_mvoType]);
+
+        _jim = new JimApplication(_repo.Object, syncRepository: _syncRepo);
+        _adapter = new ObjectMatchingPreviewAdapter(_jim);
+    }
+
+    [TearDown]
+    public void TearDown() => _jim?.Dispose();
+
+    #region contract
+
+    [Test]
+    public void Surface_IsObjectMatching()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_adapter.Surface, Is.EqualTo(ConfigurationChangePreviewSurface.ObjectMatching));
+            Assert.That(_adapter.ProducesDeltas, Is.True);
+            Assert.That(_adapter.ProposalType, Is.EqualTo(typeof(ObjectMatchingProposal)));
+        }
+    }
+
+    #endregion
+
+    #region validation
+
+    [Test]
+    public async Task ValidateAsync_ProposalMatchesStoredRules_ReportsNoChange()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+
+        var findings = await _adapter.ValidateAsync(Context(CurrentProposal()));
+
+        Assert.That(findings.Select(f => f.Message),
+            Has.Some.Contains("already"), "a proposal identical to the stored rules must say so rather than count nothing silently");
+    }
+
+    [Test]
+    public async Task ValidateAsync_RuleWithMoreThanOneSource_IsBlocking()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = ProposalWith(RuleProposal() with
+        {
+            Sources =
+            [
+                new ObjectMatchingRuleSourceProposal(0, EmployeeIdAttributeId),
+                new ObjectMatchingRuleSourceProposal(1, MailAttributeId)
+            ]
+        });
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Where(f => f.Severity == PreviewValidationSeverity.Blocking).Select(f => f.Message),
+            Has.Some.Contains("more than one source"));
+    }
+
+    [Test]
+    public async Task ValidateAsync_ExpressionSource_IsBlocking()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = ProposalWith(RuleProposal() with
+        {
+            Sources = [new ObjectMatchingRuleSourceProposal(0, null, "Lower(cs[\"mail\"])")]
+        });
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Where(f => f.Severity == PreviewValidationSeverity.Blocking).Select(f => f.Message),
+            Has.Some.Contains("expression"));
+    }
+
+    [Test]
+    public async Task ValidateAsync_UnsupportedSourceAttributeType_IsBlocking()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = ProposalWith(RuleProposal() with
+        {
+            Sources = [new ObjectMatchingRuleSourceProposal(0, CreatedAttributeId)]
+        });
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Where(f => f.Severity == PreviewValidationSeverity.Blocking).Select(f => f.Message),
+            Has.Some.Contains("whenCreated"));
+    }
+
+    [Test]
+    public async Task ValidateAsync_RuleWithNoTargetMetaverseAttribute_IsBlocking()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = ProposalWith(RuleProposal() with { TargetMetaverseAttributeId = null });
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Where(f => f.Severity == PreviewValidationSeverity.Blocking).Select(f => f.Message),
+            Has.Some.Contains("Metaverse Attribute"));
+    }
+
+    [Test]
+    public async Task ValidateAsync_EveryRuleRemoved_WarnsThatNothingWouldEverJoin()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem, []);
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Where(f => f.Severity == PreviewValidationSeverity.Warning).Select(f => f.Message),
+            Has.Some.Contains("project"));
+    }
+
+    [Test]
+    public async Task ValidateAsync_AlwaysStatesThatJoinedObjectsCannotMove()
+    {
+        // The most important sentence the preview says. Matching runs only for objects with no Metaverse Object, so
+        // an administrator fearing that a rule edit will re-home their existing joins needs telling that it cannot.
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = ProposalWith(RuleProposal() with { TargetMetaverseAttributeId = MailMetaverseAttributeId });
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Select(f => f.Message), Has.Some.Contains("already joined"));
+    }
+
+    [Test]
+    public async Task ValidateAsync_ModeSwitch_IsWarned()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var proposal = new ObjectMatchingProposal(ObjectMatchingRuleMode.SyncRule, CurrentProposal().Rules);
+
+        var findings = await _adapter.ValidateAsync(Context(proposal));
+
+        Assert.That(findings.Where(f => f.Severity == PreviewValidationSeverity.Warning).Select(f => f.Message),
+            Has.Some.Contains("Advanced"));
+    }
+
+    #endregion
+
+    #region evaluation
+
+    [Test]
+    public async Task EvaluateDeltasAsync_NoChange_ReadsNoObjects()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E1", "alice@example.com")];
+
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(CurrentProposal()), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas, Is.Empty);
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_ProposalMatchesADifferentMetaverseObject_ReportsTheSwap()
+    {
+        // employeeID E1 matches Alice on Employee ID today; mail alice@example.com matches Bob on Email.
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E1", "alice@example.com")];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(deltas, Has.Count.EqualTo(1));
+            Assert.That(deltas[0].TransitionType,
+                Is.EqualTo(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject));
+            Assert.That(deltas[0].MetaverseObjectId, Is.EqualTo(_bob.Id), "the delta names the identity the object would end up on");
+            Assert.That(deltas[0].OldValue, Is.EqualTo("Alice Smith"));
+            Assert.That(deltas[0].NewValue, Is.EqualTo("Bob Jones"));
+        }
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_ProposalMatchesWhereNothingDidBefore_ReportsJoinInsteadOfProject()
+    {
+        // No Metaverse Object carries employee id E7, so the object projects today; its mail matches Bob.
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E7", "alice@example.com")];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas.Select(d => d.TransitionType),
+            Is.EqualTo(new[] { ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject }));
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_ProposalStopsMatching_ReportsProjectInsteadOfJoin()
+    {
+        // E1 matches Alice today; no Metaverse Object carries this mail, so the proposal matches nothing and the
+        // next synchronisation would project a second identity beside the one it should have joined.
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E1", "nobody@example.com")];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas.Select(d => d.TransitionType),
+            Is.EqualTo(new[] { ActivityRunProfileExecutionItemSyncOutcomeType.WouldProjectInsteadOfJoin }));
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_ProposalMatchesMoreThanOneMetaverseObject_ReportsAmbiguity()
+    {
+        // A third identity sharing Bob's email makes the proposed rule ambiguous for this object alone: exactly the
+        // failure a rule that looks unique in the editor hides until the population is evaluated.
+        _syncRepo.SeedMetaverseObject(MetaverseObjectWith("Bobby Jones", employeeId: "E8", email: "alice@example.com"));
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E7", "alice@example.com")];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas.Select(d => d.TransitionType),
+            Is.EqualTo(new[] { ActivityRunProfileExecutionItemSyncOutcomeType.WouldMatchAmbiguously }));
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_AlreadyJoinedObject_IsNeverEvaluated()
+    {
+        // The honest negative. A joined object never re-runs matching, so a matching change cannot move it, and
+        // reporting one would send an administrator looking for a re-home that will not happen.
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var joined = UnjoinedCso("E1", "alice@example.com");
+        joined.MetaverseObjectId = _alice.Id;
+        joined.MetaverseObject = _alice;
+        _csos = [joined];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas, Is.Empty);
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_ObsoleteObject_IsNeverEvaluated()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        var obsolete = UnjoinedCso("E1", "alice@example.com");
+        obsolete.Status = ConnectedSystemObjectStatus.Obsolete;
+        _csos = [obsolete];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas, Is.Empty);
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_ObjectOutOfScopeOfEveryImportRule_IsNeverEvaluated()
+    {
+        // Matching runs only for objects a synchronisation would process, and an object out of scope of every
+        // import rule carrying criteria never reaches the join step at all.
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _importRule.ObjectScopingCriteriaGroups =
+        [
+            new SyncRuleScopingCriteriaGroup
+            {
+                Type = JIM.Models.Search.SearchGroupType.All,
+                Criteria =
+                [
+                    new SyncRuleScopingCriteria
+                    {
+                        ConnectedSystemAttribute = _csoType.Attributes.First(a => a.Id == MailAttributeId),
+                        ConnectedSystemAttributeId = MailAttributeId,
+                        ComparisonType = JIM.Models.Search.SearchComparisonType.Equals,
+                        StringValue = "never-matches@example.com"
+                    }
+                ]
+            }
+        ];
+        _csos = [UnjoinedCso("E1", "alice@example.com")];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var deltas = await _adapter.EvaluateDeltasAsync(Context(proposal), CancellationToken.None).ToListAsync();
+
+        Assert.That(deltas, Is.Empty);
+    }
+
+    [Test]
+    public async Task CountImpactAsync_CountsEachTransitionSeparately()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E1", "alice@example.com"), UnjoinedCso("E7", "alice@example.com")];
+
+        var proposal = ProposalWith(MailRuleProposal());
+        var counts = await _adapter.CountImpactAsync(Context(proposal));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(counts.Single(c => c.TransitionType == ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject).ObjectCount,
+                Is.EqualTo(1));
+            Assert.That(counts.Single(c => c.TransitionType == ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinInsteadOfProject).ObjectCount,
+                Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task EstimateCostAsync_NoChange_CostsNothing()
+    {
+        _csoType.ObjectMatchingRules = [StoredRule()];
+        _csos = [UnjoinedCso("E1", "alice@example.com")];
+
+        var estimate = await _adapter.EstimateCostAsync(Context(CurrentProposal()));
+
+        Assert.That(estimate.AffectedObjects, Is.Zero);
+    }
+
+    #endregion
+
+    #region helpers
+
+    private PreviewContext Context(ObjectMatchingProposal proposal) => new()
+    {
+        Surface = ConfigurationChangePreviewSurface.ObjectMatching,
+        ActivityId = Guid.NewGuid(),
+        TargetId = SystemId,
+        ProposedConfiguration = proposal
+    };
+
+    private ObjectMatchingRule StoredRule() => new()
+    {
+        Id = 1,
+        Order = 0,
+        ConnectedSystemObjectTypeId = CsoTypeId,
+        MetaverseObjectTypeId = MvoTypeId,
+        TargetMetaverseAttributeId = EmployeeIdMetaverseAttributeId,
+        Sources = [new ObjectMatchingRuleSource { Id = 1, Order = 0, ConnectedSystemAttributeId = EmployeeIdAttributeId }]
+    };
+
+    private ObjectMatchingProposal CurrentProposal() =>
+        ObjectMatchingProposal.FromCurrentConfiguration(_connectedSystem, [_csoType], _syncRules);
+
+    private ObjectMatchingRuleProposal RuleProposal() => ObjectMatchingRuleProposal.FromRule(StoredRule());
+
+    /// <summary>The same rule matching on mail against Email instead of employeeID against Employee ID.</summary>
+    private ObjectMatchingRuleProposal MailRuleProposal() => RuleProposal() with
+    {
+        TargetMetaverseAttributeId = MailMetaverseAttributeId,
+        Sources = [new ObjectMatchingRuleSourceProposal(0, MailAttributeId)]
+    };
+
+    private MetaverseObject MetaverseObjectWith(string displayName, string employeeId, string email) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = _mvoType,
+        CachedDisplayName = displayName,
+        AttributeValues =
+        [
+            new MetaverseObjectAttributeValue
+            {
+                AttributeId = EmployeeIdMetaverseAttributeId,
+                Attribute = _mvoType.Attributes.First(a => a.Id == EmployeeIdMetaverseAttributeId),
+                StringValue = employeeId
+            },
+            new MetaverseObjectAttributeValue
+            {
+                AttributeId = MailMetaverseAttributeId,
+                Attribute = _mvoType.Attributes.First(a => a.Id == MailMetaverseAttributeId),
+                StringValue = email
+            }
+        ]
+    };
+
+    private ObjectMatchingProposal ProposalWith(params ObjectMatchingRuleProposal[] rules) =>
+        new(_connectedSystem.ObjectMatchingRuleMode, rules);
+
+    private IEnumerable<ConnectedSystemObject> Unjoined() =>
+        _csos.Where(cso => cso.MetaverseObjectId == null && cso.Status == ConnectedSystemObjectStatus.Normal);
+
+    private ConnectedSystemObject UnjoinedCso(string employeeId, string email) => new()
+    {
+        Id = Guid.NewGuid(),
+        ConnectedSystemId = SystemId,
+        TypeId = CsoTypeId,
+        Type = _csoType,
+        Status = ConnectedSystemObjectStatus.Normal,
+        AttributeValues =
+        [
+            new ConnectedSystemObjectAttributeValue
+            {
+                AttributeId = EmployeeIdAttributeId,
+                Attribute = _csoType.Attributes.First(a => a.Id == EmployeeIdAttributeId),
+                StringValue = employeeId
+            },
+            new ConnectedSystemObjectAttributeValue
+            {
+                AttributeId = MailAttributeId,
+                Attribute = _csoType.Attributes.First(a => a.Id == MailAttributeId),
+                StringValue = email
+            }
+        ]
+    };
+
+    #endregion
+}

--- a/test/JIM.Worker.Tests/Servers/ObjectMatchingPreviewIsolationDatabaseTests.cs
+++ b/test/JIM.Worker.Tests/Servers/ObjectMatchingPreviewIsolationDatabaseTests.cs
@@ -1,0 +1,293 @@
+// Copyright (c) Tetron Limited. All rights reserved.
+// Licensed under the Tetron Commercial License. See LICENSE file in the project root.
+
+using JIM.Application;
+using JIM.Application.Servers.Preview;
+using JIM.Models.Activities;
+using JIM.Models.Core;
+using JIM.Models.Enums;
+using JIM.Models.Logic;
+using JIM.Models.Preview;
+using JIM.Models.Staging;
+using JIM.PostgresData;
+using JIM.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace JIM.Worker.Tests.Servers;
+
+/// <summary>
+/// Real-PostgreSQL proof of the Object Matching adapter (#1457) on two counts at once: that the matching query
+/// accepts the rules the adapter materialises from a proposal, and that running the preview over a live database
+/// leaves every synchronisation-integrity table byte-identical.
+///
+/// The first is not a formality. The matching query reads each rule's attribute ENTITIES rather than their ids: it
+/// switches on the source attribute's data type to pick a comparison, and filters on the target attribute's id
+/// read off the navigation property. A stand-in carrying only ids matches nothing while looking perfectly well
+/// formed, and the mocked unit fixture cannot tell the difference because its repository never looks at the
+/// entities either. This test does, because the real query does.
+/// </summary>
+/// <remarks>
+/// Opt-in via the same <c>JIM_TEST_RESET_*</c> environment variables as the other database-backed tests;
+/// ignored when <c>JIM_TEST_RESET_DB</c> is absent.
+/// </remarks>
+[TestFixture]
+[Category("RequiresPostgres")]
+public class ObjectMatchingPreviewIsolationDatabaseTests
+{
+    private string _connectionString = null!;
+
+    private JimDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<JimDbContext>()
+            .UseNpgsql(_connectionString)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new JimDbContext(options);
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var dbName = Environment.GetEnvironmentVariable("JIM_TEST_RESET_DB");
+        if (string.IsNullOrEmpty(dbName))
+            Assert.Ignore("JIM_TEST_RESET_DB not set; skipping real-PostgreSQL Object Matching preview isolation tests.");
+
+        var host = Environment.GetEnvironmentVariable("JIM_TEST_RESET_HOST") ?? "localhost";
+        var user = Environment.GetEnvironmentVariable("JIM_TEST_RESET_USER") ?? "postgres";
+        var pass = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PASSWORD") ?? "postgres";
+        var port = Environment.GetEnvironmentVariable("JIM_TEST_RESET_PORT") ?? "5432";
+        _connectionString = $"Host={host};Port={port};Database={dbName};Username={user};Password={pass}";
+
+        using var ctx = NewContext();
+        ctx.Database.Migrate();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(@"
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+                FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> '__EFMigrationsHistory') LOOP
+                    EXECUTE 'TRUNCATE TABLE ""' || r.tablename || '"" RESTART IDENTITY CASCADE';
+                END LOOP;
+            END $$;");
+    }
+
+    [Test]
+    public async Task EvaluateDeltasAsync_RuleRetargetedOverLiveDatabase_ReportsTheSwapAndPersistsNothingAsync()
+    {
+        // Arrange - matching on employeeID joins the unjoined account to Ada today; matching on mail would join it
+        // to Grace instead, which is the identity corruption this preview exists to catch before it happens.
+        var seeded = await SeedMatchingTopologyAsync();
+
+        var before = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+
+        List<PreviewDelta> deltas;
+        List<PreviewImpactCount> counts;
+        List<PreviewValidationFinding> findings;
+        await using (var ctx = NewContext())
+        {
+            var repo = new PostgresDataRepository(ctx);
+            using var jim = new JimApplication(repo, syncRepository: new JIM.PostgresData.Repositories.SyncRepository(repo));
+            var adapter = new ObjectMatchingPreviewAdapter(jim);
+            var context = new PreviewContext
+            {
+                Surface = ConfigurationChangePreviewSurface.ObjectMatching,
+                ActivityId = Guid.CreateVersion7(),
+                TargetId = seeded.ConnectedSystemId,
+                ProposedConfiguration = new ObjectMatchingProposal(ObjectMatchingRuleMode.ConnectedSystem,
+                [
+                    new ObjectMatchingRuleProposal(
+                        Order: 0,
+                        ConnectedSystemObjectTypeId: seeded.ConnectedSystemObjectTypeId,
+                        SyncRuleId: null,
+                        MetaverseObjectTypeId: seeded.MetaverseObjectTypeId,
+                        TargetMetaverseAttributeId: seeded.MetaverseEmailAttributeId,
+                        CaseSensitive: false,
+                        Sources: [new ObjectMatchingRuleSourceProposal(0, seeded.MailAttributeId)])
+                ])
+            };
+
+            // Act - the full surface a preview run exercises
+            findings = await adapter.ValidateAsync(context);
+            deltas = [];
+            await foreach (var delta in adapter.EvaluateDeltasAsync(context, CancellationToken.None))
+                deltas.Add(delta);
+            counts = await adapter.CountImpactAsync(context);
+        }
+
+        // Assert - the swap is reported against the real matching query, and nothing anywhere has changed
+        var after = await DatabaseIsolationSnapshot.CaptureAsync(_connectionString);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(findings.Any(f => f.Severity == PreviewValidationSeverity.Blocking), Is.False,
+                "the proposal is well formed; nothing about it should block");
+            Assert.That(deltas, Has.Count.EqualTo(1),
+                "only the unjoined object can move; the joined one never re-runs matching");
+            Assert.That(deltas[0].TransitionType,
+                Is.EqualTo(ActivityRunProfileExecutionItemSyncOutcomeType.WouldJoinDifferentMetaverseObject));
+            Assert.That(deltas[0].MetaverseObjectId, Is.EqualTo(seeded.GraceId),
+                "the delta names the identity the account would end up on");
+            Assert.That(counts.Sum(c => c.ObjectCount), Is.EqualTo(deltas.Count),
+                "the counts are the same stream the drill-down reports");
+            Assert.That(() => after.AssertUnchangedSince(before), Throws.Nothing,
+                "a preview that asked the matching engine twice must not have joined anything");
+        }
+    }
+
+    private sealed record SeededTopology(
+        int ConnectedSystemId,
+        int ConnectedSystemObjectTypeId,
+        int MetaverseObjectTypeId,
+        int MetaverseEmailAttributeId,
+        int MailAttributeId,
+        Guid GraceId);
+
+    /// <summary>
+    /// Seeds one Connected System matching in Simple mode on employeeID, two Metaverse Objects (one reachable by
+    /// employee id, the other by email), one UNJOINED object that the proposal would move between them, and one
+    /// JOINED object that no matching change can move.
+    /// </summary>
+    private async Task<SeededTopology> SeedMatchingTopologyAsync()
+    {
+        await using var seedCtx = NewContext();
+
+        var connectorDefinition = new ConnectorDefinition { Name = "Object Matching Preview Test Connector", BuiltIn = false };
+        var connectedSystem = new ConnectedSystem
+        {
+            Name = "Object Matching Preview Source",
+            ObjectMatchingRuleMode = ObjectMatchingRuleMode.ConnectedSystem,
+            ConnectorDefinition = connectorDefinition
+        };
+        seedCtx.ConnectorDefinitions.Add(connectorDefinition);
+        seedCtx.ConnectedSystems.Add(connectedSystem);
+        await seedCtx.SaveChangesAsync();
+
+        var csoType = new ConnectedSystemObjectType
+        {
+            ConnectedSystemId = connectedSystem.Id,
+            Name = "User",
+            Selected = true,
+            Attributes =
+            [
+                new ConnectedSystemObjectTypeAttribute { Name = "ExternalId", Type = AttributeDataType.Guid, IsExternalId = true, Selected = true },
+                new ConnectedSystemObjectTypeAttribute { Name = "employeeID", Type = AttributeDataType.Text, Selected = true },
+                new ConnectedSystemObjectTypeAttribute { Name = "mail", Type = AttributeDataType.Text, Selected = true }
+            ]
+        };
+        seedCtx.ConnectedSystemObjectTypes.Add(csoType);
+
+        var employeeIdAttribute = new MetaverseAttribute
+        {
+            Name = "Employee ID",
+            Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.SingleValued,
+            BuiltIn = false
+        };
+        var emailAttribute = new MetaverseAttribute
+        {
+            Name = "Email",
+            Type = AttributeDataType.Text,
+            AttributePlurality = AttributePlurality.SingleValued,
+            BuiltIn = false
+        };
+        var mvType = new MetaverseObjectType
+        {
+            Name = "Person",
+            PluralName = "People",
+            BuiltIn = false,
+            Attributes = [employeeIdAttribute, emailAttribute]
+        };
+        seedCtx.MetaverseObjectTypes.Add(mvType);
+        await seedCtx.SaveChangesAsync();
+
+        var employeeIdSourceAttribute = csoType.Attributes.Single(a => a.Name == "employeeID");
+        var mailSourceAttribute = csoType.Attributes.Single(a => a.Name == "mail");
+        var externalIdAttribute = csoType.Attributes.Single(a => a.IsExternalId);
+
+        var importRule = new SyncRule
+        {
+            ConnectedSystemId = connectedSystem.Id,
+            Name = "Object Matching Preview Import",
+            Direction = SyncRuleDirection.Import,
+            Enabled = true,
+            ConnectedSystemObjectTypeId = csoType.Id,
+            MetaverseObjectTypeId = mvType.Id,
+            ProjectToMetaverse = true
+        };
+        seedCtx.SyncRules.Add(importRule);
+
+        // The stored rule: match employeeID against Employee ID, in Simple mode on the object type.
+        seedCtx.Add(new ObjectMatchingRule
+        {
+            Order = 0,
+            ConnectedSystemObjectTypeId = csoType.Id,
+            MetaverseObjectTypeId = mvType.Id,
+            TargetMetaverseAttributeId = employeeIdAttribute.Id,
+            Sources = [new ObjectMatchingRuleSource { Order = 0, ConnectedSystemAttributeId = employeeIdSourceAttribute.Id }]
+        });
+        await seedCtx.SaveChangesAsync();
+
+        var ada = MetaverseObjectWith(mvType, employeeIdAttribute, "E1", emailAttribute, "ada@corp.local");
+        var grace = MetaverseObjectWith(mvType, employeeIdAttribute, "E9", emailAttribute, "shared@corp.local");
+        var joinedIdentity = MetaverseObjectWith(mvType, employeeIdAttribute, "E5", emailAttribute, "already@corp.local");
+        seedCtx.MetaverseObjects.AddRange(ada, grace, joinedIdentity);
+
+        // The unjoined account: matches Ada on employee id today, Grace on mail under the proposal.
+        var unjoined = new ConnectedSystemObject
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = connectedSystem.Id,
+            TypeId = csoType.Id,
+            Status = ConnectedSystemObjectStatus.Normal,
+            JoinType = ConnectedSystemObjectJoinType.NotJoined
+        };
+        unjoined.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Id = Guid.NewGuid(), AttributeId = externalIdAttribute.Id, GuidValue = Guid.NewGuid() });
+        unjoined.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Id = Guid.NewGuid(), AttributeId = employeeIdSourceAttribute.Id, StringValue = "E1" });
+        unjoined.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Id = Guid.NewGuid(), AttributeId = mailSourceAttribute.Id, StringValue = "shared@corp.local" });
+        seedCtx.ConnectedSystemObjects.Add(unjoined);
+
+        // The joined account, carrying values that would match differently if it were ever re-matched. It is not.
+        var joined = new ConnectedSystemObject
+        {
+            Id = Guid.NewGuid(),
+            ConnectedSystemId = connectedSystem.Id,
+            TypeId = csoType.Id,
+            Status = ConnectedSystemObjectStatus.Normal,
+            JoinType = ConnectedSystemObjectJoinType.Joined,
+            MetaverseObject = joinedIdentity
+        };
+        joined.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Id = Guid.NewGuid(), AttributeId = externalIdAttribute.Id, GuidValue = Guid.NewGuid() });
+        joined.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Id = Guid.NewGuid(), AttributeId = employeeIdSourceAttribute.Id, StringValue = "E1" });
+        joined.AttributeValues.Add(new ConnectedSystemObjectAttributeValue { Id = Guid.NewGuid(), AttributeId = mailSourceAttribute.Id, StringValue = "shared@corp.local" });
+        seedCtx.ConnectedSystemObjects.Add(joined);
+
+        await seedCtx.SaveChangesAsync();
+
+        return new SeededTopology(
+            connectedSystem.Id,
+            csoType.Id,
+            mvType.Id,
+            emailAttribute.Id,
+            mailSourceAttribute.Id,
+            grace.Id);
+    }
+
+    private static MetaverseObject MetaverseObjectWith(
+        MetaverseObjectType type,
+        MetaverseAttribute employeeIdAttribute,
+        string employeeId,
+        MetaverseAttribute emailAttribute,
+        string email)
+    {
+        var mvo = new MetaverseObject { Id = Guid.NewGuid(), Type = type };
+        mvo.AttributeValues.Add(new MetaverseObjectAttributeValue { Id = Guid.NewGuid(), Attribute = employeeIdAttribute, StringValue = employeeId });
+        mvo.AttributeValues.Add(new MetaverseObjectAttributeValue { Id = Guid.NewGuid(), Attribute = emailAttribute, StringValue = email });
+        return mvo;
+    }
+}


### PR DESCRIPTION
## Description

The bottom layer of a three-layer stack delivering #1457, the Object Matching adapter for the Configuration Change Preview framework (#827). This layer is the adapter, the REST endpoint and the PowerShell parameter set; the portal migration lands two layers above, behind a bug fix it depends on.

Object Matching Rules decide which Metaverse Object an account joins to, and they were the last high-severity surface in #827's coverage map with no preview. Their mistakes never fail: a rule matched too loosely merges an account into the wrong identity and takes every value it contributes with it; one matched too tightly projects a duplicate identity beside the right one. Both look like a successful synchronisation.

The adapter asks the matching engine itself twice per candidate object, once with the stored rules and once with the proposal, and reports where the two answers differ: joins a different Metaverse Object, joins instead of projecting, projects instead of joining, matches ambiguously. One surface covers Simple and Advanced mode and the switch between them, because a mode switch changes which rules apply without editing a rule.

The population is the live, unjoined objects only, which the preview states before anything else: an account already joined never re-runs matching, so no matching edit can re-home it.

Two things were found by running it against a live database rather than only against the unit fixture:

- Streaming the population while querying per object is refused outright by Npgsql (one command per connection). The matching engine reported every such failure as no match, so the preview answered that nothing would change. The population is now read as identifiers and the objects fetched in batches behind it, via two new set-based repository reads that also make the cost estimate the unjoined count rather than the whole type.
- The matching query reads the attribute entities rather than their ids, so the materialiser resolves them; the database fixture is what proves it, because a mocked repository never looks at them either.

Closes #1457

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [x] `dotnet build JIM.sln` succeeds with zero errors
- [x] `dotnet test JIM.sln` passes
- [x] New functionality has tests (unit, workflow, or integration as appropriate)
- [x] Manually tested in a local development environment

19 adapter tests (the four transitions, the validation refusals, and three honest negatives: joined objects, obsolete objects and objects out of scope of every import rule are never evaluated). 10 proposal tests, including order-sensitivity, which is where matching parts company with Scoping Criteria: rules are evaluated in ascending order until one matches, so reordering is a real change. 7 REST tests over the omitted/empty/mode-switch semantics and the JSON round trip to the worker. 5 Pester tests. One `RequiresPostgres` fixture proves the real matching query accepts the materialised rules and that the whole preview leaves every synchronisation-integrity table byte-identical.

The two honest negatives were mutation-tested: removing the joined guard and the scope guard each fails exactly the test that pins it.

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [ ] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [x] No documentation needed

Docs: n/a - the customer-facing documentation and changelog entry for this feature ship with the portal layer at the top of this stack, where the feature becomes visible in the product.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

Stack, bottom to top:

1. **this PR**: the adapter, REST endpoint and PowerShell parameter set
2. #1458: a portal bug the surface migration cannot be built on (Simple mode rules created in the portal name no Metaverse Object Type and so never match)
3. the portal migration for #1457

Opened from a cloud sandbox, which cannot link a GitHub stack (the relay serves the MCP tool surface only), so the layers land bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR

---
_Generated by [Claude Code](https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR)_