### PR TITLE
docs: file the Configuration Change Preview PRD and plan as done (#827)

### DIFF
--- a/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
+++ b/engineering/CONFIGURATION_CHANGE_CLASSIFICATION.md
@@ -4,7 +4,7 @@
 
 - **Status:** Done
 - **Applies to:** every configuration property captured in a `ConfigurationSnapshot`
-- **Related:** [`plans/doing/CONFIGURATION_CHANGE_PREVIEW.md`](plans/doing/CONFIGURATION_CHANGE_PREVIEW.md) (the framework this feeds), issue #827
+- **Related:** [`plans/done/CONFIGURATION_CHANGE_PREVIEW.md`](plans/done/CONFIGURATION_CHANGE_PREVIEW.md) (the framework this feeds), issue #827
 
 ## Why this exists
 

--- a/engineering/plans/done/CONFIGURATION_CHANGE_PREVIEW.md
+++ b/engineering/plans/done/CONFIGURATION_CHANGE_PREVIEW.md
@@ -1,9 +1,10 @@
 # Configuration Change Preview Framework - Implementation Plan
 
-- **Status:** Doing (Phases 0 to 4 complete; the framework is proven end-to-end by five shipped adapters, and the #288 engine core (Phase 1) delivered Aug 2026. Phase 5 is the remaining work: Waves 1 (G5 and G3), 2 (G4) and 3 (G1 and G2) are delivered, and Wave 4 is unfiled)
+- **Status:** Done
+- **Note:** All phases and Phase 5 waves delivered (G5, G3 destructive and behaviour toggles, G4, G1, G2 and G6, plus the schema refresh decision #1485 which deliberately sits beside the framework rather than on it). Deferred, tracked on their own issues: #91 mode 2 (Attribute Priority as an adapter) and #134/#809 (Connected System deletion re-platformed onto the framework).
 - **Created:** 2026-07-20
 - **Issue:** [#827](https://github.com/TetronIO/JIM/issues/827)
-- **PRD:** [PRD_CONFIGURATION_CHANGE_PREVIEW.md](../../prd/doing/PRD_CONFIGURATION_CHANGE_PREVIEW.md)
+- **PRD:** [PRD_CONFIGURATION_CHANGE_PREVIEW.md](../../prd/done/PRD_CONFIGURATION_CHANGE_PREVIEW.md)
 
 ## Overview
 
@@ -187,7 +188,7 @@ Consequence for this plan: no preview-specific notifier is built (see Progress n
 
 ### Phase 1: #288 engine core (separate issue) ✅
 
-The other true build dependency. Scope belongs to #288; this plan defines only what the framework consumes. **Delivered (Aug 2026):** the work planned in [SYNC_PREVIEW_ENGINE.md](../done/SYNC_PREVIEW_ENGINE.md) landed across PRs #1416 to #1419, #1422, #1423 and #1425; the zero-side-effect design is written up in [SYNC_PREVIEW_ZERO_SIDE_EFFECTS.md](../../SYNC_PREVIEW_ZERO_SIDE_EFFECTS.md). Wave 3 (G1/G2) was filed as #1436 and #1437.
+The other true build dependency. Scope belongs to #288; this plan defines only what the framework consumes. **Delivered (Aug 2026):** the work planned in [SYNC_PREVIEW_ENGINE.md](SYNC_PREVIEW_ENGINE.md) landed across PRs #1416 to #1419, #1422, #1423 and #1425; the zero-side-effect design is written up in [SYNC_PREVIEW_ZERO_SIDE_EFFECTS.md](../../SYNC_PREVIEW_ZERO_SIDE_EFFECTS.md). Wave 3 (G1/G2) was filed as #1436 and #1437.
 
 - [x] Inbound: `SyncEngine` is already a pure decision engine; expose an orchestration path that evaluates projection, join, and Attribute Flow decisions for a given CSO/MVO population **without persisting**, returning decision records. **Delivered:** `JimApplication.SyncPreview.PreviewSyncForCsoAsync` / `PreviewSyncForMvoAsync` evaluate the full chain read-only under a write-throwing repository guard and a rollback-only transaction, returning `SyncPreviewResult` with the speculative `SyncOutcomeNode` tree and programmatic Errors/Warnings; fidelity to real sync is pinned by release-blocking paired tests.
 - [x] Outbound: extract an evaluation-only path from `ExportEvaluationServer` (today it stages Pending Exports as it evaluates); generalise `SyncRunMode.PreviewOnly` beyond export execution so the mode means "evaluate, never persist" across the pipeline. **Delivered:** the outbound braid was extracted into pure `SyncEngine` partials (#288 plan Phase 1), and `ExportEvaluationServer.EvaluateOutboundPreviewAsync` is the evaluation-only path #1115 consumes; the "mode" landed structurally rather than flag-gated (the preview path IS evaluate-never-persist), which is what D1 = C's shared-core shape makes possible.

--- a/engineering/prd/done/PRD_CONFIGURATION_CHANGE_PREVIEW.md
+++ b/engineering/prd/done/PRD_CONFIGURATION_CHANGE_PREVIEW.md
@@ -1,6 +1,7 @@
 # Configuration Change Preview Framework
 
-- **Status:** Doing (framework complete and proven by two shipped adapters, G5 deletion settings and G4 partition/container deselection, each across portal, REST and PowerShell; four of six coverage-map gaps remain, all blocked on the #288 engine core)
+- **Status:** Done
+- **Note:** The framework and every coverage-map gap (G1 to G6, including the destructive-toggle and behaviour-toggle halves of G3) shipped as adapters with portal, REST and PowerShell parity; the schema refresh phase and its three-way decision closed with #421 and #1485. Deferred, tracked on their own issues: #91 mode 2 (Attribute Priority as an adapter) and #134/#809 (Connected System deletion re-platformed onto the framework).
 - **Created:** 2026-07-16
 - **Author:** JayVDZ
 - **Issue:** [#827](https://github.com/TetronIO/JIM/issues/827)
@@ -193,7 +194,7 @@ The core scenario governs the whole framework; the rest exercise specific surfac
 ## Acceptance Criteria
 
 - [x] Framework design agreed (this PRD reviewed and approved, Jul 2026)
-- [x] Implementation plan generated from this PRD (adapter contract, result schema, dispatch, notification abstraction, UI shell) and approved (Jul 2026: [`engineering/plans/doing/CONFIGURATION_CHANGE_PREVIEW.md`](../../plans/doing/CONFIGURATION_CHANGE_PREVIEW.md))
+- [x] Implementation plan generated from this PRD (adapter contract, result schema, dispatch, notification abstraction, UI shell) and approved (Jul 2026: [`engineering/plans/done/CONFIGURATION_CHANGE_PREVIEW.md`](../../plans/done/CONFIGURATION_CHANGE_PREVIEW.md))
 - [x] Per-surface adapter issues split out in severity order: G5 and G3-destructive first (Jul 2026: [#1114](https://github.com/TetronIO/JIM/issues/1114), [#1115](https://github.com/TetronIO/JIM/issues/1115)), then G4, then G1/G2, then G6 and remaining toggles as each wave starts; #204, #134, #421, #91 mode 2 re-scoped as adapter issues in the final wave
 - [ ] Interim apply-time messaging delivered as an early phase of the framework implementation plan, covering all surfaces awaiting adapters
 - [x] #307/#202 alignment recorded on those issues (Jul 2026: #307 blocks #827; sequencing and notifier contract recorded on #307 and in the implementation plan)


### PR DESCRIPTION
## Description

Lifecycle housekeeping for the closure of #827: the Configuration Change Preview framework and every coverage-map adapter shipped, and the schema refresh decision (#1485) closed the final piece today, so the PRD and implementation plan move to their `done/` folders with `Status: Done` and a Note recording the deferrals (#91 mode 2 and #134/#809, each tracked on its own issue). Cross-references updated in the same commit: the inbound link from `CONFIGURATION_CHANGE_CLASSIFICATION.md`, the PRD↔plan links, and the plan's now-same-folder link to `SYNC_PREVIEW_ENGINE.md`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Testing

- [ ] `dotnet build JIM.sln` succeeds with zero errors
- [ ] `dotnet test JIM.sln` passes
- [ ] New functionality has tests (unit, workflow, or integration as appropriate)
- [ ] Manually tested in a local development environment

Markdown-only change; per the repository's build/test exceptions no build or test applies. Link and folder correctness verified by grep (no remaining references to the `doing/` paths; both outbound link targets exist).

## Documentation

- [ ] Public documentation updated (`docs/`); page(s):
- [x] Engineering reference documentation updated (`engineering/`) where a design/architecture doc would otherwise be stale
- [ ] No documentation needed

Docs: n/a - engineering lifecycle move only; no user-facing behaviour changes and no changelog entry.

## Screenshots / output (if applicable)

Not applicable.

## Checklist

- [x] My commit messages are descriptive and reference the relevant Issue (if any)
- [x] My code follows the conventions in [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md)
- [x] User-facing text uses British English (en-GB)
- [x] This PR does **not** include security-sensitive information (real credentials, customer data, internal hostnames)

## Additional context

Point-in-time content is untouched per the retro-editing rule; only the Status/Note headers, folders and link hygiene changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR

---
_Generated by [Claude Code](https://claude.ai/code/session_016u3WRmv6FGhr7bDfLarQnR)_