### PR TITLE
chore: remove terminal font family override from VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -125,6 +125,5 @@
         "Xamarin",
         "xpress"
     ],
-    "editor.mouseWheelZoom": true,
-    "terminal.integrated.fontFamily": "Consolas, 'Courier New', monospace"
+    "editor.mouseWheelZoom": true
 }


### PR DESCRIPTION
## Summary
- Removes the `terminal.integrated.fontFamily` override (Consolas/Courier New) from `.vscode/settings.json` so the integrated terminal falls back to the editor default.

## Test plan
- N/A - config-only change (VS Code workspace settings), no build/test required per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)